### PR TITLE
Add analyzers for Halstead measures & maintainability index

### DIFF
--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -91,6 +91,16 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     }
 
     /**
+     * Getter method for the system wide used cache.
+     *
+     * @return \PDepend\Util\Cache\CacheDriver $cache
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
      * Tries to restore the metrics for a cached node. If this method has
      * restored the metrics it will return <b>TRUE</b>, otherwise the return
      * value will be <b>FALSE</b>.

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -110,7 +110,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     {
         if (isset($this->metrics[$artifact->getId()])) {
             $basis = $this->metrics[$artifact->getId()];
-
             return $this->calculateHalsteadMeasures($basis);
         }
 
@@ -323,7 +322,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                         // Undo all of "define", "(", name, ",", value, ")"
                         $skipUntil = Tokens::T_PARENTHESIS_CLOSE;
                     } else {
-                        $operands++;
+                        $operands[] = $token->image;
                     }
                     break;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -1,0 +1,386 @@
+<?php
+
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2015, Matthias Mullie <pdepend@mullie.eu>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractCachingAnalyzer;
+use PDepend\Metrics\AnalyzerNodeAware;
+use PDepend\Source\AST\AbstractASTCallable;
+use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\Tokenizer\Tokens;
+
+/**
+ * This class calculates the Halstead Complexity Measures for the project,
+ * methods and functions.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAware
+{
+    /**
+     * Metrics provided by the analyzer implementation.
+     */
+    const M_HALSTEAD_LENGTH = 'hnt', // N = N1 + N2 (total operators + operands)
+          M_HALSTEAD_VOCABULARY = 'hnd', // n = n1 + n2 (distinct operators + operands)
+          M_HALSTEAD_VOLUME = 'hv', // V = N * log2(n)
+          M_HALSTEAD_DIFFICULTY = 'hd', // D = (n1 / 2) * (N2 / n2)
+          M_HALSTEAD_LEVEL = 'hl', // L = 1 / D
+          M_HALSTEAD_EFFORT = 'he', // E = V * D
+          M_HALSTEAD_TIME = 'ht', // T = E / 18
+          M_HALSTEAD_BUGS = 'hb', // B = (E ** (2/3)) / 3000
+          M_HALSTEAD_CONTENT = 'hi'; // I = (V / D)
+
+    /**
+     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     *
+     * @param  \PDepend\Source\AST\ASTNamespace $namespaces
+     * @return void
+     */
+    public function analyze($namespaces)
+    {
+        if ($this->metrics === null) {
+            $this->loadCache();
+            $this->fireStartAnalyzer();
+
+            // Init node metrics
+            $this->metrics = array();
+
+            foreach ($namespaces as $namespace) {
+                $namespace->accept($this);
+            }
+
+            $this->fireEndAnalyzer();
+            $this->unloadCache();
+        }
+    }
+
+    /**
+     * This method will return an <b>array</b> with all generated metric values
+     * for the given <b>$node</b>. If there are no metrics for the requested
+     * node, this method will return an empty <b>array</b>.
+     *
+     * @param \PDepend\Source\AST\ASTArtifact $artifact
+     * @return array
+     */
+    public function getNodeMetrics(ASTArtifact $artifact)
+    {
+        if (isset($this->metrics[$artifact->getId()])) {
+            $basis = $this->metrics[$artifact->getId()];
+
+            return $this->calculateHalsteadMeasures($basis);
+        }
+
+        return array();
+    }
+
+    /**
+     * Visits a function node.
+     *
+     * @param  \PDepend\Source\AST\ASTFunction $function
+     * @return void
+     */
+    public function visitFunction(ASTFunction $function)
+    {
+        $this->fireStartFunction($function);
+
+        if (false === $this->restoreFromCache($function)) {
+            $this->calculateHalsteadBasis($function);
+        }
+
+        $this->fireEndFunction($function);
+    }
+
+    /**
+     * Visits a code interface object.
+     *
+     * @param  \PDepend\Source\AST\ASTInterface $interface
+     * @return void
+     */
+    public function visitInterface(ASTInterface $interface)
+    {
+        // Empty visit method, we don't want interface metrics
+    }
+
+    /**
+     * Visits a method node.
+     *
+     * @param  \PDepend\Source\AST\ASTMethod $method
+     * @return void
+     */
+    public function visitMethod(ASTMethod $method)
+    {
+        $this->fireStartMethod($method);
+
+        if (false === $this->restoreFromCache($method)) {
+            $this->calculateHalsteadBasis($method);
+        }
+
+        $this->fireEndMethod($method);
+    }
+
+    /**
+     * @see http://www.scribd.com/doc/99533/Halstead-s-Operators-and-Operands-in-C-C-JAVA-by-Indranil-Nandy
+     *
+     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
+     * @return void
+     */
+    public function calculateHalsteadBasis(AbstractASTCallable $callable)
+    {
+        $operators = array();
+        $operands = array();
+
+        $skipUntil = null;
+
+        $tokens = $callable->getTokens();
+        foreach ($tokens as $i => $token) {
+            /*
+             * Some operations should be ignored, e.g. function declarations.
+             * When we encounter a new function, we'll skip all tokens until we
+             * find the closing token.
+             */
+            if ($skipUntil !== null) {
+                if ($token->type === $skipUntil) {
+                    $skipUntil = null;
+                }
+
+                continue;
+            }
+
+            switch ($token->type) {
+                // A pair of parenthesis is considered a single operator.
+                case Tokens::T_PARENTHESIS_CLOSE:
+                case Tokens::T_CURLY_BRACE_CLOSE:
+                case Tokens::T_SQUARED_BRACKET_CLOSE:
+                case Tokens::T_ANGLE_BRACKET_CLOSE:
+                    break;
+
+                // A label is considered an operator if it is used as the target
+                // of a GOTO statement.
+                case Tokens::T_GOTO:
+                    $operators[] = $token->image;
+                    // Ignore next token as operand but count as operator instead.
+                    $skipUntil = $tokens[$i + 1]->type;
+                    $operators[] = $tokens[$i + 1]->image;
+                    break;
+
+                /*
+                 * The following control structures case ...: for (...) if (...)
+                 * switch (...) while(...) and try-catch (...) are treated in a
+                 * special way. The colon and the parentheses are considered to
+                 * be a part of the constructs. The case and the colon or the
+                 * “for (...)”, “if (...)”, “switch (...)”, “while(...)”,
+                 * “try-catch( )” are counted together as one operator.
+                 */
+                case Tokens::T_IF:
+                case Tokens::T_FOR:
+                case Tokens::T_FOREACH:
+                case Tokens::T_WHILE:
+                case Tokens::T_CATCH:
+                // case Tokens::T_SWITCH: // not followed by ()
+                // case Tokens::T_TRY: // not followed by ()
+                // case Tokens::T_DO: // always come with while, which accounts for () already
+                    $operators[] = $token->image;
+                    /*
+                     * These are always followed by parenthesis, which would add
+                     * another operator (only opening parenthesis counts)
+                     * so we'll have to skip that one.
+                     */
+                    $skipUntil = Tokens::T_PARENTHESIS_OPEN;
+                    $operators[] = $token->image;
+                    break;
+
+                /*
+                 * The ternary operator ‘?’ followed by ‘:’ is considered a
+                 * single operator as it is equivalent to “if-else” construct.
+                 */
+                case Tokens::T_COLON:
+                    /*
+                     * Colon is used after keyword, where it counts as part of
+                     * that operator, or in ternary operator, where it also
+                     * counts as 1.
+                     */
+                    break;
+
+                // The comments are considered neither an operator nor an operand.
+                case Tokens::T_DOC_COMMENT:
+                case Tokens::T_COMMENT:
+                    break;
+
+                /*
+                 * `new` is considered same as the function call, mainly because
+                 * it's equivalent to the function call.
+                 */
+                case Tokens::T_NEW:
+                    break;
+
+                /*
+                 * Like T_IF & co, array(..) needs 3 tokens ("array", "(" and
+                 * ")") for what's essentially just 1 operator.
+                 */
+                case Tokens::T_ARRAY:
+                    break;
+
+                /*
+                 * Class::method or $object->method both only count as 1
+                 * identifier, even though they consist of 3 tokens.
+                 */
+                case Tokens::T_OBJECT_OPERATOR:
+                case Tokens::T_DOUBLE_COLON:
+                    // Glue ->/:: and before & after parts together.
+                    $image = array_pop($operands).$token->image.$tokens[$i + 1]->image;
+                    $operands[] = $image;
+
+                    // Skip next part (would be seen as operand)
+                    $skipUntil = $tokens[$i + 1]->type;
+                    break;
+
+                // Ignore HEREDOC delimiters.
+                case Tokens::T_START_HEREDOC:
+                case Tokens::T_END_HEREDOC:
+                    break;
+
+                // Ignore PHP open & close tags and non-PHP content.
+                case Tokens::T_OPEN_TAG:
+                case Tokens::T_CLOSE_TAG:
+                case Tokens::T_NO_PHP:
+                    break;
+
+                /*
+                 * The function name is considered a single operator when it
+                 * appears as calling a function, but when it appears in
+                 * declarations or in function definitions it is not counted as
+                 * operator.
+                 * Default parameter assignments are not counted.
+                 */
+                case Tokens::T_FUNCTION:
+                    // Because `)` could appear in default argument assignment
+                    // (`$var = array()`), we need to skip until `{`, but that
+                    // one should be included in operators.
+                    $skipUntil = Tokens::T_CURLY_BRACE_OPEN;
+                    $operators[] = '{';
+                    break;
+
+                /*
+                 * When variables or constants appear in declaration they are
+                 * not considered as operands, they are considered operands only
+                 * when they appear with operators in expressions.
+                 */
+                case Tokens::T_VAR:
+                    /*
+                     * Ignore this token, and the next one will be recognized as
+                     * operand but should be cancelled out.
+                     */
+                    $skipUntil = $tokens[$i + 1]->type;
+                    break;
+
+                case Tokens::T_STRING:
+                    // `define` is T_STRING, just like any other identifier.
+                    if ($token->image === 'define') {
+                        // Undo all of "define", "(", name, ",", value, ")"
+                        $skipUntil = Tokens::T_PARENTHESIS_CLOSE;
+                    } else {
+                        $operands++;
+                    }
+                    break;
+
+                // Operands
+                case Tokens::T_CONSTANT_ENCAPSED_STRING:
+                case Tokens::T_VARIABLE:
+                case Tokens::T_LNUMBER:
+                case Tokens::T_DNUMBER:
+                case Tokens::T_NULL:
+                case Tokens::T_TRUE:
+                case Tokens::T_FALSE:
+                case Tokens::T_CLASS_FQN:
+                case Tokens::T_LINE:
+                case Tokens::T_METHOD_C:
+                case Tokens::T_NS_C:
+                case Tokens::T_DIR:
+                case TOKENS::T_ENCAPSED_AND_WHITESPACE: // content of HEREDOC
+                    $operands[] = $token->image;
+                    break;
+
+                // Everything else is an operator.
+                default:
+                    $operators[] = $token->image;
+                    break;
+            }
+        }
+
+        $this->metrics[$callable->getId()] = array(
+            'n1' => count($operators),
+            'n2' => count($operands),
+            'N1' => count(array_unique($operators)),
+            'N2' => count(array_unique($operands)),
+        );
+    }
+
+    /**
+     * Calculates Halstead measures from n1, n2, N1 & N2.
+     *
+     * @see http://www.verifysoft.com/en_halstead_metrics.html
+     * @see http://www.grammatech.com/codesonar/workflow-features/halstead
+     *
+     * @param array $basis [n1, n2, N1, N2]
+     * @return array
+     */
+    public function calculateHalsteadMeasures(array $basis)
+    {
+        $measures = array();
+        $measures[self::M_HALSTEAD_LENGTH] = $basis['N1'] + $basis['N2'];
+        $measures[self::M_HALSTEAD_VOCABULARY] = $basis['n1'] + $basis['n2'];
+        $measures[self::M_HALSTEAD_VOLUME] = $measures[self::M_HALSTEAD_LENGTH] * log($measures[self::M_HALSTEAD_VOCABULARY], 2);
+        $measures[self::M_HALSTEAD_DIFFICULTY] = ($basis['n1'] / 2) * ($basis['N1'] / ($basis['n2'] ?: 1));
+        $measures[self::M_HALSTEAD_LEVEL] = 1 / $measures[self::M_HALSTEAD_DIFFICULTY];
+        $measures[self::M_HALSTEAD_EFFORT] = $measures[self::M_HALSTEAD_VOLUME] * $measures[self::M_HALSTEAD_DIFFICULTY];
+        $measures[self::M_HALSTEAD_TIME] = $measures[self::M_HALSTEAD_EFFORT] / 18;
+        $measures[self::M_HALSTEAD_BUGS] = pow($measures[self::M_HALSTEAD_EFFORT], (2/3)) / 3000;
+        $measures[self::M_HALSTEAD_CONTENT] = $measures[self::M_HALSTEAD_VOLUME] / ($measures[self::M_HALSTEAD_DIFFICULTY] ?: 1);
+
+        return $measures;
+    }
+}

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -99,6 +99,23 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     }
 
     /**
+     * This method will return an <b>array</b> with all generated basis metrics
+     * for the given <b>$node</b> (n1, n2, N1, N2). If there are no metrics for
+     * the requested node, this method will return an empty <b>array</b>.
+     *
+     * @param \PDepend\Source\AST\ASTArtifact $artifact
+     * @return array
+     */
+    public function getNodeBasisMetrics(ASTArtifact $artifact)
+    {
+        if (isset($this->metrics[$artifact->getId()])) {
+            return $this->metrics[$artifact->getId()];
+        }
+
+        return array();
+    }
+
+    /**
      * This method will return an <b>array</b> with all generated metric values
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
@@ -108,8 +125,8 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
-        if (isset($this->metrics[$artifact->getId()])) {
-            $basis = $this->metrics[$artifact->getId()];
+        $basis = $this->getNodeBasisMetrics($artifact);
+        if ($basis) {
             return $this->calculateHalsteadMeasures($basis);
         }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -238,7 +238,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                 case Tokens::T_CATCH:
                 // case Tokens::T_SWITCH: // not followed by ()
                 // case Tokens::T_TRY: // not followed by ()
-                // case Tokens::T_DO: // always come with while, which accounts for () already
+                // case Tokens::T_DO: // always comes with while, which accounts for () already
                     $operators[] = $token->image;
                     /*
                      * These are always followed by parenthesis, which would add
@@ -246,7 +246,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                      * so we'll have to skip that one.
                      */
                     $skipUntil = Tokens::T_PARENTHESIS_OPEN;
