### PR TITLE
Add configuration for PHP_CodeSniffer

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_Depend">
+	<description>Coding standard for PDepend.</description>
+
+	<file>scripts</file>
+	<file>src</file>
+        
+        <!-- Website content -->
+        <exclude-pattern>src/site/</exclude-pattern>
+        <!-- Files for unit tests -->
+        <exclude-pattern>src/test/resources/</exclude-pattern>
+
+	<arg name="colors"/>
+	<arg value="np"/>
+
+	<rule ref="PSR2"/>
+
+</ruleset>

--- a/scripts/php-keywords.php
+++ b/scripts/php-keywords.php
@@ -15,7 +15,7 @@ if (isset($argv[1])) {
     } else {
         $file = $argv[1];
     }
-} else if (false === file_exists($file) || time() - filemtime($file) > 7200) {
+} elseif (false === file_exists($file) || time() - filemtime($file) > 7200) {
     shell_exec(sprintf("wget -c '%s'", $url));
     touch($file);
 }
@@ -103,7 +103,8 @@ function test($type, $code, $image, $constant, array &$valid)
 
 function dump($type, array $valid)
 {
-    $code = sprintf('
+    $code = sprintf(
+        '
     /**
      * Tests if the give token is a valid %s name in the supported PHP
      * version.

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -411,7 +411,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
                     $metrics[self::M_NUMBER_OF_CLASSES]
                 );
             }
-
         }
     }
 

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -235,7 +235,6 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
                 $legend->nodeValue = $found[1];
                 $legendTemplate->parentNode->appendChild($legend);
             }
-
         }
 
         $bad->parentNode->removeChild($bad);

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -256,7 +256,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
         }
 
         parent::__wakeup();
-
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -145,7 +145,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     public function getId()
     {
         if ($this->id === null) {
-            $this->id = md5(uniqid('', TRUE));
+            $this->id = md5(uniqid('', true));
         }
         return $this->id;
     }

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
@@ -270,7 +270,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
      */
     protected function startVisitNode(AbstractASTArtifact $node)
     {
-
     }
 
     /**
@@ -281,6 +280,5 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
      */
     protected function endVisitNode(AbstractASTArtifact $node)
     {
-
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -6005,7 +6005,6 @@ abstract class AbstractPHPParser
             $this->namespaceName = $qualifiedName;
 
             $this->useSymbolTable->resetScope();
-
         } elseif ($tokenType === Tokens::T_BACKSLASH) {
             // Same namespace reference, something like:
             //   new namespace\Foo();
@@ -6299,7 +6298,6 @@ abstract class AbstractPHPParser
 
         $declaration = $this->parseStaticVariableDeclaration($token);
         return $this->setNodePositionsAndReturn($declaration);
-
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
@@ -52,5 +52,4 @@ namespace PDepend\Source\Language\PHP;
  */
 abstract class PHPParserVersion55 extends PHPParserVersion54
 {
-
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -178,5 +178,4 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
 
         return parent::parseScalarOrCallableTypeHint($image);
     }
-
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -781,7 +781,6 @@ class PHPTokenizerInternal implements Tokenizer
 
                         array_pop($this->tokens);
                     }
-
                 } elseif (isset($tokenMap[$token[0]])) {
                     $type = $tokenMap[$token[0]];
                     // Check for a context sensitive alternative

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -112,7 +112,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
      */
     public function endFileParsing(Tokenizer $tokenizer)
     {
-
     }
 
     /**

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -89,7 +89,6 @@ class IdBuilder
      */
     public function forClassOrInterface(AbstractASTType $type)
     {
-
         return $this->forOffsetItem(
             $type,
             ltrim(strrchr(strtolower(get_class($type)), '_'), '_')

--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -769,7 +769,6 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
         // Is it not installed?
         if (is_file(dirname(__FILE__) . '/../../../main/php/PDepend/Engine.php')) {
-
             $path  = realpath(dirname(__FILE__) . '/../../../main/php/');
             $path .= PATH_SEPARATOR . get_include_path();
             set_include_path($path);
@@ -780,7 +779,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
         $path .= PATH_SEPARATOR . get_include_path();
         set_include_path($path);
 
-        self::_initVersionCompatibility();
+        self::initVersionCompatibility();
     }
 
     /**
@@ -807,7 +806,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      *
      * @return void
      */
-    private static function _initVersionCompatibility()
+    private static function initVersionCompatibility()
     {
         $reflection = new \ReflectionClass('Iterator');
         $extension  = strtolower($reflection->getExtensionName());

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTest.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTest.php
@@ -89,7 +89,8 @@ abstract class AbstractRegressionTest extends AbstractTest
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
         return $this->parseSource(
-            $this->getSourceFileForTestCase($testCase), $ignoreAnnotations
+            $this->getSourceFileForTestCase($testCase),
+            $ignoreAnnotations
         );
     }
 

--- a/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -62,7 +62,7 @@ class ClassLevelAnalyzerBug09936901Test extends AbstractRegressionTest
 {
     /**
      * testWmciMetricIsCalculatedForCurrentAndNotParentClass
-     * 
+     *
      * @return void
      */
     public function testWmciMetricIsCalculatedForCurrentAndNotParentClass()

--- a/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -58,7 +58,7 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTest
 {
     /**
      * testParserHandlesStringWithEmbeddedBacktickExpression
-     * 
+     *
      * @return void
      */
     public function testParserHandlesStringWithEmbeddedBacktickExpression()

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -77,7 +77,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTest
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForTwoLevelClassHierarchy
-     * 
+     *
      * @return void
      * @expectedException \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
      */
@@ -133,7 +133,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTest
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForDeepInterfaceHierarchy
-     * 
+     *
      * @return void
      */
     public function testClassLevelAnalyzerNotRunsEndlessForDeepInterfaceHierarchy()
@@ -205,7 +205,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTest
 
     /**
      * testFullStackNotRunsEndless
-     * 
+     *
      * @return void
      */
     public function testFullStackNotRunsEndless()

--- a/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
+++ b/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
@@ -55,7 +55,7 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 {
     /**
      * testParserNotThrowsAnExceptionForKeywordUse
-     * 
+     *
      * @return void
      */
     public function testParserNotThrowsAnExceptionForKeywordUse()

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -92,7 +92,7 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTest
 
     /**
      * testParserThrowsExpectedExceptionForParentTypeHintWithRootClass
-     * 
+     *
      * @return void
      */
     public function testParserThrowsExpectedExceptionForParentTypeHintWithRootClass()

--- a/src/test/php/PDepend/Bugs/ParserBug006Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug006Test.php
@@ -56,7 +56,7 @@ class ParserBug006Test extends AbstractRegressionTest
 {
     /**
      * testParserNotSetsReferenceForVariableObjectInstantiation
-     * 
+     *
      * @return void
      */
     public function testParserNotSetsReferenceForVariableObjectInstantiation()

--- a/src/test/php/PDepend/Bugs/ParserBug124Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug124Test.php
@@ -45,7 +45,6 @@ namespace PDepend\Bugs;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Source\Tokenizer\Tokens;
 
-
 /**
  * Test case for bug #124.
  *
@@ -68,7 +67,6 @@ class ParserBug124Test extends AbstractRegressionTest
      */
     public function testClassNameScalarKeyword()
     {
-
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile($this->createCodeResourceURI('bugs/124/testClassNameScalarKeyword.php'));
 
@@ -77,15 +75,14 @@ class ParserBug124Test extends AbstractRegressionTest
             $actual[] = $token->type;
         }
 
-
-         $tokenTypes = array(
-             Tokens::T_OPEN_TAG,
-             Tokens::T_VARIABLE,
-             Tokens::T_EQUAL,
-             Tokens::T_STRING,
-             Tokens::T_DOUBLE_COLON,
-             Tokens::T_CLASS_FQN,
-             Tokens::T_SEMICOLON
+        $tokenTypes = array(
+            Tokens::T_OPEN_TAG,
+            Tokens::T_VARIABLE,
+            Tokens::T_EQUAL,
+            Tokens::T_STRING,
+            Tokens::T_DOUBLE_COLON,
+            Tokens::T_CLASS_FQN,
+            Tokens::T_SEMICOLON
         );
 
         $this->assertEquals($tokenTypes, $actual);

--- a/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -58,7 +58,7 @@ class ParserBug17264279Test extends AbstractRegressionTest
 {
     /**
      * testParserAcceptsUseAsClassName
-     * 
+     *
      * @return void
      */
     public function testParserAcceptsUseAsClassName()

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -60,7 +60,7 @@ class ParserBug23905939Test extends AbstractRegressionTest
 {
     /**
      * testParserExtractsCorrectClassPackage
-     * 
+     *
      * @return void
      */
     public function testParserExtractsCorrectClassPackage()

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -60,7 +60,7 @@ class ParserBug8927377Test extends AbstractRegressionTest
 {
     /**
      * testPropertyPostfixHasExpectedStartLine
-     * 
+     *
      * @return void
      */
     public function testPropertyPostfixHasExpectedStartLine()
@@ -104,7 +104,7 @@ class ParserBug8927377Test extends AbstractRegressionTest
 
     /**
      * Returns the property postfix found in a class.
-     * 
+     *
      * @return \PDepend\Source\AST\ASTPropertyPostfix
      */
     protected function getFirstPropertyPostfixInClass()

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -128,4 +128,3 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTest
         );
     }
 }
-?>

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
@@ -90,7 +90,7 @@ class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegress
     }
 
     /**
-     * Tests that the parser handles multiple comma separated constant 
+     * Tests that the parser handles multiple comma separated constant
      * definitions as expected.
      *
      * @return void

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
@@ -58,7 +58,7 @@ class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegres
 {
     /**
      * Tests that the parser handles a comma separated property declaration.
-     * 
+     *
      * @return void
      */
     public function testParserHandlesSimpleCommaSeparatedPropertyDeclaration()

--- a/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -51,13 +51,15 @@ namespace PDepend\Bugs;
  * @covers \stdClass
  * @group regressiontest
  */
-class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTest {
+class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTest
+{
     /**
      * testTrueKeywordInNamespace
      *
      * @return void
      */
-    public function testTrueKeywordInNamespace() {
+    public function testTrueKeywordInNamespace()
+    {
         $this->parseCodeResourceForTest();
     }
 
@@ -66,7 +68,8 @@ class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTes
      *
      * @return void
      */
-    public function testFalseKeywordInNamespace() {
+    public function testFalseKeywordInNamespace()
+    {
         $this->parseCodeResourceForTest();
     }
 }

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -200,7 +200,7 @@ class EngineTest extends AbstractTest
     public function testCountClassesWithoutAnalyzeFail()
     {
         $this->setExpectedException(
-            'RuntimeException', 
+            'RuntimeException',
             'countClasses() doesn\'t work before the source was analyzed.'
         );
         
@@ -255,8 +255,8 @@ class EngineTest extends AbstractTest
         $engine->analyze();
         
         $namespaces = array(
-            'package1', 
-            'package2', 
+            'package1',
+            'package2',
             'package3'
         );
         

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -188,7 +188,9 @@ class ExcludePathFilterTest extends AbstractTest
      */
     public function testExcludePathFilterRejectsFilesAndDirectories()
     {
-        $actual   = $this->createFilteredFileList(array(DIRECTORY_SEPARATOR . 'package1', DIRECTORY_SEPARATOR . 'file3.php'));
+        $actual   = $this->createFilteredFileList(
+            array(DIRECTORY_SEPARATOR . 'package1', DIRECTORY_SEPARATOR . 'file3.php')
+        );
         $expected = array('file2.php');
 
         $this->assertEquals($expected, $actual);
@@ -215,7 +217,7 @@ class ExcludePathFilterTest extends AbstractTest
         $actual = array();
         foreach ($files as $file) {
             if ($filter->accept($file, $file)
-                && $file->isFile() 
+                && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')
             ) {
                 $actual[] = $file->getFilename();

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -102,7 +102,7 @@ class ExtensionFilterTest extends AbstractTest
         $actual = array();
         foreach ($files as $file) {
             if ($filter->accept($file, $file)
-                && $file->isFile() 
+                && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')
             ) {
                 $actual[] = $file->getFilename();

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -83,7 +83,7 @@ class IteratorTest extends AbstractTest
 
     /**
      * Tests that iterator returns only files.
-     * 
+     *
      * @return void
      */
     public function testIteratorReturnsOnlyFiles()
@@ -104,7 +104,7 @@ class IteratorTest extends AbstractTest
 
         $expected = array('file.php', 'file_process.php');
         
-        $this->assertEquals($expected,$actual);
+        $this->assertEquals($expected, $actual);
     }
     
     /**

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -51,8 +51,7 @@ namespace PDepend\Issues;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class HandlingOfIdeStyleDependenciesInCommentsIssue087Test
-    extends AbstractFeatureTest
+class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatureTest
 {
     /**
      * Tests that the parser recognizes a inline type definition within a comment.

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -62,7 +62,7 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTest
      *
      * @param string $actual   The actual used type identifier.
      * @param string $expected The expected primitive type image.
-     * 
+     *
      * @return void
      * @dataProvider dataProviderParserSetsExpectedPrimitivePropertyType
      */

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -180,7 +180,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTest
         $this->setExpectedException(
             '\\PDepend\\Source\\Parser\\UnexpectedTokenException',
             'Unexpected token: ;, line: 2, col: 18, file: '
-
         );
 
         $this->parseSource('issues/002-008-namespace-declaration.php');
@@ -197,7 +196,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTest
         $this->setExpectedException(
             '\\PDepend\\Source\\Parser\\UnexpectedTokenException',
             'Unexpected token: {, line: 2, col: 13, file: '
-
         );
 
         $this->parseSource('issues/002-009-namespace-declaration.php');

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -113,7 +113,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
      */
     public function testParserSetsExpectedNumberOfMethodParameters()
     {
-        $parameters = $this->_getParametersOfFirstMethod();
+        $parameters = $this->getParametersOfFirstMethod();
         $this->assertEquals(3, count($parameters));
     }
 
@@ -125,7 +125,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
     public function testParserSetsExpectedPositionOfMethodParameters()
     {
         $actual = array();
-        foreach ($this->_getParametersOfFirstMethod() as $parameter) {
+        foreach ($this->getParametersOfFirstMethod() as $parameter) {
             $actual[] = $parameter->getPosition();
         }
         $this->assertEquals(array(0, 1, 2), $actual);
@@ -139,7 +139,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
     public function testParserSetsMethodParametersInExpectedOrder()
     {
         $actual = array();
-        foreach ($this->_getParametersOfFirstMethod() as $parameter) {
+        foreach ($this->getParametersOfFirstMethod() as $parameter) {
             $actual[] = $parameter->getName();
         }
         $this->assertEquals(array('$foo', '$bar', '$foobar'), $actual);
@@ -153,7 +153,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
     public function testParserSetsExpectedTypeHintsForMethodParameters()
     {
         $actual = array();
-        foreach ($this->_getParametersOfFirstMethod() as $parameter) {
+        foreach ($this->getParametersOfFirstMethod() as $parameter) {
             $actual[] = is_null($parameter->getClass());
         }
         $this->assertEquals(array(true, false, true), $actual);
@@ -164,7 +164,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
      *
      * @return \PDepend\Source\AST\ASTParameter[]
      */
-    private function _getParametersOfFirstMethod()
+    private function getParametersOfFirstMethod()
     {
         $namespaces = $this->parseTestCase();
         return $namespaces->current()

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -171,7 +171,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForNullDefaultValue
-     * 
+     *
      * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForNullDefaultValue()
@@ -481,7 +481,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsUserDefinedFlagForClass()
     {
-        $actual = $this->_getFirstClass()->isUserDefined();
+        $actual = $this->getFirstClass()->isUserDefined();
         $this->assertTrue($actual);
     }
 
@@ -493,7 +493,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserNotSetsUserDefinedFlagForUnknownClass()
     {
-        $class  = $this->_getFirstClass();
+        $class  = $this->getFirstClass();
         $actual = $class->getParentClass()->isUserDefined();
 
         $this->assertFalse($actual);
@@ -506,7 +506,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsUserDefinedFlagForInterface()
     {
-        $this->assertTrue($this->_getFirstInterface()->isUserDefined());
+        $this->assertTrue($this->getFirstInterface()->isUserDefined());
     }
 
     /**
@@ -517,7 +517,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserNotSetsUserDefinedFlagForUnknownInterface()
     {
-        $interface = $this->_getFirstInterface()->getInterfaces()->current();
+        $interface = $this->getFirstInterface()->getInterfaces()->current();
         $this->assertFalse($interface->isUserDefined());
     }
 
@@ -529,7 +529,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserFlagsFunctionWithReturnsReference()
     {
-        $this->assertTrue($this->_getFirstFunction()->returnsReference());
+        $this->assertTrue($this->getFirstFunction()->returnsReference());
     }
 
     /**
@@ -540,7 +540,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserDoesNotFlagFunctionWithReturnsReference()
     {
-        $this->assertFalse($this->_getFirstFunction()->returnsReference());
+        $this->assertFalse($this->getFirstFunction()->returnsReference());
     }
 
     /**
@@ -551,7 +551,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserFlagsClassMethodWithReturnsReferences()
     {
-        $actual = $this->_getFirstMethod()->returnsReference();
+        $actual = $this->getFirstMethod()->returnsReference();
         $this->assertTrue($actual);
     }
 
@@ -563,7 +563,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserDoesNotFlagClassMethodWithReturnsReferences()
     {
-        $actual = $this->_getFirstMethod()->returnsReference();
+        $actual = $this->getFirstMethod()->returnsReference();
         $this->assertFalse($actual);
     }
 
@@ -575,7 +575,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsFunctionStaticVariableSingleUninitialized()
     {
-        $actual   = $this->_getFirstFunction()->getStaticVariables();
+        $actual   = $this->getFirstFunction()->getStaticVariables();
         $expected = array('x' => null);
 
         $this->assertEquals($expected, $actual);
@@ -589,7 +589,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsFunctionStaticVariableSingleInitialized()
     {
-        $actual   = $this->_getFirstFunction()->getStaticVariables();
+        $actual   = $this->getFirstFunction()->getStaticVariables();
         $expected = array('x' => 42);
 
         $this->assertEquals($expected, $actual);
@@ -603,7 +603,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsFunctionStaticVariablesInSingleDeclaration()
     {
-        $actual   = $this->_getFirstFunction()->getStaticVariables();
+        $actual   = $this->getFirstFunction()->getStaticVariables();
         $expected = array('x' => true, 'y' => null, 'z' => array());
 
         $this->assertEquals($expected, $actual);
@@ -617,7 +617,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserSetsFunctionStaticVariablesInMultipleDeclarations()
     {
-        $actual   = $this->_getFirstFunction()->getStaticVariables();
+        $actual   = $this->getFirstFunction()->getStaticVariables();
         $expected = array('x' => false, 'y' => null, 'z' => 3.14);
 
         $this->assertEquals($expected, $actual);
@@ -630,7 +630,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserStaticVariablesDoNotConflictWithStaticInvoke()
     {
-        $actual   = $this->_getFirstMethod()->getStaticVariables();
+        $actual   = $this->getFirstMethod()->getStaticVariables();
         $expected = array();
 
         $this->assertEquals($expected, $actual);
@@ -643,7 +643,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      */
     public function testParserStaticVariablesDoNotConflictWithStaticAllocation()
     {
-        $actual   = $this->_getFirstMethod()->getStaticVariables();
+        $actual   = $this->getFirstMethod()->getStaticVariables();
         $expected = array('x' => true, 'y' => false);
 
         $this->assertEquals($expected, $actual);
@@ -680,7 +680,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      *
      * @return \PDepend\Source\AST\ASTInterface
      */
-    private function _getFirstInterface()
+    private function getFirstInterface()
     {
         $namespaces = $this->parseTestCase();
         return $namespaces->current()
@@ -693,7 +693,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      *
      * @return \PDepend\Source\AST\ASTClass
      */
-    private function _getFirstClass()
+    private function getFirstClass()
     {
         $namespaces = $this->parseTestCase();
         return $namespaces->current()
@@ -706,7 +706,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      *
      * @return \PDepend\Source\AST\ASTMethod
      */
-    private function _getFirstMethod()
+    private function getFirstMethod()
     {
         $namespaces = $this->parseTestCase();
         return $namespaces->current()
@@ -721,7 +721,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
      *
      * @return \PDepend\Source\AST\ASTFunction
      */
-    private function _getFirstFunction()
+    private function getFirstFunction()
     {
         $namespaces = $this->parseTestCase();
         return $namespaces->current()

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -110,7 +110,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
     {
         $this->assertEquals(
             array('impl', 'cis', 'csz', 'npm', 'vars', 'varsi', 'varsnp', 'wmc', 'wmci', 'wmcnp'),
-            array_keys($this->_calculateClassMetrics())
+            array_keys($this->calculateClassMetrics())
         );
     }
 
@@ -121,7 +121,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetric()
     {
-        $this->assertEquals(4, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(4, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -131,7 +131,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetric1()
     {
-        $this->assertEquals(6, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(6, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -141,7 +141,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetric2()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(2, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -151,7 +151,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetricContainsUnknownImplementedInterface()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(1, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -161,7 +161,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetricContainsUnknownIndirectImplementedInterface()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(1, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -171,7 +171,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateIMPLMetricContainsInternalImplementedInterface()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('impl'));
+        $this->assertEquals(1, $this->calculateClassMetric('impl'));
     }
 
     /**
@@ -181,7 +181,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCISMetricZeroInheritance()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('cis'));
+        $this->assertEquals(2, $this->calculateClassMetric('cis'));
     }
 
     /**
@@ -191,7 +191,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCISMetricOneLevelInheritance()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('cis'));
+        $this->assertEquals(2, $this->calculateClassMetric('cis'));
     }
 
     /**
@@ -201,7 +201,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCISMetricTwoLevelInheritance()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('cis'));
+        $this->assertEquals(3, $this->calculateClassMetric('cis'));
     }
 
     /**
@@ -211,7 +211,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCISMetricOnlyCountsMethodsAndNotSumsComplexity()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('cis'));
+        $this->assertEquals(2, $this->calculateClassMetric('cis'));
     }
 
     /**
@@ -221,7 +221,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCSZMetricZeroInheritance()
     {
-        $this->assertEquals(6, $this->_calculateClassMetric('csz'));
+        $this->assertEquals(6, $this->calculateClassMetric('csz'));
     }
 
     /**
@@ -231,7 +231,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCSZMetricOneLevelInheritance()
     {
-        $this->assertEquals(4, $this->_calculateClassMetric('csz'));
+        $this->assertEquals(4, $this->calculateClassMetric('csz'));
     }
 
     /**
@@ -241,7 +241,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCSZMetricOnlyCountsMethodsAndNotSumsComplexity()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('csz'));
+        $this->assertEquals(2, $this->calculateClassMetric('csz'));
     }
 
     /**
@@ -251,7 +251,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForEmptyClass()
     {
-        $this->assertEquals(0, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(0, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -261,7 +261,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithPublicMethod()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(1, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -271,7 +271,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithPublicMethods()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(3, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -281,7 +281,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithPublicStaticMethod()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(1, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -291,7 +291,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithProtectedMethod()
     {
-        $this->assertEquals(0, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(0, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -301,7 +301,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithPrivateMethod()
     {
-        $this->assertEquals(0, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(0, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -311,7 +311,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateNpmMetricForClassWithAllVisibilityMethods()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('npm'));
+        $this->assertEquals(1, $this->calculateClassMetric('npm'));
     }
 
     /**
@@ -321,7 +321,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSMetricZeroInheritance()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('vars'));
+        $this->assertEquals(1, $this->calculateClassMetric('vars'));
     }
 
     /**
@@ -331,7 +331,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSMetricOneLevelInheritance()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('vars'));
+        $this->assertEquals(3, $this->calculateClassMetric('vars'));
     }
 
     /**
@@ -341,7 +341,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSiMetric()
     {
-        $this->assertEquals(4, $this->_calculateClassMetric('varsi'));
+        $this->assertEquals(4, $this->calculateClassMetric('varsi'));
     }
 
     /**
@@ -351,7 +351,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSiMetricWithInheritance()
     {
-        $this->assertEquals(5, $this->_calculateClassMetric('varsi'));
+        $this->assertEquals(5, $this->calculateClassMetric('varsi'));
     }
 
     /**
@@ -361,7 +361,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSnpMetric()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('varsnp'));
+        $this->assertEquals(2, $this->calculateClassMetric('varsnp'));
     }
 
     /**
@@ -371,7 +371,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateVARSnpMetricWithInheritance()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('varsnp'));
+        $this->assertEquals(1, $this->calculateClassMetric('varsnp'));
     }
 
     /**
@@ -381,7 +381,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCMetric()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('wmc'));
+        $this->assertEquals(3, $this->calculateClassMetric('wmc'));
     }
 
     /**
@@ -391,7 +391,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCMetricOneLevelInheritance()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('wmc'));
+        $this->assertEquals(3, $this->calculateClassMetric('wmc'));
     }
 
     /**
@@ -401,7 +401,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCMetricTwoLevelInheritance()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('wmc'));
+        $this->assertEquals(3, $this->calculateClassMetric('wmc'));
     }
 
     /**
@@ -411,7 +411,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCiMetric()
     {
-        $this->assertEquals(3, $this->_calculateClassMetric('wmci'));
+        $this->assertEquals(3, $this->calculateClassMetric('wmci'));
     }
 
     /**
@@ -421,7 +421,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCiMetricOneLevelInheritance()
     {
-        $this->assertEquals(4, $this->_calculateClassMetric('wmci'));
+        $this->assertEquals(4, $this->calculateClassMetric('wmci'));
     }
 
     /**
@@ -431,7 +431,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCiMetricTwoLevelInheritance()
     {
-        $this->assertEquals(5, $this->_calculateClassMetric('wmci'));
+        $this->assertEquals(5, $this->calculateClassMetric('wmci'));
     }
 
     /**
@@ -441,7 +441,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCnpMetric()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('wmcnp'));
+        $this->assertEquals(1, $this->calculateClassMetric('wmcnp'));
     }
 
     /**
@@ -451,7 +451,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCnpMetricOneLevelInheritance()
     {
-        $this->assertEquals(2, $this->_calculateClassMetric('wmcnp'));
+        $this->assertEquals(2, $this->calculateClassMetric('wmcnp'));
     }
 
     /**
@@ -461,7 +461,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateWMCnpMetricTwoLevelInheritance()
     {
-        $this->assertEquals(1, $this->_calculateClassMetric('wmcnp'));
+        $this->assertEquals(1, $this->calculateClassMetric('wmcnp'));
     }
 
     /**
@@ -472,9 +472,9 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      *
      * @return mixed
      */
-    private function _calculateClassMetric($name)
+    private function calculateClassMetric($name)
     {
-        $metrics = $this->_calculateClassMetrics();
+        $metrics = $this->calculateClassMetrics();
         return $metrics[$name];
     }
 
@@ -484,7 +484,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      *
      * @return mixed
      */
-    private function _calculateClassMetrics()
+    private function calculateClassMetrics()
     {
         $namespaces = $this->parseTestCaseSource($this->getCallingTestMethod());
 
@@ -506,7 +506,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsForTrait()
     {
-        $metrics = $this->_calculateTraitMetrics();
+        $metrics = $this->calculateTraitMetrics();
 
         $this->assertInternalType('array', $metrics);
 
@@ -677,7 +677,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTest
      * @return mixed
      * @since 1.0.6
      */
-    private function _calculateTraitMetrics()
+    private function calculateTraitMetrics()
     {
         $namespaces = $this->parseCodeResourceForTest();
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -100,7 +100,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithoutDependencies()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(0, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -110,7 +110,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithObjectInstantiation()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -120,7 +120,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithStaticReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -130,7 +130,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithReturnReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -140,7 +140,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithExceptionReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -150,7 +150,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithPropertyReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -160,7 +160,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaWithoutDuplicateCount()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -170,7 +170,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForParameterTypes()
     {
-        $this->assertEquals(3, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(3, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -180,7 +180,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForParentTypeReference()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(0, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -190,7 +190,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForChildTypeReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -200,7 +200,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -210,7 +210,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionException()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -220,7 +220,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionReturnType()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -230,7 +230,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionParameter()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -240,7 +240,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctions()
     {
-        $this->assertEquals(3, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(3, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -250,7 +250,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionCountsTypeOnce()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ca'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ca'));
     }
 
     /**
@@ -260,7 +260,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithoutDependencies()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(0, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -270,7 +270,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithObjectInstantiation()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -280,7 +280,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithStaticReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -290,7 +290,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithReturnReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -300,7 +300,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithExceptionReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(2, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -310,7 +310,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithPropertyReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -320,7 +320,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboWithoutDuplicateCount()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(2, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -330,7 +330,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboForParameterTypes()
     {
-        $this->assertEquals(3, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(3, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -340,7 +340,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboForParentTypeReference()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(0, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -350,7 +350,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboForChildTypeReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(2, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -360,7 +360,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboForUseInSameNamespace()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -370,7 +370,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCboForUseInPartialSameNamespace()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('cbo'));
+        $this->assertEquals(1, $this->calculateTypeMetric('cbo'));
     }
 
     /**
@@ -380,7 +380,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithoutDependencies()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(0, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -390,7 +390,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithObjectInstantiation()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -400,7 +400,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithStaticReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -410,7 +410,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithReturnReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -420,7 +420,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithExceptionReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -430,7 +430,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithPropertyReference()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -440,7 +440,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeWithoutDuplicateCount()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -450,7 +450,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeForParameterTypes()
     {
-        $this->assertEquals(3, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(3, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -460,7 +460,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeForParentTypeReference()
     {
-        $this->assertEquals(0, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(0, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -470,7 +470,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeForChildTypeReference()
     {
-        $this->assertEquals(2, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(2, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -480,7 +480,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeForUseInSameNamespace()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -490,7 +490,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsExpectedCeForUseInPartialSameNamespace()
     {
-        $this->assertEquals(1, $this->_calculateTypeMetric('ce'));
+        $this->assertEquals(1, $this->calculateTypeMetric('ce'));
     }
 
     /**
@@ -501,7 +501,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      *
      * @return mixed
      */
-    private function _calculateTypeMetric($name)
+    private function calculateTypeMetric($name)
     {
         $namespaces = $this->parseCodeResourceForTest();
         $types = $namespaces[0]->getTypes();
@@ -521,7 +521,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerGetProjectMetricsReturnsArrayWithExpectedKeys()
     {
         $expected = array('calls', 'fanout');
-        $actual   = array_keys($this->_calculateProjectMetrics());
+        $actual   = array_keys($this->calculateProjectMetrics());
 
         $this->assertEquals($expected, $actual);
     }
@@ -535,7 +535,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerCalculatesCorrectFunctionCoupling()
     {
         $expected = array('calls' => 10, 'fanout' => 7);
-        $actual   = $this->_calculateProjectMetrics();
+        $actual   = $this->calculateProjectMetrics();
 
         $this->assertEquals($expected, $actual);
     }
@@ -549,7 +549,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerCalculatesCorrectMethodCoupling()
     {
         $expected = array('calls' => 10, 'fanout' => 9);
-        $actual   = $this->_calculateProjectMetrics();
+        $actual   = $this->calculateProjectMetrics();
 
         $this->assertEquals($expected, $actual);
     }
@@ -563,7 +563,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerCalculatesCorrectPropertyCoupling()
     {
         $expected = array('calls' => 0, 'fanout' => 3);
-        $actual   = $this->_calculateProjectMetrics();
+        $actual   = $this->calculateProjectMetrics();
 
         $this->assertEquals($expected, $actual);
     }
@@ -577,7 +577,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerCalculatesCorrectClassCoupling()
     {
         $expected = array('calls' => 10, 'fanout' => 12);
-        $actual   = $this->_calculateProjectMetrics();
+        $actual   = $this->calculateProjectMetrics();
 
         $this->assertEquals($expected, $actual);
     }
@@ -591,7 +591,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
     public function testAnalyzerCalculatesCorrectCoupling()
     {
         $expected = array('calls' => 30, 'fanout' => 31);
-        $actual   = $this->_calculateProjectMetrics();
+        $actual   = $this->calculateProjectMetrics();
 
         $this->assertEquals($expected, $actual);
     }
@@ -604,7 +604,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsForTrait()
     {
-        $metrics = $this->_calculateTraitMetrics();
+        $metrics = $this->calculateTraitMetrics();
         $this->assertInternalType('array', $metrics);
 
         return $metrics;
@@ -732,7 +732,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      * @return mixed
      * @since 1.0.6
      */
-    private function _calculateTraitMetrics()
+    private function calculateTraitMetrics()
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -758,7 +758,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
         $fanout
     ) {
         $expected = array('calls' => $calls, 'fanout' => $fanout);
-        $actual   = $this->_calculateProjectMetrics($testCase);
+        $actual   = $this->calculateProjectMetrics($testCase);
 
         $this->assertEquals($expected, $actual);
     }
@@ -772,7 +772,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTest
      * @return array(string=>mixed)
      * @since 0.10.2
      */
-    private function _calculateProjectMetrics($testCase = null)
+    private function calculateProjectMetrics($testCase = null)
     {
         $testCase = ($testCase ? $testCase : $this->getCallingTestMethod());
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -88,7 +88,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyzerIsEnabledReturnsTrueWhenCoverageReportFileWasSupplied()
     {
-        $options  = array('coverage-report' => $this->_createCloverReportFile());
+        $options  = array('coverage-report' => $this->createCloverReportFile());
         $analyzer = new CrapIndexAnalyzer($options);
 
         $this->assertTrue($analyzer->isEnabled());
@@ -96,34 +96,34 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
 
     /**
      * testAnalyzerIgnoresAbstractMethods
-     * 
+     *
      * @return void
      */
     public function testAnalyzerIgnoresAbstractMethods()
     {
-        $metrics = $this->_calculateCrapIndex(__METHOD__, 42);
+        $metrics = $this->calculateCrapIndex(__METHOD__, 42);
         $this->assertSame(array(), $metrics);
     }
 
     /**
      * testAnalyzerIgnoresInterfaceMethods
-     * 
+     *
      * @return void
      */
     public function testAnalyzerIgnoresInterfaceMethods()
     {
-        $metrics = $this->_calculateCrapIndex(__METHOD__, 42);
+        $metrics = $this->calculateCrapIndex(__METHOD__, 42);
         $this->assertSame(array(), $metrics);
     }
 
     /**
      * testAnalyzerReturnsExpectedResultForMethodWithoutCoverage
-     * 
+     *
      * @return void
      */
     public function testAnalyzerReturnsExpectedResultForMethodWithoutCoverage()
     {
-        $this->_testCrapIndexCalculation(__METHOD__, 12, 156);
+        $this->doTestCrapIndexCalculation(__METHOD__, 12, 156);
     }
 
     /**
@@ -133,7 +133,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyzerReturnsExpectedResultForMethodWith100PercentCoverage()
     {
-        $this->_testCrapIndexCalculation(__METHOD__, 12, 12);
+        $this->doTestCrapIndexCalculation(__METHOD__, 12, 12);
     }
 
     /**
@@ -143,7 +143,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyzerReturnsExpectedResultForMethodWith50PercentCoverage()
     {
-        $this->_testCrapIndexCalculation(__METHOD__, 12, 30);
+        $this->doTestCrapIndexCalculation(__METHOD__, 12, 30);
     }
 
     /**
@@ -153,7 +153,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyterReturnsExpectedResultForMethodWithoutCoverageData()
     {
-        $this->_testCrapIndexCalculation(__METHOD__, 12, 156);
+        $this->doTestCrapIndexCalculation(__METHOD__, 12, 156);
     }
 
     /**
@@ -163,7 +163,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyterReturnsExpectedResultForFunctionWithoutCoverageData()
     {
-        $this->_testCrapIndexCalculation(__METHOD__, 12, 156);
+        $this->doTestCrapIndexCalculation(__METHOD__, 12, 156);
     }
 
     /**
@@ -175,9 +175,9 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      *
      * @return void
      */
-    private function _testCrapIndexCalculation($testCase, $ccn, $crapIndex)
+    private function doTestCrapIndexCalculation($testCase, $ccn, $crapIndex)
     {
-        $metrics = $this->_calculateCrapIndex($testCase, $ccn);
+        $metrics = $this->calculateCrapIndex($testCase, $ccn);
         $this->assertEquals($crapIndex, $metrics['crap'], '', 0.005);
     }
 
@@ -189,13 +189,13 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      *
      * @return array
      */
-    private function _calculateCrapIndex($testCase, $ccn)
+    private function calculateCrapIndex($testCase, $ccn)
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $options  = array('coverage-report' => $this->_createCloverReportFile());
+        $options  = array('coverage-report' => $this->createCloverReportFile());
         $analyzer = new CrapIndexAnalyzer($options);
-        $analyzer->addAnalyzer($this->_createCyclomaticComplexityAnalyzerMock($ccn));
+        $analyzer->addAnalyzer($this->createCyclomaticComplexityAnalyzerMock($ccn));
         $analyzer->analyze($namespaces);
 
         $namespaces->rewind();
@@ -221,7 +221,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      *
      * @return string
      */
-    private function _createCloverReportFile()
+    private function createCloverReportFile()
     {
         $pathName = $this->createRunResourceURI('clover.xml');
 
@@ -239,7 +239,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
      * @param integer $ccn
      * @return \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
      */
-    private function _createCyclomaticComplexityAnalyzerMock($ccn = 42)
+    private function createCyclomaticComplexityAnalyzerMock($ccn = 42)
     {
         $mock = $this->getMockBuilder('PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer')
             ->getMock();

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -82,7 +82,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetCCNReturnsZeroForUnknownNode()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
             ->getMock();
         $this->assertEquals(0, $analyzer->getCcn($astArtifact));
@@ -95,7 +95,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetCCN2ReturnsZeroForUnknownNode()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
             ->getMock();
         $this->assertEquals(0, $analyzer->getCcn2($astArtifact));
@@ -110,7 +110,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = array();
@@ -136,7 +136,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateFunctionCCNAndCNN2ProjectMetrics()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 12, 'ccn2' => 16);
@@ -154,7 +154,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $classes = $namespaces[0]->getClasses();
@@ -184,7 +184,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCCNWithConditionalExprInCompoundExpr()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 2, 'ccn2' => 2);
@@ -203,7 +203,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
         $namespaces = $this->parseCodeResourceForTest();
         $functions = $namespaces[0]->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $this->assertEquals(3, $analyzer->getCcn($functions[0]));
@@ -219,7 +219,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
         $namespaces = $this->parseCodeResourceForTest();
         $functions = $namespaces[0]->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $this->assertEquals(3, $analyzer->getCcn2($functions[0]));
@@ -232,7 +232,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCCNIgnoresDefaultLabelInSwitchStatement()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 3, 'ccn2' => 3);
@@ -248,7 +248,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCCNCountsAllCaseLabelsInSwitchStatement()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 4, 'ccn2' => 4);
@@ -264,7 +264,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCCNDetectsExpressionsInAForLoop()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 2, 'ccn2' => 4);
@@ -280,7 +280,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateCCNDetectsExpressionsInAWhileLoop()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 2, 'ccn2' => 4);
@@ -296,7 +296,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateProjectMetrics()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
         
         $expected = array('ccn' => 24, 'ccn2' => 32);
@@ -312,7 +312,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testAnalyzerAlsoCalculatesCCNAndCCN2OfClosureInMethod()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $expected = array('ccn' => 3, 'ccn2' => 3);
@@ -332,12 +332,12 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
         $namespaces = $this->parseCodeResourceForTest();
         $functions = $namespaces[0]->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($functions[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($functions[0]);
@@ -357,12 +357,12 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
         $classes = $namespaces[0]->getClasses();
         $methods = $classes[0]->getMethods();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($methods[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($methods[0]);
@@ -376,7 +376,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
      * @since 1.0.0
      */
-    private function _createAnalyzer()
+    private function createAnalyzer()
     {
         $analyzer = new CyclomaticComplexityAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -82,7 +82,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsNothingForUnknownNode()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
             ->getMock();
         $this->assertEquals(array(), $analyzer->getNodeMetrics($astArtifact));
@@ -98,7 +98,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = array();
@@ -127,7 +127,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = array();
@@ -176,7 +176,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $classes = $namespaces[0]->getClasses();
@@ -208,7 +208,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $classes = $namespaces[0]->getClasses();
@@ -261,12 +261,12 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
         $namespaces = $this->parseCodeResourceForTest();
         $functions = $namespaces[0]->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($functions[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($functions[0]);
@@ -286,12 +286,12 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
         $classes = $namespaces[0]->getClasses();
         $methods = $classes[0]->getMethods();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($methods[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($methods[0]);
@@ -305,7 +305,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Metrics\Analyzer\HalsteadAnalyzer
      * @since 1.0.0
      */
-    private function _createAnalyzer()
+    private function createAnalyzer()
     {
         $analyzer = new HalsteadAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -104,7 +104,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoccMetricForClassWithoutChildren()
     {
-        $this->assertEquals(0, $this->_getCalculatedMetric(__METHOD__, 'nocc'));
+        $this->assertEquals(0, $this->getCalculatedMetric(__METHOD__, 'nocc'));
     }
 
     /**
@@ -114,7 +114,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoccMetricForClassWithDirectChildren()
     {
-        $this->assertEquals(3, $this->_getCalculatedMetric(__METHOD__, 'nocc'));
+        $this->assertEquals(3, $this->getCalculatedMetric(__METHOD__, 'nocc'));
     }
 
     /**
@@ -124,7 +124,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoccMetricForClassWithDirectAndIndirectChildren()
     {
-        $this->assertEquals(1, $this->_getCalculatedMetric(__METHOD__, 'nocc'));
+        $this->assertEquals(1, $this->getCalculatedMetric(__METHOD__, 'nocc'));
     }
 
     /**
@@ -134,7 +134,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricNoInheritance()
     {
-        $this->assertEquals(0, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(0, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -144,7 +144,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricOneLevelInheritance()
     {
-        $this->assertEquals(1, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(1, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -154,7 +154,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricTwoLevelNoInheritance()
     {
-        $this->assertEquals(2, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(2, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -164,7 +164,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricThreeLevelNoInheritance()
     {
-        $this->assertEquals(3, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(3, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -174,7 +174,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricFourLevelNoInheritance()
     {
-        $this->assertEquals(4, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(4, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -184,7 +184,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricForUnknownParentIncrementsMetricWithTwo()
     {
-        $this->assertEquals(3, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(3, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -194,7 +194,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculateDITMetricForInternalParentIncrementsMetricWithTwo()
     {
-        $this->assertEquals(3, $this->_getCalculatedMetric(__METHOD__, 'dit'));
+        $this->assertEquals(3, $this->getCalculatedMetric(__METHOD__, 'dit'));
     }
 
     /**
@@ -250,7 +250,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoamMetricForClassWithoutParent()
     {
-        $this->assertEquals(0, $this->_getCalculatedMetric(__METHOD__, 'noam'));
+        $this->assertEquals(0, $this->getCalculatedMetric(__METHOD__, 'noam'));
     }
 
     /**
@@ -260,7 +260,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoamMetricForClassWithDirectParent()
     {
-        $this->assertEquals(2, $this->_getCalculatedMetric(__METHOD__, 'noam'));
+        $this->assertEquals(2, $this->getCalculatedMetric(__METHOD__, 'noam'));
     }
 
     /**
@@ -270,7 +270,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoamMetricForClassWithIndirectParent()
     {
-        $this->assertEquals(2, $this->_getCalculatedMetric(__METHOD__, 'noam'));
+        $this->assertEquals(2, $this->getCalculatedMetric(__METHOD__, 'noam'));
     }
 
     /**
@@ -280,7 +280,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoomMetricForClassWithoutParent()
     {
-        $this->assertEquals(0, $this->_getCalculatedMetric(__METHOD__, 'noom'));
+        $this->assertEquals(0, $this->getCalculatedMetric(__METHOD__, 'noom'));
     }
 
     /**
@@ -290,7 +290,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoomMetricForClassWithParent()
     {
-        $this->assertEquals(2, $this->_getCalculatedMetric(__METHOD__, 'noom'));
+        $this->assertEquals(2, $this->getCalculatedMetric(__METHOD__, 'noom'));
     }
 
     /**
@@ -300,7 +300,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedNoomMetricForClassWithParentPrivateMethods()
     {
-        $this->assertEquals(1, $this->_getCalculatedMetric(__METHOD__, 'noom'));
+        $this->assertEquals(1, $this->getCalculatedMetric(__METHOD__, 'noom'));
     }
 
     /**
@@ -328,7 +328,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
      *
      * @return mixed
      */
-    private function _getCalculatedMetric($testCase, $metric)
+    private function getCalculatedMetric($testCase, $metric)
     {
         $namespaces = $this->parseTestCaseSource($testCase);
         $namespace  = $namespaces->current();

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -82,7 +82,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
      */
     public function testGetNodeMetricsReturnsNothingForUnknownNode()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
             ->getMock();
         $this->assertEquals(array(), $analyzer->getNodeMetrics($astArtifact));
@@ -98,7 +98,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = array();
@@ -127,7 +127,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $classes = $namespaces[0]->getClasses();
@@ -161,12 +161,12 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
         $namespaces = $this->parseCodeResourceForTest();
         $functions = $namespaces[0]->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($functions[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($functions[0]);
@@ -186,12 +186,12 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
         $classes = $namespaces[0]->getClasses();
         $methods = $classes[0]->getMethods();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($methods[0]);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($methods[0]);
@@ -205,7 +205,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
      * @since 1.0.0
      */
-    private function _createAnalyzer()
+    private function createAnalyzer()
     {
         $analyzer = new MaintainabilityIndexAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -89,12 +89,12 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
             ->getFunctions()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($function);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($function);
@@ -117,12 +117,12 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
             ->getMethods()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($method);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($method);
@@ -138,7 +138,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForNestedIfStatementsWithScope()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -149,7 +149,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForNestedIfStatementsWithoutScope()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -160,7 +160,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSiblingConditionalExpressions()
     {
-        $this->assertEquals(4, $this->_calculateFunctionMetric());
+        $this->assertEquals(4, $this->calculateFunctionMetric());
     }
 
     /**
@@ -173,7 +173,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSiblingExpressions()
     {
-        $this->assertEquals(6, $this->_calculateFunctionMetric());
+        $this->assertEquals(6, $this->calculateFunctionMetric());
     }
 
     /**
@@ -184,7 +184,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForTwoSiblingIfStatetements()
     {
-        $this->assertEquals(4, $this->_calculateFunctionMetric());
+        $this->assertEquals(4, $this->calculateFunctionMetric());
     }
 
     /**
@@ -195,7 +195,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForForeachStatementWithNestedIfStatetements()
     {
-        $this->assertEquals(3, $this->_calculateFunctionMetric());
+        $this->assertEquals(3, $this->calculateFunctionMetric());
     }
 
     /**
@@ -206,7 +206,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSiblingIfStatementsAndForeachStatement()
     {
-        $this->assertEquals(12, $this->_calculateFunctionMetric());
+        $this->assertEquals(12, $this->calculateFunctionMetric());
     }
 
     /**
@@ -217,7 +217,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForComplexFunction()
     {
-        $this->assertEquals(24, $this->_calculateFunctionMetric());
+        $this->assertEquals(24, $this->calculateFunctionMetric());
     }
 
     /**
@@ -228,7 +228,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForComplexNestedControlStatements()
     {
-        $this->assertEquals(63, $this->_calculateFunctionMetric());
+        $this->assertEquals(63, $this->calculateFunctionMetric());
     }
     
     /**
@@ -239,7 +239,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConditionalsInArrayDeclaration()
     {
-        $this->assertEquals(16, $this->_calculateFunctionMetric());
+        $this->assertEquals(16, $this->calculateFunctionMetric());
     }
 
     /**
@@ -249,7 +249,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityIsZeroForEmptyMethod()
     {
-        $this->assertEquals(1, $this->_calculateMethodMetric());
+        $this->assertEquals(1, $this->calculateMethodMetric());
     }
 
     /**
@@ -259,7 +259,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForMethodWithSimpleIfStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -269,7 +269,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForIfStatementWithNestedDynamicIdentifier()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -279,7 +279,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConsecutiveIfStatements()
     {
-        $this->assertEquals(80, $this->_calculateMethodMetric());
+        $this->assertEquals(80, $this->calculateMethodMetric());
     }
 
     /**
@@ -289,7 +289,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConsecutiveIfElseIfStatements()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -299,7 +299,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConsecutiveIfElsifStatements()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -309,7 +309,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForEmptyWhileStatement()
     {
-        $this->assertEquals(3, $this->_calculateMethodMetric());
+        $this->assertEquals(3, $this->calculateMethodMetric());
     }
 
     /**
@@ -319,7 +319,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForNestedWhileStatements()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->calculateMethodMetric());
     }
 
     /**
@@ -329,7 +329,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleDoWhileStatement()
     {
-        $this->assertEquals(3, $this->_calculateMethodMetric());
+        $this->assertEquals(3, $this->calculateMethodMetric());
     }
 
     /**
@@ -339,7 +339,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleForStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -349,7 +349,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForComplexForStatement()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -359,7 +359,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleForeachStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -369,7 +369,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleReturnStatement()
     {
-        $this->assertEquals(1, $this->_calculateMethodMetric());
+        $this->assertEquals(1, $this->calculateMethodMetric());
     }
 
     /**
@@ -379,7 +379,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForReturnStatementWithBooleanExpressions()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -389,7 +389,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForReturnStatementWithConditionalStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -400,7 +400,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleSwitchStatement()
     {
-        $this->assertEquals(1, $this->_calculateMethodMetric());
+        $this->assertEquals(1, $this->calculateMethodMetric());
     }
 
     /**
@@ -411,7 +411,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSwitchStatementWithMultipleCaseStatements()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->calculateMethodMetric());
     }
 
     /**
@@ -422,7 +422,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSwitchStatementWithComplexCaseStatements()
     {
-        $this->assertEquals(8, $this->_calculateMethodMetric());
+        $this->assertEquals(8, $this->calculateMethodMetric());
     }
 
     /**
@@ -432,7 +432,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleTryCatchStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -442,7 +442,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForTryStatementWithMutlipleCatchStatements()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->calculateMethodMetric());
     }
 
     /**
@@ -452,7 +452,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForTryCatchStatementWithNestedIfStatements()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->calculateMethodMetric());
     }
 
     /**
@@ -462,7 +462,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForSimpleConditionalStatement()
     {
-        $this->assertEquals(2, $this->_calculateMethodMetric());
+        $this->assertEquals(2, $this->calculateMethodMetric());
     }
 
     /**
@@ -472,7 +472,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForTwoNestedConditionalStatements()
     {
-        $this->assertEquals(4, $this->_calculateMethodMetric());
+        $this->assertEquals(4, $this->calculateMethodMetric());
     }
 
     /**
@@ -482,7 +482,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForThreeNestedConditionalStatements()
     {
-        $this->assertEquals(6, $this->_calculateMethodMetric());
+        $this->assertEquals(6, $this->calculateMethodMetric());
     }
 
     /**
@@ -493,7 +493,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForConditionalStatementWithLogicalExpressions()
     {
-        $this->assertEquals(5, $this->_calculateMethodMetric());
+        $this->assertEquals(5, $this->calculateMethodMetric());
     }
 
     /**
@@ -504,7 +504,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      */
     public function testNPathComplexityForReturnStatementWithConditional()
     {
-        $npath = $this->_calculateMethodMetric();
+        $npath = $this->calculateMethodMetric();
         $this->assertEquals(3, $npath);
     }
 
@@ -515,10 +515,10 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return integer
      * @since 0.9.12
      */
-    private function _calculateFunctionMetric()
+    private function calculateFunctionMetric()
     {
-        return $this->_calculateNPathComplexity(
-            $this->_getFirstFunctionForTestCase()
+        return $this->calculateNPathComplexity(
+            $this->getFirstFunctionForTestCaseInternal()
         );
     }
 
@@ -529,7 +529,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Source\AST\ASTFunction
      * @since 0.9.12
      */
-    private function _getFirstFunctionForTestCase()
+    private function getFirstFunctionForTestCaseInternal()
     {
         return $this->parseTestCaseSource($this->getCallingTestMethod())
             ->current()
@@ -544,10 +544,10 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return integer
      * @since 0.9.12
      */
-    private function _calculateMethodMetric()
+    private function calculateMethodMetric()
     {
-        return $this->_calculateNPathComplexity(
-            $this->_getFirstMethodForTestCase()
+        return $this->calculateNPathComplexity(
+            $this->getFirstMethodForTestCaseInternal()
         );
     }
 
@@ -558,7 +558,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Source\AST\ASTMethod
      * @since 0.9.12
      */
-    private function _getFirstMethodForTestCase()
+    private function getFirstMethodForTestCaseInternal()
     {
         return $this->parseTestCaseSource($this->getCallingTestMethod())
             ->current()
@@ -575,9 +575,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return string
      * @since 0.9.12
      */
-    private function _calculateNPathComplexity(AbstractASTCallable $callable)
+    private function calculateNPathComplexity(AbstractASTCallable $callable)
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $callable->accept($analyzer);
 
         $metrics = $analyzer->getNodeMetrics($callable);
@@ -590,7 +590,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
      * @since 1.0.0
      */
-    private function _createAnalyzer()
+    private function createAnalyzer()
     {
         $analyzer = new NPathComplexityAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -59,7 +59,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTest
 {
     /**
      * testVisitClassIgnoresClassesThatAreNotUserDefined
-     * 
+     *
      * @return void
      */
     public function testVisitClassIgnoresClassesThatAreNotUserDefined()

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -87,7 +87,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
         $functions = $namespaces->current()
             ->getFunctions();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $expected = array(
@@ -145,7 +145,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->current()
             ->getCompilationUnit();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getNodeMetrics($file);
@@ -172,7 +172,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($class);
@@ -191,7 +191,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($class);
@@ -210,7 +210,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($class);
@@ -230,7 +230,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->current()
             ->getCompilationUnit();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getNodeMetrics($file);
@@ -256,7 +256,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getNodeMetrics($class);
@@ -283,7 +283,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->current()
             ->getCompilationUnit();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getNodeMetrics($file);
@@ -309,7 +309,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getInterfaces()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getNodeMetrics($interface);
@@ -332,7 +332,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $actual   = $analyzer->getProjectMetrics();
@@ -361,7 +361,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getMethods()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($method);
@@ -382,7 +382,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getMethods()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($method);
@@ -401,7 +401,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($class);
@@ -420,7 +420,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($class);
@@ -434,7 +434,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedProjectLLocForFileWithInterfaces()
     {
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($this->parseTestCaseSource(__METHOD__));
 
         $metrics = $analyzer->getProjectMetrics();
@@ -455,12 +455,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->current()
             ->getCompilationUnit();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($file);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($file);
@@ -481,12 +481,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getClasses()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($class);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($class);
@@ -507,12 +507,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getInterfaces()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($interface);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($interface);
@@ -535,12 +535,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getMethods()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($method);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($method);
@@ -561,12 +561,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
             ->getFunctions()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getNodeMetrics($function);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getNodeMetrics($function);
@@ -584,12 +584,12 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics0 = $analyzer->getProjectMetrics();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics1 = $analyzer->getProjectMetrics();
@@ -604,7 +604,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForReturnStatement()
     {
-        $this->assertEquals(1, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(1, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -614,7 +614,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForIfAndElseIfStatement()
     {
-        $this->assertEquals(5, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(5, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -624,7 +624,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForForStatement()
     {
-        $this->assertEquals(3, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(3, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -634,7 +634,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForSwitchStatement()
     {
-        $this->assertEquals(7, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(7, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -644,7 +644,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForTryCatchStatement()
     {
-        $this->assertEquals(8, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(8, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -654,7 +654,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForForeachStatement()
     {
-        $this->assertEquals(2, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(2, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -664,7 +664,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForWhileStatement()
     {
-        $this->assertEquals(2, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(2, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -674,7 +674,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      */
     public function testCalculatesExpectedLLocForDoWhileStatement()
     {
-        $this->assertEquals(3, $this->_calculateFunctionMetric('lloc'));
+        $this->assertEquals(3, $this->calculateFunctionMetric('lloc'));
     }
 
     /**
@@ -687,7 +687,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
         $compilationUnit = new ASTCompilationUnit(null);
         $compilationUnit->setId(42);
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->visitCompilationUnit($compilationUnit);
 
         $metrics = $analyzer->getNodeMetrics($compilationUnit);
@@ -697,20 +697,20 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
     /**
      * Calculates the metrics of the code under test that is associated with
      * the calling test case and returns the metric value for <b>$name</b>.
-     *  
+     *
      * @param string $name The name of the requested metric.
      *
      * @return mixed
      * @since 0.10.2
      */
-    private function _calculateFunctionMetric($name)
+    private function calculateFunctionMetric($name)
     {
         $namespaces = $this->parseTestCaseSource($this->getCallingTestMethod());
         $function = $namespaces->current()
             ->getFunctions()
             ->current();
 
-        $analyzer = $this->_createAnalyzer();
+        $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
 
         $metrics = $analyzer->getNodeMetrics($function);
@@ -723,7 +723,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
      * @return \PDepend\Metrics\Analyzer\NodeLocAnalyzer
      * @since 1.0.0
      */
-    private function _createAnalyzer()
+    private function createAnalyzer()
     {
         $analyzer = new NodeLocAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -1113,8 +1113,7 @@ class ParserTest extends AbstractTest
             ->getClasses()
             ->current();
 
-        $this->assertSame(State::IS_FINAL, $class->getModifiers() & State::IS_FINAL
-        );
+        $this->assertSame(State::IS_FINAL, $class->getModifiers() & State::IS_FINAL);
     }
 
     /**

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -233,7 +233,7 @@ class XmlTest extends AbstractTest
         return preg_replace(
             array('(file\s+name="[^"]+")', '(generated="[^"]*")'),
             array('file name="' . __FILE__ . '"', 'generated=""'),
-             file_get_contents($fileName)
+            file_get_contents($fileName)
         );
     }
 }

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -78,7 +78,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      */
     public function __construct(array $options = array())
     {
-        
     }
     
     /**

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -68,7 +68,7 @@ class ChartTest extends AbstractTest
 
     /**
      * setUp()
-     * 
+     *
      * @return void
      */
     protected function setUp()
@@ -148,7 +148,7 @@ class ChartTest extends AbstractTest
      */
     public function testGeneratesCorrectSVGImageFile()
     {
-        $nodes = new ASTArtifactList($this->_createPackages(true, true));
+        $nodes = new ASTArtifactList($this->createPackages(true, true));
 
         $analyzer = new DependencyAnalyzer();
         $analyzer->analyze($nodes);
@@ -169,7 +169,7 @@ class ChartTest extends AbstractTest
      */
     public function testGeneratedSvgImageContainsExpectedPackages()
     {
-        $nodes = new ASTArtifactList($this->_createPackages(true, true));
+        $nodes = new ASTArtifactList($this->createPackages(true, true));
 
         $analyzer = new DependencyAnalyzer();
         $analyzer->analyze($nodes);
@@ -197,7 +197,7 @@ class ChartTest extends AbstractTest
      */
     public function testGeneratesSVGImageDoesNotContainNoneUserDefinedPackages()
     {
-        $nodes = new ASTArtifactList($this->_createPackages(true, false, true));
+        $nodes = new ASTArtifactList($this->createPackages(true, false, true));
 
         $analyzer = new DependencyAnalyzer();
         $analyzer->analyze($nodes);
@@ -224,7 +224,7 @@ class ChartTest extends AbstractTest
      */
     public function testCalculateCorrectEllipseSize()
     {
-        $nodes = $this->_createPackages(true, true);
+        $nodes = $this->createPackages(true, true);
 
         $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\DependencyAnalyzer')
             ->getMock();
@@ -302,7 +302,7 @@ class ChartTest extends AbstractTest
             unlink($fileName);
         }
 
-        $nodes = new ASTArtifactList($this->_createPackages(true, true));
+        $nodes = new ASTArtifactList($this->createPackages(true, true));
 
         $analyzer = new DependencyAnalyzer();
         $analyzer->analyze($nodes);
@@ -327,11 +327,11 @@ class ChartTest extends AbstractTest
     /**
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
-    private function _createPackages()
+    private function createPackages()
     {
         $packages = array();
         foreach (func_get_args() as $i => $userDefined) {
-            $packages[] = $this->_createPackage(
+            $packages[] = $this->createPackage(
                 $userDefined,
                 'package' . $i
             );
@@ -344,7 +344,7 @@ class ChartTest extends AbstractTest
      * @param string $packageName
      * @return \PDepend\Source\AST\ASTNamespace
      */
-    private function _createPackage($userDefined, $packageName)
+    private function createPackage($userDefined, $packageName)
     {
         $packageA = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTNamespace')
             ->setMethods(array('isUserDefined'))

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -190,8 +190,7 @@ class XmlTest extends AbstractTest
         return preg_replace(
             '(sourceFile="[^"]+/([^/"]+)")',
             'sourceFile="' . $path . '/\\1"',
-             file_get_contents($fileName)
+            file_get_contents($fileName)
         );
     }
-
 }

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -286,10 +286,10 @@ class PyramidTest extends AbstractTest
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
-                    array(
-                        'ccn2'  =>  5579
-                    )
-                ));
+                array(
+                    'ccn2'  =>  5579
+                )
+            ));
 
         return $mock;
     }
@@ -301,11 +301,11 @@ class PyramidTest extends AbstractTest
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
-                    array(
-                        'andc'  =>  0.31,
-                        'ahh'   =>  0.12
-                    )
-                ));
+                array(
+                    'andc'  =>  0.31,
+                    'ahh'   =>  0.12
+                )
+            ));
 
         return $mock;
     }
@@ -317,13 +317,13 @@ class PyramidTest extends AbstractTest
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
-                    array(
-                        'nop'  =>  19,
-                        'noc'  =>  384,
-                        'nom'  =>  2018,
-                        'nof'  =>  1600
-                    )
-                ));
+                array(
+                    'nop'  =>  19,
+                    'noc'  =>  384,
+                    'nom'  =>  2018,
+                    'nof'  =>  1600
+                )
+            ));
 
         return $mock;
     }
@@ -335,10 +335,10 @@ class PyramidTest extends AbstractTest
         $mock->expects($this->any())
             ->method('getProjectMetrics')
             ->will($this->returnValue(
-                    array(
-                        'eloc'  =>  35175
-                    )
-                ));
+                array(
+                    'eloc'  =>  35175
+                )
+            ));
 
         return $mock;
     }

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -87,7 +87,8 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * @param AnalyzerListener $listener The listener instance.
      * @return void
      */
-    public function addAnalyzeListener(AnalyzerListener $listener) {
+    public function addAnalyzeListener(AnalyzerListener $listener)
+    {
     }
 
     /**
@@ -96,7 +97,8 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
      * @return void
      */
-    public function removeAnalyzeListener(AnalyzerListener $listener) {
+    public function removeAnalyzeListener(AnalyzerListener $listener)
+    {
     }
 
     /**

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -77,7 +77,8 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
      * @return void
      */
-    public function addAnalyzeListener(AnalyzerListener $listener) {
+    public function addAnalyzeListener(AnalyzerListener $listener)
+    {
     }
 
     /**
@@ -86,7 +87,8 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
      * @return void
      */
-    public function removeAnalyzeListener(AnalyzerListener $listener) {
+    public function removeAnalyzeListener(AnalyzerListener $listener)
+    {
     }
 
     /**
@@ -134,5 +136,4 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
     public function setOptions(array $options = array())
     {
     }
-
 }

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -131,5 +131,4 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
     public function setOptions(array $options = array())
     {
     }
-
 }

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -62,7 +62,7 @@ class ASTArgumentsTest extends ASTNodeTest
      */
     public function testArgumentsGraphWithMagicClassConstant()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
         $this->assertGraph(
             $arguments,
             array(
@@ -82,7 +82,7 @@ class ASTArgumentsTest extends ASTNodeTest
      */
     public function testArgumentsHasExpectedStartLine()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
         $this->assertEquals(5, $arguments->getStartLine());
     }
 
@@ -93,7 +93,7 @@ class ASTArgumentsTest extends ASTNodeTest
      */
     public function testArgumentsHasExpectedStartColumn()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
         $this->assertEquals(8, $arguments->getStartColumn());
     }
 
@@ -104,7 +104,7 @@ class ASTArgumentsTest extends ASTNodeTest
      */
     public function testArgumentsHasExpectedEndLine()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
         $this->assertEquals(7, $arguments->getEndLine());
     }
 
@@ -115,7 +115,7 @@ class ASTArgumentsTest extends ASTNodeTest
      */
     public function testArgumentsHasExpectedEndColumn()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
         $this->assertEquals(21, $arguments->getEndColumn());
     }
 
@@ -124,7 +124,7 @@ class ASTArgumentsTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTArguments
      */
-    private function _getFirstArgumentsOfFunction()
+    private function getFirstArgumentsOfFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -77,7 +77,7 @@ class ASTArrayElementTest extends ASTNodeTest
     public function testArrayElementGraphSimpleValue()
     {
         $this->assertGraph(
-            $this->_getFirstArrayElementInFunction(),
+            $this->getFirstArrayElementInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)'
             )
@@ -104,7 +104,7 @@ class ASTArrayElementTest extends ASTNodeTest
     public function testArrayElementGraphSimpleValueByReference()
     {
         $this->assertGraph(
-            $this->_getFirstArrayElementInFunction(),
+            $this->getFirstArrayElementInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)'
             )
@@ -132,7 +132,7 @@ class ASTArrayElementTest extends ASTNodeTest
     public function testArrayElementGraphKeyValue()
     {
         $this->assertGraph(
-            $this->_getFirstArrayElementInFunction(),
+            $this->getFirstArrayElementInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($value)'
@@ -161,7 +161,7 @@ class ASTArrayElementTest extends ASTNodeTest
     public function testArrayElementGraphKeyValueByReference()
     {
         $this->assertGraph(
-            $this->_getFirstArrayElementInFunction(),
+            $this->getFirstArrayElementInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($value)'
@@ -209,7 +209,7 @@ class ASTArrayElementTest extends ASTNodeTest
     public function testArrayElementGraphWithTwoDimensions()
     {
         $this->assertGraph(
-            $this->_getFirstArrayElementInFunction(),
+            $this->getFirstArrayElementInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTLiteral'                              . ' ("bar")',
                 'PDepend\\Source\\AST\\ASTArray'                                . ' ()', array(
@@ -238,7 +238,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementByReferenceReturnsFalseByDefault()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertFalse($array->isByReference());
     }
 
@@ -249,7 +249,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementByReferenceReturnsTrueForValue()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertTrue($array->isByReference());
     }
 
@@ -260,7 +260,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementByReferenceReturnsFalseForKeyValue()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertFalse($array->isByReference());
     }
 
@@ -271,7 +271,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementByReferenceReturnsTrueForKeyValue()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertTrue($array->isByReference());
     }
 
@@ -282,7 +282,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementHasExpectedStartLine()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertEquals(5, $array->getStartLine());
     }
 
@@ -293,7 +293,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementHasExpectedStartColumn()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertEquals(9, $array->getStartColumn());
     }
 
@@ -304,7 +304,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementHasExpectedEndLine()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertEquals(11, $array->getEndLine());
     }
 
@@ -315,7 +315,7 @@ class ASTArrayElementTest extends ASTNodeTest
      */
     public function testArrayElementHasExpectedEndColumn()
     {
-        $array = $this->_getFirstArrayElementInFunction();
+        $array = $this->getFirstArrayElementInFunction();
         $this->assertEquals(29, $array->getEndColumn());
     }
 
@@ -324,7 +324,7 @@ class ASTArrayElementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTArrayElement
      */
-    private function _getFirstArrayElementInFunction()
+    private function getFirstArrayElementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -78,7 +78,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromFunctionCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
@@ -111,7 +111,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromVariableFunctionCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTVariable',
@@ -146,7 +146,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromMethodCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
@@ -183,7 +183,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromVariableMethodCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
@@ -220,7 +220,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromStaticMethodCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -257,7 +257,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexGraphDereferencedFromVariableStaticMethodCall()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -281,7 +281,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexExpressionGraphForVariable()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTLiteral'
@@ -301,7 +301,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexExpressionGraphForProperty()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTLiteral'
@@ -321,7 +321,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
     public function testArrayIndexExpressionGraphForChainedArrayAccess()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArrayIndexExpressionInFunction(),
+            $this->getFirstArrayIndexExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression',
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression',
@@ -340,7 +340,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
      */
     public function testArrayIndexExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstArrayIndexExpressionInFunction();
+        $expr = $this->getFirstArrayIndexExpressionInFunction();
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -351,7 +351,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
      */
     public function testArrayIndexExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstArrayIndexExpressionInFunction();
+        $expr = $this->getFirstArrayIndexExpressionInFunction();
         $this->assertEquals(10, $expr->getStartColumn());
     }
 
@@ -362,7 +362,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
      */
     public function testArrayIndexExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstArrayIndexExpressionInFunction();
+        $expr = $this->getFirstArrayIndexExpressionInFunction();
         $this->assertEquals(6, $expr->getEndLine());
     }
 
@@ -373,7 +373,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
      */
     public function testArrayIndexExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstArrayIndexExpressionInFunction();
+        $expr = $this->getFirstArrayIndexExpressionInFunction();
         $this->assertEquals(13, $expr->getEndColumn());
     }
 
@@ -382,10 +382,10 @@ class ASTArrayIndexExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTArrayIndexExpression
      */
-    private function _getFirstArrayIndexExpressionInFunction()
+    private function getFirstArrayIndexExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $this->getCallingTestMethod(), 
+            $this->getCallingTestMethod(),
             'PDepend\\Source\\AST\\ASTArrayIndexExpression'
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -74,7 +74,7 @@ class ASTArrayTest extends ASTNodeTest
     public function testArrayGraphForEmptyArrayDefinition()
     {
         $this->assertGraph(
-            $this->_getFirstArrayInFunction(),
+            $this->getFirstArrayInFunction(),
             array()
         );
     }
@@ -97,7 +97,7 @@ class ASTArrayTest extends ASTNodeTest
     public function testArrayGraphForEmptyShortArrayDefinition()
     {
         $this->assertGraph(
-            $this->_getFirstArrayInFunction(),
+            $this->getFirstArrayInFunction(),
             array()
         );
     }
@@ -109,7 +109,7 @@ class ASTArrayTest extends ASTNodeTest
      */
     public function testArrayHasExpectedStartLine()
     {
-        $array = $this->_getFirstArrayInFunction();
+        $array = $this->getFirstArrayInFunction();
         $this->assertEquals(4, $array->getStartLine());
     }
 
@@ -120,7 +120,7 @@ class ASTArrayTest extends ASTNodeTest
      */
     public function testArrayHasExpectedStartColumn()
     {
-        $array = $this->_getFirstArrayInFunction();
+        $array = $this->getFirstArrayInFunction();
         $this->assertEquals(12, $array->getStartColumn());
     }
 
@@ -131,7 +131,7 @@ class ASTArrayTest extends ASTNodeTest
      */
     public function testArrayHasExpectedEndLine()
     {
-        $array = $this->_getFirstArrayInFunction();
+        $array = $this->getFirstArrayInFunction();
         $this->assertEquals(13, $array->getEndLine());
     }
 
@@ -142,7 +142,7 @@ class ASTArrayTest extends ASTNodeTest
      */
     public function testArrayHasExpectedEndColumn()
     {
-        $array = $this->_getFirstArrayInFunction();
+        $array = $this->getFirstArrayInFunction();
         $this->assertEquals(5, $array->getEndColumn());
     }
 
@@ -151,7 +151,7 @@ class ASTArrayTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTArray
      */
-    private function _getFirstArrayInFunction()
+    private function getFirstArrayInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -68,7 +68,7 @@ class ASTArtifactTest extends AbstractTest
     
     /**
      * testSetNameOverridesPreviousItemName
-     * 
+     *
      * @since 1.0.0
      */
     public function testSetNameOverridesPreviousItemName()
@@ -76,7 +76,7 @@ class ASTArtifactTest extends AbstractTest
         $item = $this->getItemMock();
         $item->setName(__FUNCTION__);
         
-        $this->assertEquals(__FUNCTION__, $item->getName());        
+        $this->assertEquals(__FUNCTION__, $item->getName());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -62,7 +62,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
     public function testAssignmentExpressionFromMethodInvocation()
     {
         $this->assertGraphEquals(
-            $this->_getFirstAssignmentExpressionInFunction(),
+            $this->getFirstAssignmentExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
@@ -82,7 +82,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
     public function testAssignmentExpressionFromPropertyAccess()
     {
         $this->assertGraphEquals(
-            $this->_getFirstAssignmentExpressionInFunction(),
+            $this->getFirstAssignmentExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
@@ -101,7 +101,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
     public function testAssignmentExpressionFromFunctionReturnValue()
     {
         $this->assertGraphEquals(
-            $this->_getFirstAssignmentExpressionInFunction(),
+            $this->getFirstAssignmentExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
@@ -116,13 +116,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
 
     /**
      * Tests the resulting object graph.
-     * 
+     *
      * @return void
      */
     public function testAssignmentExpressionGraphForIntegerLiteral()
     {
         $this->assertGraphEquals(
-            $this->_getFirstAssignmentExpressionInFunction(),
+            $this->getFirstAssignmentExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTLiteral'
@@ -138,7 +138,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
     public function testAssignmentExpressionGraphForFloatLiteral()
     {
         $this->assertGraphEquals(
-            $this->_getFirstAssignmentExpressionInFunction(),
+            $this->getFirstAssignmentExpressionInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTLiteral'
@@ -154,7 +154,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('=', $expr->getImage());
     }
 
@@ -166,7 +166,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithAndEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('&=', $expr->getImage());
     }
 
@@ -178,7 +178,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithConcatEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('.=', $expr->getImage());
     }
 
@@ -190,7 +190,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithDivEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('/=', $expr->getImage());
     }
 
@@ -202,7 +202,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithMinusEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('-=', $expr->getImage());
     }
 
@@ -214,7 +214,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithModEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('%=', $expr->getImage());
     }
 
@@ -226,7 +226,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithMulEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('*=', $expr->getImage());
     }
 
@@ -238,7 +238,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithOrEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('|=', $expr->getImage());
     }
 
@@ -250,7 +250,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithPlusEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('+=', $expr->getImage());
     }
 
@@ -262,7 +262,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithXorEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('^=', $expr->getImage());
     }
 
@@ -274,7 +274,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithShiftLeftEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('<<=', $expr->getImage());
     }
 
@@ -286,7 +286,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testAssignmentExpressionWithShiftRightEqual()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertEquals('>>=', $expr->getImage());
     }
 
@@ -298,7 +298,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testVariableAssignmentExpression()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
 
         return $expr;
@@ -364,7 +364,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testStaticPropertyAssignmentExpression()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
 
         return $expr;
@@ -430,7 +430,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testObjectPropertyAssignmentExpression()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
 
         return $expr;
@@ -496,7 +496,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      */
     public function testChainedPropertyAssignmentExpression()
     {
-        $expr = $this->_getFirstAssignmentExpressionInFunction();
+        $expr = $this->getFirstAssignmentExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
 
         return $expr;
@@ -559,7 +559,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTAssignmentExpression
      */
-    private function _getFirstAssignmentExpressionInFunction()
+    private function getFirstAssignmentExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -61,7 +61,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTest
      */
     public function testBooleanAndExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstBooleanAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanAndExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTest
      */
     public function testBooleanAndExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstBooleanAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanAndExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTest
      */
     public function testBooleanAndExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstBooleanAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanAndExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTest
      */
     public function testBooleanAndExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstBooleanAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanAndExpressionInFunction(__METHOD__);
         $this->assertEquals(19, $expr->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTBooleanAndExpression
      */
-    private function _getFirstBooleanAndExpressionInFunction($testCase)
+    private function getFirstBooleanAndExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -61,7 +61,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTest
      */
     public function testBooleanOrExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstBooleanOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanOrExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTest
      */
     public function testBooleanOrExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstBooleanOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanOrExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTest
      */
     public function testBooleanOrExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstBooleanOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanOrExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTest
      */
     public function testBooleanOrExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstBooleanOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstBooleanOrExpressionInFunction(__METHOD__);
         $this->assertEquals(19, $expr->getEndColumn());
     }
     
@@ -105,7 +105,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTBooleanOrExpression
      */
-    private function _getFirstBooleanOrExpressionInFunction($testCase)
+    private function getFirstBooleanOrExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -61,7 +61,7 @@ class ASTBreakStatementTest extends ASTNodeTest
      */
     public function testBreakStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstBreakStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstBreakStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTBreakStatementTest extends ASTNodeTest
      */
     public function testBreakStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstBreakStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstBreakStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTBreakStatementTest extends ASTNodeTest
      */
     public function testBreakStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstBreakStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstBreakStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTBreakStatementTest extends ASTNodeTest
      */
     public function testBreakStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstBreakStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstBreakStatementInFunction(__METHOD__);
         $this->assertEquals(17, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTBreakStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTBreakStatement
      */
-    private function _getFirstBreakStatementInFunction($testCase)
+    private function getFirstBreakStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -281,7 +281,7 @@ class ASTCastExpressionTest extends ASTNodeTest
      */
     public function testParserHandlesNestedCastExpressions()
     {
-        $expr = $this->_getFirstCastExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCastExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -300,7 +300,7 @@ class ASTCastExpressionTest extends ASTNodeTest
      */
     public function testCastExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstCastExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCastExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -311,7 +311,7 @@ class ASTCastExpressionTest extends ASTNodeTest
      */
     public function testCastExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstCastExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCastExpressionInFunction(__METHOD__);
         $this->assertEquals(12, $expr->getStartColumn());
     }
 
@@ -322,7 +322,7 @@ class ASTCastExpressionTest extends ASTNodeTest
      */
     public function testCastExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstCastExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCastExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -333,7 +333,7 @@ class ASTCastExpressionTest extends ASTNodeTest
      */
     public function testCastExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstCastExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCastExpressionInFunction(__METHOD__);
         $this->assertEquals(26, $expr->getEndColumn());
     }
 
@@ -344,10 +344,11 @@ class ASTCastExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTCastExpression
      */
-    private function _getFirstCastExpressionInFunction($testCase)
+    private function getFirstCastExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTCastExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTCastExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -61,7 +61,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstCatchStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstCatchStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstCatchStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstCatchStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
         $this->assertEquals(29, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementVariableHasExpectedStartLine()
     {
-        $variable = $this->_getFirstCatchStatementInFunction(__METHOD__)
+        $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
         $this->assertEquals(8, $variable->getStartLine());
     }
@@ -117,7 +117,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementVariableHasExpectedStartColumn()
     {
-        $variable = $this->_getFirstCatchStatementInFunction(__METHOD__)
+        $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
         $this->assertEquals(9, $variable->getStartColumn());
     }
@@ -129,7 +129,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementVariableHasExpectedEndLine()
     {
-        $variable = $this->_getFirstCatchStatementInFunction(__METHOD__)
+        $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
         $this->assertEquals(8, $variable->getStartLine());
     }
@@ -141,7 +141,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testCatchStatementVariableHasExpectedEndColumn()
     {
-        $variable = $this->_getFirstCatchStatementInFunction(__METHOD__)
+        $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
         $this->assertEquals(10, $variable->getEndColumn());
     }
@@ -153,7 +153,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfCatchStatementIsScopeStatement()
     {
-        $stmt = $this->_getFirstCatchStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
     }
 
@@ -164,7 +164,7 @@ class ASTCatchStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTCatchStatement
      */
-    private function _getFirstCatchStatementInFunction($testCase)
+    private function getFirstCatchStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -65,7 +65,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testGetImage()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass();
+        $postfix = $this->getFirstClassFqnPostfixInClass();
         $this->assertEquals('class', $postfix->getImage());
     }
 
@@ -77,7 +77,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
     public function testClassFqnPostfixStructureWithStatic()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTStaticReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -92,7 +92,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testGetImageWorksCaseInsensitive()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass();
+        $postfix = $this->getFirstClassFqnPostfixInClass();
         $this->assertEquals('class', $postfix->getImage());
     }
 
@@ -104,7 +104,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
     public function testClassFqnPostfixStructureWithSelf()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -120,7 +120,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
     public function testClassFqnPostfixStructureWithParent()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTParentReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -136,7 +136,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
     public function testClassFqnPostfixStructureWithClassName()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -159,7 +159,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -182,7 +182,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -201,7 +201,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -220,7 +220,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -239,7 +239,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -258,7 +258,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
 
         $this->markTestIncomplete('We do not handle default values.');
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__),
+            $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             array(
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTClassFqnPostfix'
@@ -273,7 +273,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testClassFqnPostfixHasExpectedStartLine()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass(__METHOD__);
+        $postfix = $this->getFirstClassFqnPostfixInClass(__METHOD__);
         $this->assertEquals(6, $postfix->getStartLine());
     }
 
@@ -284,7 +284,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testClassFqnPostfixHasExpectedStartColumn()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass(__METHOD__);
+        $postfix = $this->getFirstClassFqnPostfixInClass(__METHOD__);
         $this->assertEquals(26, $postfix->getStartColumn());
     }
 
@@ -295,7 +295,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testClassFqnPostfixHasExpectedEndLine()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass(__METHOD__);
+        $postfix = $this->getFirstClassFqnPostfixInClass(__METHOD__);
         $this->assertEquals(6, $postfix->getEndLine());
     }
 
@@ -306,7 +306,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      */
     public function testClassFqnPostfixHasExpectedEndColumn()
     {
-        $postfix = $this->_getFirstClassFqnPostfixInClass(__METHOD__);
+        $postfix = $this->getFirstClassFqnPostfixInClass(__METHOD__);
         $this->assertEquals(63, $postfix->getEndColumn());
     }
 
@@ -325,7 +325,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTClassFqnPostfix
      */
-    private function _getFirstClassFqnPostfixInClass()
+    private function getFirstClassFqnPostfixInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -339,7 +339,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInClass($testCase)
+    private function getFirstMemberPrimaryPrefixInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -173,7 +173,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      */
     public function testReferenceInInterfaceExtendsHasExpectedStartLine()
     {
-        $reference = $this->_getFirstReferenceInInterface();
+        $reference = $this->getFirstReferenceInInterface();
         $this->assertEquals(3, $reference->getStartLine());
     }
 
@@ -185,7 +185,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      */
     public function testReferenceInInterfaceExtendsHasExpectedStartColumn()
     {
-        $reference = $this->_getFirstReferenceInInterface();
+        $reference = $this->getFirstReferenceInInterface();
         $this->assertEquals(13, $reference->getStartColumn());
     }
 
@@ -197,7 +197,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      */
     public function testReferenceInInterfaceExtendsHasExpectedEndLine()
     {
-        $reference = $this->_getFirstReferenceInInterface();
+        $reference = $this->getFirstReferenceInInterface();
         $this->assertEquals(3, $reference->getEndLine());
     }
 
@@ -209,7 +209,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      */
     public function testReferenceInInterfaceExtendsHasExpectedEndColumn()
     {
-        $reference = $this->_getFirstReferenceInInterface();
+        $reference = $this->getFirstReferenceInInterface();
         $this->assertEquals(15, $reference->getEndColumn());
     }
 
@@ -296,7 +296,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
      * @since 0.10.5
      */
-    private function _getFirstReferenceInInterface()
+    private function getFirstReferenceInInterface()
     {
         return $this->getFirstNodeOfTypeInInterface(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -115,7 +115,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testClassReferenceHasExpectedStartLine()
     {
-        $reference = $this->_getFirstReferenceInFunction(__METHOD__);
+        $reference = $this->getFirstReferenceInFunction(__METHOD__);
         $this->assertEquals(4, $reference->getStartLine());
     }
 
@@ -126,7 +126,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testClassReferenceHasExpectedStartColumn()
     {
-        $reference = $this->_getFirstReferenceInFunction(__METHOD__);
+        $reference = $this->getFirstReferenceInFunction(__METHOD__);
         $this->assertEquals(16, $reference->getStartColumn());
     }
 
@@ -137,7 +137,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testClassReferenceHasExpectedEndLine()
     {
-        $reference = $this->_getFirstReferenceInFunction(__METHOD__);
+        $reference = $this->getFirstReferenceInFunction(__METHOD__);
         $this->assertEquals(4, $reference->getEndLine());
     }
 
@@ -148,7 +148,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testClassReferenceHasExpectedEndColumn()
     {
-        $reference = $this->_getFirstReferenceInFunction(__METHOD__);
+        $reference = $this->getFirstReferenceInFunction(__METHOD__);
         $this->assertEquals(18, $reference->getEndColumn());
     }
 
@@ -160,7 +160,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testReferenceInClassExtendsHasExpectedStartLine()
     {
-        $reference = $this->_getFirstReferenceInClass();
+        $reference = $this->getFirstReferenceInClass();
         $this->assertEquals(2, $reference->getStartLine());
     }
 
@@ -172,7 +172,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testReferenceInClassExtendsHasExpectedStartColumn()
     {
-        $reference = $this->_getFirstReferenceInClass();
+        $reference = $this->getFirstReferenceInClass();
         $this->assertEquals(65, $reference->getStartColumn());
     }
 
@@ -184,7 +184,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testReferenceInClassExtendsHasExpectedEndLine()
     {
-        $reference = $this->_getFirstReferenceInClass();
+        $reference = $this->getFirstReferenceInClass();
         $this->assertEquals(2, $reference->getEndLine());
     }
 
@@ -196,7 +196,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      */
     public function testReferenceInClassExtendsHasExpectedEndColumn()
     {
-        $reference = $this->_getFirstReferenceInClass();
+        $reference = $this->getFirstReferenceInClass();
         $this->assertEquals(65, $reference->getEndColumn());
     }
 
@@ -207,10 +207,11 @@ class ASTClassReferenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTClassReference
      */
-    private function _getFirstReferenceInFunction($testCase)
+    private function getFirstReferenceInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTClassReference'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTClassReference'
         );
     }
 
@@ -220,7 +221,7 @@ class ASTClassReferenceTest extends ASTNodeTest
      * @return \PDepend\Source\AST\ASTClassReference
      * @since 0.10.5
      */
-    private function _getFirstReferenceInClass()
+    private function getFirstReferenceInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -61,7 +61,7 @@ class ASTCloneExpressionTest extends ASTNodeTest
      */
     public function testCloneExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstCloneExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCloneExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTCloneExpressionTest extends ASTNodeTest
      */
     public function testCloneExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstCloneExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCloneExpressionInFunction(__METHOD__);
         $this->assertEquals(12, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTCloneExpressionTest extends ASTNodeTest
      */
     public function testCloneExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstCloneExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCloneExpressionInFunction(__METHOD__);
         $this->assertEquals(6, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTCloneExpressionTest extends ASTNodeTest
      */
     public function testCloneExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstCloneExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstCloneExpressionInFunction(__METHOD__);
         $this->assertEquals(21, $expr->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTCloneExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTCloneExpression
      */
-    private function _getFirstCloneExpressionInFunction($testCase)
+    private function getFirstCloneExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -62,7 +62,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testReturnsByReferenceReturnsFalseByDefault()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertFalse($closure->returnsByReference());
     }
 
@@ -73,7 +73,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testReturnsByReferenceReturnsFalseByDefaultForStaticClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertFalse($closure->returnsByReference());
     }
 
@@ -84,7 +84,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testReturnsByReferenceReturnsTrueForClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertTrue($closure->returnsByReference());
     }
 
@@ -95,7 +95,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testReturnsByReferenceReturnsTrueForStaticClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertTrue($closure->returnsByReference());
     }
 
@@ -106,7 +106,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testReturnsByReferenceReturnsTrueForAssignedClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertTrue($closure->returnsByReference());
     }
 
@@ -118,7 +118,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testParserHandlesPureClosureStatementWithoutAssignment()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClosure', $closure);
     }
 
@@ -168,12 +168,12 @@ class ASTClosureTest extends ASTNodeTest
      *     return pow($x, $y);
      * }
      * </code>
-     * 
+     *
      * @return void
      */
     public function testIsStaticReturnsFalseForNonStaticClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertFalse($closure->isStatic());
     }
 
@@ -191,7 +191,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testIsStaticReturnsTrueForStaticClosure()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertTrue($closure->isStatic());
     }
 
@@ -202,7 +202,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testClosureContainsExpectedNumberChildNodes()
     {
-        $closure = $this->_getFirstClosureInFunction();
+        $closure = $this->getFirstClosureInFunction();
         $this->assertEquals(2, count($closure->getChildren()));
     }
 
@@ -213,7 +213,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testClosureHasExpectedStartLine()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(4, $label->getStartLine());
     }
 
@@ -224,7 +224,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testClosureHasExpectedStartColumn()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(12, $label->getStartColumn());
     }
 
@@ -235,7 +235,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testClosureHasExpectedEndLine()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(6, $label->getEndLine());
     }
 
@@ -246,7 +246,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testClosureHasExpectedEndColumn()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(5, $label->getEndColumn());
     }
 
@@ -257,7 +257,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testStaticClosureHasExpectedStartLine()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(4, $label->getStartLine());
     }
 
@@ -268,7 +268,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testStaticClosureHasExpectedEndLine()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(7, $label->getEndLine());
     }
 
@@ -279,7 +279,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testStaticClosureHasExpectedStartColumn()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(12, $label->getStartColumn());
     }
 
@@ -290,7 +290,7 @@ class ASTClosureTest extends ASTNodeTest
      */
     public function testStaticClosureHasExpectedEndColumn()
     {
-        $label = $this->_getFirstClosureInFunction();
+        $label = $this->getFirstClosureInFunction();
         $this->assertEquals(9, $label->getEndColumn());
     }
 
@@ -299,7 +299,7 @@ class ASTClosureTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTClosure
      */
-    private function _getFirstClosureInFunction()
+    private function getFirstClosureInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -61,7 +61,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testSingleLineCommentHasExpectedStartLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(4, $comment->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testSingleLineCommentHasExpectedStartColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(5, $comment->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testSingleLineCommentHasExpectedEndLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(4, $comment->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testSingleLineCommentHasExpectedEndColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(48, $comment->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testMultiLineCommentHasExpectedStartLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(4, $comment->getStartLine());
     }
 
@@ -116,7 +116,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testMultiLineCommentHasExpectedStartColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(5, $comment->getStartColumn());
     }
 
@@ -127,7 +127,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testMultiLineCommentHasExpectedEndLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(8, $comment->getEndLine());
     }
 
@@ -138,7 +138,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testMultiLineCommentHasExpectedEndColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(7, $comment->getEndColumn());
     }
 
@@ -149,7 +149,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testDocCommentHasExpectedStartLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(4, $comment->getStartLine());
     }
 
@@ -160,7 +160,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testDocCommentHasExpectedStartColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(5, $comment->getStartColumn());
     }
 
@@ -171,7 +171,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testDocCommentHasExpectedEndLine()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(8, $comment->getEndLine());
     }
 
@@ -182,7 +182,7 @@ class ASTCommentTest extends ASTNodeTest
      */
     public function testDocCommentHasExpectedEndColumn()
     {
-        $comment = $this->_getFirstCommentInClass(__METHOD__);
+        $comment = $this->getFirstCommentInClass(__METHOD__);
         $this->assertEquals(7, $comment->getEndColumn());
     }
 
@@ -193,7 +193,7 @@ class ASTCommentTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTComment
      */
-    private function _getFirstCommentInClass($testCase)
+    private function getFirstCommentInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -57,7 +57,7 @@ class ASTCompilationUnitTest extends AbstractTest
 {
     /**
      * testGetNameReturnsTheFileName
-     * 
+     *
      * @return void
      */
     public function testGetNameReturnsTheFileName()
@@ -212,7 +212,7 @@ class ASTCompilationUnitTest extends AbstractTest
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     * 
+     *
      * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames()

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -61,7 +61,7 @@ class ASTCompoundExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertSame(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTCompoundExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertSame(19, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTCompoundExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertSame(5, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTCompoundExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertSame(13, $expr->getEndColumn());
     }
 
@@ -105,10 +105,11 @@ class ASTCompoundExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTCompoundExpression
      */
-    private function _getFirstExpressionInFunction($testCase)
+    private function getFirstExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTCompoundExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTCompoundExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -61,7 +61,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableGraphWithInlineLiteral()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
 
         $string = $variable->getChild(0);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTString', $string);
@@ -74,7 +74,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableGraphWithInlineConstantEscapedLiteral()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
 
         $literal = $variable->getChild(0);
         $this->assertEquals("'FOO{\$bar}'", $literal->getImage());
@@ -87,7 +87,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableGraphWithInlineBacktickLiteral()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
 
         $string = $variable->getChild(0);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTString', $string);
@@ -100,7 +100,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableGraphWithMemberPrimaryPrefix()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
             'PDepend\\Source\\AST\\ASTVariable',
@@ -130,7 +130,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableHasExpectedStartLine()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
         $this->assertSame(4, $variable->getStartLine());
     }
 
@@ -141,7 +141,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableHasExpectedStartColumn()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
         $this->assertSame(5, $variable->getStartColumn());
     }
 
@@ -152,7 +152,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableHasExpectedEndLine()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
         $this->assertSame(7, $variable->getEndLine());
     }
 
@@ -163,7 +163,7 @@ class ASTCompoundVariableTest extends ASTNodeTest
      */
     public function testCompoundVariableHasExpectedEndColumn()
     {
-        $variable = $this->_getFirstVariableInFunction(__METHOD__);
+        $variable = $this->getFirstVariableInFunction(__METHOD__);
         $this->assertSame(11, $variable->getEndColumn());
     }
 
@@ -174,10 +174,11 @@ class ASTCompoundVariableTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTCompoundVariable
      */
-    private function _getFirstVariableInFunction($testCase)
+    private function getFirstVariableInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTCompoundVariable'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTCompoundVariable'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -61,7 +61,7 @@ class ASTConditionalExpressionTest extends ASTNodeTest
      */
     public function testConditionalExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstConditionalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstConditionalExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTConditionalExpressionTest extends ASTNodeTest
      */
     public function testConditionalExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstConditionalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstConditionalExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTConditionalExpressionTest extends ASTNodeTest
      */
     public function testConditionalExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstConditionalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstConditionalExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTConditionalExpressionTest extends ASTNodeTest
      */
     public function testConditionalExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstConditionalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstConditionalExpressionInFunction(__METHOD__);
         $this->assertEquals(26, $expr->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTConditionalExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTConditionalExpression
      */
-    private function _getFirstConditionalExpressionInFunction($testCase)
+    private function getFirstConditionalExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -80,7 +80,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTest
      */
     public function testParserInjectsValueObjectIntoConstantDeclarator()
     {
-        $declarator = $this->_getFirstConstantDeclaratorInClass();
+        $declarator = $this->getFirstConstantDeclaratorInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $declarator->getValue());
     }
 
@@ -91,7 +91,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTest
      */
     public function testParserInjectsExpectedScalarValueIntoConstantDeclarator()
     {
-        $declarator = $this->_getFirstConstantDeclaratorInClass();
+        $declarator = $this->getFirstConstantDeclaratorInClass();
         $this->assertEquals(42, $declarator->getValue()->getValue());
     }
 
@@ -103,7 +103,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTest
      */
     public function testParserInjectsExpectedHeredocValueIntoConstantDeclarator()
     {
-        $declarator = $this->_getFirstConstantDeclaratorInClass();
+        $declarator = $this->getFirstConstantDeclaratorInClass();
         $this->assertEquals('Testing!', $declarator->getValue()->getValue());
     }
 
@@ -115,7 +115,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTest
      */
     public function testConstantDeclarator()
     {
-        $declarator = $this->_getFirstConstantDeclaratorInClass();
+        $declarator = $this->getFirstConstantDeclaratorInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $declarator);
 
         return $declarator;
@@ -178,10 +178,10 @@ class ASTConstantDeclaratorTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTConstantDeclarator
      */
-    private function _getFirstConstantDeclaratorInClass()
+    private function getFirstConstantDeclaratorInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
-            $this->getCallingTestMethod(), 
+            $this->getCallingTestMethod(),
             'PDepend\\Source\\AST\\ASTConstantDeclarator'
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -172,7 +172,7 @@ class ASTConstantDefinitionTest extends ASTNodeTest
      */
     public function testConstantDefinitionHasExpectedDocComment()
     {
-        $constant = $this->_getFirstConstantDefinitionInClass();
+        $constant = $this->getFirstConstantDefinitionInClass();
         $this->assertEquals(
             "/**\n" .
             "     * Foo bar baz foobar.\n" .
@@ -188,7 +188,7 @@ class ASTConstantDefinitionTest extends ASTNodeTest
      */
     public function testConstantDefinitionHasExpectedDocCommentWithInlineCommentBetween()
     {
-        $constant = $this->_getFirstConstantDefinitionInClass();
+        $constant = $this->getFirstConstantDefinitionInClass();
         $this->assertEquals(
             "/**\n" .
             "     * Foo bar baz foobar.\n" .
@@ -205,7 +205,7 @@ class ASTConstantDefinitionTest extends ASTNodeTest
      */
     public function testConstantDefinition()
     {
-        $constant = $this->_getFirstConstantDefinitionInClass();
+        $constant = $this->getFirstConstantDefinitionInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constant);
 
         return $constant;
@@ -271,7 +271,7 @@ class ASTConstantDefinitionTest extends ASTNodeTest
      */
     public function testConstantDefinitionWithDeclarators()
     {
-        $constant = $this->_getFirstConstantDefinitionInClass();
+        $constant = $this->getFirstConstantDefinitionInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constant);
 
         return $constant;
@@ -360,10 +360,10 @@ class ASTConstantDefinitionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTConstantDefinition
      */
-    private function _getFirstConstantDefinitionInClass()
+    private function getFirstConstantDefinitionInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
-            $this->getCallingTestMethod(), 
+            $this->getCallingTestMethod(),
             'PDepend\\Source\\AST\\ASTConstantDefinition'
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -61,7 +61,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixStructureForSimpleStaticAccess()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertEquals('BAZ', $postfix->getImage());
     }
 
@@ -72,7 +72,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixStructureForStaticAccessOnVariable()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $postfix->getChild(0));
     }
 
@@ -83,7 +83,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixHasExpectedStartLine()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertEquals(4, $postfix->getStartLine());
     }
 
@@ -94,7 +94,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixHasExpectedStartColumn()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertEquals(11, $postfix->getStartColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixHasExpectedEndLine()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertEquals(4, $postfix->getEndLine());
     }
 
@@ -116,7 +116,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      */
     public function testConstantPostfixHasExpectedEndColumn()
     {
-        $postfix = $this->_getFirstConstantPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
         $this->assertEquals(13, $postfix->getEndColumn());
     }
 
@@ -127,7 +127,7 @@ class ASTConstantPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTConstantPostfix
      */
-    private function _getFirstConstantPostfixInFunction($testCase)
+    private function getFirstConstantPostfixInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -61,7 +61,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantGraphSimple()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals('FOO', $constant->getImage());
     }
 
@@ -72,7 +72,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantGraphKeywordSelf()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals('self', $constant->getImage());
     }
 
@@ -83,7 +83,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantGraphKeywordParent()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals('parent', $constant->getImage());
     }
 
@@ -94,7 +94,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantHasExpectedStartLine()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals(4, $constant->getStartLine());
     }
 
@@ -105,7 +105,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantHasExpectedStartColumn()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals(12, $constant->getStartColumn());
     }
 
@@ -116,7 +116,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantHasExpectedEndLine()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals(4, $constant->getEndLine());
     }
 
@@ -127,7 +127,7 @@ class ASTConstantTest extends ASTNodeTest
      */
     public function testConstantHasExpectedEndColumn()
     {
-        $constant = $this->_getFirstConstantInFunction(__METHOD__);
+        $constant = $this->getFirstConstantInFunction(__METHOD__);
         $this->assertEquals(14, $constant->getEndColumn());
     }
 
@@ -138,10 +138,11 @@ class ASTConstantTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTConstant
      */
-    private function _getFirstConstantInFunction($testCase)
+    private function getFirstConstantInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTConstant'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTConstant'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -61,7 +61,7 @@ class ASTContinueStatementTest extends ASTNodeTest
      */
     public function testContinueStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstContinueStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstContinueStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTContinueStatementTest extends ASTNodeTest
      */
     public function testContinueStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstContinueStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstContinueStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTContinueStatementTest extends ASTNodeTest
      */
     public function testContinueStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstContinueStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstContinueStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTContinueStatementTest extends ASTNodeTest
      */
     public function testContinueStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstContinueStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstContinueStatementInFunction(__METHOD__);
         $this->assertEquals(17, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTContinueStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTContinueStatement
      */
-    private function _getFirstContinueStatementInFunction($testCase)
+    private function getFirstContinueStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -63,7 +63,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithSingleParameter()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(1, count($stmt->getValues()));
     }
 
@@ -74,7 +74,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithMultipleParameter()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(2, count($stmt->getValues()));
     }
 
@@ -104,7 +104,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -115,7 +115,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -126,7 +126,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getEndLine());
     }
 
@@ -137,7 +137,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(22, $stmt->getEndColumn());
     }
 
@@ -148,7 +148,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -159,7 +159,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -170,7 +170,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(10, $stmt->getEndLine());
     }
 
@@ -181,7 +181,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -192,7 +192,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -203,7 +203,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -214,7 +214,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndLine());
     }
 
@@ -225,7 +225,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstDeclareStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDeclareStatementInFunction(__METHOD__);
         $this->assertEquals(15, $stmt->getEndColumn());
     }
 
@@ -236,7 +236,7 @@ class ASTDeclareStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTDeclareStatement
      */
-    private function _getFirstDeclareStatementInFunction($testCase)
+    private function getFirstDeclareStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -61,7 +61,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementHasExpectedNumberOfChildNodes()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(2, count($stmt->getChildren()));
     }
     
@@ -72,7 +72,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfDoWhileStatementIsInstanceOfScopeStatement()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
     }
     
@@ -83,7 +83,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfDoWhileStatementIsInstanceOfExpression()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(1));
     }
 
@@ -94,7 +94,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -105,7 +105,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -116,7 +116,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getEndLine());
     }
 
@@ -127,7 +127,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(31, $stmt->getEndColumn());
     }
     
@@ -138,7 +138,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      */
     public function testDoWhileStatementWithoutScopeStatementChild()
     {
-        $stmt = $this->_getFirstDoWhileStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIfStatement', $stmt->getChild(0));
     }
 
@@ -149,7 +149,7 @@ class ASTDoWhileStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTDoWhileStatement
      */
-    private function _getFirstDoWhileStatementInFunction($testCase)
+    private function getFirstDoWhileStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -61,7 +61,7 @@ class ASTEchoStatementTest extends ASTNodeTest
      */
     public function testEchoStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstEchoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstEchoStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTEchoStatementTest extends ASTNodeTest
      */
     public function testEchoStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstEchoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstEchoStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTEchoStatementTest extends ASTNodeTest
      */
     public function testEchoStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstEchoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstEchoStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTEchoStatementTest extends ASTNodeTest
      */
     public function testEchoStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstEchoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstEchoStatementInFunction(__METHOD__);
         $this->assertEquals(26, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTEchoStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTEchoStatement
      */
-    private function _getFirstEchoStatementInFunction($testCase)
+    private function getFirstEchoStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -61,7 +61,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsFalseByDefault()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertFalse($stmt->hasElse());
     }
 
@@ -72,7 +72,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseIfBranchExists()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
 
@@ -83,7 +83,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchWithIfExists()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
 
@@ -94,7 +94,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchExists()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
 
@@ -105,7 +105,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementGraphWithBooleanExpressions()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(2, count($stmt->getChildren()));
     }
     
@@ -116,7 +116,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfElseIfStatementIsInstanceOfExpression()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
     
@@ -127,7 +127,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfElseIfStatementIsInstanceOfScopeStatement()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
     }
 
@@ -138,7 +138,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getStartLine());
     }
 
@@ -149,7 +149,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getStartColumn());
     }
 
@@ -160,7 +160,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(8, $stmt->getEndLine());
     }
 
@@ -171,7 +171,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
     
@@ -182,7 +182,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementWithoutScopeStatementBody()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForeachStatement', $stmt->getChild(1));
     }
 
@@ -193,7 +193,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getStartLine());
     }
 
@@ -204,7 +204,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -215,7 +215,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(11, $stmt->getEndLine());
     }
 
@@ -226,7 +226,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      */
     public function testElseIfStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstElseIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -237,7 +237,7 @@ class ASTElseIfStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTElseIfStatement
      */
-    private function _getFirstElseIfStatementInFunction($testCase)
+    private function getFirstElseIfStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -61,7 +61,7 @@ class ASTEvalExpressionTest extends ASTNodeTest
      */
     public function testEvalExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstEvalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstEvalExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTEvalExpressionTest extends ASTNodeTest
      */
     public function testEvalExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstEvalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstEvalExpressionInFunction(__METHOD__);
         $this->assertEquals(10, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTEvalExpressionTest extends ASTNodeTest
      */
     public function testEvalExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstEvalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstEvalExpressionInFunction(__METHOD__);
         $this->assertEquals(7, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTEvalExpressionTest extends ASTNodeTest
      */
     public function testEvalExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstEvalExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstEvalExpressionInFunction(__METHOD__);
         $this->assertEquals(17, $expr->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTEvalExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTEvalExpression
      */
-    private function _getFirstEvalExpressionInFunction($testCase)
+    private function getFirstEvalExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -62,7 +62,7 @@ class ASTExitExpressionTest extends ASTNodeTest
      */
     public function testExitExpressionWithExitCode()
     {
-        $expr = $this->_getFirstExitExpressionInFunction();
+        $expr = $this->getFirstExitExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
 
         return $expr;
@@ -132,7 +132,7 @@ class ASTExitExpressionTest extends ASTNodeTest
      */
     public function testExitExpressionWithEmptyArgs()
     {
-        $expr = $this->_getFirstExitExpressionInFunction();
+        $expr = $this->getFirstExitExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
 
         return $expr;
@@ -202,7 +202,7 @@ class ASTExitExpressionTest extends ASTNodeTest
      */
     public function testExitExpressionWithoutArgs()
     {
-        $expr = $this->_getFirstExitExpressionInFunction();
+        $expr = $this->getFirstExitExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
 
         return $expr;
@@ -265,7 +265,7 @@ class ASTExitExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTExitExpression
      */
-    private function _getFirstExitExpressionInFunction()
+    private function getFirstExitExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -61,7 +61,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedNumberOfChildNodes()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertEquals(5, count($expr->getChild(0)->getChildren()));
     }
 
@@ -72,7 +72,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionGraphWithBooleanExpressions()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $expected   = array(
             'PDepend\\Source\\AST\\ASTExpression',
             'PDepend\\Source\\AST\\ASTVariable',
@@ -92,7 +92,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -103,7 +103,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertEquals(8, $expr->getStartColumn());
     }
 
@@ -114,7 +114,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertEquals(6, $expr->getEndLine());
     }
 
@@ -125,7 +125,7 @@ class ASTExpressionTest extends ASTNodeTest
      */
     public function testExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $this->assertEquals(14, $expr->getEndColumn());
     }
 
@@ -136,10 +136,11 @@ class ASTExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTExpression
      */
-    private function _getFirstExpressionInFunction($testCase)
+    private function getFirstExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -41,6 +41,7 @@
  */
 
 namespace PDepend\Source\AST;
+
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTFieldDeclaration;
 
@@ -63,7 +64,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testFieldDeclarationContainsClassReferenceWithAnnotationsEnabled()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
 
         $reference = $declaration->getChild(0);
         $this->assertEquals(__FUNCTION__, $reference->getType()->getName());
@@ -98,7 +99,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testClassReferenceForJavaStyleArrayNotation()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
         $reference = $declaration->getFirstChildOfType(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
         );
@@ -278,7 +279,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testFieldDeclarationHasExpectedStartLine()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
         $this->assertEquals(4, $declaration->getStartLine());
     }
 
@@ -289,7 +290,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testFieldDeclarationHasExpectedStartColumn()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
         $this->assertEquals(5, $declaration->getStartColumn());
     }
 
@@ -300,7 +301,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testFieldDeclarationHasExpectedEndLine()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
         $this->assertEquals(5, $declaration->getEndLine());
     }
 
@@ -311,7 +312,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      */
     public function testFieldDeclarationHasExpectedEndColumn()
     {
-        $declaration = $this->_getFirstFieldDeclarationInClass();
+        $declaration = $this->getFirstFieldDeclarationInClass();
         $this->assertEquals(22, $declaration->getEndColumn());
     }
 
@@ -320,7 +321,7 @@ class ASTFieldDeclarationTest extends ASTNodeTest
      *
      * @return ASTFieldDeclaration
      */
-    private function _getFirstFieldDeclarationInClass()
+    private function getFirstFieldDeclarationInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -384,4 +385,3 @@ class ASTFieldDeclarationTest extends ASTNodeTest
         );
     }
 }
-?>

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -61,7 +61,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testFinallyStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(8, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testFinallyStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testFinallyStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(10, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testFinallyStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testOnlyFinallyStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getStartLine());
     }
 
@@ -116,7 +116,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testOnlyFinallyStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(7, $stmt->getStartColumn());
     }
 
@@ -127,7 +127,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testOnlyFinallyStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(8, $stmt->getEndLine());
     }
 
@@ -138,7 +138,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testOnlyFinallyStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -149,7 +149,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      */
     public function testChildOfFinallyStatementIsScopeStatement()
     {
-        $stmt = $this->_getFirstFinallyStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
     }
 
@@ -160,7 +160,7 @@ class ASTFinallyStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTFinallyStatement
      */
-    private function _getFirstFinallyStatementInFunction($testCase)
+    private function getFirstFinallyStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -61,7 +61,7 @@ class ASTForInitTest extends ASTNodeTest
      */
     public function testForInitHasExpectedStartLine()
     {
-        $init = $this->_getFirstForInitInFunction(__METHOD__);
+        $init = $this->getFirstForInitInFunction(__METHOD__);
         $this->assertEquals(4, $init->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTForInitTest extends ASTNodeTest
      */
     public function testForInitHasExpectedStartColumn()
     {
-        $init = $this->_getFirstForInitInFunction(__METHOD__);
+        $init = $this->getFirstForInitInFunction(__METHOD__);
         $this->assertEquals(10, $init->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTForInitTest extends ASTNodeTest
      */
     public function testForInitHasExpectedEndLine()
     {
-        $init = $this->_getFirstForInitInFunction(__METHOD__);
+        $init = $this->getFirstForInitInFunction(__METHOD__);
         $this->assertEquals(4, $init->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTForInitTest extends ASTNodeTest
      */
     public function testForInitHasExpectedEndColumn()
     {
-        $init = $this->_getFirstForInitInFunction(__METHOD__);
+        $init = $this->getFirstForInitInFunction(__METHOD__);
         $this->assertEquals(24, $init->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTForInitTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTForInit
      */
-    private function _getFirstForInitInFunction($testCase)
+    private function getFirstForInitInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -61,7 +61,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForExpressionHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getChild(1)->getStartLine());
     }
 
@@ -116,7 +116,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForExpressionHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(27, $stmt->getChild(1)->getStartColumn());
     }
 
@@ -127,7 +127,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForExpressionHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getChild(1)->getEndLine());
     }
 
@@ -138,7 +138,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForExpressionHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(33, $stmt->getChild(1)->getEndColumn());
     }
 
@@ -149,7 +149,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfForStatementIsInstanceOfForInit()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForInit', $stmt->getChild(0));
     }
 
@@ -160,7 +160,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfForStatementCanBeLeftBlank()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
 
@@ -182,7 +182,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfForStatementIsInstanceOfExpression()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(1));
     }
 
@@ -193,7 +193,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfForStatementCanBeLeftBlank()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForUpdate', $stmt->getChild(1));
     }
 
@@ -204,7 +204,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfForStatementIsInstanceOfForUpdate()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForUpdate', $stmt->getChild(2));
     }
 
@@ -215,7 +215,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfForStatementCanBeLeftBlank()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
     }
 
@@ -226,7 +226,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testFourthChildOfForStatementIsInstanceOfScopeStatement()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(3));
     }
 
@@ -237,7 +237,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testFourthChildOfForStatementIsInstanceOfStatement()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStatement', $stmt->getChild(3));
     }
 
@@ -278,7 +278,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -289,7 +289,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -300,7 +300,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(12, $stmt->getEndLine());
     }
 
@@ -311,7 +311,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(11, $stmt->getEndColumn());
     }
 
@@ -322,7 +322,7 @@ class ASTForStatementTest extends ASTNodeTest
      */
     public function testForStatementTerminatedByPhpCloseTag()
     {
-        $stmt = $this->_getFirstForStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -378,24 +378,11 @@ class ASTForStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTForStatement
      */
-    private function _getFirstForStatementInFunction($testCase)
+    private function getFirstForStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTForStatement'
-        );
-    }
-
-    /**
-     * Returns a node instance for the currently executed test case.
-     *
-     * @param string $testCase Name of the calling test case.
-     *
-     * @return \PDepend\Source\AST\ASTForStatement
-     */
-    private function _getFirstForStatementInClass($testCase)
-    {
-        return $this->getFirstNodeOfTypeInClass(
-            $testCase, 'PDepend\\Source\\AST\\ASTForStatement'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTForStatement'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -61,7 +61,7 @@ class ASTForUpdateTest extends ASTNodeTest
      */
     public function testForUpdateHasExpectedStartLine()
     {
-        $init = $this->_getFirstForUpdateInFunction(__METHOD__);
+        $init = $this->getFirstForUpdateInFunction(__METHOD__);
         $this->assertEquals(4, $init->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTForUpdateTest extends ASTNodeTest
      */
     public function testForUpdateHasExpectedStartColumn()
     {
-        $init = $this->_getFirstForUpdateInFunction(__METHOD__);
+        $init = $this->getFirstForUpdateInFunction(__METHOD__);
         $this->assertEquals(36, $init->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTForUpdateTest extends ASTNodeTest
      */
     public function testForUpdateHasExpectedEndLine()
     {
-        $init = $this->_getFirstForUpdateInFunction(__METHOD__);
+        $init = $this->getFirstForUpdateInFunction(__METHOD__);
         $this->assertEquals(4, $init->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTForUpdateTest extends ASTNodeTest
      */
     public function testForUpdateHasExpectedEndColumn()
     {
-        $init = $this->_getFirstForUpdateInFunction(__METHOD__);
+        $init = $this->getFirstForUpdateInFunction(__METHOD__);
         $this->assertEquals(45, $init->getEndColumn());
     }
 
@@ -105,10 +105,11 @@ class ASTForUpdateTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTForUpdate
      */
-    private function _getFirstForUpdateInFunction($testCase)
+    private function getFirstForUpdateInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTForUpdate'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTForUpdate'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -61,7 +61,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfForeachStatementIsASTScopeStatement()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
     }
 
@@ -72,7 +72,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -83,7 +83,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -94,7 +94,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -105,7 +105,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -116,7 +116,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementContainsExpressionAsFirstChild()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
 
@@ -127,7 +127,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithoutKeyAndWithValue()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(1));
     }
 
@@ -138,7 +138,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithoutKeyAndWithValueByReference()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(1));
     }
 
@@ -149,7 +149,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithKeyAndValue()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(2));
     }
 
@@ -160,7 +160,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithKeyAndValueByReference()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(2));
     }
 
@@ -171,7 +171,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithObjectPropertyByReference()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(1));
     }
 
