### PR TITLE
Make dev-master alias as 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
     "bin": ["src/bin/pdepend"],
     "autoload": {
         "psr-0": {"PDepend\\": "src/main/php/"}
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.0-dev"
+        }
     }
 }
 


### PR DESCRIPTION
Allows to use "2.0@dev" as version constraint.
