### PR TITLE
Updating ASTAnonymousClass to implement ASTNode, Retaining Class Behavior

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -52,8 +52,253 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 2.3
  */
-class ASTAnonymousClass extends ASTClass
+class ASTAnonymousClass extends ASTClass implements ASTNode
 {
+
+    /**
+     * Parsed child nodes of this node.
+     *
+     * @var \PDepend\Source\AST\ASTNode[]
+     */
+    protected $nodes = array();
+
+    /**
+     * The parent node of this node or <b>null</b> when this node is the root
+     * of a node tree.
+     *
+     * @var \PDepend\Source\AST\ASTNode
+     */
+    protected $parent = null;
+
+    /**
+     * An optional doc comment for this node.
+     *
+     * @var string
+     */
+    protected $comment = null;
+
+    /**
+     * Metadata for this node instance, serialized in a string. This string
+     * contains the start, end line, and the start, end column and the node
+     * image in a colon seperated string.
+     *
+     * @var string
+     * @since 0.10.4
+     */
+    protected $metadata = '::::';
+
+    /**
+     * Returns the source image of this ast node.
+     *
+     * @return string
+     */
+    public function getImage()
+    {
+        return $this->getMetadata(4);
+    }
+
+    /**
+     * Returns the start line for this ast node.
+     *
+     * @return integer
+     */
+    public function getStartLine()
+    {
+        return $this->getMetadataInteger(0);
+    }
+
+    /**
+     * Returns the start column for this ast node.
+     *
+     * @return integer
+     */
+    public function getStartColumn()
+    {
+        return $this->getMetadataInteger(2);
+    }
+
+    /**
+     * Returns the end line for this ast node.
+     *
+     * @return integer
+     */
+    public function getEndLine()
+    {
+        return $this->getMetadataInteger(1);
+    }
+
+    /**
+     * Returns the end column for this ast node.
+     *
+     * @return integer
+     */
+    public function getEndColumn()
+    {
+        return $this->getMetadataInteger(3);
+    }
+
+    /**
+     * For better performance we have moved the single setter methods for the
+     * node columns and lines into this configure method.
+     *
+     * @param integer $startLine
+     * @param integer $endLine
+     * @param integer $startColumn
+     * @param integer $endColumn
+     * @return void
+     * @since 0.9.10
+     */
+    public function configureLinesAndColumns(
+      $startLine,
+      $endLine,
+      $startColumn,
+      $endColumn
+    ) {
+        $this->setMetadataInteger(0, $startLine);
+        $this->setMetadataInteger(1, $endLine);
+        $this->setMetadataInteger(2, $startColumn);
+        $this->setMetadataInteger(3, $endColumn);
+    }
+
+    /**
+     * Returns the node instance for the given index or throws an exception.
+     *
+     * @param integer $index
+     * @return \PDepend\Source\AST\ASTNode
+     * @throws \OutOfBoundsException When no node exists at the given index.
+     */
+    public function getChild($index)
+    {
+        if (isset($this->nodes[$index])) {
+            return $this->nodes[$index];
+        }
+        throw new \OutOfBoundsException(
+          sprintf(
+            'No node found at index %d in node of type: %s',
+            $index,
+            get_class($this)
+          )
+        );
+    }
+
+    /**
+     * This method returns all direct children of the actual node.
+     *
+     * @return \PDepend\Source\AST\ASTNode[]
+     */
+    public function getChildren()
+    {
+        return $this->nodes;
+    }
+
+    /**
+     * This method will search recursive for the first child node that is an
+     * instance of the given <b>$targetType</b>. The returned value will be
+     * <b>null</b> if no child exists for that.
+     *
+     * @param string $targetType
+     * @return \PDepend\Source\AST\ASTNode
+     */
+    public function getFirstChildOfType($targetType)
+    {
+        foreach ($this->nodes as $node) {
+            if ($node instanceof $targetType) {
+                return $node;
+            }
+            if (($child = $node->getFirstChildOfType($targetType)) !== null) {
+                return $child;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * This method will search recursive for all child nodes that are an
+     * instance of the given <b>$targetType</b>. The returned value will be
+     * an empty <b>array</b> if no child exists for that.
+     *
+     * @param string $targetType Searched class or interface type.
+     * @param array  &$results   Already found node instances. This parameter
+     *        is only for internal usage.
+     * @return \PDepend\Source\AST\ASTNode[]
+     */
+    public function findChildrenOfType($targetType, array &$results = array())
+    {
+        foreach ($this->nodes as $node) {
+            if ($node instanceof $targetType) {
+                $results[] = $node;
+            }
+            $node->findChildrenOfType($targetType, $results);
+        }
+        return $results;
+    }
+
+    /**
+     * Returns the parent node of this node or <b>null</b> when this node is
+     * the root of a node tree.
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Sets the parent node of this node.
+     *
+     * @param \PDepend\Source\AST\ASTNode $node
+     * @return void
+     */
+    public function setParent(ASTNode $node)
+    {
+        $this->parent = $node;
+    }
+
+    /**
+     * Traverses up the node tree and finds all parent nodes that are instances
+     * of <b>$parentType</b>.
+     *
+     * @param string $parentType
+     * @return \PDepend\Source\AST\ASTNode[]
+     */
+    public function getParentsOfType($parentType)
+    {
+        $parents = array();
+
+        $parentNode = $this->parent;
+        while (is_object($parentNode)) {
+            if ($parentNode instanceof $parentType) {
+                array_unshift($parents, $parentNode);
+            }
+            $parentNode = $parentNode->getParent();
+        }
+        return $parents;
+    }
+
+    /**
+     * Returns a doc comment for this node or <b>null</b> when no comment was
+     * found.
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Sets the raw doc comment for this node.
+     *
+     * @param string $comment The doc comment block for this node.
+     *
+     * @return void
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }
+
     /**
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
@@ -77,6 +322,22 @@ class ASTAnonymousClass extends ASTClass
     }
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array
+     * @since 0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(
+          array('comment', 'metadata', 'nodes'),
+          parent::__sleep()
+        );
+    }
+
+    /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation
      * of the wakeup method will register this object in the the global class
@@ -87,5 +348,79 @@ class ASTAnonymousClass extends ASTClass
     public function __wakeup()
     {
         $this->methods = null;
+
+        foreach ($this->nodes as $node) {
+            $node->setParent($this);
+        }
+
+        parent::__wakeup();
+
+    }
+
+    /**
+     * Returns an integer value that was stored under the given index.
+     *
+     * @param integer $index
+     * @return integer
+     * @since 0.10.4
+     */
+    protected function getMetadataInteger($index)
+    {
+        return (int) $this->getMetadata($index);
+    }
+
+    /**
+     * Stores an integer value under the given index in the internally used data
+     * string.
+     *
+     * @param integer $index
+     * @param integer $value
+     * @return void
+     * @since 0.10.4
+     */
+    protected function setMetadataInteger($index, $value)
+    {
+        $this->setMetadata($index, $value);
+    }
+
+    /**
+     * Returns the value that was stored under the given index.
+     *
+     * @param integer $index
+     * @return mixed
+     * @since 0.10.4
+     */
+    protected function getMetadata($index)
+    {
+        $metadata = explode(':', $this->metadata, $this->getMetadataSize());
+        return $metadata[$index];
+    }
+
+    /**
+     * Stores the given value under the given index in an internal storage
+     * container.
+     *
+     * @param integer $index
+     * @param mixed $value
+     * @return void
+     * @since 0.10.4
+     */
+    protected function setMetadata($index, $value)
+    {
+        $metadata         = explode(':', $this->metadata, $this->getMetadataSize());
+        $metadata[$index] = $value;
+
+        $this->metadata = join(':', $metadata);
+    }
+
+    /**
+     * Returns the total number of the used property bag.
+     *
+     * @return integer
+     * @since 0.10.4
+     */
+    protected function getMetadataSize()
+    {
+        return 5;
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -134,6 +134,14 @@ interface ASTNode
     public function getParent();
 
     /**
+     * Sets the parent node of this node.
+     *
+     * @param \PDepend\Source\AST\ASTNode $node
+     * @return void
+     */
+    public function setParent(ASTNode $node);
+
+    /**
      * Traverses up the node tree and finds all parent nodes that are instances
      * of <b>$parentType</b>.
      *
@@ -158,4 +166,17 @@ interface ASTNode
      * @return void
      */
     public function setComment($comment);
+
+    /**
+     * For better performance we have moved the single setter methods for the
+     * node columns and lines into this configure method.
+     *
+     * @param integer $startLine
+     * @param integer $endLine
+     * @param integer $startColumn
+     * @param integer $endColumn
+     * @return void
+     * @since 0.9.10
+     */
+    public function configureLinesAndColumns($startLine, $endLine, $startColumn, $endColumn);
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -191,6 +191,13 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         return parent::parseAllocationExpressionTypeReference($allocation);
     }
 
+    /**
+     * Attempts to the next sequence of tokens as an anonymous class and adds it to the allocation expression
+     *
+     * @param \PDepend\Source\AST\ASTAllocationExpression $allocation
+     *
+     * @return null|\PDepend\Source\AST\ASTAnonymousClass
+     */
     protected function parseAnonymousClassDeclaration(ASTAllocationExpression $allocation)
     {
         $this->consumeComments();


### PR DESCRIPTION
This PR sets out to provide `ASTNode`-behavior to the existing `ASTAnonymousClass` structure, while maintaining its lineage in the `ASTClass` family.  The introduction of anonymous classes in PHP brings with it this odd structure: one that might act as a node in PDepend and yet also have parent classes and interfaces to track in an object hierarchy.  For this reason, it seems this should support both sets of behavior.

@manuelpichler - Would it be possible to accept this PR or guide me through improvements to it?  Our team remains blocked on using anonymous classes in PHP7 in conjunction with the PHPMD scripts that fail our build pipelines when using them.

I see the original commit for `ASTAnonymousClass` did not include any unit tests, and I have not completely sorted out the methodology therein, so I haven't yet added any.

Please feel free to reach out to me anytime - just trying to move the issue along.

Resolves #250