@@ -182,7 +182,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithKeyAndObjectPropertyByReference()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(2));
     }
 
@@ -193,7 +193,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithObjectPropertyAsKey()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
     }
 
@@ -204,7 +204,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithObjectPropertyAsValue()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
     }
 
@@ -215,7 +215,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithObjectPropertyAsKeyAndValue()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
     }
 
@@ -227,7 +227,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementThrowsExpectedExceptionForKeyByReference()
     {
-        $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->getFirstForeachStatementInFunction(__METHOD__);
     }
 
     /**
@@ -237,7 +237,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithCommentBeforeClosingParenthesis()
     {
-        $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->getFirstForeachStatementInFunction(__METHOD__);
     }
 
     /**
@@ -247,7 +247,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -258,7 +258,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -269,7 +269,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -280,7 +280,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(15, $stmt->getEndColumn());
     }
 
@@ -291,7 +291,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementTerminatedByPhpCloseTag()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -302,7 +302,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithList()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(1));
     }
 
@@ -313,7 +313,7 @@ class ASTForeachStatementTest extends ASTNodeTest
      */
     public function testForeachStatementWithKeyAndList()
     {
-        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(2));
     }
 
@@ -324,10 +324,11 @@ class ASTForeachStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTForeachStatement
      */
