### PR TITLE
Calculate type dependencies

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -137,21 +137,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     }
 
     /**
-     * Returns the statistics for the requested node.
-     *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
-     * @return array
-     */
-    public function getStats(AbstractASTArtifact $node)
-    {
-        $stats = array();
-        if (isset($this->nodeMetrics[$node->getId()])) {
-            $stats = $this->nodeMetrics[$node->getId()];
-        }
-        return $stats;
-    }
-
-    /**
      * Returns an array of all afferent nodes.
      *
      * @param  \PDepend\Source\AST\AbstractASTArtifact $node

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2015, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractAnalyzer;
+use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+
+/**
+ * This visitor generates the metrics for the analyzed namespaces.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+class ClassDependencyAnalyzer extends AbstractAnalyzer
+{
+    /**
+     * Metrics provided by the analyzer implementation.
+     */
+    const M_AFFERENT_COUPLING          = 'ca',
+          M_EFFERENT_COUPLING          = 'ce';
+
+    /**
+     * Hash with all calculated node metrics.
+     *
+     * <code>
+     * array(
+     *     '0375e305-885a-4e91-8b5c-e25bda005438'  =>  array(
+     *         'loc'    =>  42,
+     *         'ncloc'  =>  17,
+     *         'cc'     =>  12
+     *     ),
+     *     'e60c22f0-1a63-4c40-893e-ed3b35b84d0b'  =>  array(
+     *         'loc'    =>  42,
+     *         'ncloc'  =>  17,
+     *         'cc'     =>  12
+     *     )
+     * )
+     * </code>
+     *
+     * @var array(string=>array)
+     */
+    private $nodeMetrics = null;
+
+    protected $nodeSet = array();
+
+    private $efferentNodes = array();
+
+    private $afferentNodes = array();
+
+    /**
+     * All collected cycles for the input code.
+     *
+     * <code>
+     * array(
+     *     <type-id> => array(
+     *         \PDepend\Source\AST\AbstractASTClassOrInterface {},
+     *         \PDepend\Source\AST\AbstractASTClassOrInterface {},
+     *     ),
+     *     <type-id> => array(
+     *         \PDepend\Source\AST\AbstractASTClassOrInterface {},
+     *         \PDepend\Source\AST\AbstractASTClassOrInterface {},
+     *     ),
+     * )
+     * </code>
+     *
+     * @var array(string=>array)
+     */
+    private $collectedCycles = array();
+
+    /**
+     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     *
+     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @return void
+     */
+    public function analyze($namespaces)
+    {
+        if ($this->nodeMetrics === null) {
+            $this->fireStartAnalyzer();
+
+            $this->nodeMetrics = array();
+
+            foreach ($namespaces as $namespace) {
+                $namespace->accept($this);
+            }
+
+            $this->postProcess();
+
+            $this->fireEndAnalyzer();
+        }
+    }
+
+    /**
+     * Returns the statistics for the requested node.
+     *
+     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @return array
+     */
+    public function getStats(AbstractASTArtifact $node)
+    {
+        $stats = array();
+        if (isset($this->nodeMetrics[$node->getId()])) {
+            $stats = $this->nodeMetrics[$node->getId()];
+        }
+        return $stats;
+    }
+
+    /**
+     * Returns an array of all afferent nodes.
+     *
+     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     */
+    public function getAfferents(AbstractASTArtifact $node)
+    {
+        $afferents = array();
+        if (isset($this->afferentNodes[$node->getId()])) {
+            $afferents = $this->afferentNodes[$node->getId()];
+        }
+        return $afferents;
+    }
+
+    /**
+     * Returns an array of all efferent nodes.
+     *
+     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     */
+    public function getEfferents(AbstractASTArtifact $node)
+    {
+        $efferents = array();
+        if (isset($this->efferentNodes[$node->getId()])) {
+            $efferents = $this->efferentNodes[$node->getId()];
+        }
+        return $efferents;
+    }
+
+    /**
+     * Returns an array of nodes that build a cycle for the requested node or it
+     * returns <b>null</b> if no cycle exists .
+     *
+     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     */
+    public function getCycle(AbstractASTArtifact $node)
+    {
+        if (array_key_exists($node->getId(), $this->collectedCycles)) {
+            return $this->collectedCycles[$node->getId()];
+        }
+
+        $list = array();
+        if ($this->collectCycle($list, $node)) {
+            $this->collectedCycles[$node->getId()] = $list;
+        } else {
+            $this->collectedCycles[$node->getId()] = null;
+        }
+
+        return $this->collectedCycles[$node->getId()];
+    }
+
+    /**
+     * Visits a method node.
+     *
+     * @param  \PDepend\Source\AST\ASTMethod $method
+     * @return void
+     */
+    public function visitMethod(ASTMethod $method)
+    {
+        $this->fireStartMethod($method);
+
+        $type = $method->getParent();
+        foreach ($method->getDependencies() as $dependency) {
+            $this->collectDependencies($type, $dependency);
+        }
+
+        $this->fireEndMethod($method);
+    }
+
+    /**
+     * Visits a namespace node.
+     *
+     * @param  \PDepend\Source\AST\ASTNamespace $namespace
+     * @return void
+     */
+    public function visitNamespace(ASTNamespace $namespace)
+    {
+        $this->fireStartNamespace($namespace);
+
+        $this->nodeSet[$namespace->getId()] = $namespace;
+
+        foreach ($namespace->getTypes() as $type) {
+            $type->accept($this);
+        }
+
+        $this->fireEndNamespace($namespace);
+    }
+
+    /**
+     * Visits a class node.
+     *
+     * @param  \PDepend\Source\AST\ASTClass $class
+     * @return void
+     */
+    public function visitClass(ASTClass $class)
+    {
+        $this->fireStartClass($class);
+        $this->visitType($class);
+        $this->fireEndClass($class);
+    }
+
+    /**
+     * Visits an interface node.
+     *
+     * @param  \PDepend\Source\AST\ASTInterface $interface
+     * @return void
+     */
+    public function visitInterface(ASTInterface $interface)
+    {
+        $this->fireStartInterface($interface);
+        $this->visitType($interface);
+        $this->fireEndInterface($interface);
+    }
+
+    /**
+     * Generic visit method for classes and interfaces. Both visit methods
+     * delegate calls to this method.
+     *
+     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @return void
+     */
+    protected function visitType(AbstractASTClassOrInterface $type)
+    {
+        $id = $type->getId();
+
+        foreach ($type->getDependencies() as $dependency) {
+            $this->collectDependencies($type, $dependency);
+        }
+
+        foreach ($type->getMethods() as $method) {
+            $method->accept($this);
+        }
+    }
+
+    /**
+     * Collects the dependencies between the two given classes.
+     *
+     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $typeB
+     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $typeB
+     *
+     * @return void
+     */
+    private function collectDependencies(AbstractASTClassOrInterface $typeA, AbstractASTClassOrInterface $typeB)
+    {
+        $idA = $typeA->getId();
+        $idB = $typeB->getId();
+
+        if ($idB === $idA) {
+            return;
+        }
+
+        // Create a container for this dependency
+        $this->initTypeMetric($typeA);
+        $this->initTypeMetric($typeB);
+
+        if (!in_array($idB, $this->nodeMetrics[$idA][self::M_EFFERENT_COUPLING])) {
+            $this->nodeMetrics[$idA][self::M_EFFERENT_COUPLING][] = $idB;
+            $this->nodeMetrics[$idB][self::M_AFFERENT_COUPLING][] = $idA;
+        }
+    }
+
+    /**
+     * Initializes the node metric record for the given <b>$type</b>.
+     *
+     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @return void
+     */
+    protected function initTypeMetric(AbstractASTClassOrInterface $type)
+    {
+        $id = $type->getId();
+
+        if (!isset($this->nodeMetrics[$id])) {
+            $this->nodeSet[$id] = $type;
+
+            $this->nodeMetrics[$id] = array(
+                self::M_AFFERENT_COUPLING =>  array(),
+                self::M_EFFERENT_COUPLING =>  array(),
+            );
+        }
+    }
+
+    /**
+     * Post processes all analyzed nodes.
+     *
+     * @return void
+     */
+    protected function postProcess()
+    {
+        foreach ($this->nodeMetrics as $id => $metrics) {
+            $this->afferentNodes[$id] = array();
+            foreach ($metrics[self::M_AFFERENT_COUPLING] as $caId) {
+                $this->afferentNodes[$id][] = $this->nodeSet[$caId];
+            }
+
+            sort($this->afferentNodes[$id]);
+
+            $this->efferentNodes[$id] = array();
+            foreach ($metrics[self::M_EFFERENT_COUPLING] as $ceId) {
+                $this->efferentNodes[$id][] = $this->nodeSet[$ceId];
+            }
+
+            sort($this->efferentNodes[$id]);
+
+            $afferent = count($metrics[self::M_AFFERENT_COUPLING]);
+            $efferent = count($metrics[self::M_EFFERENT_COUPLING]);
+
+            $this->nodeMetrics[$id][self::M_AFFERENT_COUPLING] = $afferent;
+            $this->nodeMetrics[$id][self::M_EFFERENT_COUPLING] = $efferent;
+        }
+    }
+
+    /**
+     * Collects a single cycle that is reachable by this namespace. All namespaces
+     * that are part of the cylce are stored in the given <b>$list</b> array.
+     *
+     * @param  \PDepend\Source\AST\AbstractASTArtifact[] &$list
+     * @param  \PDepend\Source\AST\AbstractASTArtifact   $namespace
+     * @return boolean If this method detects a cycle the return value is <b>true</b>
+     *                 otherwise this method will return <b>false</b>.
+     */
+    protected function collectCycle(array &$list, AbstractASTArtifact $node)
+    {
+        if (in_array($node, $list, true)) {
+            $list[] = $node;
+            return true;
+        }
+
+        $list[] = $node;
+
+        foreach ($this->getEfferents($node) as $efferent) {
+            if ($this->collectCycle($list, $efferent)) {
+                return true;
+            }
+        }
+
+        if (is_int($idx = array_search($node, $list, true))) {
+            unset($list[$idx]);
+        }
+        return false;
+    }
+}

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -332,14 +332,10 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
                 $this->afferentNodes[$id][] = $this->nodeSet[$caId];
             }
 
