### PR TITLE
add environment variable to prefer logical packages to namespaces

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -6577,6 +6577,12 @@ abstract class AbstractPHPParser
      */
     private function getNamespaceOrPackageName()
     {
+        if (getenv('PREFER_LOGICAL_PACKAGENAMES')) {
+            if ($this->packageName === null) {
+                return $this->namespaceName;
+            }
+            return $this->packageName;
+        }
         if ($this->namespaceName === null) {
             return $this->packageName;
         }


### PR DESCRIPTION
The current heuristic used by pdepend to groups classes into packages stems from the pre-namespace PHP.

With the advent of PHP 5.3, it might make more sense for some users to decide to which package a compilation unit belongs to, regardless of its namespace.

Make this available through the environment variable `PREFER_LOGICAL_PACKAGENAMES`.