### PR TITLE
Fix syntax error in composer.json example

### DIFF
--- a/src/site/rst/news/pdepend-1.1.0-released.rst
+++ b/src/site/rst/news/pdepend-1.1.0-released.rst
@@ -16,7 +16,7 @@ PHP_Depend, just add PHP_Depend as a dependency to your ``composer.json`` ::
 
   {
       "require": {
-          "pdepend/pdepend: "1.1.0"
+          "pdepend/pdepend": "1.1.0"
       }
   }
 


### PR DESCRIPTION
The pdepend/pdepend was missing a trailing quote character.