-                    $operators[] = $token->image;
                     break;
 
                 /*
@@ -326,11 +325,8 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                  * when they appear with operators in expressions.
                  */
                 case Tokens::T_VAR:
-                    /*
-                     * Ignore this token, and the next one will be recognized as
-                     * operand but should be cancelled out.
-                     */
-                    $skipUntil = $tokens[$i + 1]->type;
+                case Tokens::T_CONST:
+                    $skipUntil = Tokens::T_SEMICOLON;
                     break;
 
                 case Tokens::T_STRING:
@@ -348,6 +344,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                 case Tokens::T_VARIABLE:
                 case Tokens::T_LNUMBER:
                 case Tokens::T_DNUMBER:
+                case Tokens::T_NUM_STRING:
                 case Tokens::T_NULL:
                 case Tokens::T_TRUE:
                 case Tokens::T_FALSE:

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -43,7 +43,6 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\AbstractASTCallable;
@@ -67,7 +66,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     const M_MAINTAINABILITY_INDEX = 'mi';
 
     /**
-     * @var AbstractAnalyzer[]
+     * @var AbstractCachingAnalyzer[]
      */
     private $analyzers = array();
 
@@ -96,6 +95,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     {
         // Run CCN, Halstead & LOC analyzers first
         foreach ($this->analyzers as $analyzer) {
+            $analyzer->setCache($this->getCache());
             $analyzer->analyze($namespaces);
         }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -193,7 +193,8 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
         $loc = $this->analyzers['loc']->getNodeMetrics($callable);
         $eloc = $loc[NodeLocAnalyzer::M_EXECUTABLE_LINES_OF_CODE];
 
-        $maintainabilityIndex = max(0, (171 - 5.2 * log($halsteadVolume) - 0.23 * $cyclomaticComplexity - 16.2 * log($eloc)) * 100 / 171);
+        $maintainabilityIndex = 171 - 5.2 * log($halsteadVolume) - 0.23 * $cyclomaticComplexity - 16.2 * log($eloc);
+        $maintainabilityIndex = min(100, max(0, $maintainabilityIndex * 100 / 171));
         $this->metrics[$callable->getId()] = array(self::M_MAINTAINABILITY_INDEX => $maintainabilityIndex);
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2015, Matthias Mullie <pdepend@mullie.eu>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractAnalyzer;
+use PDepend\Metrics\AbstractCachingAnalyzer;
+use PDepend\Metrics\AnalyzerNodeAware;
+use PDepend\Source\AST\AbstractASTCallable;
+use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
+
+/**
+ * This class calculates the Halstead Complexity Measures for the project,
+ * methods and functions.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license   http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAware
+{
+    /**
+     * Metrics provided by the analyzer implementation.
+     */
+    const M_MAINTAINABILITY_INDEX = 'mi';
+
+    /**
+     * @var AbstractAnalyzer[]
+     */
+    private $analyzers = array();
+
+    /**
+     * Maintainability index is a combination of cyclomatic complexity,
+     * halstead volume & lines of code, all of which we already have analyzers
+     * for.
+     *
+     * @param array $options
+     */
+    public function __construct(array $options = array()) {
+        parent::__construct($options);
+
+        $this->analyzers['ccn'] = new CyclomaticComplexityAnalyzer();
+        $this->analyzers['halstead'] = new HalsteadAnalyzer();
+        $this->analyzers['loc'] = new NodeLocAnalyzer();
+    }
+
+    /**
+     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     *
+     * @param  \PDepend\Source\AST\ASTNamespace $namespaces
+     * @return void
+     */
+    public function analyze($namespaces)
+    {
+        // Run CCN, Halstead & LOC analyzers first
+        foreach ($this->analyzers as $analyzer) {
+            $analyzer->analyze($namespaces);
+        }
+
+        if ($this->metrics === null) {
+            $this->loadCache();
+            $this->fireStartAnalyzer();
+
+            // Init node metrics
+            $this->metrics = array();
+
+            foreach ($namespaces as $namespace) {
+                $namespace->accept($this);
+            }
+
+            $this->fireEndAnalyzer();
+            $this->unloadCache();
+        }
+    }
+
+    /**
+     * This method will return an <b>array</b> with all generated metric values
+     * for the given <b>$node</b>. If there are no metrics for the requested
+     * node, this method will return an empty <b>array</b>.
+     *
+     * @param \PDepend\Source\AST\ASTArtifact $artifact
+     * @return array
+     */
+    public function getNodeMetrics(ASTArtifact $artifact)
+    {
+        if (isset($this->metrics[$artifact->getId()])) {
+            return $this->metrics[$artifact->getId()];
+        }
+
+        return array();
+    }
+
+    /**
+     * Visits a function node.
+     *
+     * @param  \PDepend\Source\AST\ASTFunction $function
+     * @return void
+     */
+    public function visitFunction(ASTFunction $function)
+    {
+        $this->fireStartFunction($function);
+
+        if (false === $this->restoreFromCache($function)) {
+            $this->calculateMaintainabilityIndex($function);
+        }
+
+        $this->fireEndFunction($function);
+    }
+
+    /**
+     * Visits a code interface object.
+     *
+     * @param  \PDepend\Source\AST\ASTInterface $interface
+     * @return void
+     */
+    public function visitInterface(ASTInterface $interface)
+    {
+        // Empty visit method, we don't want interface metrics
+    }
+
+    /**
+     * Visits a method node.
+     *
+     * @param  \PDepend\Source\AST\ASTMethod $method
+     * @return void
+     */
+    public function visitMethod(ASTMethod $method)
+    {
+        $this->fireStartMethod($method);
+
+        if (false === $this->restoreFromCache($method)) {
+            $this->calculateMaintainabilityIndex($method);
+        }
+
+        $this->fireEndMethod($method);
+    }
+
+    /**
+     * @see http://blogs.msdn.com/b/codeanalysis/archive/2007/11/20/maintainability-index-range-and-meaning.aspx
+     *
+     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
+     * @return void
+     */
+    public function calculateMaintainabilityIndex(AbstractASTCallable $callable)
+    {
+        $cyclomaticComplexity = $this->analyzers['ccn']->getCcn2($callable);
+
+        $halstead = $this->analyzers['halstead']->getNodeMetrics($callable);
+        $halsteadVolume = $halstead[HalsteadAnalyzer::M_HALSTEAD_VOLUME];
+
+        $loc = $this->analyzers['loc']->getNodeMetrics($callable);
+        $eloc = $loc[NodeLocAnalyzer::M_EXECUTABLE_LINES_OF_CODE];
+
+        $maintainabilityIndex = max(0, (171 - 5.2 * log($halsteadVolume) - 0.23 * $cyclomaticComplexity - 16.2 * log($eloc)) * 100 / 171);
+        $this->metrics[$callable->getId()] = array(self::M_MAINTAINABILITY_INDEX => $maintainabilityIndex);
+    }
+}

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -145,6 +145,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             'pdepend.analyzer.class_level',
             'pdepend.analyzer.cohesion',
             'pdepend.analyzer.halstead',