-    private function _getFirstForeachStatementInFunction($testCase)
+    private function getFirstForeachStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTForeachStatement'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTForeachStatement'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -118,7 +118,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testIsVariableArgListReturnsFalseByDefault()
     {
-        $parameter = $this->_getFirstFormalParameterInFunction();
+        $parameter = $this->getFirstFormalParameterInFunction();
         $this->assertFalse($parameter->isVariableArgList());
     }
 
@@ -129,7 +129,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testIsVariableArgListReturnsTrue()
     {
-        $parameter = $this->_getFirstFormalParameterInFunction();
+        $parameter = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($parameter->isVariableArgList());
     }
 
@@ -140,7 +140,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testIsVariableArgListWithArrayTypeHint()
     {
-        $parameter = $this->_getFirstFormalParameterInFunction();
+        $parameter = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($parameter->isVariableArgList());
     }
 
@@ -151,7 +151,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testIsVariableArgListWithClassTypeHint()
     {
-        $parameter = $this->_getFirstFormalParameterInFunction();
+        $parameter = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($parameter->isVariableArgList());
     }
 
@@ -162,7 +162,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testIsVariableArgListPassedByReference()
     {
-        $parameter = $this->_getFirstFormalParameterInFunction();
+        $parameter = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($parameter->isVariableArgList());
     }
 
