### PR TITLE
Fix annotation-typo in AbstractPHPParser.php

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -3465,7 +3465,7 @@ abstract class AbstractPHPParser
      * This method parses a do/while-statement.
      *
      * @return \PDepend\Source\AST\ASTDoWhileStatement
-     * @sibce  0.9.12
+     * @since  0.9.12
      */
     private function parseDoWhileStatement()
     {


### PR DESCRIPTION
The typo causes an error in Doctrine's annotation parser.