### PR TITLE
Fixing parsing True/False keywords in namespaces

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -286,6 +286,7 @@ class PHPTokenizerInternal implements Tokenizer
         Tokens::T_TRUE => array(
             Tokens::T_OBJECT_OPERATOR  =>  Tokens::T_STRING,
             Tokens::T_DOUBLE_COLON     =>  Tokens::T_STRING,
+            Tokens::T_NAMESPACE        =>  Tokens::T_STRING,
             Tokens::T_CONST            =>  Tokens::T_STRING,
             Tokens::T_FUNCTION         =>  Tokens::T_STRING,
         ),
@@ -295,6 +296,7 @@ class PHPTokenizerInternal implements Tokenizer
         Tokens::T_FALSE => array(
             Tokens::T_OBJECT_OPERATOR  =>  Tokens::T_STRING,
             Tokens::T_DOUBLE_COLON     =>  Tokens::T_STRING,
+            Tokens::T_NAMESPACE        =>  Tokens::T_STRING,
             Tokens::T_CONST            =>  Tokens::T_STRING,
             Tokens::T_FUNCTION         =>  Tokens::T_STRING,
         ),

--- a/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2014, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2014 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Bugs;
+
+/**
+ * Test case issue 1412288686.
+ *
+ * @copyright 2008-2014 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @covers \stdClass
+ * @group regressiontest
+ */
+class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTest {
+    /**
+     * testTrueKeywordInNamespace
+     *
+     * @return void
+     */
+    public function testTrueKeywordInNamespace() {
+        self::parseCodeResourceForTest();
+    }
+
+    /**
+     * testFalseKeywordInNamespace
+     *
+     * @return void
+     */
+    public function testFalseKeywordInNamespace() {
+        self::parseCodeResourceForTest();
+    }
+}

--- a/src/test/resources/files/bugs/1412288686/testFalseKeywordInNamespace.php
+++ b/src/test/resources/files/bugs/1412288686/testFalseKeywordInNamespace.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace False;
+namespace Foo\False;
+namespace False\Bar;
+namespace Foo\False\Bar;

--- a/src/test/resources/files/bugs/1412288686/testTrueKeywordInNamespace.php
+++ b/src/test/resources/files/bugs/1412288686/testTrueKeywordInNamespace.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace True;
+namespace Foo\True;
+namespace True\Bar;
+namespace Foo\True\Bar;


### PR DESCRIPTION
Usage of `true` and `false` keywords are allowed in namespace declarations in PHP.
For classes, traits and interfaces those keywords are correctly handled.