@@ -197,7 +197,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testSimpleParameterIsFlaggedAsPassedByReference()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($param->isPassedByReference());
     }
 
@@ -208,7 +208,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testParameterWithTypeHintIsFlaggedAsPassedByReference()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($param->isPassedByReference());
     }
 
@@ -219,13 +219,13 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testParameterWithDefaultValueIsFlaggedAsPassedByReference()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($param->isPassedByReference());
     }
     
     /**
      * testFormalParameterWithArrayTypeHint
-     * 
+     *
      * @return void
      * @since 1.0.0
      */
@@ -233,7 +233,7 @@ class ASTFormalParameterTest extends ASTNodeTest
     {
         $this->assertInstanceOf(
             'PDepend\\Source\\AST\\ASTTypeArray',
-            $this->_getFirstFormalParameterInFunction()->getChild(0)
+            $this->getFirstFormalParameterInFunction()->getChild(0)
         );
     }
 
@@ -264,7 +264,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testFormalParameterHasExpectedStartLine()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertEquals(3, $param->getStartLine());
     }
 
@@ -275,7 +275,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testFormalParameterHasExpectedStartColumn()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertEquals(5, $param->getStartColumn());
     }
 
@@ -286,7 +286,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testFormalParameterHasExpectedEndLine()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertEquals(6, $param->getEndLine());
     }
 
