### PR TITLE
Fix Invalid argument supplied for foreach() in FileCacheDriver.php

### DIFF
--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -228,8 +228,12 @@ class FileCacheDriver implements CacheDriver
     public function remove($pattern)
     {
         $file = $this->getCacheFileWithoutExtension($pattern);
-        foreach (glob("{$file}*.*") as $f) {
-            unlink($f);
+        $glob = glob("{$file}*.*");
+        // avoid error if we dont find files
+        if ($glob !== false) {
+            foreach (glob("{$file}*.*") as $f) {
+                unlink($f);
+            }
         }
     }
 


### PR DESCRIPTION
I sometimes get errors in this function if it does not find files
