### PR TITLE
Fix NPath calculations for the ternary operator

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -214,7 +214,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
         // The complexity of each child has no minimum
         foreach ($node->getChildren() as $child) {
-            $cn = $this->sumComplexity($child)
+            $cn = $this->sumComplexity($child);
             $npath = MathUtil::add($npath, $cn);
         }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -203,20 +203,24 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      */
     public function visitConditionalExpression($node, $data)
     {
+        // Calculate the complexity of the condition
+        $parent = $node->getParent()->getChild(0);
+        $npath = $this->sumComplexity($parent);
+        
         // New PHP 5.3 ifsetor-operator $x ?: $y
         if (count($node->getChildren()) === 1) {
-            $npath = '4';
-        } else {
-            $npath = '3';
+            $npath = MathUtil::mul($npath, '2');
         }
 
+        // The complexity of each child has no minimum
         foreach ($node->getChildren() as $child) {
-            if (($cn = $this->sumComplexity($child)) === '0') {
-                $cn = '1';
-            }
+            $cn = $this->sumComplexity($child)
             $npath = MathUtil::add($npath, $cn);
         }
 
+        // Add 2 for the branching per the NPath spec
+        $npath = MathUtil::add($npath, '2');
+        
         return MathUtil::mul($npath, $data);
     }
 

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -160,7 +160,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSiblingConditionalExpressions()
     {
-        $this->assertEquals(25, $this->_calculateFunctionMetric());
+        $this->assertEquals(4, $this->_calculateFunctionMetric());
     }
 
     /**
@@ -173,7 +173,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSiblingExpressions()
     {
-        $this->assertEquals(15, $this->_calculateFunctionMetric());
+        $this->assertEquals(6, $this->_calculateFunctionMetric());
     }
 
     /**
@@ -217,7 +217,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForComplexFunction()
     {
-        $this->assertEquals(60, $this->_calculateFunctionMetric());
+        $this->assertEquals(24, $this->_calculateFunctionMetric());
     }
 
     /**
@@ -239,7 +239,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConditionalsInArrayDeclaration()
     {
-        $this->assertEquals(625, $this->_calculateFunctionMetric());
+        $this->assertEquals(16, $this->_calculateFunctionMetric());
     }
 
     /**
@@ -389,7 +389,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForReturnStatementWithConditionalStatement()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->_calculateMethodMetric());
     }
 
     /**
@@ -462,7 +462,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleConditionalStatement()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->_calculateMethodMetric());
     }
 
     /**
@@ -472,7 +472,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForTwoNestedConditionalStatements()
     {
-        $this->assertEquals(9, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->_calculateMethodMetric());
     }
 
     /**
@@ -482,7 +482,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForThreeNestedConditionalStatements()
     {
-        $this->assertEquals(13, $this->_calculateMethodMetric());
+        $this->assertEquals(6, $this->_calculateMethodMetric());
     }
 
     /**
@@ -493,7 +493,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConditionalStatementWithLogicalExpressions()
     {
-        $this->assertEquals(6, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->_calculateMethodMetric());
     }
 
     /**
@@ -505,7 +505,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
     public function testNPathComplexityForReturnStatementWithConditional()
     {
         $npath = $this->_calculateMethodMetric();
-        $this->assertEquals(6, $npath);
+        $this->assertEquals(3, $npath);
     }
 
     /**


### PR DESCRIPTION
This change fixes the ternary operator complexity calculation to meet the original spec of NP(?) = NP(expr1) + NP(expr2) + NP(expr3) + 2.  Previously it was calculated with NP(expr1) explicitly being set to 1, as well as NP(expr2) and NP(expr3) having an artificial floor of 1 despite 0 being a valid value.  Now, NP(expr1) is actually calculated, and the artificial floor has been removed.
