### PR TITLE
Use uniqid() in AbstractASTArtifact::getId() instead of microtime()

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -145,7 +145,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     public function getId()
     {
         if ($this->id === null) {
-            $this->id = md5(microtime());
+            $this->id = md5(uniqid('', TRUE));
         }
         return $this->id;
     }


### PR DESCRIPTION
On Windows microtime() creates collisions and tests then fail.