@@ -297,7 +297,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      */
     public function testFormalParameterHasExpectedEndColumn()
     {
-        $param = $this->_getFirstFormalParameterInFunction();
+        $param = $this->getFirstFormalParameterInFunction();
         $this->assertEquals(20, $param->getEndColumn());
     }
 
@@ -306,7 +306,7 @@ class ASTFormalParameterTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
      */
-    private function _getFirstFormalParameterInFunction()
+    private function getFirstFormalParameterInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -63,7 +63,7 @@ class ASTFormalParametersTest extends ASTNodeTest
      */
     public function testFormalParametersHasExpectedStartLine()
     {
-        $param = $this->_getFirstFormalParametersInFunction(__METHOD__);
+        $param = $this->getFirstFormalParametersInFunction(__METHOD__);
         $this->assertEquals(2, $param->getStartLine());
     }
 
@@ -74,7 +74,7 @@ class ASTFormalParametersTest extends ASTNodeTest
      */
     public function testFormalParametersHasExpectedStartColumn()
     {
-        $param = $this->_getFirstFormalParametersInFunction(__METHOD__);
+        $param = $this->getFirstFormalParametersInFunction(__METHOD__);
         $this->assertEquals(52, $param->getStartColumn());
     }
 
@@ -85,7 +85,7 @@ class ASTFormalParametersTest extends ASTNodeTest
      */
     public function testFormalParametersHasExpectedEndLine()
     {
-        $param = $this->_getFirstFormalParametersInFunction(__METHOD__);
+        $param = $this->getFirstFormalParametersInFunction(__METHOD__);
         $this->assertEquals(6, $param->getEndLine());
     }
 
@@ -96,7 +96,7 @@ class ASTFormalParametersTest extends ASTNodeTest
      */
     public function testFormalParametersHasExpectedEndColumn()
     {
-        $param = $this->_getFirstFormalParametersInFunction(__METHOD__);
+        $param = $this->getFirstFormalParametersInFunction(__METHOD__);
         $this->assertEquals(1, $param->getEndColumn());
     }
 
@@ -107,7 +107,7 @@ class ASTFormalParametersTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTFormalParameters
      */
-    private function _getFirstFormalParametersInFunction($testCase)
+    private function getFirstFormalParametersInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -67,7 +67,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testGetImageForVariableFunction()
     {
-        $postfix = $this->_getFirstFunctionPostfixInFunction();
+        $postfix = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals('$function', $postfix->getImage());
     }
 
@@ -83,7 +83,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testGetImageForArrayIndexedVariableFunction()
     {
-        $postfix = $this->_getFirstFunctionPostfixInFunction();
+        $postfix = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals('$function', $postfix->getImage());
     }
 
@@ -94,7 +94,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForSimpleInvocation()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
@@ -111,7 +111,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForVariableInvocation()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTArguments'
@@ -127,7 +127,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForCompoundVariableInvocation()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTCompoundVariable',
             'PDepend\\Source\\AST\\ASTConstant',
@@ -140,12 +140,12 @@ class ASTFunctionPostfixTest extends ASTNodeTest
 
     /**
      * testFunctionPostfixGraphForArrayIndexedVariableInvocation
-     * 
+     *
      * @return void
      */
     public function testFunctionPostfixGraphForArrayIndexedVariableInvocation()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
@@ -165,7 +165,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForInvocationWithMemberPrimaryPrefixMethod()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
@@ -182,7 +182,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForInvocationWithMemberPrimaryPrefixProperty()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
@@ -199,7 +199,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixGraphForObjectProperty()
     {
-        $postfix  = $this->_getFirstFunctionPostfixInFunction();
+        $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = array(
             'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
             'PDepend\\Source\\AST\\ASTVariable',
@@ -220,7 +220,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixHasExpectedStartLine()
     {
-        $init = $this->_getFirstFunctionPostfixInFunction();
+        $init = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals(4, $init->getStartLine());
     }
 
@@ -231,7 +231,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixHasExpectedStartColumn()
     {
-        $init = $this->_getFirstFunctionPostfixInFunction();
+        $init = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals(5, $init->getStartColumn());
     }
 
@@ -242,7 +242,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixHasExpectedEndLine()
     {
-        $init = $this->_getFirstFunctionPostfixInFunction();
+        $init = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals(8, $init->getEndLine());
     }
 
@@ -253,7 +253,7 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      */
     public function testFunctionPostfixHasExpectedEndColumn()
     {
-        $init = $this->_getFirstFunctionPostfixInFunction();
+        $init = $this->getFirstFunctionPostfixInFunction();
         $this->assertEquals(13, $init->getEndColumn());
     }
 
@@ -272,10 +272,10 @@ class ASTFunctionPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTFunctionPostfix
      */
-    private function _getFirstFunctionPostfixInFunction()
+    private function getFirstFunctionPostfixInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $this->getCallingTestMethod(), 
+            $this->getCallingTestMethod(),
             'PDepend\\Source\\AST\\ASTFunctionPostfix'
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -66,7 +66,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testReturnsReferenceReturnsExpectedTrue()
     {
-        $function = $this->_getFirstFunctionForTestCase();
+        $function = $this->getFirstFunctionForTestCaseInternal();
         $this->assertTrue($function->returnsReference());
     }
 
@@ -77,7 +77,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testReturnsReferenceReturnsExpectedFalse()
     {
-        $function = $this->_getFirstFunctionForTestCase();
+        $function = $this->getFirstFunctionForTestCaseInternal();
         $this->assertFalse($function->returnsReference());
     }
 
@@ -101,7 +101,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
     {
         $this->assertEquals(
             array('a' => 42, 'b' => 23),
-            $this->_getFirstFunctionForTestCase()->getStaticVariables()
+            $this->getFirstFunctionForTestCaseInternal()->getStaticVariables()
         );
     }
 
@@ -114,7 +114,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
     {
         $this->assertEquals(
             array('a' => 42, 'b' => 23, 'c' => 17),
-            $this->_getFirstFunctionForTestCase()->getStaticVariables()
+            $this->getFirstFunctionForTestCaseInternal()->getStaticVariables()
         );
     }
 
@@ -177,7 +177,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testClassReferenceForJavaStyleArrayNotation()
     {
-        $function = $this->_getFirstFunctionForTestCase();
+        $function = $this->getFirstFunctionForTestCaseInternal();
         $type = $function->getReturnClass();
 
         $this->assertEquals('Sindelfingen', $type->getName());
@@ -495,7 +495,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSameDependency()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame(
@@ -511,7 +511,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSameReturnClass()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame(
@@ -527,7 +527,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSameParameterClass()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame(
@@ -543,7 +543,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSameExceptionClass()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame(
@@ -559,7 +559,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSameDependencyInterface()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame(
@@ -575,7 +575,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionStillReferencesSamePackage()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame($orig->getNamespace(), $copy->getNamespace());
@@ -588,7 +588,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionIsInSameNamespace()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertEquals(
@@ -604,7 +604,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionNotAddsDublicateToPackage()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertEquals(1, count($copy->getNamespace()->getFunctions()));
@@ -617,7 +617,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      */
     public function testUnserializedFunctionIsChildOfParentPackage()
     {
-        $orig = $this->_getFirstFunctionForTestCase();
+        $orig = $this->getFirstFunctionForTestCaseInternal();
         $copy = unserialize(serialize($orig));
 
         $this->assertSame($copy, $orig->getNamespace()->getFunctions()->current());
@@ -643,7 +643,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
      *
      * @return ASTFunction
      */
-    private function _getFirstFunctionForTestCase()
+    private function getFirstFunctionForTestCaseInternal()
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -61,7 +61,7 @@ class ASTGlobalStatementTest extends ASTNodeTest
      */
     public function testGlobalStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstGlobalStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGlobalStatementInFunction(__METHOD__);
         $this->assertSame(4, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTGlobalStatementTest extends ASTNodeTest
      */
     public function testGlobalStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstGlobalStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGlobalStatementInFunction(__METHOD__);
         $this->assertSame(5, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTGlobalStatementTest extends ASTNodeTest
      */
     public function testGlobalStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstGlobalStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGlobalStatementInFunction(__METHOD__);
         $this->assertSame(6, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTGlobalStatementTest extends ASTNodeTest
      */
     public function testGlobalStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstGlobalStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGlobalStatementInFunction(__METHOD__);
         $this->assertSame(19, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTGlobalStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTGlobalStatement
      */
-    private function _getFirstGlobalStatementInFunction($testCase)
+    private function getFirstGlobalStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -61,7 +61,7 @@ class ASTGotoStatementTest extends ASTNodeTest
      */
     public function testGotoStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstGotoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGotoStatementInFunction(__METHOD__);
         $this->assertSame(8, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTGotoStatementTest extends ASTNodeTest
      */
     public function testGotoStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstGotoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGotoStatementInFunction(__METHOD__);
         $this->assertSame(9, $stmt->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTGotoStatementTest extends ASTNodeTest
      */
     public function testGotoStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstGotoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGotoStatementInFunction(__METHOD__);
         $this->assertSame(8, $stmt->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTGotoStatementTest extends ASTNodeTest
      */
     public function testGotoStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstGotoStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstGotoStatementInFunction(__METHOD__);
         $this->assertSame(23, $stmt->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTGotoStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTGotoStatement
      */
-    private function _getFirstGotoStatementInFunction($testCase)
+    private function getFirstGotoStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -64,7 +64,7 @@ class ASTHeredocTest extends ASTNodeTest
     {
         $this->assertInstanceOf(
             'PDepend\\Source\\AST\\ASTLiteral',
-            $this->_getFirstHeredocInClass()->getChild(0)
+            $this->getFirstHeredocInClass()->getChild(0)
         );
     }
 
@@ -75,7 +75,7 @@ class ASTHeredocTest extends ASTNodeTest
      */
     public function testHeredocHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstHeredocInFunction();
+        $stmt = $this->getFirstHeredocInFunction();
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -86,7 +86,7 @@ class ASTHeredocTest extends ASTNodeTest
      */
     public function testHeredocHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstHeredocInFunction();
+        $stmt = $this->getFirstHeredocInFunction();
         $this->assertEquals(10, $stmt->getStartColumn());
     }
 
@@ -97,7 +97,7 @@ class ASTHeredocTest extends ASTNodeTest
      */
     public function testHeredocHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstHeredocInFunction();
+        $stmt = $this->getFirstHeredocInFunction();
         $this->assertEquals(8, $stmt->getEndLine());
     }
 
@@ -108,7 +108,7 @@ class ASTHeredocTest extends ASTNodeTest
      */
     public function testHeredocHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstHeredocInFunction();
+        $stmt = $this->getFirstHeredocInFunction();
         $this->assertEquals(3, $stmt->getEndColumn());
     }
 
@@ -117,7 +117,7 @@ class ASTHeredocTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTHeredoc
      */
-    private function _getFirstHeredocInFunction()
+    private function getFirstHeredocInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -130,7 +130,7 @@ class ASTHeredocTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTHeredoc
      */
-    private function _getFirstHeredocInClass()
+    private function getFirstHeredocInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -61,7 +61,7 @@ class ASTIdentifierTest extends ASTNodeTest
      */
     public function testIdentifierHasExpectedStartLine()
     {
-        $param = $this->_getFirstIdentifierInFunction(__METHOD__);
+        $param = $this->getFirstIdentifierInFunction(__METHOD__);
         $this->assertEquals(4, $param->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTIdentifierTest extends ASTNodeTest
      */
     public function testIdentifierHasExpectedStartColumn()
     {
-        $param = $this->_getFirstIdentifierInFunction(__METHOD__);
+        $param = $this->getFirstIdentifierInFunction(__METHOD__);
         $this->assertEquals(22, $param->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTIdentifierTest extends ASTNodeTest
      */
     public function testIdentifierHasExpectedEndLine()
     {
-        $param = $this->_getFirstIdentifierInFunction(__METHOD__);
+        $param = $this->getFirstIdentifierInFunction(__METHOD__);
         $this->assertEquals(4, $param->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTIdentifierTest extends ASTNodeTest
      */
     public function testIdentifierHasExpectedEndColumn()
     {
-        $param = $this->_getFirstIdentifierInFunction(__METHOD__);
+        $param = $this->getFirstIdentifierInFunction(__METHOD__);
         $this->assertEquals(29, $param->getEndColumn());
     }
 
@@ -105,10 +105,11 @@ class ASTIdentifierTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTIdentifier
      */
-    private function _getFirstIdentifierInFunction($testCase)
+    private function getFirstIdentifierInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTIdentifier'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTIdentifier'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -61,7 +61,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsFalseByDefault()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertFalse($stmt->hasElse());
     }
 
@@ -72,7 +72,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseIfBranchExists()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
 
@@ -83,7 +83,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchWithIfExists()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
 
@@ -94,7 +94,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchExists()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
     
@@ -105,7 +105,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementGraphWithBooleanExpressions()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(2, count($stmt->getChildren()));
     }
 
@@ -116,7 +116,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfIfStatementIsInstanceOfExpression()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
 
@@ -127,7 +127,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfIfStatementIsInstanceOfScopeStatement()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
     }
 
@@ -139,7 +139,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testParserThrowsExpectedExceptionWhenIfStatementHasNoBody()
     {
-        $this->_getFirstIfStatementInFunction(__METHOD__);
+        $this->getFirstIfStatementInFunction(__METHOD__);
     }
 
     /**
@@ -149,7 +149,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -160,7 +160,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -171,7 +171,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -182,7 +182,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
 
@@ -193,7 +193,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -204,7 +204,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -215,7 +215,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(10, $stmt->getEndLine());
     }
 
@@ -226,7 +226,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -237,7 +237,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfElseStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(4, $stmt->getStartLine());
     }
 
@@ -248,7 +248,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfElseStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getStartColumn());
     }
 
@@ -259,7 +259,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfElseStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(8, $stmt->getEndLine());
     }
 
@@ -270,7 +270,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfElseStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(10, $stmt->getEndColumn());
     }
 
@@ -281,7 +281,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testElseStatementAlternativeScopeHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__)->getChild(2);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__)->getChild(2);
         $this->assertEquals(7, $stmt->getStartLine());
     }
 
@@ -292,7 +292,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testElseStatementAlternativeScopeHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__)->getChild(2);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__)->getChild(2);
         $this->assertEquals(13, $stmt->getStartColumn());
     }
 
@@ -303,7 +303,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testElseStatementAlternativeScopeHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__)->getChild(2);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__)->getChild(2);
         $this->assertEquals(10, $stmt->getEndLine());
     }
 
@@ -314,7 +314,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testElseStatementAlternativeScopeHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__)->getChild(2);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__)->getChild(2);
         $this->assertEquals(17, $stmt->getEndColumn());
     }
 
@@ -325,7 +325,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementTerminatedByPhpCloseTag()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -336,7 +336,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testIfStatementWithElseContainsExpectedNumberOfChildNodes()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertEquals(3, count($stmt->getChildren()));
     }
 
@@ -347,7 +347,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfIfStatementIsInstanceOfScopeStatementForElse()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
     }
 
@@ -358,7 +358,7 @@ class ASTIfStatementTest extends ASTNodeTest
      */
     public function testThirdChildOfIfStatementIsInstanceOfIfStatementForElseIf()
     {
-        $stmt = $this->_getFirstIfStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIfStatement', $stmt->getChild(2));
     }
 
@@ -369,10 +369,11 @@ class ASTIfStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTIfStatement
      */
-    private function _getFirstIfStatementInFunction($testCase)
+    private function getFirstIfStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTIfStatement'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTIfStatement'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -74,7 +74,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIsOnceReturnsTrueForIncludeOnceExpression()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertTrue($expression->isOnce());
     }
 
@@ -104,7 +104,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionHasExpectedStartLine()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expression->getStartLine());
     }
 
@@ -115,7 +115,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionHasExpectedStartColumn()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(5, $expression->getStartColumn());
     }
 
@@ -126,7 +126,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionHasExpectedEndLine()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expression->getEndLine());
     }
 
@@ -137,7 +137,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionHasExpectedEndColumn()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(35, $expression->getEndColumn());
     }
 
@@ -148,7 +148,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionWithParenthesisHasExpectedStartLine()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expression->getStartLine());
     }
 
@@ -159,7 +159,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionWithParenthesisHasExpectedStartColumn()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(5, $expression->getStartColumn());
     }
 
@@ -170,7 +170,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionWithParenthesisHasExpectedEndLine()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(6, $expression->getEndLine());
     }
 
@@ -181,7 +181,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      */
     public function testIncludeExpressionWithParenthesisHasExpectedEndColumn()
     {
-        $expression = $this->_getFirstIncludeExpressionInFunction(__METHOD__);
+        $expression = $this->getFirstIncludeExpressionInFunction(__METHOD__);
         $this->assertEquals(5, $expression->getEndColumn());
     }
 
@@ -192,7 +192,7 @@ class ASTIncludeExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTIncludeExpression
      */
-    private function _getFirstIncludeExpressionInFunction($testCase)
+    private function getFirstIncludeExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -56,7 +56,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
 {
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     * 
+     *
      * @return void
      */
     public function testInstanceOfExpressionGraphWithStringIdentifier()
@@ -66,7 +66,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                __FUNCTION__
+            __FUNCTION__
         );
     }
 
@@ -82,7 +82,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                'foo\bar\Baz'
+            'foo\bar\Baz'
         );
     }
 
@@ -98,7 +98,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                '\foo\bar\Baz'
+            '\foo\bar\Baz'
         );
     }
 
@@ -114,7 +114,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                '\foo\bar\Baz'
+            '\foo\bar\Baz'
         );
     }
 
