### PR TITLE
Skip resolved classnames that contain a dot

### DIFF
--- a/src/main/php/PHP/Depend/Metrics/AnalyzerClassFileSystemLocator.php
+++ b/src/main/php/PHP/Depend/Metrics/AnalyzerClassFileSystemLocator.php
@@ -139,6 +139,9 @@ class PHP_Depend_Metrics_AnalyzerClassFileSystemLocator
                     $className = $this->createClassNameFromPath(
                         $dir, $file->getPathname()
                     );
+                    if (strpos($className, '.') !== false) {
+                        continue;
+                    }
                     if (!class_exists($className)) {
                         include_once $file->getPathname();
                     }


### PR DESCRIPTION
For some reason, sometimes structures that are psr-0 compatible contain folders starting with a dot - in my case it was .AppleDouble. Preventing this would have a been a huge pain, so I figured it could be a good idea to do this. If could be enhanced by a whole set of blacklisted characters, or a regex whitelisting the format of allowed classnames in php.