+            'pdepend.analyzer.maintainability',
         );
     }
 
@@ -406,7 +407,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         foreach ($this->nodeAwareAnalyzers as $analyzer) {
             $metrics = array_merge($metrics, $analyzer->getNodeMetrics($node));
         }
-        ksort($metrics);
 
         foreach ($metrics as $name => $value) {
             $xml->setAttribute($name, $value);

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -144,6 +144,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             'pdepend.analyzer.coupling',
             'pdepend.analyzer.class_level',
             'pdepend.analyzer.cohesion',
+            'pdepend.analyzer.halstead',
         );
     }
 

--- a/src/main/resources/services.xml
+++ b/src/main/resources/services.xml
@@ -111,5 +111,9 @@
         <service id="pdepend.analyzer.halstead" class="PDepend\Metrics\Analyzer\HalsteadAnalyzer">
             <tag name="pdepend.analyzer" />
         </service>
+
+        <service id="pdepend.analyzer.maintainability" class="PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer">
+            <tag name="pdepend.analyzer" />
+        </service>
     </services>
 </container>

--- a/src/main/resources/services.xml
+++ b/src/main/resources/services.xml
@@ -107,5 +107,9 @@
         <service id="pdepend.analyzer.node_loc" class="PDepend\Metrics\Analyzer\NodeLocAnalyzer">
             <tag name="pdepend.analyzer" />
         </service>
