### PR TITLE
Added line numbers to summary log

### DIFF
--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -292,6 +292,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         $typeXml = $doc->createElement($typeIdentifier);
         $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+        $typeXml->setAttribute('start', Utf8Util::ensureEncoding($type->getStartLine()));
+        $typeXml->setAttribute('end', Utf8Util::ensureEncoding($type->getEndLine()));
 
         $this->writeNodeMetrics($typeXml, $type);
         $this->writeFileReference($typeXml, $type->getCompilationUnit());
@@ -323,6 +325,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         $functionXml = $doc->createElement('function');
         $functionXml->setAttribute('name', Utf8Util::ensureEncoding($function->getName()));
+        $functionXml->setAttribute('start', Utf8Util::ensureEncoding($function->getStartLine()));
+        $functionXml->setAttribute('end', Utf8Util::ensureEncoding($function->getEndLine()));
 
         $this->writeNodeMetrics($functionXml, $function);
         $this->writeFileReference($functionXml, $function->getCompilationUnit());
@@ -354,6 +358,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         $methodXml = $doc->createElement('method');
         $methodXml->setAttribute('name', Utf8Util::ensureEncoding($method->getName()));
+        $methodXml->setAttribute('start', Utf8Util::ensureEncoding($method->getStartLine()));
+        $methodXml->setAttribute('end', Utf8Util::ensureEncoding($method->getEndLine()));
 
         $this->writeNodeMetrics($methodXml, $method);
 

--- a/src/test/php/PDepend/Report/Summary/_expected/node-and-project-aware-result-set.xml
+++ b/src/test/php/PDepend/Report/Summary/_expected/node-and-project-aware-result-set.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<metrics generated="2009-07-27T18:00:36" pdepend="@package_version@" bar="23" foo="42">
+<metrics generated="2015-09-23T06:23:29" pdepend="@package_version@" bar="23" foo="42">
   <files>
     <file name="???" baz="23" foobar="42"/>
   </files>
   <package name="+global" baz="23" foobar="42">
-    <function name="bar" baz="23" foobar="42">
+    <function name="bar" start="56" end="58" baz="23" foobar="42">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg1" baz="23" foobar="42">
-    <class name="FooBar" baz="23" foobar="42">
+    <class name="FooBar" start="30" end="49" baz="23" foobar="42">
       <file name="???"/>
-      <method name="x" baz="23" foobar="42"/>
-      <method name="y" baz="23" foobar="42"/>
+      <method name="x" start="43" end="43" baz="23" foobar="42"/>
+      <method name="y" start="44" end="48" baz="23" foobar="42"/>
     </class>
-    <function name="foo" baz="23" foobar="42">
+    <function name="foo" start="7" end="11" baz="23" foobar="42">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg3" baz="23" foobar="42">
-    <class name="Bar" baz="23" foobar="42">
+    <class name="Bar" start="23" end="25" baz="23" foobar="42">
       <file name="???"/>
-      <method name="y" baz="23" foobar="42"/>
+      <method name="y" start="24" end="24" baz="23" foobar="42"/>
     </class>
   </package>
 </metrics>

--- a/src/test/php/PDepend/Report/Summary/_expected/node-aware-result-set.xml
+++ b/src/test/php/PDepend/Report/Summary/_expected/node-aware-result-set.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<metrics generated="2009-07-27T18:00:36" pdepend="@package_version@">
+<metrics generated="2015-09-23T06:23:41" pdepend="@package_version@">
   <files>
     <file name="???"/>
   </files>
   <package name="+global" loc="42" ncloc="23">
-    <function name="bar" loc="9" ncloc="7">
+    <function name="bar" start="56" end="58" loc="9" ncloc="7">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg1" loc="101" ncloc="99">
-    <class name="FooBar" loc="90" ncloc="80">
+    <class name="FooBar" start="30" end="49" loc="90" ncloc="80">
       <file name="???"/>
-      <method name="x" loc="50" ncloc="45"/>
-      <method name="y" loc="30" ncloc="22"/>
+      <method name="x" start="43" end="43" loc="50" ncloc="45"/>
+      <method name="y" start="44" end="48" loc="30" ncloc="22"/>
     </class>
-    <function name="foo" loc="9" ncloc="9">
+    <function name="foo" start="7" end="11" loc="9" ncloc="9">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg3" loc="42" ncloc="23">
-    <class name="Bar" loc="33" ncloc="20">
+    <class name="Bar" start="23" end="25" loc="33" ncloc="20">
       <file name="???"/>
-      <method name="y" loc="9" ncloc="7"/>
+      <method name="y" start="24" end="24" loc="9" ncloc="7"/>
     </class>
   </package>
 </metrics>

--- a/src/test/php/PDepend/Report/Summary/_expected/xml-log-without-metrics.xml
+++ b/src/test/php/PDepend/Report/Summary/_expected/xml-log-without-metrics.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<metrics generated="2009-07-27T18:00:36" pdepend="@package_version@">
+<metrics generated="2015-09-23T06:23:10" pdepend="@package_version@">
   <files>
     <file name="???"/>
   </files>
   <package name="+global">
-    <function name="bar">
+    <function name="bar" start="56" end="58">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg1">
-    <class name="FooBar">
+    <class name="FooBar" start="30" end="49">
       <file name="???"/>
-      <method name="x"/>
-      <method name="y"/>
+      <method name="x" start="43" end="43"/>
+      <method name="y" start="44" end="48"/>
     </class>
-    <function name="foo">
+    <function name="foo" start="7" end="11">
       <file name="???"/>
     </function>
   </package>
   <package name="pkg3">
-    <class name="Bar">
+    <class name="Bar" start="23" end="25">
       <file name="???"/>
-      <method name="y"/>
+      <method name="y" start="24" end="24"/>
     </class>
   </package>
 </metrics>


### PR DESCRIPTION
Added line numbers in summary log.

This is useful for external tools which want to reference the classes or methods in the files.

I used `start` and `end` for now. I could change to anything like `sl` and `el` or `startLine` and `endLine`.