### PR TITLE
Fixes #304: Object operator on objects returned by callable object

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -389,7 +389,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             return $this->parseStaticMemberPrimaryPrefix($expr->getChild(0));
         }
         if ($this->tokenizer->peek() === Tokens::T_OBJECT_OPERATOR) {
-            return $this->parseMemberPrimaryPrefix($expr->getChild(0));
+            $node = count($expr->getChildren()) === 0 ? $expr : $expr->getChild(0);
+            return $this->parseMemberPrimaryPrefix($node);
         }
         return $expr;
     }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -518,4 +518,12 @@ class PHPParserGenericVersion70Test extends AbstractTest
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
+
+    /**
+     * @return void
+     */
+    public function testMethodsCanBeCallOnInstancesReturnedByInvokableObject()
+    {
+        $this->assertNotNull($this->parseCodeResourceForTest());
+    }
 }

--- a/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testMethodsCanBeCallOnInstancesReturnedByInvokableObject.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testMethodsCanBeCallOnInstancesReturnedByInvokableObject.php
@@ -1,0 +1,19 @@
+<?php
+
+class Foo
+{
+    public function bar()
+    {
+        echo 'baz';
+    }
+}
+
+class FooFactory
+{
+    public function __invoke()
+    {
+        return new Foo();
+    }
+}
+
+(new FooFactory())()->bar();


### PR DESCRIPTION
I'm not sure about this solution, but it seems to work. Analysing a codebase at work, I had this same problem, and with this fix now the analysis works as expected. I hope this to fix #304.

Please let me know of any change needed as I would like to get this fix :).