@@ -130,7 +130,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                'stdClass'
+            'stdClass'
         );
     }
 
@@ -146,7 +146,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                '__PHP_Incomplete_Class'
+            '__PHP_Incomplete_Class'
         );
     }
 
@@ -162,7 +162,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTest
                 ->current()
                 ->getFunctions()
                 ->current(),
-                '::'
+            '::'
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -235,7 +235,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testIsSubtypeOnInheritanceHierarchy()
     {
-        $this->_testIsSubtypeOnInheritanceHierarchy(
+        $this->doTestIsSubtypeOnInheritanceHierarchy(
             array(
                 'A' => true,
                 'B' => false,
@@ -254,7 +254,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testIsSubtypeOnInheritanceHierarchy1()
     {
-        $this->_testIsSubtypeOnInheritanceHierarchy(
+        $this->doTestIsSubtypeOnInheritanceHierarchy(
             array(
                 'A' => true,
                 'B' => true,
@@ -273,7 +273,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testIsSubtypeOnInheritanceHierarchy2()
     {
-        $this->_testIsSubtypeOnInheritanceHierarchy(
+        $this->doTestIsSubtypeOnInheritanceHierarchy(
             array(
                 'B' => false,
                 'C' => false,
@@ -292,7 +292,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      */
     public function testIsSubtypeOnInheritanceHierarchy3()
     {
-        $this->_testIsSubtypeOnInheritanceHierarchy(
+        $this->doTestIsSubtypeOnInheritanceHierarchy(
             array(
                 'B' => false,
                 'C' => false,
@@ -311,7 +311,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
      *
      * @return void
      */
-    private function _testIsSubtypeOnInheritanceHierarchy(array $expected)
+    private function doTestIsSubtypeOnInheritanceHierarchy(array $expected)
     {
         $namespaces = $this->parseCodeResourceForTest();
         $namespace = $namespaces->current();

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -63,7 +63,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionGraphWithMultipleVariables()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable');
         $this->assertEquals(3, count($vars));
     }
@@ -75,7 +75,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionGraphWithStaticProperty()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix');
         $this->assertEquals(1, count($vars));
     }
@@ -87,7 +87,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionGraphWithArrayProperty()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix');
         $this->assertEquals(1, count($vars));
     }
@@ -99,7 +99,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -110,7 +110,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $this->assertEquals(9, $expr->getStartColumn());
     }
 
@@ -121,7 +121,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -132,7 +132,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      */
     public function testIssetExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstIssetExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
         $this->assertEquals(30, $expr->getEndColumn());
     }
 
@@ -143,7 +143,7 @@ class ASTIssetExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTIssetExpression
      */
-    private function _getFirstIssetExpressionInFunction($testCase)
+    private function getFirstIssetExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -61,7 +61,7 @@ class ASTLabelStatementTest extends ASTNodeTest
      */
     public function testLabelStatementHasExpectedStartLine()
     {
-        $stmt = $this->_getFirstLabelStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstLabelStatementInFunction(__METHOD__);
         $this->assertSame(4, $stmt->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTLabelStatementTest extends ASTNodeTest
      */
     public function testLabelStatementHasExpectedStartColumn()
     {
-        $stmt = $this->_getFirstLabelStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstLabelStatementInFunction(__METHOD__);
         $this->assertSame(5, $stmt->getStartColumn());
     }
 
@@ -84,7 +84,7 @@ class ASTLabelStatementTest extends ASTNodeTest
      */
     public function testLabelStatementHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstLabelStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstLabelStatementInFunction(__METHOD__);
         $this->assertSame(4, $stmt->getEndLine());
     }
 
@@ -95,7 +95,7 @@ class ASTLabelStatementTest extends ASTNodeTest
      */
     public function testLabelStatementHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstLabelStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstLabelStatementInFunction(__METHOD__);
         $this->assertSame(14, $stmt->getEndColumn());
     }
 
@@ -106,7 +106,7 @@ class ASTLabelStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTLabelStatement
      */
-    private function _getFirstLabelStatementInFunction($testCase)
+    private function getFirstLabelStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -62,7 +62,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpression()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
 
         return $expr;
@@ -128,7 +128,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithNestedList()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
 
         return $expr;
@@ -197,7 +197,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionSupportsManyVariables()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $vars = $expr->getChildren();
         $this->assertEquals(3, count($vars));
     }
@@ -209,7 +209,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionSupportsSingleVariable()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $vars = $expr->getChildren();
         $this->assertEquals(1, count($vars));
     }
@@ -221,7 +221,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionSupportsExtraCommas()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $vars = $expr->getChildren();
         $this->assertEquals(3, count($vars));
     }
@@ -233,7 +233,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithComments()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $vars = $expr->getChildren();
         $this->assertEquals(3, count($vars));
     }
@@ -245,7 +245,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithoutChildExpression()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $vars = $expr->getChildren();
         $this->assertEquals(0, count($vars));
     }
@@ -257,7 +257,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithVariableVariable()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $var  = $expr->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableVariable', $var);
@@ -270,7 +270,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithCompoundVariable()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $var  = $expr->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundVariable', $var);
@@ -283,7 +283,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithArrayElement()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $var  = $expr->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArrayIndexExpression', $var);
@@ -296,7 +296,7 @@ class ASTListExpressionTest extends ASTNodeTest
      */
     public function testListExpressionWithObjectProperty()
     {
-        $expr = $this->_getFirstListExpressionInFunction();
+        $expr = $this->getFirstListExpressionInFunction();
         $var  = $expr->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $var);
@@ -307,7 +307,7 @@ class ASTListExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTListExpression
      */
-    private function _getFirstListExpressionInFunction()
+    private function getFirstListExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -61,7 +61,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithBooleanTrueExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('True', $literal->getImage());
     }
 
@@ -72,7 +72,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithBooleanFalseExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('False', $literal->getImage());
     }
 
@@ -83,7 +83,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithIntegerExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('42', $literal->getImage());
     }
 
@@ -94,7 +94,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithSignedIntegerExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('42', $literal->getImage());
     }
 
@@ -105,7 +105,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithFloatExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('42.23', $literal->getImage());
     }
 
@@ -116,7 +116,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithSignedFloatExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('42.23', $literal->getImage());
     }
 
@@ -127,7 +127,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithNullExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('NULL', $literal->getImage());
     }
 
@@ -139,7 +139,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithZeroIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('0', $literal->getImage());
     }
 
@@ -151,7 +151,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithZeroOctalIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('00', $literal->getImage());
     }
 
@@ -163,7 +163,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithZeroHexIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('0x0', $literal->getImage());
     }
 
@@ -176,7 +176,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithZeroBinaryIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('0b0', $literal->getImage());
     }
 
@@ -188,7 +188,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithNonZeroOctalIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('02342', $literal->getImage());
     }
 
@@ -200,7 +200,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithNonZeroHexIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('0x926', $literal->getImage());
     }
 
@@ -213,7 +213,7 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithNonZeroBinaryIntegerValue()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('0b100100100110', $literal->getImage());
     }
 
@@ -230,7 +230,7 @@ class ASTLiteralTest extends ASTNodeTest
         if (version_compare(phpversion(), '5.4alpha') >= 0) {
             $this->markTestSkipped('This test only affects PHP < 5.4');
         }
-        $this->_getFirstLiteralInFunction();
+        $this->getFirstLiteralInFunction();
     }
 
     /**
@@ -241,13 +241,13 @@ class ASTLiteralTest extends ASTNodeTest
      */
     public function testLiteralWithCurlyBraceFollowedByCompoundExpression()
     {
-        $literal = $this->_getFirstLiteralInFunction();
+        $literal = $this->getFirstLiteralInFunction();
         $this->assertEquals('{', $literal->getImage());
     }
 
     /**
      * Tests that an invalid literal results in the expected exception.
-     * 
+     *
      * @return void
      * @expectedException \PDepend\Source\Parser\TokenStreamEndException
      */
@@ -271,7 +271,7 @@ class ASTLiteralTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTLiteral
      */
-    private function _getFirstLiteralInFunction()
+    private function getFirstLiteralInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -63,7 +63,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTest
      */
     public function testLogicalAndExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstLogicalAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalAndExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -74,7 +74,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTest
      */
     public function testLogicalAndExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstLogicalAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalAndExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -85,7 +85,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTest
      */
     public function testLogicalAndExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstLogicalAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalAndExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -96,7 +96,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTest
      */
     public function testLogicalAndExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstLogicalAndExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalAndExpressionInFunction(__METHOD__);
         $this->assertEquals(20, $expr->getEndColumn());
     }
 
@@ -107,7 +107,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTLogicalAndExpression
      */
-    private function _getFirstLogicalAndExpressionInFunction($testCase)
+    private function getFirstLogicalAndExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -63,7 +63,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTest
      */
     public function testLogicalOrExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstLogicalOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalOrExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -74,7 +74,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTest
      */
     public function testLogicalOrExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstLogicalOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalOrExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -85,7 +85,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTest
      */
     public function testLogicalOrExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstLogicalOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalOrExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -96,7 +96,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTest
      */
     public function testLogicalOrExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstLogicalOrExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalOrExpressionInFunction(__METHOD__);
         $this->assertEquals(19, $expr->getEndColumn());
     }
 
@@ -107,7 +107,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTLogicalOrExpression
      */
-    private function _getFirstLogicalOrExpressionInFunction($testCase)
+    private function getFirstLogicalOrExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -61,7 +61,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTest
      */
     public function testLogicalXorExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstLogicalXorExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalXorExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -72,7 +72,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTest
      */
     public function testLogicalXorExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstLogicalXorExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalXorExpressionInFunction(__METHOD__);
         $this->assertEquals(18, $expr->getStartColumn());
     }
 
@@ -83,7 +83,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTest
      */
     public function testLogicalXorExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstLogicalXorExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalXorExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -94,7 +94,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTest
      */
     public function testLogicalXorExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstLogicalXorExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstLogicalXorExpressionInFunction(__METHOD__);
         $this->assertEquals(20, $expr->getEndColumn());
     }
 
@@ -105,7 +105,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTLogicalXorExpression
      */
-    private function _getFirstLogicalXorExpressionInFunction($testCase)
+    private function getFirstLogicalXorExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -62,7 +62,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphDereferencedFromArray()
     {
-        $this->_getFirstMemberPrimaryPrefixInFunction();
+        $this->getFirstMemberPrimaryPrefixInFunction();
     }
 
     /**
@@ -96,7 +96,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testMemberPrimaryPrefixGraphInIssetExpression()
     {
         $this->assertGraph(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable'                          . ' ($object)',
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'               . ' (->)', array(
@@ -136,7 +136,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticConstant()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTConstantPostfix',
@@ -166,7 +166,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticProperty()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -200,7 +200,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticMethod()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -236,7 +236,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndDynamicMethod()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -272,7 +272,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndMethodInvocation()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraph(
             $prefix,
             array(
@@ -312,7 +312,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndMethodChain()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraph(
             $prefix,
             array(
@@ -351,7 +351,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndPropertyAccess()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraph(
             $prefix,
             array(
@@ -388,7 +388,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndPropertyChain()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraph(
             $prefix,
             array(
@@ -405,16 +405,16 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
 
     /**
      * testMemberPrimaryPrefixGraphForObjectPropertyAccess
-     * 
+     *
      * <code>
      * $obj->foo = 42;
      * </code>
-     * 
+     *
      * @return void
      */
     public function testMemberPrimaryPrefixGraphForObjectPropertyAccess()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -446,7 +446,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphForObjectWithVariablePropertyAccess()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -468,7 +468,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphForObjectMethodAccess()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraphEquals(
             $prefix,
             array(
@@ -504,7 +504,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testMemberPrimaryPrefixGraphForObjectWithVariableMethodAccess()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertGraph(
             $prefix,
             array(
@@ -545,7 +545,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testGraphDereferencedArrayFromFunctionCallAndMethodInvocation()
     {
         $this->assertGraphEquals(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression',
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
@@ -572,7 +572,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testMemberPrimaryPrefixGraphForChainedObjectMemberAccess()
     {
         $this->assertGraph(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariable'                    . ' ($obj)',
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'         . ' (->)',     array(
@@ -596,13 +596,13 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      * <code>
      * foo(23)[42]->bar()[17]->baz()[0]
      * </code>
-     * 
+     *
      * @return void
      */
     public function testGraphDereferencedArrayFromFunctionCallAndMultipleMethodInvocations()
     {
         $this->assertGraph(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression'         . ' ()',    array(
                     'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'      . ' (->)',  array(
@@ -636,7 +636,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testGraphDereferencedArrayFromStaticMethodCallAndMultipleMethodInvocations()
     {
         $this->assertGraph(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression'                      . ' ()',    array(
                     'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'                   . ' (->)',  array(
@@ -672,7 +672,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
     public function testGraphDereferencedArrayFromVariableClassStaticMethodCallAndMultipleMethodInvocations()
     {
         $this->assertGraph(
-            $this->_getFirstMemberPrimaryPrefixInFunction(),
+            $this->getFirstMemberPrimaryPrefixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression'                      . ' ()',    array(
                     'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'                   . ' (->)',  array(
@@ -702,7 +702,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectMemberPrimaryPrefixHasExpectedStartLine()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertEquals(4, $prefix->getStartLine());
     }
 
@@ -713,7 +713,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectMemberPrimaryPrefixHasExpectedStartColumn()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertEquals(5, $prefix->getStartColumn());
     }
 
@@ -724,7 +724,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectMemberPrimaryPrefixHasExpectedEndLine()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertEquals(6, $prefix->getEndLine());
     }
 
@@ -735,7 +735,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectMemberPrimaryPrefixHasExpectedEndColumn()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertEquals(10, $prefix->getEndColumn());
     }
 
@@ -746,7 +746,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectPropertyMemberPrimaryPrefixIsStaticReturnsFalse()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertFalse($prefix->isStatic());
     }
 
@@ -757,7 +757,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testObjectMethodMemberPrimaryPrefixIsStaticReturnsFalse()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertFalse($prefix->isStatic());
     }
 
@@ -768,7 +768,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testClassPropertyMemberPrimaryPrefixIsStaticReturnsTrue()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertTrue($prefix->isStatic());
     }
 
@@ -779,7 +779,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      */
     public function testClassMethodMemberPrimaryPrefixIsStaticReturnsTrue()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction();
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction();
         $this->assertTrue($prefix->isStatic());
     }
 
@@ -788,7 +788,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInFunction()
+    private function getFirstMemberPrimaryPrefixInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -67,7 +67,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testGetImageForVariableMethod()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals('$method', $postfix->getImage());
     }
 
@@ -83,7 +83,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testGetImageForVariableStaticMethod()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals('$method', $postfix->getImage());
     }
 
@@ -99,7 +99,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testGetImageForArrayIndexedVariableStaticMethod()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals('$method', $postfix->getImage());
     }
 
@@ -115,7 +115,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testGetImageForMultiArrayIndexedVariableStaticMethod()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals('$method', $postfix->getImage());
     }
 
@@ -126,7 +126,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixGraphForVariable()
     {
-        $postfix  = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $postfix  = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -144,7 +144,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixGraphForArrayIndexedVariable()
     {
-        $postfix  = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $postfix  = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -179,7 +179,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testMethodPostfixGraphForCompoundExpression()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", array(
                 'PDepend\\Source\\AST\\ASTLiteral'            . " ('method')"),
@@ -210,7 +210,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testMethodPostfixGraphForCompoundVariable()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", array(
                 'PDepend\\Source\\AST\\ASTLiteral'          . " ('method')"),
@@ -241,7 +241,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testMethodPostfixGraphForVariableVariable()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', array(
                 'PDepend\\Source\\AST\\ASTVariable'         . ' ($method)'),
@@ -272,7 +272,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testStaticMethodPostfixGraphForCompoundExpression()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", array(
                 'PDepend\\Source\\AST\\ASTLiteral'            . " ('method')"),
@@ -303,7 +303,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testStaticMethodPostfixGraphForCompoundVariable()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", array(
                 'PDepend\\Source\\AST\\ASTLiteral'          . " ('method')"),
@@ -334,7 +334,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
     public function testStaticMethodPostfixGraphForVariableVariable()
     {
         $this->assertGraph(
-            $this->_getFirstMethodPostfixInFunction(),
+            $this->getFirstMethodPostfixInFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', array(
                 'PDepend\\Source\\AST\\ASTVariable'         . ' ($method)'),
@@ -350,7 +350,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testObjectMethodPostfixHasExpectedStartLine()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(6, $postfix->getStartLine());
     }
 
@@ -361,7 +361,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testObjectMethodPostfixHasExpectedStartColumn()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(13, $postfix->getStartColumn());
     }
 
@@ -372,7 +372,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testObjectMethodPostfixHasExpectedEndLine()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(7, $postfix->getEndLine());
     }
 
@@ -383,7 +383,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testObjectMethodPostfixHasExpectedEndColumn()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(17, $postfix->getEndColumn());
     }
 
@@ -394,7 +394,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testClassMethodPostfixHasExpectedStartLine()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(6, $postfix->getStartLine());
     }
 
@@ -405,7 +405,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testClassMethodPostfixHasExpectedStartColumn()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(13, $postfix->getStartColumn());
     }
 
@@ -416,7 +416,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testClassMethodPostfixHasExpectedEndLine()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(7, $postfix->getEndLine());
     }
 
@@ -427,7 +427,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testClassMethodPostfixHasExpectedEndColumn()
     {
-        $postfix = $this->_getFirstMethodPostfixInFunction();
+        $postfix = $this->getFirstMethodPostfixInFunction();
         $this->assertEquals(17, $postfix->getEndColumn());
     }
 
@@ -438,7 +438,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForSimpleInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -456,7 +456,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForVariableInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -474,7 +474,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForVariableVariableInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -493,7 +493,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForCompoundVariableInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -507,12 +507,12 @@ class ASTMethodPostfixTest extends ASTNodeTest
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     * 
+     *
      * @return void
      */
     public function testMethodPostfixStructureForSimpleStaticInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -530,7 +530,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForVariableStaticInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -548,7 +548,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForVariableVariableStaticInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -567,7 +567,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForCompoundVariableStaticInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -586,7 +586,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForVariableCompoundVariableStaticInvocation()
     {
-        $prefix = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -607,7 +607,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForStaticInvocationWithConsecutiveInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
@@ -629,7 +629,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForStaticInvocationOnVariable()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -647,7 +647,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForSelfInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTSelfReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -665,7 +665,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixStructureForParentInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTParentReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -683,7 +683,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixGraphForStaticReferenceInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTStaticReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -705,7 +705,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      */
     public function testMethodPostfixGraphForVariableArrayElementInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -723,7 +723,7 @@ class ASTMethodPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMethodPostfix
      */
-    private function _getFirstMethodPostfixInFunction()
+    private function getFirstMethodPostfixInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -738,10 +738,11 @@ class ASTMethodPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInFunction($testCase)
+    private function getFirstMemberPrimaryPrefixInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
         );
     }
 
@@ -752,10 +753,11 @@ class ASTMethodPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInClass($testCase)
+    private function getFirstMemberPrimaryPrefixInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
-            $testCase, 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -63,7 +63,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testGetIdReturnsExpectedObjectHash()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertEquals(spl_object_hash($parameters[0]), $parameters[0]->getId());
     }
 
@@ -74,7 +74,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterAllowsNullForSimpleVariableIssue67()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertTrue($parameters[0]->allowsNull());
     }
 
@@ -86,7 +86,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterAllowsNullForSimpleVariablePassedByReferenceIssue67()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertTrue($parameters[0]->allowsNull());
     }
 
@@ -98,7 +98,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterNotAllowsNullForArrayHintVariableIssue67()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertFalse($parameters[0]->allowsNull());
     }
 
@@ -110,7 +110,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterAllowsNullForArrayHintVariableIssue67()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertTrue($parameters[0]->allowsNull());
     }
 
@@ -122,7 +122,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterNotAllowsNullForTypeHintVariableIssue67()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertFalse($parameters[0]->allowsNull());
     }
 
@@ -134,7 +134,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterAllowsNullForTypeHintVariableIssue67()
     {
-        $parameter = $this->_getFirstMethodInClass()->getParameters();
+        $parameter = $this->getFirstMethodInClass()->getParameters();
         $this->assertTrue($parameter[0]->allowsNull());
     }
 
@@ -196,7 +196,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterReturnNullForTypeWhenNoASTClassOrInterfaceReferenceWasSet()
     {
-        $parameters = $this->_getFirstMethodInClass()->getParameters();
+        $parameters = $this->getFirstMethodInClass()->getParameters();
         $this->assertNull($parameters[0]->getClass());
     }
 
@@ -219,7 +219,7 @@ class ASTParameterTest extends AbstractTest
      */
     public function testParameterReturnsExpectedDeclaringMethod()
     {
-        $method     = $this->_getFirstMethodInClass();
+        $method     = $this->getFirstMethodInClass();
         $parameters = $method->getParameters();
         $this->assertSame($method, $parameters[0]->getDeclaringFunction());
     }
@@ -231,7 +231,7 @@ class ASTParameterTest extends AbstractTest
      * @return \PDepend\Source\AST\ASTMethod
      * @since 1.0.0
      */
-    private function _getFirstMethodInClass()
+    private function getFirstMethodInClass()
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -148,7 +148,7 @@ class ASTParentReferenceTest extends ASTNodeTest
      */
     public function testParentReferenceHasExpectedStartLine()
     {
-        $reference = $this->_getFirstParentReferenceInClass(__METHOD__);
+        $reference = $this->getFirstParentReferenceInClass(__METHOD__);
         $this->assertEquals(5, $reference->getStartLine());
     }
 
@@ -159,7 +159,7 @@ class ASTParentReferenceTest extends ASTNodeTest
      */
     public function testParentReferenceHasExpectedStartColumn()
     {
-        $reference = $this->_getFirstParentReferenceInClass(__METHOD__);
+        $reference = $this->getFirstParentReferenceInClass(__METHOD__);
         $this->assertEquals(20, $reference->getStartColumn());
     }
 
@@ -170,7 +170,7 @@ class ASTParentReferenceTest extends ASTNodeTest
      */
     public function testParentReferenceHasExpectedEndLine()
     {
-        $reference = $this->_getFirstParentReferenceInClass(__METHOD__);
+        $reference = $this->getFirstParentReferenceInClass(__METHOD__);
         $this->assertEquals(5, $reference->getEndLine());
     }
 
@@ -181,7 +181,7 @@ class ASTParentReferenceTest extends ASTNodeTest
      */
     public function testParentReferenceHasExpectedEndColumn()
     {
-        $reference = $this->_getFirstParentReferenceInClass(__METHOD__);
+        $reference = $this->getFirstParentReferenceInClass(__METHOD__);
         $this->assertEquals(25, $reference->getEndColumn());
     }
 
@@ -206,10 +206,11 @@ class ASTParentReferenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTParentReference
      */
-    private function _getFirstParentReferenceInClass($testCase)
+    private function getFirstParentReferenceInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
-            $testCase, 'PDepend\\Source\\AST\\ASTParentReference'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTParentReference'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -61,7 +61,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnStaticClassMember()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -80,7 +80,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnSelfClassMember()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -99,7 +99,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnParentClassMember()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -118,7 +118,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnThisObjectMember()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -137,7 +137,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnFunctionPostfix()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -156,7 +156,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnVariableVariable()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -174,7 +174,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnCompoundVariable()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -191,7 +191,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnObjectMethodPostfix()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -212,7 +212,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionOnStaticMethodPostfix()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -227,12 +227,12 @@ class ASTPostfixExpressionTest extends ASTNodeTest
 
     /**
      * testIncrementPostfixExpressionArrayPropertyPostfix
-     * 
+     *
      * @return void
      */
     public function testIncrementPostfixExpressionArrayPropertyPostfix()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__)->getParent();
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__)->getParent();
         $this->assertGraphEquals(
             $expr,
             array(
@@ -254,7 +254,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(5, $expr->getStartLine());
     }
 
@@ -265,7 +265,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(9, $expr->getStartColumn());
     }
 
@@ -276,7 +276,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(7, $expr->getEndLine());
     }
 
@@ -287,7 +287,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testIncrementPostfixExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(14, $expr->getEndColumn());
     }
 
@@ -298,7 +298,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testDecrementPostfixExpressionArrayPropertyPostfix()
     {
-        $expr = $this->_getFirstPostfixExpressionInClass(__METHOD__)->getParent();
+        $expr = $this->getFirstPostfixExpressionInClass(__METHOD__)->getParent();
         $this->assertGraphEquals(
             $expr,
             array(
@@ -320,7 +320,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testDecrementPostfixExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(7, $expr->getStartLine());
     }
 
@@ -331,7 +331,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testDecrementPostfixExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(17, $expr->getStartColumn());
     }
 
@@ -342,7 +342,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testDecrementPostfixExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(9, $expr->getEndLine());
     }
 
@@ -353,7 +353,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      */
     public function testDecrementPostfixExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstPostfixExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPostfixExpressionInFunction(__METHOD__);
         $this->assertEquals(10, $expr->getEndColumn());
     }
 
@@ -364,7 +364,7 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      *
      * @return ASTPostfixExpression
      */
-    private function _getFirstPostfixExpressionInClass($testCase)
+    private function getFirstPostfixExpressionInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
@@ -379,10 +379,11 @@ class ASTPostfixExpressionTest extends ASTNodeTest
      *
      * @return ASTPostfixExpression
      */
-    private function _getFirstPostfixExpressionInFunction($testCase)
+    private function getFirstPostfixExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTPostfixExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTPostfixExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -61,7 +61,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionOnStaticClassMember()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -80,7 +80,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionOnSelfClassMember()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -99,7 +99,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionOnParentClassMember()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -118,7 +118,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionOnFunctionPostfix()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -136,7 +136,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionOnStaticVariableMember()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -155,7 +155,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -166,7 +166,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertEquals(12, $expr->getStartColumn());
     }
 
@@ -177,7 +177,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertEquals(7, $expr->getEndLine());
     }
 
@@ -188,7 +188,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      */
     public function testPreDecrementExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstPreDecrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreDecrementExpressionInFunction(__METHOD__);
         $this->assertEquals(21, $expr->getEndColumn());
     }
 
@@ -198,7 +198,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      * @param string $testCase Name of the calling test case.
      * @return \PDepend\Source\AST\ASTPreDecrementExpression
      */
-    private function _getFirstPreDecrementExpressionInClass($testCase)
+    private function getFirstPreDecrementExpressionInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
@@ -213,10 +213,11 @@ class ASTPreDecrementExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTPreDecrementExpression
      */
