### PR TITLE
Fix UnexpectedTokenException on null coalesce operator

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -263,10 +263,12 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     protected function parseExpressionVersion70()
     {
         $this->consumeComments();
+        $nextTokenType = $this->tokenizer->peek();
 
-        switch ($this->tokenizer->peek()) {
+        switch ($nextTokenType) {
             case Tokens::T_SPACESHIP:
-                $token = $this->consumeToken(Tokens::T_SPACESHIP);
+            case Tokens::T_COALESCE:
+                $token = $this->consumeToken($nextTokenType);
 
                 $expr = $this->builder->buildAstExpression($token->image);
                 $expr->configureLinesAndColumns(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -153,6 +153,13 @@ if (!defined('T_SPACESHIP')) {
 }
 
 /**
+ * Define PHP 7's '??' token constant
+ */
+if (!defined('T_COALESCE')) {
+    define('T_COALESCE', 42014);
+}
+
+/**
  * This tokenizer uses the internal {@link token_get_all()} function as token stream
  * generator.
  *
@@ -295,6 +302,7 @@ class PHPTokenizerInternal implements Tokenizer
         T_CONSTANT_ENCAPSED_STRING  =>  Tokens::T_CONSTANT_ENCAPSED_STRING,
         T_YIELD                     =>  Tokens::T_YIELD,
         T_FINALLY                   =>  Tokens::T_FINALLY,
+        T_COALESCE                  =>  Tokens::T_COALESCE,
         //T_DOLLAR_OPEN_CURLY_BRACES  =>  Tokens::T_CURLY_BRACE_OPEN,
     );
 

--- a/src/main/php/PDepend/Source/Tokenizer/Tokens.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokens.php
@@ -863,6 +863,11 @@ interface Tokens
     const T_SPACESHIP = 162;
 
     /**
+     * Token that represents the '??' null coalescing operator
+     */
+    const T_COALESCE = 163;
+
+    /**
      * Marks any content not between php tags.
      */
     const T_NO_PHP = 255;

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -394,4 +394,18 @@ class PHPParserGenericVersion70Test extends AbstractTest
     {
         $this->assertSame(29, $expr->getEndColumn());
     }
+
+    /**
+     * testNullCoalesceOperator
+     *
+     * @return void
+     */
+    public function testNullCoalesceOperator()
+    {
+        $expr = $this->getFirstClassMethodForTestCase()
+            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
+            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression');
+
+        $this->assertSame('??', $expr->getImage());
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
@@ -400,6 +400,20 @@ class PHPParserVersion70Test extends AbstractTest
     }
 
     /**
+     * testNullCoalesceOperator
+     *
+     * @return void
+     */
+    public function testNullCoalesceOperator()
+    {
+        $expr = $this->getFirstClassMethodForTestCase()
+            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
+            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression');
+
+        $this->assertSame('??', $expr->getImage());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testNullCoalesceOperator.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testNullCoalesceOperator.php
@@ -1,0 +1,8 @@
+<?php
+class testNullCoalesceOperator_class
+{
+    public function testNullCoalesceOperator()
+    {
+        return null ?? 1;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testNullCoalesceOperator.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testNullCoalesceOperator.php
@@ -1,0 +1,8 @@
+<?php
+class testNullCoalesceOperator_class
+{
+    public function testNullCoalesceOperator()
+    {
+        return null ?? 1;
+    }
+}


### PR DESCRIPTION
This seems to fix the UnexpectedTokenException that gets triggered when parsing PHP 7 code containing a null coalescing operator (??).

Let me know if there are any further considerations that need to be addressed before merging.

Relates to: pdepend/pdepend#254, phpmd/phpmd#347