+
+        <service id="pdepend.analyzer.halstead" class="PDepend\Metrics\Analyzer\HalsteadAnalyzer">
+            <tag name="pdepend.analyzer" />
+        </service>
     </services>
 </container>

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2015 Matthias Mullie <pdepend@mullie.eu>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+
+/**
+ * Test case for the cyclomatic analyzer.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
+ * @group unittest
+ */
+class HalsteadAnalyzerTest extends AbstractMetricsTest
+{
+    /**
+     * @var \PDepend\Util\Cache\CacheDriver
+     * @since 1.0.0
+     */
+    private $cache;
+
+    /**
+     * Initializes a in memory cache.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cache = new MemoryCacheDriver();
+    }
+
+    /**
+     * testGetNodeMetricsReturnsNothingForUnknownNode
+     *
+     * @return void
+     */
+    public function testGetNodeMetricsReturnsNothingForUnknownNode()
+    {
+        $analyzer = $this->_createAnalyzer();
+        $this->assertEquals(array(), $analyzer->getNodeMetrics($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct function Halstead n1, n2,
+     * N1 & N2.
+     *
+     * @return void
+     */
+    public function testCalculateFunctionBaseMeasures()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array('n1' => 6, 'n2' => 4, 'N1' => 5, 'N2' => 3),
+            'pdepend2' => array('n1' => 4, 'n2' => 2, 'N1' => 4, 'N2' => 2),
+        );
+
+        foreach ($namespaces[0]->getFunctions() as $function) {
+            $actual[$function->getName()] = $analyzer->getNodeBasisMetrics($function);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct function Halstead n1, n2,
+     * N1 & N2.
+     *
+     * @return void
+     */
+    public function testCalculateFunctionMeasures()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array(
+                'hnt' => 8,
+                'hnd' => 10,
+                'hv' => 26.575424759099,
+                'hd' => 3.75,
+                'hl' => 0.26666666666667,
+                'he' => 99.657842846621,
+                'ht' => 5.5365468248123,
+                'hb' => 0.0071650583833777,
+                'hi' => 7.0867799357597,
+            ),
+            'pdepend2' => array(
+                'hnt' => 6,
+                'hnd' => 6,
+                'hv' => 15.509775004327,
+                'hd' => 4,
+                'hl' => 0.25,
+                'he' => 62.039100017308,
+                'ht' => 3.4466166676282,
+                'hb' => 0.0052238304343202,
+                'hi' => 3.8774437510817,
+            ),
+        );
+
+        foreach ($namespaces[0]->getFunctions() as $function) {
+            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct method Halstead n1, n2,
+     * N1 & N2.
+     *
+     * @return void
+     */
+    public function testCalculateMethodBaseMeasures()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $classes = $namespaces[0]->getClasses();
+        $methods = $classes[0]->getMethods();
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array('n1' => 6, 'n2' => 4, 'N1' => 5, 'N2' => 3),
+            'pdepend2' => array('n1' => 4, 'n2' => 2, 'N1' => 4, 'N2' => 2),
+        );
+
+        foreach ($methods as $method) {
+            $actual[$method->getName()] = $analyzer->getNodeBasisMetrics($method);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct method Halstead n1, n2,
+     * N1 & N2.
+     *
+     * @return void
+     */
+    public function testCalculateMethodMeasures()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $classes = $namespaces[0]->getClasses();
+        $methods = $classes[0]->getMethods();
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array(
+                'hnt' => 8,
+                'hnd' => 10,
+                'hv' => 26.575424759099,
+                'hd' => 3.75,
+                'hl' => 0.26666666666667,
+                'he' => 99.657842846621,
+                'ht' => 5.5365468248123,
+                'hb' => 0.0071650583833777,
+                'hi' => 7.0867799357597,
+            ),
+            'pdepend2' => array(
+                'hnt' => 6,
+                'hnd' => 6,
+                'hv' => 15.509775004327,
+                'hd' => 4,
+                'hl' => 0.25,
+                'he' => 62.039100017308,
+                'ht' => 3.4466166676282,
+                'hb' => 0.0052238304343202,
+                'hi' => 3.8774437510817,
+            ),
+        );
+
+        foreach ($methods as $method) {
+            $actual[$method->getName()] = $analyzer->getNodeMetrics($method);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * testAnalyzerRestoresExpectedFunctionMetricsFromCache
+     *
+     * @return void
+     * @since 1.0.0
+     */
+    public function testAnalyzerRestoresExpectedFunctionMetricsFromCache()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+        $functions = $namespaces[0]->getFunctions();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics0 = $analyzer->getNodeMetrics($functions[0]);
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics1 = $analyzer->getNodeMetrics($functions[0]);
+
+        $this->assertEquals($metrics0, $metrics1);
+    }
+
+    /**
+     * testAnalyzerRestoresExpectedMethodMetricsFromCache
+     *
+     * @return void
+     * @since 1.0.0
+     */
+    public function testAnalyzerRestoresExpectedMethodMetricsFromCache()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+        $classes = $namespaces[0]->getClasses();
+        $methods = $classes[0]->getMethods();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics0 = $analyzer->getNodeMetrics($methods[0]);
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics1 = $analyzer->getNodeMetrics($methods[0]);
+
+        $this->assertEquals($metrics0, $metrics1);
+    }
+
+    /**
+     * Returns a pre configured ccn analyzer.
+     *
+     * @return \PDepend\Metrics\Analyzer\HalsteadAnalyzer
+     * @since 1.0.0
+     */
+    private function _createAnalyzer()
+    {
+        $analyzer = new HalsteadAnalyzer();
+        $analyzer->setCache($this->cache);
+
+        return $analyzer;
+    }
+}

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2015 Matthias Mullie <pdepend@mullie.eu>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+
+/**
+ * Test case for the cyclomatic analyzer.
+ *
+ * @copyright 2015 Matthias Mullie. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
+ * @group unittest
+ */
+class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
+{
+    /**
+     * @var \PDepend\Util\Cache\CacheDriver
+     * @since 1.0.0
+     */
+    private $cache;
+
+    /**
+     * Initializes a in memory cache.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->cache = new MemoryCacheDriver();
+    }
+
+    /**
+     * testGetNodeMetricsReturnsNothingForUnknownNode
+     *
+     * @return void
+     */
+    public function testGetNodeMetricsReturnsNothingForUnknownNode()
+    {
+        $analyzer = $this->_createAnalyzer();
+        $this->assertEquals(array(), $analyzer->getNodeMetrics($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct function maintainability
+     * index.
+     *
+     * @return void
+     */
+    public function testCalculateFunctionMaintainabilityIndex()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array('mi' => 76.757952883513823),
+            'pdepend2' => array('mi' => 81.120955834208331),
+        );
+
+        foreach ($namespaces[0]->getFunctions() as $function) {
+            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the analyzer calculates the correct method maintainability
+     * index.
+     *
+     * @return void
+     */
+    public function testCalculateMethodMaintainabilityIndex()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $classes = $namespaces[0]->getClasses();
+        $methods = $classes[0]->getMethods();
+
+        $actual   = array();
+        $expected = array(
+            'pdepend1' => array('mi' => 76.757952883513823),
+            'pdepend2' => array('mi' => 81.120955834208331),
+        );
+
+        foreach ($methods as $method) {
+            $actual[$method->getName()] = $analyzer->getNodeMetrics($method);
+        }
+
+        ksort($expected);
+        ksort($actual);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * testAnalyzerRestoresExpectedFunctionMetricsFromCache
+     *
+     * @return void
+     * @since 1.0.0
+     */
+    public function testAnalyzerRestoresExpectedFunctionMetricsFromCache()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+        $functions = $namespaces[0]->getFunctions();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics0 = $analyzer->getNodeMetrics($functions[0]);
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics1 = $analyzer->getNodeMetrics($functions[0]);
+
+        $this->assertEquals($metrics0, $metrics1);
+    }
+
+    /**
+     * testAnalyzerRestoresExpectedMethodMetricsFromCache
+     *
+     * @return void
+     * @since 1.0.0
+     */
+    public function testAnalyzerRestoresExpectedMethodMetricsFromCache()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+        $classes = $namespaces[0]->getClasses();
+        $methods = $classes[0]->getMethods();
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics0 = $analyzer->getNodeMetrics($methods[0]);
+
+        $analyzer = $this->_createAnalyzer();
+        $analyzer->analyze($namespaces);
+
+        $metrics1 = $analyzer->getNodeMetrics($methods[0]);
+
+        $this->assertEquals($metrics0, $metrics1);
+    }
+
+    /**
+     * Returns a pre configured ccn analyzer.
+     *
+     * @return \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
+     * @since 1.0.0
+     */
+    private function _createAnalyzer()
+    {
+        $analyzer = new MaintainabilityIndexAnalyzer();
+        $analyzer->setCache($this->cache);
+
+        return $analyzer;
+    }
+}

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -135,6 +135,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
         $expected = array(
             'pdepend1' => array('mi' => 76.757952883513823),
             'pdepend2' => array('mi' => 81.120955834208331),
+            'pdepend3' => array('mi' => 100),
         );
 
         foreach ($methods as $method) {

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -115,6 +115,7 @@ class XmlTest extends AbstractTest
             'pdepend.analyzer.coupling',
             'pdepend.analyzer.class_level',
             'pdepend.analyzer.cohesion',
+            'pdepend.analyzer.halstead',
         );
 
         $this->assertEquals($expected, $actual);

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -116,6 +116,7 @@ class XmlTest extends AbstractTest
             'pdepend.analyzer.class_level',
             'pdepend.analyzer.cohesion',
             'pdepend.analyzer.halstead',
+            'pdepend.analyzer.maintainability',
         );
 
         $this->assertEquals($expected, $actual);

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testAnalyzerRestoresExpectedFunctionMetricsFromCache.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testAnalyzerRestoresExpectedFunctionMetricsFromCache.php
@@ -1,0 +1,15 @@
+<?php
+function pdepend1($x)
+{
+    // operands: $value, $x, 1, $value
+    // operators: {}, =, +, ;, return, ;
+    $value = $x + 1;
+    return $value;
+}
+
+function pdepend2($x)
+{
+    // operands: pdepend1, $x
+    // operators: {}, return, (), ;
+    return pdepend1($x);
+}

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testAnalyzerRestoresExpectedMethodMetricsFromCache.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testAnalyzerRestoresExpectedMethodMetricsFromCache.php
@@ -1,0 +1,24 @@
+<?php
+interface HMethodInterface {
+    function pdepend1($x);
+    function pdepend2($x);
+}
+
+
+class HMethodClass implements HMethodInterface
+{
+    function pdepend1($x)
+    {
+        // operands: $value, $x, 1, $value
+        // operators: {}, =, +, ;, return, ;
+        $value = $x + 1;
+        return $value;
+    }
+
+    function pdepend2($x)
+    {
+        // operands: $this->pdepend1, $x
+        // operators: {}, return, (), ;
+        return $this->pdepend1( $x );
+    }
+}

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateFunctionBaseMeasures.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateFunctionBaseMeasures.php
@@ -1,0 +1,15 @@
+<?php
+function pdepend1($x)
+{
+    // operands: $value, $x, 1, $value
+    // operators: {}, =, +, ;, return, ;
+    $value = $x + 1;
+    return $value;
+}
+
+function pdepend2($x)
+{
+    // operands: pdepend1, $x
+    // operators: {}, return, (), ;
+    return pdepend1($x);
+}

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateFunctionMeasures.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateFunctionMeasures.php
@@ -1,0 +1,15 @@
+<?php
+function pdepend1($x)
+{
+    // operands: $value, $x, 1, $value
+    // operators: {}, =, +, ;, return, ;
+    $value = $x + 1;
+    return $value;
+}
+
+function pdepend2($x)
+{
+    // operands: pdepend1, $x
+    // operators: {}, return, (), ;
+    return pdepend1($x);
+}

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateMethodBaseMeasures.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateMethodBaseMeasures.php
@@ -1,0 +1,24 @@
+<?php
+interface HMethodInterface {
+    function pdepend1($x);
+    function pdepend2($x);
+}
+
+
+class HMethodClass implements HMethodInterface
+{
+    function pdepend1($x)
+    {
+        // operands: $value, $x, 1, $value
+        // operators: {}, =, +, ;, return, ;
+        $value = $x + 1;
+        return $value;
+    }
+
+    function pdepend2($x)
+    {
+        // operands: $this->pdepend1, $x
+        // operators: {}, return, (), ;
+        return $this->pdepend1( $x );
+    }
+}

--- a/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateMethodMeasures.php
+++ b/src/test/resources/files/Metrics/Analyzer/HalsteadAnalyzer/testCalculateMethodMeasures.php
@@ -1,0 +1,24 @@
+<?php
+interface HMethodInterface {
+    function pdepend1($x);
+    function pdepend2($x);
+}
+
+
+class HMethodClass implements HMethodInterface
+{
+    function pdepend1($x)
+    {
+        // operands: $value, $x, 1, $value
+        // operators: {}, =, +, ;, return, ;
+        $value = $x + 1;
+        return $value;
+    }
+
+    function pdepend2($x)
+    {
+        // operands: $this->pdepend1, $x
+        // operators: {}, return, (), ;
+        return $this->pdepend1( $x );
+    }
+}

--- a/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testAnalyzerRestoresExpectedFunctionMetricsFromCache.php
+++ b/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testAnalyzerRestoresExpectedFunctionMetricsFromCache.php
@@ -1,0 +1,11 @@
+<?php
+function pdepend1($x)
+{
+    $value = $x + 1;
+    return $value;
+}
+
+function pdepend2($x)
+{
+    return pdepend1($x);
+}

--- a/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testAnalyzerRestoresExpectedMethodMetricsFromCache.php
+++ b/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testAnalyzerRestoresExpectedMethodMetricsFromCache.php
@@ -1,0 +1,20 @@
+<?php
+interface MIMethodInterface {
+    function pdepend1($x);
+    function pdepend2($x);
+}
+
+
+class MIMethodClass implements MIMethodInterface
+{
+    function pdepend1($x)
+    {
+        $value = $x + 1;
+        return $value;
+    }
+
+    function pdepend2($x)
+    {
+        return $this->pdepend1( $x );
+    }
+}

--- a/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateFunctionMaintainabilityIndex.php
+++ b/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateFunctionMaintainabilityIndex.php
@@ -1,0 +1,11 @@
+<?php
+function pdepend1($x)
+{
+    $value = $x + 1;
+    return $value;
+}
+
+function pdepend2($x)
+{
+    return pdepend1($x);
+}

--- a/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateMethodMaintainabilityIndex.php
+++ b/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateMethodMaintainabilityIndex.php
@@ -17,4 +17,6 @@ class MIMethodClass implements MIMethodInterface
     {
         return $this->pdepend1( $x );
     }
+
+    abstract function pdepend3($x);
 }