-    private function _getFirstPreDecrementExpressionInFunction($testCase)
+    private function getFirstPreDecrementExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTPreDecrementExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTPreDecrementExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -62,7 +62,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionOnStaticClassMember()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -81,7 +81,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionOnSelfClassMember()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -100,7 +100,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionOnParentClassMember()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInClass(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInClass(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -119,7 +119,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionOnFunctionPostfix()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -137,7 +137,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionOnStaticVariableMember()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertGraphEquals(
             $expr,
             array(
@@ -151,7 +151,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
 
     /**
      * testPreIncrementExpressionsInArithmeticOperation
-     * 
+     *
      * @return void
      */
     public function testPreIncrementExpressionsInArithmeticOperation()
@@ -171,7 +171,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionHasExpectedStartLine()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
@@ -182,7 +182,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionHasExpectedStartColumn()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertEquals(13, $expr->getStartColumn());
     }
 
@@ -193,7 +193,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionHasExpectedEndLine()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getEndLine());
     }
 
@@ -204,7 +204,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      */
     public function testPreIncrementExpressionHasExpectedEndColumn()
     {
-        $expr = $this->_getFirstPreIncrementExpressionInFunction(__METHOD__);
+        $expr = $this->getFirstPreIncrementExpressionInFunction(__METHOD__);
         $this->assertEquals(20, $expr->getEndColumn());
     }
 
@@ -214,10 +214,11 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      * @param string $testCase Name of the calling test case.
      * @return \PDepend\Source\AST\ASTPreIncrementExpression
      */
-    private function _getFirstPreIncrementExpressionInClass($testCase)
+    private function getFirstPreIncrementExpressionInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
-            $testCase, 'PDepend\\Source\\AST\\ASTPreIncrementExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTPreIncrementExpression'
         );
     }
 
@@ -227,10 +228,11 @@ class ASTPreIncrementExpressionTest extends ASTNodeTest
      * @param string $testCase Name of the calling test case.
      * @return \PDepend\Source\AST\ASTPreIncrementExpression
      */
-    private function _getFirstPreIncrementExpressionInFunction($testCase)
+    private function getFirstPreIncrementExpressionInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTPreIncrementExpression'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTPreIncrementExpression'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -60,12 +60,12 @@ class ASTPropertyPostfixTest extends ASTNodeTest
 {
     /**
      * testGetImageForArrayIndexedRegularProperty
-     * 
+     *
      * @return void
      */
     public function testGetImageForArrayIndexedRegularProperty()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction();
+        $postfix = $this->getFirstPropertyPostfixInFunction();
         $this->assertEquals('property', $postfix->getImage());
     }
 
@@ -76,29 +76,29 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testGetImageForMultiDimensionalArrayIndexedRegularProperty()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction();
+        $postfix = $this->getFirstPropertyPostfixInFunction();
         $this->assertEquals('property', $postfix->getImage());
     }
 
     /**
      * testGetImageForVariableProperty
-     * 
+     *
      * @return void
      */
     public function testGetImageForVariableProperty()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction();
+        $postfix = $this->getFirstPropertyPostfixInFunction();
         $this->assertEquals('$property', $postfix->getImage());
     }
 
     /**
      * testGetImageForArrayIndexedVariableProperty
-     * 
+     *
      * @return void
      */
     public function testGetImageForArrayIndexedVariableProperty()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction();
+        $postfix = $this->getFirstPropertyPostfixInFunction();
         $this->assertEquals('$property', $postfix->getImage());
     }
 
@@ -113,7 +113,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixGraphForArrayElementInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -136,7 +136,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixGraphForPropertyArrayElementInvocation()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -155,7 +155,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForSimpleIdentifierAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -172,7 +172,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -189,7 +189,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForVariableVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -207,7 +207,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForCompoundVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -228,7 +228,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForCompoundExpressionAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -246,7 +246,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForStaticVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -263,7 +263,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForStaticAccessOnVariable()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInFunction(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -280,7 +280,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForSelfVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTSelfReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -297,7 +297,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixStructureForParentVariableAccess()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTParentReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -318,7 +318,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixGraphForObjectPropertyArrayIndexExpression()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -341,7 +341,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixGraphForStaticPropertyArrayIndexExpression()
     {
-        $prefix   = $this->_getFirstMemberPrimaryPrefixInClass(__METHOD__);
+        $prefix   = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = array(
             'PDepend\\Source\\AST\\ASTSelfReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
@@ -393,7 +393,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixHasExpectedStartLine()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstPropertyPostfixInFunction(__METHOD__);
         $this->assertEquals(4, $postfix->getStartLine());
     }
 
@@ -404,7 +404,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixHasExpectedStartColumn()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstPropertyPostfixInFunction(__METHOD__);
         $this->assertEquals(21, $postfix->getStartColumn());
     }
 
@@ -415,7 +415,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixHasExpectedEndLine()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstPropertyPostfixInFunction(__METHOD__);
         $this->assertEquals(4, $postfix->getEndLine());
     }
 
@@ -426,7 +426,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      */
     public function testPropertyPostfixHasExpectedEndColumn()
     {
-        $postfix = $this->_getFirstPropertyPostfixInFunction(__METHOD__);
+        $postfix = $this->getFirstPropertyPostfixInFunction(__METHOD__);
         $this->assertEquals(23, $postfix->getEndColumn());
     }
 
@@ -445,7 +445,7 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTPropertyPostfix
      */
-    private function _getFirstPropertyPostfixInFunction()
+    private function getFirstPropertyPostfixInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -460,10 +460,11 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInFunction($testCase)
+    private function getFirstMemberPrimaryPrefixInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
         );
     }
 
@@ -474,10 +475,11 @@ class ASTPropertyPostfixTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
      */
-    private function _getFirstMemberPrimaryPrefixInClass($testCase)
+    private function getFirstMemberPrimaryPrefixInClass($testCase)
     {
         return $this->getFirstNodeOfTypeInClass(
-            $testCase, 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -63,7 +63,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDeclaringClass()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(__FUNCTION__, $property->getDeclaringClass()->getName());
     }
 
@@ -74,7 +74,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassForPropertyWithNamespacedRootType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('Foo', $property->getClass()->getName());
     }
 
@@ -85,7 +85,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassForPropertyWithNamespacedType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('Baz', $property->getClass()->getName());
     }
 
@@ -96,7 +96,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassForPropertyWithNamespacedArrayRootType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('Foo', $property->getClass()->getName());
     }
 
@@ -107,7 +107,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassForPropertyWithNamespacedArrayType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('Baz', $property->getClass()->getName());
     }
 
@@ -118,7 +118,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassReturnsNullForPropertyWithScalarType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getClass());
     }
 
@@ -129,7 +129,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassReturnsNullForPropertyWithoutTypeHint()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getClass());
     }
 
@@ -140,7 +140,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetClassReturnsNullForPropertyWithoutDocComment()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getClass());
     }
 
@@ -177,7 +177,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDocCommentReturnsNullByDefault()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getComment());
     }
 
@@ -188,7 +188,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDocCommentReturnsExpectedPropertyComment()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('/** Manuel */', $property->getComment());
     }
 
@@ -200,7 +200,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyIsDefaultValueAvailableReturnsFalseWhenNoValueExists()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isDefaultValueAvailable());
     }
 
@@ -212,7 +212,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyIsDefaultValueAvailableReturnsTrueWhenValueExists()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isDefaultValueAvailable());
     }
 
@@ -223,7 +223,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsDefaultValueAvailableReturnsExpectedTrueForNullValue()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isDefaultValueAvailable());
     }
 
@@ -234,7 +234,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDefaultValueReturnsByDefaultExpectedNull()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getDefaultValue());
     }
 
@@ -245,7 +245,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDefaultValueReturnsExpectedNullForNullDefaultValue()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertNull($property->getDefaultValue());
     }
 
@@ -256,7 +256,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyContainsExpectDefaultValueBooleanTrue()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->getDefaultValue());
     }
 
@@ -267,7 +267,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyContainsExpectDefaultValueBooleanFalse()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->getDefaultValue());
     }
 
@@ -278,7 +278,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyContainsExpectDefaultValueArray()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertInternalType('array', $property->getDefaultValue());
     }
 
@@ -289,7 +289,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyContainsExpectedDefaultValueFloat()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(3.14, $property->getDefaultValue(), '', 0.001);
     }
 
@@ -301,7 +301,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsArrayReturnsExpectedValueTrueForVarAnnotationWithArray()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isArray());
     }
 
@@ -313,7 +313,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsArrayReturnsExpectedValueFalseForVarAnnotationWithClassType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isArray());
     }
 
@@ -325,7 +325,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsArrayReturnsExpectedValueFalseForPropertyWithoutVarAnnotation()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isArray());
     }
 
@@ -337,7 +337,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPrimitiveReturnsExpectedValueTrueForVarAnnotationWithIntegerTypeHint()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isScalar());
     }
 
@@ -349,7 +349,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPrimitiveReturnsExpectedValueFalseForVarAnnotationWithClassType()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isScalar());
     }
 
@@ -361,7 +361,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testGetDefaultValueReturnsExpectedStringFromHeredoc()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals('Testing!', $property->getDefaultValue());
     }
 
@@ -373,7 +373,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPrimitiveReturnsExpectedValueFalseForPropertyWithoutVarAnnotation()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isScalar());
     }
 
@@ -384,7 +384,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPublicReturnsFalseByDefault()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isPublic());
     }
 
@@ -395,7 +395,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPublicReturnsTrueForPublicProperty()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isPublic());
     }
 
@@ -406,7 +406,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsProtectedReturnsFalseByDefault()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isProtected());
     }
 
@@ -417,7 +417,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsProtectedReturnsTrueForProtectedProperty()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isProtected());
     }
 
@@ -428,7 +428,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPrivateReturnsFalseByDefault()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isPrivate());
     }
 
@@ -439,7 +439,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsPrivateReturnsTrueForPrivateProperty()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isPrivate());
     }
 
@@ -450,7 +450,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsStaticReturnsFalseByDefault()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertFalse($property->isStatic());
     }
 
@@ -461,7 +461,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testIsStaticReturnsTrueForStaticProperty()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertTrue($property->isStatic());
     }
 
@@ -488,7 +488,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyHasExpectedStartLine()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(4, $property->getStartLine());
     }
 
@@ -499,7 +499,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyHasExpectedStartColumn()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(13, $property->getStartColumn());
     }
 
@@ -510,7 +510,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyHasExpectedEndLine()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(6, $property->getEndLine());
     }
 
@@ -521,7 +521,7 @@ class ASTPropertyTest extends AbstractTest
      */
     public function testPropertyHasExpectedEndColumn()
     {
-        $property = $this->_getFirstPropertyInClass();
+        $property = $this->getFirstPropertyInClass();
         $this->assertEquals(13, $property->getEndColumn());
     }
 
@@ -530,7 +530,7 @@ class ASTPropertyTest extends AbstractTest
      *
      * @return \PDepend\Source\AST\ASTProperty
      */
-    private function _getFirstPropertyInClass()
+    private function getFirstPropertyInClass()
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -74,7 +74,7 @@ class ASTRequireExpressionTest extends ASTNodeTest
      */
     public function testIsOnceReturnsTrueForRequireOnceExpression()
     {
-        $expr = $this->_getFirstRequireExpressionInFunction();
+        $expr = $this->getFirstRequireExpressionInFunction();
         $this->assertTrue($expr->isOnce());
     }
 
