### PR TITLE
Fixed display of duration longer than one hour

### DIFF
--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -248,7 +248,11 @@ class Command
                 echo PHP_EOL;
             }
 
-            echo PHP_EOL, 'Time: ', date('i:s', time() - $startTime);
+            $duration = time() - $startTime;
+            $hours = intval($duration / 3600);
+            $minutes = intval(($duration - $hours * 3600) / 60);
+            $seconds = $duration % 60;
+            echo PHP_EOL, 'Time: ', sprintf('%d:%02d:%02d', $hours, $minutes, $seconds);
             if (function_exists('memory_get_peak_usage')) {
                 $memory = (memory_get_peak_usage(true) / (1024 * 1024));
                 printf('; Memory: %4.2fMb', $memory);


### PR DESCRIPTION
If pdepend runs longer than one hour, then wrong time is displayed. Hours are ignored and just minutes and seconds are shown.
This PR fixes this issue and displays duration with hours.
