### PR TITLE
Add support for PHP 7.1 optionals

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5295,7 +5295,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterOrTypeHintOrByReference()
+    protected function parseFormalParameterOrTypeHintOrByReference()
     {
         $this->consumeComments();
         $tokenType = $this->tokenizer->peek();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -58,7 +58,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
  */
-class PHPParserGeneric extends PHPParserVersion70
+class PHPParserGeneric extends PHPParserVersion71
 {
     /**
      * Tests if the given token type is a reserved keyword in the supported PHP

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.3
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+use PDepend\Source\Tokenizer\Tokens;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 7.1.
+ *
+ * TODO:
+ *   - void http://php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
+ *   - Symmetric array destructuring http://php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
+ *   - Class constant visibility http://php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility
+ *   - Multi catch exception handling http://php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
+ *   - see full list http://php.net/manual/en/migration71.php
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.4
+ */
+abstract class PHPParserVersion71 extends PHPParserVersion70
+{
+    /**
+     * @return \PDepend\Source\AST\ASTType
+     */
+    protected function parseReturnTypeHint()
+    {
+        $this->consumeComments();
+
+        $tokenType = $this->tokenizer->peek();
+        if (Tokens::T_QUESTION_MARK === $tokenType) {
+            $this->consumeToken(Tokens::T_QUESTION_MARK);
+        }
+
+        return parent::parseReturnTypeHint();
+    }
+
+    /**
+     * This method parses a formal parameter in all it's variations.
+     *
+     * <code>
+     * //                ------------
+     * function traverse(Iterator $it) {}
+     * //                ------------
+     *
+     * //                ---------
+     * function traverse(array $ar) {}
+     * //                ---------
+     *
+     * //                ---
+     * function traverse(&$x) {}
+     * //                ---
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTFormalParameter
+     */
+    protected function parseFormalParameterOrTypeHintOrByReference()
+    {
+        $this->consumeComments();
+        $tokenType = $this->tokenizer->peek();
+        if ($tokenType === Tokens::T_QUESTION_MARK) {
+            $this->consumeToken(Tokens::T_QUESTION_MARK);
+        }
+
+        return parent::parseFormalParameterOrTypeHintOrByReference();
+    }
+
+    /**
+     * Parses a type hint that is valid in the supported PHP version.
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     */
+    protected function parseTypeHint()
+    {
+        $tokenType = $this->tokenizer->peek();
+        if (Tokens::T_QUESTION_MARK === $tokenType) {
+            $this->consumeToken(Tokens::T_QUESTION_MARK);
+        }
+
+        return parent::parseTypeHint();
+    }
+}


### PR DESCRIPTION
This pull request tries to fix #279 

It only skip the T_QUESTION_MARK whenever it finds it.  
I'm not sure this is the way to support optionals for this project.