### PR TITLE
Fix FileUtil::getUserHomeDir on Mac

### DIFF
--- a/src/main/php/PDepend/Util/FileUtil.php
+++ b/src/main/php/PDepend/Util/FileUtil.php
@@ -84,7 +84,7 @@ final class FileUtil
      */
     public static function getUserHomeDir()
     {
-        if (false === stripos(PHP_OS, 'win')) {
+        if ((PHP_OS === 'Darwin') || (false === stripos(PHP_OS, 'win'))) {
             return getenv('HOME');
         }
         return getenv('HOMEDRIVE') . getenv('HOMEPATH');


### PR DESCRIPTION
getUserHomeDir of PDepend\Util\FileUtil is using stripos(PHP_OS, 'win')
for judgment of Windows system.
But it is not right, because PHP_OS on Mac is 'Darwin'.

``` sh
% php -r 'var_dump(PHP_OS);'
string(6) "Darwin"
```
- before

``` sh
PHPUnit 3.7.35 by Sebastian Bergmann.

.FF

Time: 27 ms, Memory: 3.25Mb

There were 2 failures:

1) PDepend\Util\FileUtilTest::testGetUserHomeDirReturnsExpectedDirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/Users/monmon'
+''

/Users/monmon/tmp/2014-07-18/pdpend/pdepend/src/test/php/PDepend/Util/FileUtilTest.php:81

2) PDepend\Util\FileUtilTest::testGetUserHomeDirOrSysTempDirReturnsExpectedUserHomeDirectory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/Users/monmon'
+'/var/folders/sr/d025cb3s2xs7mx0w_qy8kcnh0000gn/T'

/Users/monmon/tmp/2014-07-18/pdpend/pdepend/src/test/php/PDepend/Util/FileUtilTest.php:94

FAILURES!
Tests: 3, Assertions: 3, Failures: 2.
```
- after

``` sh
% phpunit --colors --bootstrap=test/php/PDepend/bootstrap.php test/php/PDepend/Util/FileUtilTest.php
PHPUnit 3.7.35 by Sebastian Bergmann.

...

Time: 29 ms, Memory: 3.00Mb

OK (3 tests, 3 assertions)
```
