### PR TITLE
Fix support to files filters

### DIFF
--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -659,6 +659,12 @@ class Engine
             }
         }
 
+        foreach ($files as $key => $file) {
+            if (!$this->fileFilter->accept($file, $file)) {
+                unset($files[$key]);
+            }
+        }
+
         ksort($files);
         // END
 

--- a/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -56,6 +56,29 @@ use PDepend\AbstractTest;
  */
 class DependExcludePathFilterTest extends AbstractTest
 {
+
+    /**
+     * testPDependFiltersSingleFileWithPattern
+     *
+     * @return void
+     */
+    public function testPDependFiltersSingleFileWithPattern()
+    {
+        $this->changeWorkingDirectory();
+
+        $directory = $this->createCodeResourceUriForTest();
+        $pattern   = '*/Integration/*';
+
+        $pdepend = $this->createEngineFixture();
+        $pdepend->addFile($this->createCodeResourceUriForTest().'/Integration/FilteredClass.php');
+        $pdepend->addFileFilter(
+            new \PDepend\Input\ExcludePathFilter(array($pattern))
+        );
+
+        $this->assertEquals(0, count($pdepend->analyze()));
+    }
+
+
     /**
      * testPDependFiltersByRelativePath
      *
@@ -74,7 +97,7 @@ class DependExcludePathFilterTest extends AbstractTest
             new \PDepend\Input\ExcludePathFilter(array($pattern))
         );
 
-        $this->assertEquals(1, count($pdepend->analyze()));
+        $this->assertEquals(0, count($pdepend->analyze()));
     }
 
     /**
@@ -128,6 +151,6 @@ class DependExcludePathFilterTest extends AbstractTest
             new \PDepend\Input\ExcludePathFilter(array($pattern))
         );
 
-        $this->assertEquals(2, count($pdepend->analyze()));
+        $this->assertEquals(1, count($pdepend->analyze()));
     }
 }

--- a/src/test/resources/files/Integration/DependExcludePathFilter/testPDependFiltersSingleFileWithPattern/Integration/FilteredClass.php
+++ b/src/test/resources/files/Integration/DependExcludePathFilter/testPDependFiltersSingleFileWithPattern/Integration/FilteredClass.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @package filteredPackage
+ */
+class FilteredClass
+{
+    
+}


### PR DESCRIPTION
When passing full files to process and a exclude by pattern, the exclude was not being applied on those files. The exclude only worked on directories.

This problem was reflecting on phpmd as well, checkout the issue: https://github.com/phpmd/phpmd/issues/102.