--- a/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateMethodMaintainabilityIndex.php
+++ b/src/test/resources/files/Metrics/Analyzer/MaintainabilityIndexAnalyzer/testCalculateMethodMaintainabilityIndex.php
@@ -1,0 +1,20 @@
+<?php
+interface MIMethodInterface {
+    function pdepend1($x);
+    function pdepend2($x);
+}
+
+
+class MIMethodClass implements MIMethodInterface
+{
+    function pdepend1($x)
+    {
+        $value = $x + 1;
+        return $value;
+    }
+
+    function pdepend2($x)
+    {
+        return $this->pdepend1( $x );
+    }
+}


### PR DESCRIPTION
Halstead measures are some metrics based on the amount of operators & operands in a "program".
Judging from examples, "program" seems to be limited to function/method.

Operators/operands is fuzzy too & Halstead measure implementations for PHP are quasi non-existant.
It's currently mostly based on some Java implementation spec, with some PHP-specific adjusments.
http://en.wikipedia.org/wiki/Halstead_complexity_measures

Maintainability index uses cyclomatic complexity, Halstead volume & lines of code to determine how
"maintainable" a piece of code is, all of which we (now) have analyzers for already.
http://blogs.msdn.com/b/codeanalysis/archive/2007/11/20/maintainability-index-range-and-meaning.aspx