@@ -105,7 +105,7 @@ class ASTRequireExpressionTest extends ASTNodeTest
      */
     public function testRequireExpression()
     {
-        $expr = $this->_getFirstRequireExpressionInFunction();
+        $expr = $this->getFirstRequireExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTRequireExpression', $expr);
 
         return $expr;
@@ -171,7 +171,7 @@ class ASTRequireExpressionTest extends ASTNodeTest
      */
     public function testRequireExpressionWithParenthesis()
     {
-        $expr = $this->_getFirstRequireExpressionInFunction();
+        $expr = $this->getFirstRequireExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTRequireExpression', $expr);
 
         return $expr;
@@ -234,7 +234,7 @@ class ASTRequireExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTRequireExpression
      */
-    private function _getFirstRequireExpressionInFunction()
+    private function getFirstRequireExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -62,7 +62,7 @@ class ASTReturnStatementTest extends ASTNodeTest
      */
     public function testReturnStatement()
     {
-        $stmt = $this->_getFirstReturnStatementInFunction();
+        $stmt = $this->getFirstReturnStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $stmt);
 
         return $stmt;
@@ -127,7 +127,7 @@ class ASTReturnStatementTest extends ASTNodeTest
      */
     public function testParserHandlesEmptyReturnStatement()
     {
-        $stmt = $this->_getFirstReturnStatementInFunction();
+        $stmt = $this->getFirstReturnStatementInFunction();
         $this->assertEquals(12, $stmt->getEndColumn());
     }
 
@@ -138,7 +138,7 @@ class ASTReturnStatementTest extends ASTNodeTest
      */
     public function testParserHandlesReturnStatementWithSimpleBoolean()
     {
-        $stmt = $this->_getFirstReturnStatementInFunction();
+        $stmt = $this->getFirstReturnStatementInFunction();
         $this->assertEquals(17, $stmt->getEndColumn());
     }
 
@@ -147,7 +147,7 @@ class ASTReturnStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTReturnStatement
      */
-    private function _getFirstReturnStatementInFunction()
+    private function getFirstReturnStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -62,7 +62,7 @@ class ASTScopeStatementTest extends ASTNodeTest
      */
     public function testParserHandlesInlineScopeStatement()
     {
-        $stmt = $this->_getFirstScopeStatementInFunction();
+        $stmt = $this->getFirstScopeStatementInFunction();
         $this->assertEquals(1, count($stmt->getChildren()));
 
         return $stmt;
@@ -138,7 +138,7 @@ class ASTScopeStatementTest extends ASTNodeTest
      */
     public function testScopeStatement()
     {
-        $stmt = $this->_getFirstScopeStatementInFunction();
+        $stmt = $this->getFirstScopeStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt);
 
         return $stmt;
@@ -198,13 +198,13 @@ class ASTScopeStatementTest extends ASTNodeTest
 
     /**
      * testScopeStatementWithAlternative
-     * 
+     *
      * @return \PDepend\Source\AST\ASTScopeStatement
      * @since 1.0.2
      */
     public function testScopeStatementWithAlternative()
     {
-        $stmt = $this->_getFirstScopeStatementInFunction();
+        $stmt = $this->getFirstScopeStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt);
 
         return $stmt;
@@ -267,7 +267,7 @@ class ASTScopeStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
      */
-    private function _getFirstScopeStatementInFunction()
+    private function getFirstScopeStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -63,7 +63,7 @@ class ASTScopeTest extends ASTNodeTest
      */
     public function testScope()
     {
-        $scope = $this->_getFirstScopeInFunction();
+        $scope = $this->getFirstScopeInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScope', $scope);
 
         return $scope;
@@ -126,7 +126,7 @@ class ASTScopeTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTScope
      */
-    private function _getFirstScopeInFunction()
+    private function getFirstScopeInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -64,7 +64,10 @@ class ASTSelfReferenceTest extends ASTNodeTest
      */
     public function testGetTypeReturnsInjectedConstructorTargetArgument()
     {
-        $target  = $this->getMockForAbstractClass('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(__CLASS__));
+        $target  = $this->getMockForAbstractClass(
+            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            array(__CLASS__)
+        );
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
 
@@ -79,7 +82,10 @@ class ASTSelfReferenceTest extends ASTNodeTest
      */
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull()
     {
-        $target = $this->getMockForAbstractClass('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', array(__CLASS__));
+        $target = $this->getMockForAbstractClass(
+            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            array(__CLASS__)
+        );
 
         $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
             ->getMock();
@@ -155,7 +161,7 @@ class ASTSelfReferenceTest extends ASTNodeTest
      */
     public function testSelfReference()
     {
-        $reference = $this->_getFirstSelfReferenceInClass();
+        $reference = $this->getFirstSelfReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $reference);
 
         return $reference;
@@ -234,7 +240,7 @@ class ASTSelfReferenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTSelfReference
      */
-    private function _getFirstSelfReferenceInClass()
+    private function getFirstSelfReferenceInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -74,7 +74,7 @@ class ASTShiftLeftExpressionTest extends ASTNodeTest
      */
     public function testShiftLeftExpression()
     {
-        $expr = $this->_getFirstShiftLeftExpressionInFunction();
+        $expr = $this->getFirstShiftLeftExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTShiftLeftExpression', $expr);
 
         return $expr;
@@ -137,7 +137,7 @@ class ASTShiftLeftExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTShiftLeftExpression
      */
-    private function _getFirstShiftLeftExpressionInFunction()
+    private function getFirstShiftLeftExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -145,4 +145,3 @@ class ASTShiftLeftExpressionTest extends ASTNodeTest
         );
     }
 }
-

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -74,7 +74,7 @@ class ASTShiftRightExpressionTest extends ASTNodeTest
      */
     public function testShiftRightExpression()
     {
-        $expr = $this->_getFirstShiftRightExpressionInFunction();
+        $expr = $this->getFirstShiftRightExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTShiftRightExpression', $expr);
 
         return $expr;
@@ -137,7 +137,7 @@ class ASTShiftRightExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTShiftRightExpression
      */
-    private function _getFirstShiftRightExpressionInFunction()
+    private function getFirstShiftRightExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -145,4 +145,3 @@ class ASTShiftRightExpressionTest extends ASTNodeTest
         );
     }
 }
-

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -62,7 +62,7 @@ class ASTStatementTest extends ASTNodeTest
      */
     public function testStatement()
     {
-        $stmt = $this->_getFirstStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStatement', $stmt);
 
         return $stmt;
@@ -127,10 +127,11 @@ class ASTStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTStatement
      */
-    private function _getFirstStatementInFunction($testCase)
+    private function getFirstStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTStatement'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTStatement'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -168,7 +168,7 @@ class ASTStaticReferenceTest extends ASTNodeTest
      */
     public function testStaticReference()
     {
-        $reference = $this->_getFirstStaticReferenceInClass();
+        $reference = $this->getFirstStaticReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStaticReference', $reference);
 
         return $reference;
@@ -251,7 +251,7 @@ class ASTStaticReferenceTest extends ASTNodeTest
      * @param string $testCase Name of the calling test case.
      * @return \PDepend\Source\AST\ASTStaticReference
      */
-    private function _getFirstStaticReferenceInClass()
+    private function getFirstStaticReferenceInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -62,7 +62,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTest
      */
     public function testStaticVariableDeclaration()
     {
-        $declaration = $this->_getFirstStaticVariableDeclarationInFunction();
+        $declaration = $this->getFirstStaticVariableDeclarationInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStaticVariableDeclaration', $declaration);
 
         return $declaration;
@@ -72,7 +72,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTest
      * Tests that the declaration has the expected start line value.
      *
      * @param \PDepend\Source\AST\ASTStringIndexExpression $declaration
-     * 
+     *
      * @return void
      * @depends testStaticVariableDeclaration
      */
@@ -125,7 +125,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTStringIndexExpression
      */
-    private function _getFirstStaticVariableDeclarationInFunction()
+    private function getFirstStaticVariableDeclarationInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -65,7 +65,7 @@ class ASTStringIndexExpressionTest extends ASTNodeTest
      */
     public function testStringIndexExpression()
     {
-        $expr = $this->_getFirstStringIndexExpressionInFunction();
+        $expr = $this->getFirstStringIndexExpressionInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStringIndexExpression', $expr);
 
         return $expr;
@@ -128,7 +128,7 @@ class ASTStringIndexExpressionTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTStringIndexExpression
      */
-    private function _getFirstStringIndexExpressionInFunction()
+    private function getFirstStringIndexExpressionInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -81,7 +81,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testDefaultFlagIsSetOnDefaultLabel()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertTrue($label->isDefault());
     }
 
@@ -93,7 +93,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testDefaultFlagIsNotSetOnCaseLabel()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertFalse($label->isDefault());
     }
 
@@ -105,7 +105,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabel()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
 
         return $label;
@@ -170,7 +170,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelCanBeTerminatedWithSemicolon()
     {
-        $this->_getFirstSwitchLabelInFunction();
+        $this->getFirstSwitchLabelInFunction();
     }
 
     /**
@@ -180,7 +180,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelWithNestedSwitchStatementHasExpectedChildren()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
 
         $actual = array();
         foreach ($label->getChildren() as $child) {
@@ -204,7 +204,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelWithNestedNonePhpCode()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
 
         return $label;
@@ -270,7 +270,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelDefault()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
 
         return $label;
@@ -335,7 +335,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchDefaultLabelCanBeTerminatedWithSemicolon()
     {
-        $this->_getFirstSwitchLabelInFunction();
+        $this->getFirstSwitchLabelInFunction();
     }
 
     /**
@@ -345,7 +345,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelDefaultWithNestedSwitchStatementHasExpectedChildren()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
 
         $actual = array();
         foreach ($label->getChildren() as $child) {
@@ -368,7 +368,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCode()
     {
-        $label = $this->_getFirstSwitchLabelInFunction();
+        $label = $this->getFirstSwitchLabelInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
 
         return $label;
@@ -433,7 +433,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testParserHandlesSwitchLabelWithNestedScopeStatement()
     {
-        $this->_getFirstSwitchLabelInFunction();
+        $this->getFirstSwitchLabelInFunction();
     }
 
     /**
@@ -444,7 +444,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      */
     public function testParserThrowsExceptionForUnclosedSwitchLabelBody()
     {
-        $this->_getFirstSwitchLabelInFunction();
+        $this->getFirstSwitchLabelInFunction();
     }
 
     /**
@@ -452,7 +452,7 @@ class ASTSwitchLabelTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTSwitchLabel
      */
-    private function _getFirstSwitchLabelInFunction()
+    private function getFirstSwitchLabelInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -61,7 +61,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatementGraphWithBooleanExpressions()
     {
-        $stmt = $this->_getFirstSwitchStatementInFunction();
+        $stmt = $this->getFirstSwitchStatementInFunction();
         $children  = $stmt->getChildren();
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $children[0]);
@@ -74,7 +74,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatementGraphWithLabels()
     {
-        $stmt = $this->_getFirstSwitchStatementInFunction();
+        $stmt = $this->getFirstSwitchStatementInFunction();
         $children  = $stmt->getChildren();
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $children[1]);
@@ -89,7 +89,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatement()
     {
-        $stmt = $this->_getFirstSwitchStatementInFunction();
+        $stmt = $this->getFirstSwitchStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $stmt);
 
         return $stmt;
@@ -154,7 +154,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testParserIgnoresDocCommentInSwitchStatement()
     {
-        $this->_getFirstSwitchStatementInFunction();
+        $this->getFirstSwitchStatementInFunction();
     }
 
     /**
@@ -164,7 +164,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testParserIgnoresCommentInSwitchStatement()
     {
-        $this->_getFirstSwitchStatementInFunction();
+        $this->getFirstSwitchStatementInFunction();
     }
 
     /**
@@ -175,7 +175,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testInvalidStatementInSwitchStatementResultsInExpectedException()
     {
-        $this->_getFirstSwitchStatementInFunction();
+        $this->getFirstSwitchStatementInFunction();
     }
 
     /**
@@ -186,7 +186,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testUnclosedSwitchStatementResultsInExpectedException()
     {
-        $this->_getFirstSwitchStatementInFunction();
+        $this->getFirstSwitchStatementInFunction();
     }
 
     /**
@@ -197,7 +197,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatementWithAlternativeScope()
     {
-        $stmt = $this->_getFirstSwitchStatementInFunction();
+        $stmt = $this->getFirstSwitchStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $stmt);
 
         return $stmt;
@@ -262,7 +262,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatementTerminatedByPhpCloseTag()
     {
-        $stmt = $this->_getFirstSwitchStatementInFunction();
+        $stmt = $this->getFirstSwitchStatementInFunction();
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -274,7 +274,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      */
     public function testSwitchStatementWithNestedNonePhpCode()
     {
-        $switch = $this->_getFirstSwitchStatementInFunction();
+        $switch = $this->getFirstSwitchStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $switch);
 
         return $switch;
@@ -337,7 +337,7 @@ class ASTSwitchStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTSwitchStatement
      */
-    private function _getFirstSwitchStatementInFunction()
+    private function getFirstSwitchStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -62,7 +62,7 @@ class ASTThrowStatementTest extends ASTNodeTest
      */
     public function testThrowStatement()
     {
-        $stmt = $this->_getFirstThrowStatementInFunction();
+        $stmt = $this->getFirstThrowStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $stmt);
 
         return $stmt;
@@ -125,7 +125,7 @@ class ASTThrowStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTThrowStatement
      */
-    private function _getFirstThrowStatementInFunction()
+    private function getFirstThrowStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -58,12 +58,12 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
 {
     /**
      * testGetNewNameReturnsNullByDefault
-     * 
+     *
      * @return void
      */
     public function testGetNewNameReturnsNullByDefault()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertNull($alias->getNewName());
     }
 
@@ -74,7 +74,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testGetNewNameReturnsExpectedValue()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertEquals('myMethodAlias', $alias->getNewName());
     }
 
@@ -85,7 +85,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testGetNewModifierReturnsMinusOneByDefault()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertEquals(-1, $alias->getNewModifier());
     }
 
@@ -96,7 +96,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testGetNewModifierReturnsExpectedIsPublicValue()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertEquals(
             State::IS_PUBLIC,
             $alias->getNewModifier()
@@ -110,7 +110,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testGetNewModifierReturnsExpectedIsProtectedValue()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertEquals(
             State::IS_PROTECTED,
             $alias->getNewModifier()
@@ -144,7 +144,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testGetNewModifierReturnsExpectedIsPrivateValue()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertEquals(State::IS_PRIVATE, $alias->getNewModifier());
     }
 
@@ -156,7 +156,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testTraitAdaptationAlias()
     {
-        $alias = $this->_getFirstTraitAdaptationAliasInClass();
+        $alias = $this->getFirstTraitAdaptationAliasInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptationAlias', $alias);
 
         return $alias;
@@ -219,7 +219,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
      */
-    private function _getFirstTraitAdaptationAliasInClass()
+    private function getFirstTraitAdaptationAliasInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -235,7 +235,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      */
     public function testTraitReference()
     {
-        $reference = $this->_getFirstTraitReferenceInClass();
+        $reference = $this->getFirstTraitReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
 
         return $reference;
@@ -298,10 +298,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitReference
      */
-    private function _getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass()
     {
-        return $this->_getFirstTraitAdaptationAliasInClass()
+        return $this->getFirstTraitAdaptationAliasInClass()
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTTraitReference');
     }
 }
-

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -63,7 +63,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      */
     public function testTraitAdaptationPrecedenceHasExpectedNumberOfTraitReferences()
     {
-        $stmt = $this->_getFirstTraitAdaptationPrecedenceInClass();
+        $stmt = $this->getFirstTraitAdaptationPrecedenceInClass();
         $this->assertEquals(
             3,
             count(
@@ -82,7 +82,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      */
     public function testTraitAdaptationPrecedenceWithoutQualifiedReferenceThrowsExpectedException()
     {
-        $this->_getFirstTraitAdaptationPrecedenceInClass();
+        $this->getFirstTraitAdaptationPrecedenceInClass();
     }
 
     /**
@@ -93,7 +93,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      */
     public function testTraitAdaptationPrecedence()
     {
-        $precedence = $this->_getFirstTraitAdaptationPrecedenceInClass();
+        $precedence = $this->getFirstTraitAdaptationPrecedenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence', $precedence);
 
         return $precedence;
@@ -156,7 +156,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
      */
-    private function _getFirstTraitAdaptationPrecedenceInClass()
+    private function getFirstTraitAdaptationPrecedenceInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -172,7 +172,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      */
     public function testTraitReference()
     {
-        $reference = $this->_getFirstTraitReferenceInClass();
+        $reference = $this->getFirstTraitReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
 
         return $reference;
@@ -235,9 +235,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitReference
      */
-    private function _getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass()
     {
-        return $this->_getFirstTraitAdaptationPrecedenceInClass()
+        return $this->getFirstTraitAdaptationPrecedenceInClass()
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTTraitReference');
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -58,13 +58,13 @@ class ASTTraitAdaptationTest extends ASTNodeTest
 {
     /**
      * testTraitAdaptation
-     * 
+     *
      * @return \PDepend\Source\AST\ASTTraitAdaptation
      * @since 1.0.2
      */
     public function testTraitAdaptation()
     {
-        $scope = $this->_getFirstTraitAdaptationInClass();
+        $scope = $this->getFirstTraitAdaptationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptation', $scope);
         
         return $scope;
@@ -72,7 +72,7 @@ class ASTTraitAdaptationTest extends ASTNodeTest
    
     /**
      * testTraitAdaptationHasExpectedStartLine
-     * 
+     *
      * @param \PDepend\Source\AST\ASTTraitAdaptation $scope
      *
      * @return void
@@ -127,7 +127,7 @@ class ASTTraitAdaptationTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptation
      */
-    private function _getFirstTraitAdaptationInClass()
+    private function getFirstTraitAdaptationInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -135,4 +135,3 @@ class ASTTraitAdaptationTest extends ASTNodeTest
         );
     }
 }
-

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -77,13 +77,13 @@ class ASTTraitReferenceTest extends ASTNodeTest
     
     /**
      * testTraitReference
-     * 
+     *
      * @return \PDepend\Source\AST\ASTTraitReference
      * @since 1.0.2
      */
     public function testTraitReference()
     {
-        $reference = $this->_getFirstTraitReferenceInClass();
+        $reference = $this->getFirstTraitReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
         
         return $reference;
@@ -91,7 +91,7 @@ class ASTTraitReferenceTest extends ASTNodeTest
 
     /**
      * testTraitReferenceHasExpectedStartLine
-     * 
+     *
      * @param \PDepend\Source\AST\ASTTraitReference $reference
      *
      * @return void
@@ -146,7 +146,7 @@ class ASTTraitReferenceTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitReference
      */
-    private function _getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -127,7 +127,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsOnClassWithParentReturnsTraitMethod()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertInstanceOf(
@@ -144,7 +144,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsOnClassWithParentAndPrecedenceReturnsParentMethod()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertInstanceOf(
@@ -161,7 +161,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals('foo', $methods[0]->getName());
@@ -174,7 +174,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithAliasedMethodCollision()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(2, count($useStmt->getAllMethods()));
     }
 
@@ -185,7 +185,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithAliasedMethodTwice()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(2, count($useStmt->getAllMethods()));
     }
 
@@ -196,7 +196,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithVisibilityChangedToPublic()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -212,7 +212,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithVisibilityChangedToProtected()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -228,7 +228,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithVisibilityChangedToPrivate()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -244,7 +244,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -260,7 +260,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsStaticModifier()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -276,7 +276,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsHandlesTraitMethodPrecedence()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
         $this->assertEquals(
@@ -292,7 +292,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testGetAllMethodsExcludeTraitMethodWithPrecedence()
     {
-        $useStmt = $this->_getFirstTraitUseStatementInClass();
+        $useStmt = $this->getFirstTraitUseStatementInClass();
         $this->assertSame(2, count($useStmt->getAllMethods()));
     }
 
@@ -303,7 +303,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithSimpleAliasHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -314,7 +314,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithSimpleAliasHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(21, $stmt->getEndColumn());
     }
 
@@ -325,7 +325,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithQualifiedAliasHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(6, $stmt->getEndLine());
     }
 
@@ -336,7 +336,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithQualifiedAliasHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(21, $stmt->getEndColumn());
     }
 
@@ -347,7 +347,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithSingleInsteadofHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(9, $stmt->getEndLine());
     }
 
@@ -358,7 +358,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithSingleInsteadofHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(93, $stmt->getEndColumn());
     }
 
@@ -369,7 +369,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithMultipleInsteadofHasExpectedEndLine()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(11, $stmt->getEndLine());
     }
 
@@ -380,7 +380,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementWithMultipleInsteadofHasExpectedEndColumn()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertEquals(97, $stmt->getEndColumn());
     }
 
@@ -392,7 +392,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatement()
     {
-        $stmt = $this->_getFirstTraitUseStatementInClass();
+        $stmt = $this->getFirstTraitUseStatementInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitUseStatement', $stmt);
 
         return $stmt;
@@ -458,7 +458,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      */
     public function testTraitUseStatementInTrait()
     {
-        $stmt = $this->_getFirstTraitUseStatementInTrait();
+        $stmt = $this->getFirstTraitUseStatementInTrait();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitUseStatement', $stmt);
 
         return $stmt;
@@ -521,7 +521,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitUseStatement
      */
-    private function _getFirstTraitUseStatementInClass()
+    private function getFirstTraitUseStatementInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
@@ -534,7 +534,7 @@ class ASTTraitUseStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTraitUseStatement
      */
-    private function _getFirstTraitUseStatementInTrait()
+    private function getFirstTraitUseStatementInTrait()
     {
         return $this->getFirstNodeOfTypeInTrait(
             'PDepend\\Source\\AST\\ASTTraitUseStatement'

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -62,7 +62,7 @@ class ASTTryStatementTest extends ASTNodeTest
      */
     public function testTryStatement()
     {
-        $stmt = $this->_getFirstTryStatementInFunction();
+        $stmt = $this->getFirstTryStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTryStatement', $stmt);
 
         return $stmt;
@@ -154,7 +154,7 @@ class ASTTryStatementTest extends ASTNodeTest
     public function testTryStatementContainsMultipleChildInstancesOfCatchStatement()
     {
         $actual = array();
-        foreach ($this->_getFirstTryStatementInFunction(__METHOD__)->getChildren() as $child) {
+        foreach ($this->getFirstTryStatementInFunction(__METHOD__)->getChildren() as $child) {
             $actual[] = get_class($child);
         }
 
@@ -177,7 +177,7 @@ class ASTTryStatementTest extends ASTNodeTest
      */
     public function testParserThrowsExceptionWhenNoCatchStatementFollows()
     {
-        $this->_getFirstTryStatementInFunction();
+        $this->getFirstTryStatementInFunction();
     }
 
     /**
@@ -185,7 +185,7 @@ class ASTTryStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTryStatement
      */
-    private function _getFirstTryStatementInFunction()
+    private function getFirstTryStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -62,7 +62,7 @@ class ASTTypeArrayTest extends ASTNodeTest
      */
     public function testArrayType()
     {
-        $type = $this->_getFirstArrayTypeInFunction();
+        $type = $this->getFirstArrayTypeInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeArray', $type);
 
         return $type;
@@ -147,7 +147,7 @@ class ASTTypeArrayTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTypeArray
      */
-    private function _getFirstArrayTypeInFunction()
+    private function getFirstArrayTypeInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -63,7 +63,7 @@ class ASTTypeCallableTest extends ASTNodeTest
      */
     public function testCallableTypeIsHandledCaseInsensitive()
     {
-        $this->assertNotNull($this->_getFirstCallableTypeInFunction());
+        $this->assertNotNull($this->getFirstCallableTypeInFunction());
     }
 
     /**
@@ -74,7 +74,7 @@ class ASTTypeCallableTest extends ASTNodeTest
      */
     public function testCallableType()
     {
-        $type = $this->_getFirstCallableTypeInFunction();
+        $type = $this->getFirstCallableTypeInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeCallable', $type);
 
         return $type;
@@ -137,7 +137,7 @@ class ASTTypeCallableTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTypeCallable
      */
-    private function _getFirstCallableTypeInFunction()
+    private function getFirstCallableTypeInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -62,7 +62,7 @@ class ASTTypeIterableTest extends ASTNodeTest
      */
     public function testIterableType()
     {
-        $type = $this->_getFirstArrayTypeInFunction();
+        $type = $this->getFirstArrayTypeInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeIterable', $type);
 
         return $type;
@@ -147,7 +147,7 @@ class ASTTypeIterableTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTTypeIterable
      */
-    private function _getFirstArrayTypeInFunction()
+    private function getFirstArrayTypeInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -62,7 +62,7 @@ class ASTUnsetStatementTest extends ASTNodeTest
      */
     public function testUnsetStatement()
     {
-        $stmt = $this->_getFirstUnsetStatementInFunction(__METHOD__);
+        $stmt = $this->getFirstUnsetStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnsetStatement', $stmt);
 
         return $stmt;
@@ -127,10 +127,11 @@ class ASTUnsetStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTUnsetStatement
      */
-    private function _getFirstUnsetStatementInFunction($testCase)
+    private function getFirstUnsetStatementInFunction($testCase)
     {
         return $this->getFirstNodeOfTypeInFunction(
-            $testCase, 'PDepend\\Source\\AST\\ASTUnsetStatement'
+            $testCase,
+            'PDepend\\Source\\AST\\ASTUnsetStatement'
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTValueTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTValueTest.php
@@ -96,7 +96,7 @@ class ASTValueTest extends AbstractTest
 
     /**
      * testGetValueReturnsNullByDefault
-     * 
+     *
      * @return void
      */
     public function testGetValueReturnsNullByDefault()

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -105,7 +105,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTest
      */
     public function testVariableDeclarator()
     {
-        $declarator = $this->_getFirstVariableDeclaratorInFunction();
+        $declarator = $this->getFirstVariableDeclaratorInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $declarator);
 
         return $declarator;
@@ -164,7 +164,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTVariableDeclarator
      */
-    private function _getFirstVariableDeclaratorInFunction()
+    private function getFirstVariableDeclaratorInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -105,7 +105,7 @@ class ASTVariableTest extends ASTNodeTest
      */
     public function testVariable()
     {
-        $variable = $this->_getFirstVariableInClass();
+        $variable = $this->getFirstVariableInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
 
         return $variable;
@@ -168,10 +168,10 @@ class ASTVariableTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTVariable
      */
-    private function _getFirstVariableInClass()
+    private function getFirstVariableInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
-            $this->getCallingTestMethod(), 
+            $this->getCallingTestMethod(),
             'PDepend\\Source\\AST\\ASTVariable'
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -62,11 +62,11 @@ class ASTVariableVariableTest extends ASTNodeTest
      */
     public function testVariableVariable()
     {
-        $variable = $this->_getFirstVariableVariableInClass();
+        $variable = $this->getFirstVariableVariableInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableVariable', $variable);
 
         return $variable;
-    }    
+    }
     
     /**
      * testVariableVariableHasExpectedStartLine
@@ -127,7 +127,7 @@ class ASTVariableVariableTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTVariableVariable
      */
-    private function _getFirstVariableVariableInClass()
+    private function getFirstVariableVariableInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -61,7 +61,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testWhileStatementGraphWithBooleanExpressions()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertEquals(2, count($stmt->getChildren()));
     }
 
@@ -72,7 +72,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testFirstChildOfWhileStatementIsASTExpression()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
 
@@ -83,7 +83,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testSecondChildOfWhileStatementIsASTScopeStatement()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
     }
 
@@ -95,7 +95,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testWhileStatement()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTWhileStatement', $stmt);
 
         return $stmt;
@@ -161,7 +161,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testWhileStatementWithAlternativeScope()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTWhileStatement', $stmt);
 
         return $stmt;
@@ -226,7 +226,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      */
     public function testWhileStatementTerminatedByPhpCloseTag()
     {
-        $stmt = $this->_getFirstWhileStatementInFunction();
+        $stmt = $this->getFirstWhileStatementInFunction();
         $this->assertEquals(9, $stmt->getEndColumn());
     }
 
@@ -235,7 +235,7 @@ class ASTWhileStatementTest extends ASTNodeTest
      *
      * @return \PDepend\Source\AST\ASTWhileStatement
      */
-    private function _getFirstWhileStatementInFunction()
+    private function getFirstWhileStatementInFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTest.php
@@ -98,5 +98,5 @@ abstract class AbstractASTArtifactTest extends AbstractTest
      *
      * @return \PDepend\Source\AST\AbstractASTArtifact
      */
-    protected abstract function createItem();
+    abstract protected function createItem();
 }

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -60,7 +60,7 @@ class DefaultListenerTest extends AbstractTest
 {
     /**
      * testDefaultImplementationCallsListeners
-     * 
+     *
      * @return void
      */
     public function testDefaultImplementationCallsListeners()

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
@@ -97,7 +97,7 @@ class DefaultVisitorTest extends AbstractTest
 
     /**
      * testVisitorVisitsFunctionParameter
-     * 
+     *
      * @return void
      */
     public function testVisitorVisitsFunctionParameter()

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -225,7 +225,6 @@ class StubASTVisitor implements ASTVisitor
      */
     public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
     {
-
     }
 
     /**
@@ -253,6 +252,5 @@ class StubASTVisitor implements ASTVisitor
      */
     public function __call($method, $args)
     {
-
     }
 }

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * This file is part of PDepend.
- * 
+ *
  * PHP Version 5
  *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -1723,7 +1723,7 @@ class PHPBuilderTest extends AbstractTest
 
     /**
      * testBuildASTArrayIndexExpressionReturnsExpectedType
-     * 
+     *
      * @return void
      */
     public function testBuildASTArrayIndexExpressionReturnsExpectedType()
@@ -1928,7 +1928,7 @@ class PHPBuilderTest extends AbstractTest
 
     /**
      * testBuildASTPostfixExpressionReturnsExpectedType
-     * 
+     *
      * @return void
      */
     public function testBuildASTPostfixExpressionReturnsExpectedType()
@@ -1967,7 +1967,7 @@ class PHPBuilderTest extends AbstractTest
 
     /**
      * testBuildASTMemberPrimaryPrefixReturnsExpectedType
-     * 
+     *
      * @return void
      * @since 1.0.0
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -679,7 +679,7 @@ class PHPParserGenericTest extends AbstractTest
 
     /**
      * testParserAcceptsDirConstantAsFunctionName
-     * 
+     *
      * @return void
      * @since 1.0.0
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerHelperVersion52Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerHelperVersion52Test.php
@@ -227,7 +227,7 @@ class PHPTokenizerHelperVersion52Test extends AbstractTest
     public function testHelperThrowsExpectedExceptionWhenTokenGetAllFails()
     {
         if (version_compare(phpversion(), '5.3.0') >= 0) {
-            $this->markTestSkipped('This test only works with PHP versions < 5.2.0'); 
+            $this->markTestSkipped('This test only works with PHP versions < 5.2.0');
         }
 
         PHPTokenizerHelperVersion52::tokenize(

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -59,7 +59,7 @@ class PHPTokenizerInternalTest extends AbstractTest
 {
     /**
      * testTokenizerReturnsExpectedConstantForTraitKeyword
-     * 
+     *
      * @return void
      * @since 1.0.0
      */
@@ -83,7 +83,7 @@ class PHPTokenizerInternalTest extends AbstractTest
                 Tokens::T_CURLY_BRACE_CLOSE,
                 Tokens::T_CURLY_BRACE_CLOSE,
             ),
-            $this->_getTokenTypesForTest()
+            $this->getTokenTypesForTest()
         );
     }
 
@@ -113,7 +113,7 @@ class PHPTokenizerInternalTest extends AbstractTest
                 Tokens::T_CURLY_BRACE_CLOSE,
                 Tokens::T_CURLY_BRACE_CLOSE,
             ),
-            $this->_getTokenTypesForTest()
+            $this->getTokenTypesForTest()
         );
     }
 
@@ -161,7 +161,7 @@ class PHPTokenizerInternalTest extends AbstractTest
             Tokens::T_CURLY_BRACE_CLOSE
         );
 
-        $this->assertEquals($expected, $this->_getTokenTypesForTest());
+        $this->assertEquals($expected, $this->getTokenTypesForTest());
     }
 
     /**
@@ -269,7 +269,7 @@ class PHPTokenizerInternalTest extends AbstractTest
             Tokens::T_CLOSE_TAG
         );
 
-        $this->assertEquals($expected, $this->_getTokenTypesForTest());
+        $this->assertEquals($expected, $this->getTokenTypesForTest());
     }
 
     /**
@@ -301,7 +301,7 @@ class PHPTokenizerInternalTest extends AbstractTest
             Tokens::T_CURLY_BRACE_CLOSE,
         );
 
-        $this->assertEquals($expected, $this->_getTokenTypesForTest());
+        $this->assertEquals($expected, $this->getTokenTypesForTest());
     }
 
     /**
@@ -345,7 +345,7 @@ class PHPTokenizerInternalTest extends AbstractTest
             Tokens::T_CURLY_BRACE_CLOSE,
         );
 
-        $this->assertEquals($expected, $this->_getTokenTypesForTest());
+        $this->assertEquals($expected, $this->getTokenTypesForTest());
     }
 
     /**
@@ -600,7 +600,7 @@ Manuel', 3, 5, 61, 6),
             Tokens::T_SEMICOLON,
         );
 
-        $this->assertEquals($expected, $this->_getTokenTypesForTest());
+        $this->assertEquals($expected, $this->getTokenTypesForTest());
     }
 
     /**
@@ -609,7 +609,7 @@ Manuel', 3, 5, 61, 6),
      *
      * @return array(integer)
      */
-    private function _getTokenTypesForTest()
+    private function getTokenTypesForTest()
     {
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile($this->createCodeResourceUriForTest());

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -73,7 +73,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      */
     public function testAllocationExpressionForSelfProperty()
     {
-        $allocation = $this->_getFirstAllocationInClass();
+        $allocation = $this->getFirstAllocationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
     }
 
@@ -85,7 +85,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      */
     public function testAllocationExpressionForParentProperty()
     {
-        $allocation = $this->_getFirstAllocationInClass();
+        $allocation = $this->getFirstAllocationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
     }
 
@@ -97,7 +97,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      */
     public function testAllocationExpressionForStaticProperty()
     {
-        $allocation = $this->_getFirstAllocationInClass();
+        $allocation = $this->getFirstAllocationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
     }
 
@@ -109,7 +109,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      */
     public function testAllocationExpressionForThisProperty()
     {
-        $allocation = $this->_getFirstAllocationInClass();
+        $allocation = $this->getFirstAllocationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $allocation->getChild(0));
     }
 
@@ -121,7 +121,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      */
     public function testAllocationExpressionForObjectProperty()
     {
-        $allocation = $this->_getFirstAllocationInClass();
+        $allocation = $this->getFirstAllocationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
     }
 
@@ -287,7 +287,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTest
      * @return ASTAllocationExpression
      * @since 1.0.1
      */
-    private function _getFirstAllocationInClass()
+    private function getFirstAllocationInClass()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -63,7 +63,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsStaticMethodPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfFunction(),
+            $this->getFirstArgumentsOfFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -82,7 +82,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsMethodPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfFunction(),
+            $this->getFirstArgumentsOfFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
@@ -101,7 +101,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsConstantsPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfFunction(),
+            $this->getFirstArgumentsOfFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -119,7 +119,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsPropertyPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfFunction(),
+            $this->getFirstArgumentsOfFunction(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
@@ -137,7 +137,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsSelfPropertyPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfMethod(),
+            $this->getFirstArgumentsOfMethod(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTSelfReference',
@@ -155,7 +155,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
     public function testArgumentsContainsParentMethodPostfixExpression()
     {
         $this->assertGraphEquals(
-            $this->_getFirstArgumentsOfMethod(),
+            $this->getFirstArgumentsOfMethod(),
             array(
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTParentReference',
@@ -173,7 +173,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      */
     public function testArgumentsContainsAllocationExpression()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
 
         $allocation = $arguments->getChild(0);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $allocation);
@@ -186,7 +186,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      */
     public function testArgumentsWithSeveralParameters()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
 
         $postfix = $arguments->getFirstChildOfType(
             'PDepend\\Source\\AST\\ASTFunctionPostfix'
@@ -201,7 +201,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      */
     public function testArgumentsWithInlineComments()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
 
         $child = $arguments->getChild(0);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $child);
@@ -214,7 +214,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      */
     public function testArgumentsWithInlineConcatExpression()
     {
-        $arguments = $this->_getFirstArgumentsOfFunction();
+        $arguments = $this->getFirstArgumentsOfFunction();
 
         $postfixes = $arguments->findChildrenOfType(
             'PDepend\\Source\\AST\\ASTMethodPostfix'
@@ -239,7 +239,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      *
      * @return \PDepend\Source\AST\ASTArguments
      */
-    private function _getFirstArgumentsOfFunction()
+    private function getFirstArgumentsOfFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
@@ -252,7 +252,7 @@ class ASTArgumentsParsingTest extends AbstractParserTest
      *
      * @return \PDepend\Source\AST\ASTArguments
      */
-    private function _getFirstArgumentsOfMethod()
+    private function getFirstArgumentsOfMethod()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -58,7 +58,7 @@ class ASTFormalParameterParsingTest extends AbstractParserTest
 {
     /**
      * testWithParentTypeHint
-     * 
+     *
      * @return void
      */
     public function testWithParentTypeHint()
@@ -91,7 +91,7 @@ class ASTFormalParameterParsingTest extends AbstractParserTest
 
     /**
      * Returns the first formal parameter found in the associated test file.
-     * 
+     *
      * @return \PDepend\Source\AST\ASTFormalParameter
      */
     private function getFirstMethodFormalParameter()

--- a/src/test/php/PDepend/Source/Parser/AbstractParserTest.php
+++ b/src/test/php/PDepend/Source/Parser/AbstractParserTest.php
@@ -54,5 +54,4 @@ use PDepend\AbstractTest;
  */
 abstract class AbstractParserTest extends AbstractTest
 {
-
 }

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -59,7 +59,7 @@ class TokenStackTest extends AbstractParserTest
 {
     /**
      * testAddReturnsGivenTokenInstance
-     * 
+     *
      * @return void
      */
     public function testAddReturnsGivenTokenInstance()

--- a/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -57,7 +57,7 @@ class UnstructuredCodeTest extends AbstractParserTest
 {
     /**
      * testParserHandlesNonPhpCodeInFileProlog
-     * 
+     *
      * @return void
      */
     public function testParserHandlesNonPhpCodeInFileProlog()
@@ -67,7 +67,7 @@ class UnstructuredCodeTest extends AbstractParserTest
 
     /**
      * testParserHandlesConditionalClassDeclaration
-     * 
+     *
      * @return void
      */
     public function testParserHandlesConditionalClassDeclaration()

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -108,7 +108,7 @@ class RunnerTest extends AbstractTest
         $runner->setWithoutAnnotations();
         $runner->setFileExtensions(array('inc'));
 
-        $actual = $this->_runRunnerAndReturnStatistics(
+        $actual = $this->runRunnerAndReturnStatistics(
             $runner,
             $this->createCodeResourceUriForTest()
         );
@@ -142,7 +142,7 @@ class RunnerTest extends AbstractTest
         $runner = $this->createTextUiRunner();
         $runner->setWithoutAnnotations();
 
-        $actual = $this->_runRunnerAndReturnStatistics(
+        $actual = $this->runRunnerAndReturnStatistics(
             $runner,
             $this->createCodeResourceUriForTest()
         );
@@ -180,7 +180,7 @@ class RunnerTest extends AbstractTest
         );
 
         $runner = $this->createTextUiRunner();
-        $actual = $this->_runRunnerAndReturnStatistics(
+        $actual = $this->runRunnerAndReturnStatistics(
             $runner,
             $this->createCodeResourceUriForTest()
         );
@@ -259,7 +259,7 @@ class RunnerTest extends AbstractTest
      * @param $pathName The source path.
      * @return array
      */
-    private function _runRunnerAndReturnStatistics(Runner $runner, $pathName)
+    private function runRunnerAndReturnStatistics(Runner $runner, $pathName)
     {
         $logFile = $this->createRunResourceURI();
 

--- a/src/test/php/PDepend/Util/Cache/AbstractDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/AbstractDriverTest.php
@@ -216,5 +216,5 @@ abstract class AbstractDriverTest extends AbstractTest
      *
      * @return \PDepend\Util\Cache\CacheDriver
      */
-    protected abstract function createDriver();
+    abstract protected function createDriver();
 }

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -131,7 +131,6 @@ class FileCacheGarbageCollectorTest extends AbstractTest
 
     protected function createFile($mtime = 0, $atime = 0)
     {
-
         $time = time();
 
         $mtime = $time - $mtime;

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -64,7 +64,7 @@ class FileCacheDriverTest extends AbstractDriverTest
 
     /**
      * Initializes a temporary working directory.
-     * 
+     *
      * @return void
      */
     protected function setUp()

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -62,7 +62,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testReportReturnsExpected0PercentCoverage()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(0, $coverage);
@@ -75,7 +75,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testReportReturnsExpected50PercentCoverage()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(50, $coverage);
@@ -88,7 +88,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testReportReturnsExpected100PercentCoverage()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(100, $coverage);
@@ -101,7 +101,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testReportReturnsExpected100PercentCoverageWithCoverageIgnore()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(100, $coverage);
@@ -114,7 +114,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testReportReturnsExpected0PercentCoverageForOneLineMethod()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(0, $coverage);
@@ -127,7 +127,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testNamespacedReportReturnsExpected0PercentCoverage()
     {
-        $report   = $this->_createNamespacedCloverReport();
+        $report   = $this->createNamespacedCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(0, $coverage);
@@ -140,7 +140,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testNamespacedReportReturnsExpected50PercentCoverage()
     {
-        $report   = $this->_createNamespacedCloverReport();
+        $report   = $this->createNamespacedCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(50, $coverage);
@@ -153,7 +153,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testNamespacedReportReturnsExpected100PercentCoverage()
     {
-        $report   = $this->_createNamespacedCloverReport();
+        $report   = $this->createNamespacedCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(100, $coverage);
@@ -166,7 +166,7 @@ class CloverReportTest extends AbstractTest
      */
     public function testGetCoverageReturnsZeroCoverageWhenNoMatchingEntryExists()
     {
-        $report   = $this->_createCloverReport();
+        $report   = $this->createCloverReport();
         $coverage = $report->getCoverage($this->createMethodMock(__FUNCTION__));
 
         $this->assertEquals(0, $coverage);
@@ -177,7 +177,7 @@ class CloverReportTest extends AbstractTest
      *
      * @return \PDepend\Util\Coverage\CloverReport
      */
-    private function _createCloverReport()
+    private function createCloverReport()
     {
         $sxml = simplexml_load_file(dirname(__FILE__) . '/_files/clover.xml');
         return new CloverReport($sxml);
@@ -188,7 +188,7 @@ class CloverReportTest extends AbstractTest
      *
      * @return \PDepend\Util\Coverage\CloverReport
      */
-    private function _createNamespacedCloverReport()
+    private function createNamespacedCloverReport()
     {
         $sxml = simplexml_load_file(dirname(__FILE__) . '/_files/clover-namespaced.xml');
         return new CloverReport($sxml);

--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -57,7 +57,7 @@ class FileUtilTest extends AbstractTest
 {
     /**
      * testGetSysTempDirReturnsExpectedDirectory
-     * 
+     *
      * @return void
      */
     public function testGetSysTempDirReturnsExpectedDirectory()
@@ -93,5 +93,4 @@ class FileUtilTest extends AbstractTest
             FileUtil::getUserHomeDirOrSysTempDir()
         );
     }
-
 }


### PR DESCRIPTION
Closes #334

Also fixes coding style, mainly in unit tests.