### PR TITLE
Fix Iterator so it will not return directories

### DIFF
--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -87,6 +87,9 @@ class Iterator extends \FilterIterator
      */
     public function accept()
     {
+        if ($this->getInnerIterator()->current()->isDir()) {
+            return false;
+        }
         return $this->filter->accept($this->getLocalPath(), $this->getFullPath());
     }
 

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -82,6 +82,32 @@ class IteratorTest extends AbstractTest
     }
 
     /**
+     * Tests that iterator returns only files.
+     * 
+     * @return void
+     */
+    public function testIteratorReturnsOnlyFiles()
+    {
+        $directory=$this->createCodeResourceUriForTest();
+        $pattern = $directory . DIRECTORY_SEPARATOR . 'Ignored';
+
+        $files  = new Iterator(
+            new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory)),
+            new ExcludePathFilter(array($pattern))
+        );
+
+        $actual = array();
+        foreach ($files as $file) {
+            $actual[] = $file->getFilename();
+        }
+        sort($actual);
+
+        $expected = array('file.php', 'file_process.php');
+        
+        $this->assertEquals($expected,$actual);
+    }
+    
+    /**
      * testIteratorPassesLocalPathToFilterWhenRootIsPresent
      *
      * @return void

--- a/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/Ignored/file_ignore.php
+++ b/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/Ignored/file_ignore.php
@@ -1,0 +1,3 @@
+<?php
+
+// Empty file

--- a/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/Processed/file_process.php
+++ b/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/Processed/file_process.php
@@ -1,0 +1,3 @@
+<?php
+
+// Empty file

--- a/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/file.php
+++ b/src/test/resources/files/Input/Iterator/testIteratorReturnsOnlyFiles/file.php
@@ -1,0 +1,3 @@
+<?php
+
+// Empty file


### PR DESCRIPTION
Directories are filtered out of found files.

Without this additional filtering also directories '.' and '..' are returned and then parser ends with error md5_file(C:\Devel\pdepend\src\test\resources\files\Engine): failed to open stream: Permission denied