### PR TITLE
Fixed PHPUnit warnings

### DIFF
--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -492,7 +492,12 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockWithoutConstructor($className)
     {
-        return $this->getMock($className, array('__construct'), array(), '', false);
+        $mock = $this->getMockBuilder($className)
+            ->setMethods(array('__construct'))
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $mock;
     }
 
     /**
@@ -539,7 +544,10 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function createCacheFixture()
     {
-        return $this->getMock('\\PDepend\\Util\\Cache\\CacheDriver');
+        $cache = $this->getMockBuilder('\\PDepend\\Util\\Cache\\CacheDriver')
+            ->getMock();
+        
+        return $cache;
     }
 
     /**
@@ -588,7 +596,9 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $class = new ASTClass($name);
         $class->setCompilationUnit(new ASTCompilationUnit($GLOBALS['argv'][0]));
         $class->setCache(new MemoryCacheDriver());
-        $class->setContext($this->getMock('PDepend\\Source\\Builder\\BuilderContext'));
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        $class->setContext($context);
 
         return $class;
     }

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -63,7 +63,8 @@ class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegress
      */
     public function testIteratorOnlyPassesLocalPathToFilter()
     {
-        $filter = $this->getMock('\\PDepend\\Input\\Filter');
+        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+            ->getMock();
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo(DIRECTORY_SEPARATOR . basename(__FILE__)));

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -88,7 +88,8 @@ class IteratorTest extends AbstractTest
      */
     public function testIteratorPassesLocalPathToFilterWhenRootIsPresent()
     {
-        $filter = $this->getMock('\\PDepend\\Input\\Filter');
+        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+            ->getMock();
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo(DIRECTORY_SEPARATOR . basename(__FILE__)));
@@ -110,7 +111,8 @@ class IteratorTest extends AbstractTest
     {
         $files = new \ArrayIterator(array(new \SplFileInfo(__FILE__)));
 
-        $filter = $this->getMock('\\PDepend\\Input\\Filter');
+        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+            ->getMock();
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo(__FILE__), $this->equalTo(__FILE__));
@@ -128,7 +130,8 @@ class IteratorTest extends AbstractTest
     {
         $files = new \ArrayIterator(array(new \SplFileInfo(__FILE__)));
 
-        $filter = $this->getMock('\\PDepend\\Input\\Filter');
+        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+            ->getMock();
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo(__FILE__), $this->equalTo(__FILE__));

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -63,12 +63,13 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsAnEmptyArrayByDefault()
     {
+        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+            ->getMock();
+
         $analyzer = new CouplingAnalyzer();
         $this->assertEquals(
             array(),
-            $analyzer->getNodeMetrics(
-                $this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')
-            )
+            $analyzer->getNodeMetrics($astArtifact)
         );
     }
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -241,7 +241,8 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     private function _createCyclomaticComplexityAnalyzerMock($ccn = 42)
     {
-        $mock = $this->getMock('PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer');
+        $mock = $this->getMockBuilder('PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getCCN2')
             ->will($this->returnValue($ccn));

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -83,7 +83,9 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
     public function testGetCCNReturnsZeroForUnknownNode()
     {
         $analyzer = $this->_createAnalyzer();
-        $this->assertEquals(0, $analyzer->getCcn($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+            ->getMock();
+        $this->assertEquals(0, $analyzer->getCcn($astArtifact));
     }
 
     /**
@@ -94,7 +96,9 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
     public function testGetCCN2ReturnsZeroForUnknownNode()
     {
         $analyzer = $this->_createAnalyzer();
-        $this->assertEquals(0, $analyzer->getCcn2($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+            ->getMock();
+        $this->assertEquals(0, $analyzer->getCcn2($astArtifact));
     }
 
     /**

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -83,7 +83,9 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
     public function testGetNodeMetricsReturnsNothingForUnknownNode()
     {
         $analyzer = $this->_createAnalyzer();
-        $this->assertEquals(array(), $analyzer->getNodeMetrics($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+            ->getMock();
+        $this->assertEquals(array(), $analyzer->getNodeMetrics($astArtifact));
     }
 
     /**

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -83,7 +83,9 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
     public function testGetNodeMetricsReturnsNothingForUnknownNode()
     {
         $analyzer = $this->_createAnalyzer();
-        $this->assertEquals(array(), $analyzer->getNodeMetrics($this->getMock('\\PDepend\\Source\\AST\\ASTArtifact')));
+        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+            ->getMock();
+        $this->assertEquals(array(), $analyzer->getNodeMetrics($astArtifact));
     }
 
     /**

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -62,7 +62,8 @@ class AnalyzerIteratorTest extends AbstractTest
      */
     public function testIteratorReturnsEnabledAnalyzerInstances()
     {
-        $analyzer = $this->getMock('\\PDepend\\Metrics\\Analyzer');
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer')
+            ->getMock();
         $analyzer->expects($this->exactly(2))
             ->method('isEnabled')
             ->will($this->returnValue(true));
@@ -78,7 +79,8 @@ class AnalyzerIteratorTest extends AbstractTest
      */
     public function testIteratorDoesNotReturnDisabledAnalyzerInstances()
     {
-        $analyzer = $this->getMock('\\PDepend\\Metrics\\Analyzer');
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer')
+            ->getMock();
         $analyzer->expects($this->at(0))
             ->method('isEnabled')
             ->will($this->returnValue(true));

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -1438,7 +1438,8 @@ class ParserTest extends AbstractTest
      */
     public function testParserStopsProcessingWhenCacheContainsValidResult()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
 
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile(__FILE__);

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -134,8 +134,11 @@ class XmlTest extends AbstractTest
      */
     public function testLogMethodReturnsFalseForWrongAnalyzer()
     {
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerNodeAware')
+            ->getMock();
+        
         $logger = new Xml();
-        $actual = $logger->log($this->getMock('\\PDepend\\Metrics\\AnalyzerNodeAware'));
+        $actual = $logger->log($analyzer);
 
         $this->assertFalse($actual);
     }
@@ -147,8 +150,11 @@ class XmlTest extends AbstractTest
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeClassDepenendecyAnalyzer()
     {
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer')
+            ->getMock();
+        
         $logger = new Xml();
-        $actual = $logger->log($this->getMock('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer'));
+        $actual = $logger->log($analyzer);
 
         $this->assertTrue($actual);
     }
@@ -186,7 +192,9 @@ class XmlTest extends AbstractTest
     {
         $this->namespaces = self::parseCodeResourceForTest();
 
-        $type = $this->getMock('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(), array(), '', false);
+        $type = $this->getMockBuilder('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface')
+            ->disableOriginalConstructor()
+            ->getMock();
         $type
             ->expects($this->any())
             ->method('getName')
@@ -196,7 +204,8 @@ class XmlTest extends AbstractTest
             ->method('getNamespaceName')
             ->will($this->returnValue('namespace'));
 
-        $analyzer = $this->getMock('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer');
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer')
+            ->getMock();
         $analyzer
             ->expects($this->any())
             ->method('getEfferents')

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -226,7 +226,8 @@ class ChartTest extends AbstractTest
     {
         $nodes = $this->_createPackages(true, true);
 
-        $analyzer = $this->getMock('\\PDepend\\Metrics\\Analyzer\\DependencyAnalyzer');
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\DependencyAnalyzer')
+            ->getMock();
         $analyzer->expects($this->atLeastOnce())
             ->method('getStats')
             ->will(
@@ -345,12 +346,11 @@ class ChartTest extends AbstractTest
      */
     private function _createPackage($userDefined, $packageName)
     {
-        $packageA = $this->getMock(
-            '\\PDepend\\Source\\AST\\ASTNamespace',
-            array('isUserDefined'),
-            array($packageName),
-            'package_' . md5(microtime())
-        );
+        $packageA = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTNamespace')
+            ->setMethods(array('isUserDefined'))
+            ->setConstructorArgs(array($packageName))
+            ->setMockClassName('package_' . md5(microtime()))
+            ->getMock();
         $packageA->expects($this->atLeastOnce())
             ->method('isUserDefined')
             ->will($this->returnValue($userDefined));

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -265,7 +265,8 @@ class PyramidTest extends AbstractTest
 
     private function createCouplingAnalyzer()
     {
-        $mock = $this->getMock('\\PDepend\\Metrics\\Analyzer\\CouplingAnalyzer');
+        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\CouplingAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
@@ -280,7 +281,8 @@ class PyramidTest extends AbstractTest
 
     private function createComplexityAnalyzer()
     {
-        $mock = $this->getMock('\\PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer');
+        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
@@ -294,7 +296,8 @@ class PyramidTest extends AbstractTest
 
     private function createInheritanceAnalyzer()
     {
-        $mock = $this->getMock('\\PDepend\\Metrics\\Analyzer\\InheritanceAnalyzer');
+        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\InheritanceAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
@@ -309,7 +312,8 @@ class PyramidTest extends AbstractTest
 
     private function createNodeCountAnalyzer()
     {
-        $mock = $this->getMock('\\PDepend\\Metrics\\Analyzer\\NodeCountAnalyzer');
+        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\NodeCountAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
@@ -326,7 +330,8 @@ class PyramidTest extends AbstractTest
 
     private function createNodeLocAnalyzer()
     {
-        $mock = $this->getMock('\\PDepend\\Metrics\\Analyzer\\NodeLocAnalyzer');
+        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\NodeLocAnalyzer')
+            ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -146,8 +146,11 @@ class XmlTest extends AbstractTest
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeProjectAware()
     {
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerProjectAware')
+            ->getMock();
+
         $logger = new Xml();
-        $actual = $logger->log($this->getMock('\\PDepend\\Metrics\\AnalyzerProjectAware'));
+        $actual = $logger->log($analyzer);
 
         $this->assertTrue($actual);
     }
@@ -159,8 +162,11 @@ class XmlTest extends AbstractTest
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware()
     {
+        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerNodeAware')
+            ->getMock();
+
         $logger = new Xml();
-        $actual = $logger->log($this->getMock('\\PDepend\\Metrics\\AnalyzerNodeAware'));
+        $actual = $logger->log($analyzer);
 
         $this->assertTrue($actual);
     }

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -324,6 +324,9 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      */
     protected function getBuilderContextMock()
     {
-        return $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+
+        return $context;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -248,6 +248,9 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     protected function getBuilderContextMock()
     {
-        return $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        
+        return $context;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -596,22 +596,16 @@ class ASTClassTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->never())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -631,31 +625,22 @@ class ASTClassTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node3->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue($node1));
@@ -675,22 +660,16 @@ class ASTClassTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -1641,7 +1620,10 @@ class ASTClassTest extends AbstractASTArtifactTest
 
         $method = new ASTMethod(__FUNCTION__);
         $class->addMethod($method);
-        $class->setContext($this->getMock('PDepend\\Source\\Builder\\BuilderContext'));
+        
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        $class->setContext($context);
 
         $file = new ASTCompilationUnit(__FILE__);
         $class->setCompilationUnit($file);
@@ -1659,7 +1641,8 @@ class ASTClassTest extends AbstractASTArtifactTest
     {
         $class = new ASTClass(__CLASS__);
 
-        $context = $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
         $context->expects($this->once())
             ->method('registerClass')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTClass'));
@@ -1677,7 +1660,10 @@ class ASTClassTest extends AbstractASTArtifactTest
         $class = new ASTClass(__CLASS__);
         $class->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $class->setCache(new MemoryCacheDriver());
-        $class->setContext($this->getMock('PDepend\\Source\\Builder\\BuilderContext'));
+        
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        $class->setContext($context);
 
         return $class;
     }

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -178,7 +178,8 @@ class ASTCompilationUnitTest extends AbstractTest
      */
     public function testAcceptInvokesVisitFileOnGivenVisitor()
     {
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('visitCompilationUnit')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTCompilationUnit'));
@@ -238,11 +239,10 @@ class ASTCompilationUnitTest extends AbstractTest
      */
     public function testMagicWakeupMethodInvokesSetSourceFileOnChildNodes()
     {
-        $node = $this->getMock(
-            'PDepend\\Source\\AST\\ASTClass',
-            array('setCompilationUnit'),
-            array(__CLASS__)
-        );
+        $node = $this->getMockBuilder('PDepend\\Source\\AST\\ASTClass')
+            ->setMethods(array('setCompilationUnit'))
+            ->setConstructorArgs(array(__CLASS__))
+            ->getMock();
         $node->expects($this->once())
             ->method('setCompilationUnit')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTCompilationUnit'));

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -202,11 +202,9 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testSetNamespaceNotEstablishesBackReference()
     {
-        $namespace = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNamespace',
-            array(),
-            array(__FUNCTION__)
-        );
+        $namespace = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNamespace')
+            ->setConstructorArgs(array(__FUNCTION__))
+            ->getMock();
         $namespace->expects($this->never())
             ->method('addFunction');
 
@@ -375,22 +373,16 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->never())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -410,31 +402,22 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node3->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue($node1));
@@ -454,22 +437,16 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -489,22 +466,16 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testFindChildrenOfTypeReturnsExpectedResult()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue(array()));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue(array()));
@@ -689,7 +660,10 @@ class ASTFunctionTest extends AbstractASTArtifactTest
     {
         $function = new ASTFunction(__FUNCTION__);
         $function->setCompilationUnit(new ASTCompilationUnit(__FILE__));
-        $function->setContext($this->getMock('PDepend\\Source\\Builder\\BuilderContext'));
+        
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        $function->setContext($context);
 
         return $function;
     }

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -66,22 +66,16 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->never())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -101,31 +95,22 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node3->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue($node1));
@@ -145,22 +130,16 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Mock_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -396,15 +375,11 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
     public function testInterfaceThrowsExpectedExceptionOnSetParentClassReference()
     {
         $interface = $this->createItem();
-        $interface->setParentClassReference(
-            $this->getMock(
-                '\\PDepend\\Source\\AST\\ASTClassReference',
-                array(),
-                array(),
-                '',
-                false
-            )
-        );
+
+        $reference = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTClassReference')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $interface->setParentClassReference($reference);
     }
 
     /**
@@ -919,7 +894,8 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
     {
         $interface = $this->createItem();
 
-        $context = $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
         $context->expects($this->once())
             ->method('registerInterface')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
@@ -934,7 +910,8 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testAcceptInvokesVisitInterfaceOnGivenVisitor()
     {
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('visitInterface')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
@@ -953,7 +930,10 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
         $interface = new ASTInterface(__CLASS__);
         $interface->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $interface->setCache(new MemoryCacheDriver());
-        $interface->setContext($this->getMock('PDepend\\Source\\Builder\\BuilderContext'));
+        
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        $interface->setContext($context);
 
         return $interface;
     }

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -581,22 +581,16 @@ class ASTMethodTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->never())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -616,31 +610,22 @@ class ASTMethodTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node3->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue($node1));
@@ -660,22 +645,16 @@ class ASTMethodTest extends AbstractASTArtifactTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -697,22 +676,16 @@ class ASTMethodTest extends AbstractASTArtifactTest
      */
     public function testFindChildrenOfTypeReturnsExpectedResult()
     {
-        $node1 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue(array()));
 
-        $node2 = $this->getMock(
-            'PDepend\\Source\\AST\\ASTNode',
-            array(),
-            array(),
-            'Class_' . __FUNCTION__ . '_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+            ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue(array()));

--- a/src/test/php/PDepend/Source/AST/ASTNodeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTest.php
@@ -604,8 +604,10 @@ abstract class ASTNodeTest extends AbstractTest
      */
     public function testPrependChildAddsChildAtFirstPosition()
     {
-        $child1 = $this->getMock('PDepend\\Source\\AST\\AbstractASTNode');
-        $child2 = $this->getMock('PDepend\\Source\\AST\\AbstractASTNode');
+        $child1 = $this->getMockBuilder('PDepend\\Source\\AST\\AbstractASTNode')
+            ->getMock();
+        $child2 = $this->getMockBuilder('PDepend\\Source\\AST\\AbstractASTNode')
+            ->getMock();
 
         $parent = $this->createNodeInstance();
         $parent->prependChild($child2);
@@ -623,7 +625,8 @@ abstract class ASTNodeTest extends AbstractTest
     {
         $methodName = 'visit' . substr(get_class($this), 22, -4);
 
-        $visitor = $this->getMock('\\PDepend\\Source\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('__call')
             ->with($this->equalTo($methodName));
@@ -641,7 +644,8 @@ abstract class ASTNodeTest extends AbstractTest
     {
         $methodName = 'visit' . substr(get_class($this), 22, -4);
 
-        $visitor = $this->getMock('\\PDepend\\Source\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('__call')
             ->with($this->equalTo($methodName))
@@ -658,12 +662,9 @@ abstract class ASTNodeTest extends AbstractTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch()
     {
-        $node2 = $this->getMock(
-            '\PDepend\Source\AST\AbstractASTNode',
-            array(),
-            array(),
-            'PDepend_Source_AST_ASTNode_' . md5(microtime())
-        );
+        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+            ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
+            ->getMock();
         $node2->expects($this->never())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -682,21 +683,15 @@ abstract class ASTNodeTest extends AbstractTest
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch()
     {
-        $node1 = $this->getMock(
-            '\PDepend\Source\AST\AbstractASTNode',
-            array(),
-            array(),
-            'PDepend_Source_AST_ASTNode_' . md5(microtime())
-        );
+        $node1 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+            ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
+            ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node3 = $this->getMock(
-            '\PDepend\Source\AST\AbstractASTNode',
-            array(),
-            array(),
-            'PDepend_Source_AST_ASTNode_' . md5(microtime())
-        );
+        $node3 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+            ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
+            ->getMock();
         $node3->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue($node1));
@@ -717,12 +712,9 @@ abstract class ASTNodeTest extends AbstractTest
     {
         $name = 'PDepend_Source_AST_ASTNode_' . md5(microtime());
         
-        $node2 = $this->getMock(
-            '\PDepend\Source\AST\AbstractASTNode',
-            array(),
-            array(),
-            $name
-        );
+        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+            ->setMockClassName($name)
+            ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
@@ -742,12 +734,9 @@ abstract class ASTNodeTest extends AbstractTest
     {
         $name = 'PDepend_Source_AST_ASTNode_' . md5(microtime());
 
-        $node2 = $this->getMock(
-            '\PDepend\Source\AST\AbstractASTNode',
-            array(),
-            array(),
-            $name
-        );
+        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+            ->setMockClassName($name)
+            ->getMock();
         $node2->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue(array()));

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -248,12 +248,15 @@ class ASTParameterTest extends AbstractTest
      */
     public function testAcceptInvokesVisitParameterOnSuppliedVisitor()
     {
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('visitParameter')
             ->with($this->isInstanceOf('\\PDepend\\Source\\AST\\ASTParameter'));
 
-        $parameter = new ASTParameter($this->getMock('PDepend\\Source\\AST\\ASTFormalParameter'));
+        $formalParameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTFormalParameter')
+            ->getMock();
+        $parameter = new ASTParameter($formalParameter);
         $parameter->accept($visitor);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -192,15 +192,11 @@ class ASTParentReferenceTest extends ASTNodeTest
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTParentReference(
-            $this->referenceMock = $this->getMock(
-                '\PDepend\Source\AST\ASTClassOrInterfaceReference',
-                array(),
-                array(null, __CLASS__),
-                '',
-                false
-            )
-        );
+        $this->referenceMock = $this->getMockBuilder('\PDepend\Source\AST\ASTClassOrInterfaceReference')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return new \PDepend\Source\AST\ASTParentReference($this->referenceMock);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -472,7 +472,8 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testAcceptCallsVisitorMethodVisitProperty()
     {
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitor');
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+            ->getMock();
         $visitor->expects($this->once())
             ->method('visitProperty');
 

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -65,7 +65,8 @@ class ASTSelfReferenceTest extends ASTNodeTest
     public function testGetTypeReturnsInjectedConstructorTargetArgument()
     {
         $target  = $this->getMockForAbstractClass('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(__CLASS__));
-        $context = $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
 
         $reference = new \PDepend\Source\AST\ASTSelfReference($context, $target);
         $this->assertSame($target, $reference->getType());
@@ -80,7 +81,8 @@ class ASTSelfReferenceTest extends ASTNodeTest
     {
         $target = $this->getMockForAbstractClass('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(__CLASS__));
 
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface');
 
@@ -218,8 +220,11 @@ class ASTSelfReferenceTest extends ASTNodeTest
      */
     protected function createNodeInstance()
     {
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+
         return new \PDepend\Source\AST\ASTSelfReference(
-            $this->getMock('PDepend\\Source\\Builder\\BuilderContext'),
+            $context,
             $this->getMockForAbstractClass('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(__CLASS__))
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -67,7 +67,8 @@ class ASTStaticReferenceTest extends ASTNodeTest
             '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
             array(__CLASS__)
         );
-        $context = $this->getMock('\\PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
 
         $reference = new \PDepend\Source\AST\ASTStaticReference($context, $target);
         $this->assertSame($target, $reference->getType());
@@ -85,7 +86,8 @@ class ASTStaticReferenceTest extends ASTNodeTest
             array(__CLASS__)
         );
 
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface');
 
@@ -231,8 +233,11 @@ class ASTStaticReferenceTest extends ASTNodeTest
      */
     protected function createNodeInstance()
     {
+        $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+
         return new \PDepend\Source\AST\ASTStaticReference(
-            $this->getMock('\\PDepend\\Source\\Builder\\BuilderContext'),
+            $context,
             $this->getMockForAbstractClass(
                 '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
                 array(__CLASS__)

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -65,7 +65,8 @@ class ASTTraitReferenceTest extends ASTNodeTest
      */
     public function testGetTraitDelegatesToContextGetTraitMethod()
     {
-        $context = $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
         $context->expects($this->once())
             ->method('getTrait')
             ->with($this->equalTo(__CLASS__));
@@ -173,6 +174,9 @@ class ASTTraitReferenceTest extends ASTNodeTest
      */
     protected function getBuilderContextMock()
     {
-        return $this->getMock('PDepend\\Source\\Builder\\BuilderContext');
+        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+            ->getMock();
+        
+        return $context;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -79,7 +79,8 @@ class CollectionArtifactFilterTest extends AbstractTest
     {
         $class = new ASTClass(__CLASS__);
 
-        $filter = $this->getMock('\\PDepend\\Source\\AST\\ASTArtifactList\\ArtifactFilter');
+        $filter = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifactList\\ArtifactFilter')
+            ->getMock();
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo($class));

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -220,11 +220,15 @@ class DefaultListenerTest extends AbstractTest
      */
     public function testListenerCallsStartVisitNodeForPassedParameterInstance()
     {
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener', array('startVisitNode'));
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+            ->setMethods(array('startVisitNode'))
+            ->getMock();
         $listener->expects($this->once())
             ->method('startVisitNode');
 
-        $parameter = $this->getMock('PDepend\\Source\\AST\\ASTParameter', array(), array(null), '', false);
+        $parameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTParameter')
+            ->disableOriginalConstructor()
+            ->getMock();
         $listener->startVisitParameter($parameter);
     }
 
@@ -235,11 +239,15 @@ class DefaultListenerTest extends AbstractTest
      */
     public function testListenerCallsEndVisitNodeForPassedParameterInstance()
     {
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener', array('endVisitNode'));
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+            ->setMethods(array('endVisitNode'))
+            ->getMock();
         $listener->expects($this->once())
             ->method('endVisitNode');
 
-        $parameter = $this->getMock('PDepend\\Source\\AST\\ASTParameter', array(), array(null), '', false);
+        $parameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTParameter')
+            ->disableOriginalConstructor()
+            ->getMock();
         $listener->endVisitParameter($parameter);
     }
 
@@ -251,7 +259,9 @@ class DefaultListenerTest extends AbstractTest
      */
     public function testListenerInvokesStartVisitNotForTrait()
     {
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener', array('startVisitNode'));
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+            ->setMethods(array('startVisitNode'))
+            ->getMock();
         $listener->expects($this->once())
             ->method('startVisitNode');
 
@@ -266,7 +276,9 @@ class DefaultListenerTest extends AbstractTest
      */
     public function testListenerInvokesEndVisitNotForTrait()
     {
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener', array('endVisitNode'));
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+            ->setMethods(array('endVisitNode'))
+            ->getMock();
         $listener->expects($this->once())
             ->method('endVisitNode');
 

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -104,7 +104,9 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('visitParameter'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('visitParameter'))
+            ->getMock();
         $visitor->expects($this->exactly(2))
             ->method('visitParameter');
 
@@ -120,7 +122,9 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('visitParameter'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('visitParameter'))
+            ->getMock();
         $visitor->expects($this->exactly(3))
             ->method('visitParameter');
 
@@ -136,11 +140,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
         
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->exactly(2))
             ->method('startVisitParameter');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -155,11 +162,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->exactly(3))
             ->method('endVisitParameter');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -174,11 +184,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('startVisitInterface');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -193,11 +206,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('endVisitInterface');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -212,11 +228,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('startVisitProperty');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -231,11 +250,14 @@ class DefaultVisitorTest extends AbstractTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('endVisitProperty');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespaces[0]);
@@ -255,7 +277,9 @@ class DefaultVisitorTest extends AbstractTest
         $namespace->addType(new ASTTrait('MyTraitTwo'))
             ->setCompilationUnit(new ASTCompilationUnit(__FILE__));
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('visitTrait'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('visitTrait'))
+            ->getMock();
         $visitor->expects($this->exactly(2))
             ->method('visitTrait');
 
@@ -275,7 +299,9 @@ class DefaultVisitorTest extends AbstractTest
         $trait->addMethod($method0 = new ASTMethod('m0'));
         $trait->addMethod($method1 = new ASTMethod('m1'));
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('visitMethod'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('visitMethod'))
+            ->getMock();
         $visitor->expects($this->at(0))
             ->method('visitMethod')
             ->with($this->equalTo($method0));
@@ -300,11 +326,14 @@ class DefaultVisitorTest extends AbstractTest
         $namespace = new ASTNamespace('MyPackage');
         $namespace->addType($trait);
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('startVisitTrait');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespace);
@@ -324,11 +353,14 @@ class DefaultVisitorTest extends AbstractTest
         $namespace = new ASTNamespace('MyPackage');
         $namespace->addType($trait);
 
-        $listener = $this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener');
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
         $listener->expects($this->once())
             ->method('endVisitTrait');
 
-        $visitor = $this->getMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor', array('getVisitListeners'));
+        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+            ->setMethods(array('getVisitListeners'))
+            ->getMock();
         $visitor->addVisitListener($listener);
 
         $visitor->visitNamespace($namespace);
@@ -353,7 +385,10 @@ class DefaultVisitorTest extends AbstractTest
     public function testGetVisitListenersContainsAddedListener()
     {
         $visitor = $this->getMockForAbstractClass('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor');
-        $visitor->addVisitListener($this->getMock('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener'));
+
+        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+            ->getMock();
+        $visitor->addVisitListener($listener);
 
         $this->assertEquals(1, count($visitor->getVisitListeners()));
     }

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -68,7 +68,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testRegisterTraitCallsRestoreClassOnBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('restoreTrait')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTTrait'));
@@ -84,7 +85,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testRegisterClassCallsRestoreClassOnBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('restoreClass')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTClass'));
@@ -100,7 +102,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testRegisterInterfaceCallsRestoreInterfaceOnBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('restoreInterface')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
@@ -116,7 +119,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testRegisterFunctionCallsRestoreFunctionOnBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('restoreFunction')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTFunction'));
@@ -133,7 +137,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testGetTraitDelegatesCallToWrappedBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('getTrait')
             ->with($this->equalTo(__CLASS__));
@@ -149,7 +154,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testGetClassDelegatesCallToWrappedBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('getClass')
             ->with($this->equalTo(__CLASS__));
@@ -165,7 +171,8 @@ class GlobalBuilderContextTest extends AbstractTest
      */
     public function testGetClassOrInterfaceDelegatesCallToWrappedBuilder()
     {
-        $builder = $this->getMock('\\PDepend\\Source\\Builder\\Builder');
+        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+            ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface')
             ->with($this->equalTo(__CLASS__));

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -139,11 +139,9 @@ class PHPBuilderTest extends AbstractTest
      */
     public function testRestoreFunctionUsesGetNamespaceNameMethod()
     {
-        $function = $this->getMock(
-            'PDepend\\Source\\AST\\ASTFunction',
-            array(),
-            array(__FUNCTION__)
-        );
+        $function = $this->getMockBuilder('PDepend\\Source\\AST\\ASTFunction')
+            ->setConstructorArgs(array(__FUNCTION__))
+            ->getMock();
         $function->expects($this->once())
             ->method('getNamespaceName');
 

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -204,12 +204,16 @@ class CloverReportTest extends AbstractTest
      */
     private function createMethodMock($name, $startLine = 1, $endLine = 4)
     {
-        $file = $this->getMock('\\PDepend\\Source\\AST\\ASTCompilationUnit', array(), array(null));
+        $file = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTCompilationUnit')
+            ->setConstructorArgs(array(null))
+            ->getMock();
         $file->expects($this->any())
             ->method('getFileName')
             ->will($this->returnValue('/' . $name . '.php'));
 
-        $method = $this->getMock('\\PDepend\\Source\\AST\\ASTMethod', array(), array($name));
+        $method = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTMethod')
+            ->setConstructorArgs(array($name))
+            ->getMock();
         $method->expects($this->once())
             ->method('getCompilationUnit')
             ->will($this->returnValue($file));


### PR DESCRIPTION
Changed all uses of getMock() to getMockBuilder().

Fixes https://github.com/pdepend/pdepend/issues/327