-            sort($this->afferentNodes[$id]);
-
             $this->efferentNodes[$id] = array();
             foreach ($metrics[self::M_EFFERENT_COUPLING] as $ceId) {
                 $this->efferentNodes[$id][] = $this->nodeSet[$ceId];
             }
-
-            sort($this->efferentNodes[$id]);
 
             $afferent = count($metrics[self::M_AFFERENT_COUPLING]);
             $efferent = count($metrics[self::M_EFFERENT_COUPLING]);

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -1,0 +1,347 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2015, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Report\Dependencies;
+
+use PDepend\Metrics\Analyzer;
+use PDepend\Metrics\AnalyzerNodeAware;
+use PDepend\Metrics\AnalyzerProjectAware;
+use PDepend\Report\CodeAwareGenerator;
+use PDepend\Report\FileAwareGenerator;
+use PDepend\Report\NoLogOutputException;
+use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTTrait;
+use PDepend\Source\ASTVisitor\AbstractASTVisitor;
+use PDepend\Util\Utf8Util;
+
+/**
+ * This logger generates a summary xml document with aggregated project, class,
+ * method and file dependencies.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGenerator
+{
+    /**
+     * The log output file.
+     *
+     * @var string
+     */
+    private $logFile = null;
+
+    /**
+     * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
+     *
+     * @var \PDepend\Source\AST\ASTArtifactList
+     */
+    protected $code = null;
+
+    /**
+     * Set of all analyzed files.
+     *
+     * @var \PDepend\Source\AST\ASTCompilationUnit[]
+     */
+    protected $fileSet = array();
+
+    /**
+     * List of all analyzers that implement the node aware interface
+     * {@link \PDepend\dependencies\AnalyzerNodeAware}.
+     *
+     * @var \PDepend\dependencies\AnalyzerNodeAware[]
+     */
+    private $nodeAwareAnalyzers = array();
+
+    /**
+     * List of all analyzers that implement the node aware interface
+     * {@link \PDepend\dependencies\AnalyzerProjectAware}.
+     *
+     * @var \PDepend\dependencies\AnalyzerProjectAware[]
+     */
+    private $projectAwareAnalyzers = array();
+
+    /**
+     * The internal used xml stack.
+     *
+     * @var DOMElement[]
+     */
+    private $xmlStack = array();
+
+    /**
+     * Sets the output log file.
+     *
+     * @param string $logFile The output log file.
+     *
+     * @return void
+     */
+    public function setLogFile($logFile)
+    {
+        $this->logFile = $logFile;
+    }
+
+    /**
+     * Returns an <b>array</b> with accepted analyzer types. These types can be
+     * concrete analyzer classes or one of the descriptive analyzer interfaces.
+     *
+     * @return array(string)
+     */
+    public function getAcceptedAnalyzers()
+    {
+        return array(
+            'pdepend.analyzer.inheritance',
+            'pdepend.analyzer.hierarchy',
+            'pdepend.analyzer.coupling',
+        );
+    }
+
+    /**
+     * Sets the context code nodes.
+     *
+     * @param  \PDepend\Source\AST\ASTArtifactList $artifacts
+     * @return void
+     */
+    public function setArtifacts(ASTArtifactList $artifacts)
+    {
+        $this->code = $artifacts;
+    }
+
+    /**
+     * Adds an analyzer to log. If this logger accepts the given analyzer it
+     * with return <b>true</b>, otherwise the return value is <b>false</b>.
+     *
+     * @param  \PDepend\dependencies\Analyzer $analyzer The analyzer to log.
+     * @return boolean
+     */
+    public function log(Analyzer $analyzer)
+    {
+        if ($analyzer instanceof AnalyzerNodeAware) {
+            $this->nodeAwareAnalyzers[] = $analyzer;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Closes the logger process and writes the output file.
+     *
+     * @return void
+     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     */
+    public function close()
+    {
+        if ($this->logFile === null) {
+            throw new NoLogOutputException($this);
+        }
+
+        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom->formatOutput = true;
+
+        $dependencies = $dom->createElement('dependencies');
+        $dependencies->setAttribute('generated', date('Y-m-d\TH:i:s'));
+        $dependencies->setAttribute('pdepend', '@package_version@');
+        array_push($this->xmlStack, $dependencies);
+
+        foreach ($this->code as $node) {
+            $node->accept($this);
+        }
+
+        $dom->appendChild($dependencies);
+        $dom->save($this->logFile);
+    }
+
+    /**
+     * Visits a class node.
+     *
+     * @param  \PDepend\Source\AST\ASTClass $class
+     * @return void
+     */
+    public function visitClass(ASTClass $class)
+    {
+        $this->generateTypeXml($class, 'class');
+    }
+
+    /**
+     * Visits a trait node.
+     *
+     * @param  \PDepend\Source\AST\ASTTrait $trait
+     * @return void
+     */
+    public function visitTrait(ASTTrait $trait)
+    {
+        $this->generateTypeXml($trait, 'trait');
+    }
+
+    /**
+     * Generates the XML for a class or trait node.
+     *
+     * @param  \PDepend\Source\AST\ASTClass $type
+     * @param  string                       $typeIdentifier
+     * @return void
+     */
+    private function generateTypeXml(AbstractASTClassOrInterface $type, $typeIdentifier)
+    {
+        if (!$type->isUserDefined()) {
+            return;
+        }
+
+        $xml = end($this->xmlStack);
+        $doc = $xml->ownerDocument;
+
+        $typeXml = $doc->createElement($typeIdentifier);
+        $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+
+        $this->writeNodeDependencies($typeXml, $type);
+        $this->writeFileReference($typeXml, $type->getCompilationUnit());
+
+        $xml->appendChild($typeXml);
+
+        array_push($this->xmlStack, $typeXml);
+        array_pop($this->xmlStack);
+    }
+
+    /**
+     * Visits a function node.
+     *
+     * @param  \PDepend\Source\AST\ASTFunction $function
+     * @return void
+     */
+    public function visitFunction(ASTFunction $function)
+    {
+        // Do not care
+    }
+
+    /**
+     * Visits a code interface object.
+     *
+     * @param  \PDepend\Source\AST\ASTInterface $interface
+     * @return void
+     */
+    public function visitInterface(ASTInterface $interface)
+    {
+        $this->generateTypeXml($interface, 'interface');
+    }
+
+    /**
+     * Visits a namespace node.
+     *
+     * @param  \PDepend\Source\AST\ASTNamespace $namespace
+     * @return void
+     */
+    public function visitNamespace(ASTNamespace $namespace)
+    {
+        $xml = end($this->xmlStack);
+        $doc = $xml->ownerDocument;
+
+        $packageXml = $doc->createElement('package');
+        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getName()));
+
+        array_push($this->xmlStack, $packageXml);
+
+        foreach ($namespace->getTypes() as $type) {
+            $type->accept($this);
+        }
+        foreach ($namespace->getFunctions() as $function) {
+            $function->accept($this);
+        }
+
+        array_pop($this->xmlStack);
+
+        if ($packageXml->firstChild === null) {
+            return;
+        }
+
+        $xml->appendChild($packageXml);
+    }
+
+    /**
+     * Aggregates all dependencies for the given <b>$node</b> instance and adds them
+     * to the <b>\DOMElement</b>
+     *
+     * @param  \DOMElement                             $xml
+     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @return void
+     */
+    protected function writeNodeDependencies(\DOMElement $xml, AbstractASTArtifact $node)
+    {
+        $dependencies = array();
+        foreach ($this->nodeAwareAnalyzers as $analyzer) {
+            $dependencies = array_merge($dependencies, $analyzer->getNodedependencies($node));
+        }
+
+        foreach ($dependencies as $name => $value) {
+            $xml->setAttribute($name, $value);
+        }
+    }
+
+    /**
+     * Appends a file reference element to the given <b>$xml</b> element.
+     *
+     * <code>
+     *   <class name="\PDepend\Engine">
+     *     <file name="PDepend/Engine.php" />
+     *   </class>
+     * </code>
+     *
+     * @param  \DOMElement                            $xml             The parent xml element.
+     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     * @return void
+     */
+    protected function writeFileReference(\DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
+    {
+        if (in_array($compilationUnit, $this->fileSet, true) === false) {
+            $this->fileSet[] = $compilationUnit;
+        }
+
+        $fileXml = $xml->ownerDocument->createElement('file');
+        $fileXml->setAttribute('name', Utf8Util::ensureEncoding($compilationUnit->getFileName()));
+
+        $xml->appendChild($fileXml);
+    }
+}

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -276,6 +276,10 @@ abstract class AbstractASTVisitor implements ASTVisitor
      */
     public function __call($method, $args)
     {
+        if (!isset($args[1])) {
+            throw new \RuntimeException("No node to visit provided for $method.");
+        }
+
         $value = $args[1];
         foreach ($args[0]->getChildren() as $child) {
             $value = $child->accept($this, $value);

--- a/src/main/resources/services.xml
+++ b/src/main/resources/services.xml
@@ -37,6 +37,10 @@
             <tag name="pdepend.logger" option="--summary-xml" message="Generates a xml log with all metrics." />
         </service>
 
+        <service id="pdepend.report.dependencies.xml" class="PDepend\Report\Dependencies\Xml">
+            <tag name="pdepend.logger" option="--dependency-xml" message="Generates a xml log with all dependencies." />
+        </service>
+
         <service id="pdepend.report.jdepend.xml" class="PDepend\Report\Jdepend\Xml">
             <tag name="pdepend.logger" option="--jdepend-xml" message="Generates the package dependency log." />
         </service>
@@ -85,6 +89,10 @@
         </service>
 
         <service id="pdepend.analyzer.dependency" class="PDepend\Metrics\Analyzer\DependencyAnalyzer">
+            <tag name="pdepend.analyzer" />
+        </service>
+
+        <service id="pdepend.analyzer.class_dependency" class="PDepend\Metrics\Analyzer\ClassDependencyAnalyzer">
             <tag name="pdepend.analyzer" />
         </service>
 

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2015, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+  */
+
+namespace PDepend\Metrics\Analyzer;
+
+use PDepend\Metrics\AbstractMetricsTest;
+
+/**
+ * Tests the for the package metrics visitor.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
+ * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
+ * @group unittest
+ */
+class ClassDependencyAnalyzerTest extends AbstractMetricsTest
+{
+    /**
+     * The used node builder.
+     *
+     * @var \PDepend\Source\Builder\Builder
+     */
+    protected $builder = null;
+
+    /**
+     * Input test data.
+     *
+     * @var array(string=>array)
+     */
+    private $input = array(
+        'AbstractBase' => array(
+            'efferent' => array(),
+            'afferent' => array(
+                'BaseClass'
+            ),
+        ),
+        'SomeInterface' => array(
+            'efferent' => array(),
+            'afferent' => array(
+                'Used',
+            ),
+        ),
+        'SomeTrait' => array(
+            'efferent' => array(),
+            'afferent' => array(),
+        ),
+        'Used' => array(
+            'efferent' => array(
+                'SomeInterface',
+                'BaseClass',
+            ),
+            'afferent' => array(
+                'BaseClass',
+            ),
+        ),
+        'BaseClass' => array(
+            'efferent' => array(
+                'AbstractBase',
+                'Used',
+            ),
+            'afferent' => array(
+                'Used',
+            ),
+        ),
+    );
+
+    /**
+     * Tests the generated package metrics.
+     *
+     * @return void
+     */
+    public function testGenerateMetrics()
+    {
+        $visitor = new ClassDependencyAnalyzer();
+
+        $namespaces = self::parseCodeResourceForTest();
+        $visitor->analyze($namespaces);
+
+        $actual = array();
+        foreach ($namespaces as $namespace) {
+            foreach ($namespace->getTypes() as $type) {
+                $actual[$type->getName()]['efferent'] = array_map(
+                    function ($type) {
+                        return $type->getName();
+                    },
+                    $visitor->getEfferents($type)
+                );
+                $actual[$type->getName()]['afferent'] = array_map(
+                    function ($type) {
+                        return $type->getName();
+                    },
+                    $visitor->getAfferents($type)
+                );
+            }
+        }
+        ksort($actual);
+
+        $this->assertEquals($this->input, $actual);
+    }
+}

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2015, Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Report\Dependencies;
+
+use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTArtifactList;
+
+/**
+ * Test case for the xml summary log.
+ *
+ * @copyright 2008-2015 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @covers \PDepend\Report\Dependencies\Xml
+ * @group unittest
+ */
+class XmlTest extends AbstractTest
+{
+    /**
+     * Test code structure.
+     *
+     * @var \PDepend\Source\AST\ASTNamespace[]
+     */
+    protected $namespaces = null;
+
+    /**
+     * The temporary file name for the logger result.
+     *
+     * @var string
+     */
+    protected $resultFile = null;
+
+    /**
+     * Creates the package structure from a test source file.
+     *
+     * @return void
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->resultFile = self::createRunResourceURI('log-summary.xml');
+    }
+
+    /**
+     * Removes the temporary log files.
+     *
+     * @return void
+     */
+    protected function tearDown()
+    {
+        @unlink($this->resultFile);
+
+        parent::tearDown();
+    }
+
+    /**
+     * Tests that the logger returns the expected set of analyzers.
+     *
+     * @return void
+     */
+    public function testReturnsExceptedAnalyzers()
+    {
+        $logger    = new Xml();
+        $actual    = $logger->getAcceptedAnalyzers();
+        $expected = array(
+            'pdepend.analyzer.inheritance',
+            'pdepend.analyzer.hierarchy',
+            'pdepend.analyzer.coupling',
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Tests that the logger throws an exception if the log target wasn't
+     * configured.
+     *
+     * @return void
+     */
+    public function testThrowsExceptionForInvalidLogTarget()
+    {
+        $this->setExpectedException(
+            '\\PDepend\\Report\\NoLogOutputException',
+            "The log target is not configured for 'PDepend\\Report\\Dependencies\\Xml'."
+        );
+
+        $logger = new Xml();
+        $logger->close();
+    }
+
+    /**
+     * testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware
+     *
+     * @return void
+     */
+    public function testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware()
+    {
+        $logger = new Xml();
+        $actual = $logger->log($this->getMock('\\PDepend\\Metrics\\AnalyzerNodeAware'));
+
+        $this->assertTrue($actual);
+    }
+
+    /**
+     * Tests that {@link \PDepend\Report\Dependencies\Xml::write()} generates the
+     * expected document structure for the source, but without any applied
+     * metrics.
+     *
+     * @return void
+     */
+    public function testXmlLogWithoutMetrics()
+    {
+        $this->namespaces = self::parseCodeResourceForTest();
+
+        $log = new Xml();
+        $log->setLogFile($this->resultFile);
+        $log->setArtifacts($this->namespaces);
+        $log->close();
+
+        $fileName = 'xml-log-without-metrics.xml';
+        // copy($this->resultFile, dirname(__FILE__) . "/_expected/{$fileName}");
+        $this->assertXmlStringEqualsXmlString(
+            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml($this->resultFile)
+        );
+    }
+
+    protected function getNormalizedPathXml($fileName)
+    {
+        return preg_replace(
+            array('(file\s+name="[^"]+")', '(generated="[^"]*")'),
+            array('file name="' . __FILE__ . '"', 'generated=""'),
+             file_get_contents($fileName)
+        );
+    }
+}

--- a/src/test/php/PDepend/Report/Dependencies/_expected/xml-log-with-metrics.xml
+++ b/src/test/php/PDepend/Report/Dependencies/_expected/xml-log-with-metrics.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dependencies generated="2015-09-23T12:15:54" pdepend="@package_version@">
+  <package name="Report\Dependencies\Xml">
+    <class name="AbstractBase">
+      <efferent>
+        <type namespace="namespace" name="class"/>
+      </efferent>
+      <afferent>
+        <type namespace="namespace" name="class"/>
+        <type namespace="namespace" name="class"/>
+      </afferent>
+      <file name="???"/>
+    </class>
+  </package>
+</dependencies>

--- a/src/test/php/PDepend/Report/Dependencies/_expected/xml-log-without-metrics.xml
+++ b/src/test/php/PDepend/Report/Dependencies/_expected/xml-log-without-metrics.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dependencies generated="2015-09-23T07:41:16" pdepend="@package_version@">
+  <package name="Report\Dependencies\Xml">
+    <class name="AbstractBase">
+      <file name="???"/>
+    </class>
+    <interface name="SomeInterface">
+      <file name="???"/>
+    </interface>
+    <class name="Used">
+      <file name="???"/>
+    </class>
+    <class name="Base">
+      <file name="???"/>
+    </class>
+  </package>
+</dependencies>

--- a/src/test/resources/files/Metrics/Analyzer/ClassDependencyAnalyzer/testGenerateMetrics.php
+++ b/src/test/resources/files/Metrics/Analyzer/ClassDependencyAnalyzer/testGenerateMetrics.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ClassDependencyAnalyzer;
+
+abstract class AbstractBase {}
+
+interface SomeInterface {}
+
+// Trait usage not supported yet
+trait SomeTrait {}
+
+class Used extends BaseClass implements SomeInterface {}
+
+class BaseClass extends AbstractBase {
+    use SomeTrait;
+
+    public function __construct(Used $used)
+    {
+        $this->used = $used;
+    }
+}

--- a/src/test/resources/files/Report/Dependencies/Xml/testXmlLogWithMetrics.php
+++ b/src/test/resources/files/Report/Dependencies/Xml/testXmlLogWithMetrics.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Report\Dependencies\Xml;
+
+abstract class AbstractBase
+{
+
+}

--- a/src/test/resources/files/Report/Dependencies/Xml/testXmlLogWithoutMetrics.php
+++ b/src/test/resources/files/Report/Dependencies/Xml/testXmlLogWithoutMetrics.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Report\Dependencies\Xml;
+
+abstract class AbstractBase
+{
+
+}
+
+interface SomeInterface
+{
+
+}
+
+class Used implements SomeInterface
+{
+
+}
+
+class Base extends AbstractBase
+{
+    public function __construct(Used $used)
+    {
+        $this->used = $used;
+    }
+}


### PR DESCRIPTION
This PR adds a new analyzer and a new reporter which allows to generate a file containing all dependencies of types (classes, interfaces, …). The resulting XML file has a custom format, since I am not aware of existing formats to support.