### PR TITLE
Add directory separator to ignoredPatternList

### DIFF
--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -74,6 +74,7 @@ class ExcludePathFilter implements Filter
      */
     public function __construct(array $patterns)
     {
+        $patterns = preg_filter('/^/', DIRECTORY_SEPARATOR, $patterns);
         $quoted = array_map('preg_quote', $patterns);
 
         $this->relative = '(' . str_replace('\*', '.*', join('|', $quoted)) . ')i';


### PR DESCRIPTION
At the moment, passing `$patterns` like `array('.git', '.svn', 'CVS');` to `__construct()` will cause `accept()` to block not only directories with these names, but ALSO directory names that contain these patterns, for example:

`.git`  ==> ignored, _correct_
`.svn` ==> ignored, _correct_
`projectname.git` ==> ignored, **incorrect**
`projectname.svn` ==> ignored, **incorrect**


This patch prepends each pattern with `DIRECTORY_SEPARATOR` (which should be always present in the path) and allows blocking `.git` but not `projectname.git`.