### PR TITLE
fix count(): Parameter must be an array or an object that implements …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ matrix:
         - php: 5.6
         - php: 7.0
         - php: 7.1
+        - php: 7.2
         - php: nightly
     allow_failures:
+      - php: 7.2
       - php: nightly
     fast_finish: true
 

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -86,7 +86,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      *
      * @var array(integer)
      */
-    private $rootClasses = null;
+    private $rootClasses = array();
 
     /**
      * The maximum depth of inheritance tree value within the analyzed source code.


### PR DESCRIPTION
…Countable (php 7.2)

With PHP (and PHPUnit forced to 4.8.35)

```
There were 5 errors:

1) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #2 ('PDepend\Report\Overview\Pyramid', 'svg')
count(): Parameter must be an array or an object that implements Countable

/work/GIT/pdepend/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php:204
/work/GIT/pdepend/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php:182
/work/GIT/pdepend/src/main/php/PDepend/Engine.php:608
/work/GIT/pdepend/src/main/php/PDepend/Engine.php:331
/work/GIT/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

2) PDepend\Bugs\PHPDependBug13405179Test::testLogFileIsCreatedForUnstructuredCode with data set #3 ('PDepend\Report\Summary\Xml', 'xml')
count(): Parameter must be an array or an object that implements Countable

/work/GIT/pdepend/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php:204
/work/GIT/pdepend/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php:182
/work/GIT/pdepend/src/main/php/PDepend/Engine.php:608
/work/GIT/pdepend/src/main/php/PDepend/Engine.php:331
/work/GIT/pdepend/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php:81

3) PDepend\TextUI\RunnerTest::testRunnerHasParseErrorsReturnsFalseForValidSource
RuntimeException: count(): Parameter must be an array or an object that implements Countable

/work/GIT/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/work/GIT/pdepend/src/test/php/PDepend/AbstractTest.php:570
/work/GIT/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:202

4) PDepend\TextUI\RunnerTest::testRunnerHasParseErrorsReturnsTrueForInvalidSource
RuntimeException: count(): Parameter must be an array or an object that implements Countable

/work/GIT/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/work/GIT/pdepend/src/test/php/PDepend/AbstractTest.php:570
/work/GIT/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:218

5) PDepend\TextUI\RunnerTest::testRunnerGetParseErrorsReturnsArrayWithParsingExceptionMessages
RuntimeException: count(): Parameter must be an array or an object that implements Countable

/work/GIT/pdepend/src/main/php/PDepend/TextUI/Runner.php:320
/work/GIT/pdepend/src/test/php/PDepend/TextUI/RunnerTest.php:235
```

With this minor change, everything is ok (well... some failaure related to "Directive 'track_errors' is deprecated", but rather a PHPUnit issue)