### PR TITLE
Fix conflicting import

### DIFF
--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -45,7 +45,7 @@ namespace PDepend\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension as SymfonyExtension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**
@@ -54,7 +54,7 @@ use Symfony\Component\DependencyInjection\Loader;
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class PdependExtension extends Extension
+class PdependExtension extends SymfonyExtension
 {
     /**
      * {@inheritDoc}

--- a/src/test/php/PDepend/Bugs/ConflictingImportTest.php
+++ b/src/test/php/PDepend/Bugs/ConflictingImportTest.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2013, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2013 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Bugs;
+
+class ConflictingImportTest extends AbstractRegressionTest
+{
+    public function testSymfonyExtension()
+    {
+        // force compilation of both conflicting files
+        new \ReflectionClass('PDepend\DependencyInjection\Extension');
+        new \ReflectionClass('PDepend\DependencyInjection\PdependExtension');
+    }
+}


### PR DESCRIPTION
"Extension" is already in use in the "PDepend\DependencyInjection" namespace.

```
$ php -r '
require "vendor/autoload.php";
require "src/main/php/PDepend/DependencyInjection/Extension.php";
require "src/main/php/PDepend/DependencyInjection/PdependExtension.php";
'

PHP Fatal error:  Cannot use Symfony\Component\DependencyInjection\Extension\Extension as Extension because the name is already in use in [...]/src/main/php/PDepend/DependencyInjection/PdependExtension.php on line 48
PHP Stack trace:
PHP   1. {main}() Command line code:0
```
