### PR TITLE
Added support for foreach with list statement (PHP 5.5)

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -3409,13 +3409,22 @@ abstract class AbstractPHPParser
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
             $foreach->addChild($this->parseVariableOrMemberByReference());
         } else {
-            $foreach->addChild($this->parseVariableOrConstantOrPrimaryPrefix());
+            if ($this->tokenizer->peek() == Tokens::T_LIST) {
+                $foreach->addChild($this->parseListExpression());
+            } else {
+                $foreach->addChild($this->parseVariableOrConstantOrPrimaryPrefix());
 
-            if ($this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
-                $this->consumeToken(Tokens::T_DOUBLE_ARROW);
-                $foreach->addChild(
-                    $this->parseVariableOrMemberOptionalByReference()
-                );
+                if ($this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
+                    $this->consumeToken(Tokens::T_DOUBLE_ARROW);
+
+                    if ($this->tokenizer->peek() == Tokens::T_LIST) {
+                        $foreach->addChild($this->parseListExpression());
+                    } else {
+                        $foreach->addChild(
+                            $this->parseVariableOrMemberOptionalByReference()
+                        );
+                    }
+                }
             }
         }
 

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -296,6 +296,28 @@ class ASTForeachStatementTest extends \PDepend\Source\AST\ASTNodeTest
     }
 
     /**
+     * testForeachStatementWithList
+     *
+     * @return void
+     */
+    public function testForeachStatementWithList()
+    {
+        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(1));
+    }
+
+    /**
+     * testForeachStatementWithKeyAndList
+     *
+     * @return void
+     */
+    public function testForeachStatementWithKeyAndList()
+    {
+        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(2));
+    }
+
+    /**
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.

--- a/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithKeyAndList.php
+++ b/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithKeyAndList.php
@@ -1,0 +1,5 @@
+<?php
+function testForeachStatementWithKeyAndList()
+{
+    foreach ($expr as $key => list($a, $b)) {}
+}

--- a/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithList.php
+++ b/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithList.php
@@ -1,0 +1,5 @@
+<?php
+function testForeachStatementWithList()
+{
+    foreach ($expr as list($a, $b)) {}
+}


### PR DESCRIPTION
Currently, pdepend does not support to analyze codes which uses [foreach with list](http://php.net/manual/de/migration55.new-features.php#migration55.new-features.foreach-list) (which was introduced in PHP 5.5)

```
$array = [
    [1, 2],
    [3, 4],
];

foreach ($array as list($a, $b)) {
    echo "A: $a; B: $b\n";
}
```

Before, this code led to the following error: `Unexpected token: list, line: 8, col: 18, file: /../foreachlist.php`
