### PR TITLE
Try to include the autoload.php file from different locations

### DIFF
--- a/src/bin/pdepend
+++ b/src/bin/pdepend
@@ -49,7 +49,16 @@ if (strpos('@php_bin@', '@php_bin') === 0) {
     set_include_path('.' . PATH_SEPARATOR . dirname(__FILE__) . '/../main/php');
 }
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+$autoloadFiles = array(
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../../autoload.php'
+);
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+        break;
+    }
+}
 
 // Allow as much memory as possible by default
 if (extension_loaded('suhosin') && is_numeric(ini_get('suhosin.memory_limit'))) {

--- a/src/bin/pdepend.php
+++ b/src/bin/pdepend.php
@@ -49,7 +49,16 @@ if (strpos('@php_bin@', '@php_bin') === 0) {
     set_include_path('.' . PATH_SEPARATOR . dirname(__FILE__) . '/../main/php');
 }
 
-require_once __DIR__ . '/../../vendor/autoload.php';
+$autoloadFiles = array(
+    __DIR__ . '/../../vendor/autoload.php',
+    __DIR__ . '/../../../../autoload.php'
+);
+foreach ($autoloadFiles as $autoloadFile) {
+    if (file_exists($autoloadFile)) {
+        require_once $autoloadFile;
+        break;
+    }
+}
 
 // Allow as much memory as possible by default
 if (extension_loaded('suhosin') && is_numeric(ini_get('suhosin.memory_limit'))) {


### PR DESCRIPTION
Check for the autoload file on multiple locations, so the vendor/bin script does not break when the symlink is followed into the vendors package dir.

When I run `vendor/bin/pdepend` now, I get:

``` shell
Warning: require_once(/Users/jachim/project/vendor/pdepend/pdepend/src/bin/../../vendor/autoload.php): failed to open stream: No such file or directory in /Users/jachim/project/vendor/pdepend/pdepend/src/bin/pdepend on line 52
```
