### PR TITLE
Add dependency to help contributors with file changes for PSR standards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8|^5.7",
-        "squizlabs/php_codesniffer": "^2.0.0"
+        "squizlabs/php_codesniffer": "^2.0.0",
+        "bernardosilva/git-hooks-php": "^1.2"
     },
     "bin": ["src/bin/pdepend"],
     "autoload": {


### PR DESCRIPTION
- [x] allow contributor to have each files they change checked against PSR2 standards or any other standards if a `phpcs.xml.dist` is added
does not require contributor to do anything to have this working on their local environments

errors can always be skiped by adding `-n` option

e.g.
```
git commit -nm "my commit is skipping the rules :("
```