### PR TITLE
Traversing boolean when removing cache item (file driver)

### DIFF
--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -228,6 +228,12 @@ class FileCacheDriver implements CacheDriver
     public function remove($pattern)
     {
         $file = $this->getCacheFileWithoutExtension($pattern);
+        $files = glob("{$file}*.*");
+
+        if (false === $files) {
+            return;
+        }
+
         foreach (glob("{$file}*.*") as $f) {
             unlink($f);
         }


### PR DESCRIPTION
On some systems `glob()` returns `false` when mo matches are found ([as PHP docs state](http://php.net/glob#refsect1-function.glob-returnvalues)).
That's why it didn't work as expected on Arch Linux, for example (`foreach` threw a warning when mask didn't match anything and `glob()` returned `false`).

As far as I see, client code doesn't care much to check whether the item being removed exists or not, so this little check seems to address the problem.

It also led to multiple test failures (on the systems where `glob()` returns `false`):

```
There were 41 errors:

1) PDepend\Bugs\DefaultNamespaceBug106Test::testAllocatedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php:64

2) PDepend\Bugs\DefaultNamespaceBug106Test::testExtendedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php:75

3) PDepend\Bugs\DefaultPackageContainsBrokenAritfactsBug098Test::testDefaultPackageDoesNotContainFunctionWithBrokenSignature
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php:67

4) PDepend\Bugs\DefaultPackageContainsBrokenAritfactsBug098Test::testDefaultPackageDoesNotContainClassWithBrokenMethod
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php:85

5) PDepend\Bugs\DefaultPackageContainsBrokenAritfactsBug098Test::testDefaultPackageDoesNotContainsInterfaceWithBrokenBody
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php:103

6) PDepend\Bugs\InconsistentObjectGraphBug073Test::testPHPDependDoesNotDieWithErrorClassDeclaredBeforeInterfaceWithPackage
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php:265

7) PDepend\Bugs\InconsistentObjectGraphBug073Test::testPHPDependDoesNotDieWithErrorClassDeclaredBeforeInterfaceWithoutPackage
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php:275

8) PDepend\Bugs\InconsistentObjectGraphBug073Test::testPHPDependDoesNotDieWithErrorInterfaceDeclaredBeforeClassWithPackage
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php:285

9) PDepend\Bugs\InconsistentObjectGraphBug073Test::testPHPDependDoesNotDieWithErrorInterfaceDeclaredBeforeClassWithoutPackage
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php:295

10) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #0 ('PDepend\\Report\\Jdepend\\Chart', 'svg')
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

11) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #1 ('PDepend\\Report\\Jdepend\\Xml', 'xml')
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

12) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #2 ('PDepend\\Report\\Overview\\Pyramid', 'svg')
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

13) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #3 ('PDepend\\Report\\Summary\\Xml', 'xml')
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

14) PDepend\Bugs\SummaryReportContainsClassesWithoutSourceFileBug115Test::testSummaryReportFiltersClassesNotFlaggedUserDefined
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php:63

15) PDepend\Bugs\SummaryReportContainsClassesWithoutSourceFileBug115Test::testSummaryReportFiltersInternalClasses
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php:74

16) PDepend\Bugs\SummaryReportContainsClassesWithoutSourceFileBug115Test::testSummaryReportDoesNotContainEmptyPackages
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/AbstractRegressionTest.php:77
/home/alex/git/pdepend/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php:85

17) PDepend\EngineTest::testAnalyzeMethodReturnsAnIterator
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:97

18) PDepend\EngineTest::testAnalyze
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:112

19) PDepend\EngineTest::testAnalyzeSetsWithoutAnnotations
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:166

20) PDepend\EngineTest::testCountClasses
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:189

21) PDepend\EngineTest::testCountNamespaces
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:222

22) PDepend\EngineTest::testGetNamespace
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:255

23) PDepend\EngineTest::testGetNamespaces
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:319

24) PDepend\EngineTest::testSupportForSingleFileIssue90
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/EngineTest.php:354

25) PDepend\Integration\BuilderParserCacheTest::testUnchangedSourceFileGetsRestored
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/test/php/PDepend/Integration/BuilderParserCacheTest.php:144
/home/alex/git/pdepend/src/test/php/PDepend/Integration/BuilderParserCacheTest.php:96

26) PDepend\Integration\BuilderParserCacheTest::testChangedSourceFileGetsProcessed
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/test/php/PDepend/Integration/BuilderParserCacheTest.php:144
/home/alex/git/pdepend/src/test/php/PDepend/Integration/BuilderParserCacheTest.php:112

27) PDepend\Integration\DependExcludePathFilterTest::testPDependFiltersByRelativePath
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php:77

28) PDepend\Integration\DependExcludePathFilterTest::testPDependFiltersByAbsolutePath
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php:104

29) PDepend\Integration\DependExcludePathFilterTest::testPDependNotFiltersByOverlappingPathMatch
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php:131

30) PDepend\Issues\PHPDependCatchesParsingErrorsIssue061Test::testPHPDependReturnsExpectedExceptionInstances
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php:334
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:570
/home/alex/git/pdepend/src/main/php/PDepend/Engine.php:318
/home/alex/git/pdepend/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php:70

31) PDepend\Issues\PHPDependCatchesParsingErrorsIssue061Test::testRunnerReturnsFalseWhenNoErrorOccuredDuringTheParsingProcess
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php:91

32) PDepend\Issues\PHPDependCatchesParsingErrorsIssue061Test::testRunnerReturnsTrueWhenAnErrorOccuredDuringTheParsingProcess
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php:109

33) PDepend\TextUI\CommandTest::testCommandHandlesWithoutAnnotationsOptionCorrect
file_get_contents(/home/alex/git/pdepend/src/test/php/PDepend/_run/535d2d5039d18): failed to open stream: No such file or directory

/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:347
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:285

34) PDepend\TextUI\CommandTest::testCommandHandlesBadDocumentedSourceCode
file_get_contents(/home/alex/git/pdepend/src/test/php/PDepend/_run/535d2d5044122): failed to open stream: No such file or directory

/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:347
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:322

35) PDepend\TextUI\RunnerTest::testRunnerUsesCorrectFileFilter
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:269
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:114

36) PDepend\TextUI\RunnerTest::testRunnerHandlesWithoutAnnotationsOptionCorrect
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:269
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:148

37) PDepend\TextUI\RunnerTest::testSupportBadDocumentation
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:269
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:186

38) PDepend\TextUI\RunnerTest::testRunnerHasParseErrorsReturnsFalseForValidSource
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:202

39) PDepend\TextUI\RunnerTest::testRunnerHasParseErrorsReturnsTrueForInvalidSource
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/AbstractTest.php:514
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:218

40) PDepend\TextUI\RunnerTest::testRunnerGetParseErrorsReturnsArrayWithParsingExceptionMessages
RuntimeException: Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/home/alex/git/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:235

41) PDepend\Util\Cache\Driver\FileCacheDriverTest::testRemoveSilentlyIgnoresPatternsWithoutMatch
Invalid argument supplied for foreach()

/home/alex/git/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php:231
/home/alex/git/pdepend/src/test/php/PDepend/Util/Cache/AbstractDriverTest.php:209

--


There were 6 failures:

1) PDepend\Bugs\EndlessInheritanceBug18459091Test::testFullStackNotRunsEndless
Failed asserting that 'PDepend 2.0.0-beta.4

Parsing source files:


Critical error: 
=============== 
Invalid argument supplied for foreach()
' contains " is part of an endless inheritance hierarchy".

/home/alex/git/pdepend/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php:228

2) PDepend\EngineTest::testGetNamespacesWithUnknownPackageFail
Failed asserting that exception of type "PHPUnit_Framework_Error_Warning" matches expected exception "OutOfBoundsException". Message was: "Invalid argument supplied for foreach()".


3) PDepend\Issues\PHPDependCatchesParsingErrorsIssue061Test::testCommandPrintsExceptionMessageWhenAnErrorOccuredDuringTheParsingProcess
Failed asserting that 'PDepend 2.0.0-beta.4

Parsing source files:


Critical error: 
=============== 
Invalid argument supplied for foreach()
' contains "Unexpected token: ), line: 7, col: 49, file:".

/home/alex/git/pdepend/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php:152

4) PDepend\TextUI\CommandTest::testCommandStartsProcessWithDummyLogger
Failed asserting that 2 matches expected 0.

/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:217

5) PDepend\TextUI\CommandTest::testCommandReturnsExitCodeSuccessByDefault
Failed asserting that 2 matches expected 0.

/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:241

6) PDepend\TextUI\CommandTest::testTextUiCommandAcceptsExistingFileForCoverageReportOption
Failed asserting that 2 matches expected 0.

/home/alex/git/pdepend/src/test/php/PDepend/TextUI/CommandTest.php:523

FAILURES!
Tests: 6725, Assertions: 7536, Failures: 6, Errors: 41, Incomplete: 6, Skipped: 14.
```

Tests pass with the suggested fix.
