### PR TITLE
Added (partial) short list syntax support and key specification for list (PHP 7.1)

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1605,11 +1605,12 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTListExpression
      * @since 0.9.12
      */
-    private function parseListExpression()
+    protected function parseListExpression()
     {
         $this->tokenStack->push();
 
         $token = $this->consumeToken(Tokens::T_LIST);
+
         $this->consumeComments();
 
         $list = $this->builder->buildAstListExpression($token->image);
@@ -2428,7 +2429,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTStatement
      * @since 0.9.12
      */
-    private function parseStatementBody(\PDepend\Source\AST\ASTStatement $stmt)
+    protected function parseStatementBody(\PDepend\Source\AST\ASTStatement $stmt)
     {
         $this->consumeComments();
         $tokenType = $this->tokenizer->peek();
@@ -2593,7 +2594,7 @@ abstract class AbstractPHPParser
      * @throws \PDepend\Source\Parser\ParserException
      * @since 1.0.1
      */
-    private function parseExpression()
+    protected function parseExpression()
     {
         if (null === ($expr = $this->parseOptionalExpression())) {
             $token = $this->consumeToken($this->tokenizer->peek());
@@ -3494,7 +3495,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTForeachStatement
      * @since 0.9.8
      */
-    private function parseForeachStatement()
+    protected function parseForeachStatement()
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_FOREACH);
@@ -3512,7 +3513,7 @@ abstract class AbstractPHPParser
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
             $foreach->addChild($this->parseVariableOrMemberByReference());
         } else {
-            if ($this->tokenizer->peek() == Tokens::T_LIST) {
+            if ($this->tokenizer->peek() === Tokens::T_LIST) {
                 $foreach->addChild($this->parseListExpression());
             } else {
                 $foreach->addChild($this->parseVariableOrConstantOrPrimaryPrefix());
@@ -3520,12 +3521,10 @@ abstract class AbstractPHPParser
                 if ($this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
                     $this->consumeToken(Tokens::T_DOUBLE_ARROW);
 
-                    if ($this->tokenizer->peek() == Tokens::T_LIST) {
+                    if ($this->tokenizer->peek() === Tokens::T_LIST) {
                         $foreach->addChild($this->parseListExpression());
                     } else {
-                        $foreach->addChild(
-                            $this->parseVariableOrMemberOptionalByReference()
-                        );
+                        $foreach->addChild($this->parseVariableOrMemberOptionalByReference());
                     }
                 }
             }
@@ -4599,7 +4598,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTUnaryExpression
      * @since 0.9.18
      */
-    private function parseVariableOrMemberOptionalByReference()
+    protected function parseVariableOrMemberOptionalByReference()
     {
         $this->consumeComments();
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
@@ -4625,7 +4624,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTUnaryExpression
      * @since 0.9.18
      */
-    private function parseVariableOrMemberByReference()
+    protected function parseVariableOrMemberByReference()
     {
         $this->tokenStack->push();
 

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -318,6 +318,28 @@ class ASTForeachStatementTest extends ASTNodeTest
     }
 
     /**
+     * testForeachStatementWithList
+     *
+     * @return void
+     */
+    public function testForeachStatementWithShortList()
+    {
+        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(1));
+    }
+
+    /**
+     * testForeachStatementWithList
+     *
+     * @return void
+     */
+    public function testForeachStatementWithKeyAndShortList()
+    {
+        $stmt = $this->_getFirstForeachStatementInFunction(__METHOD__);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(2));
+    }
+
+    /**
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -303,6 +303,34 @@ class ASTListExpressionTest extends ASTNodeTest
     }
 
     /**
+     * testListExpressionWithKeys
+     *
+     * @return \PDepend\Source\AST\ASTListExpression
+     * @since 1.0.2
+     */
+    public function testListExpressionWithKeys()
+    {
+        $expr = $this->_getFirstListExpressionInFunction();
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+
+        return $expr;
+    }
+
+    /**
+     * testListExpressionWithKeysAndNestedList
+     *
+     * @return \PDepend\Source\AST\ASTListExpression
+     * @since 1.0.2
+     */
+    public function testListExpressionWithKeysAndNestedList()
+    {
+        $expr = $this->_getFirstListExpressionInFunction();
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+
+        return $expr;
+    }
+
+    /**
      * Returns a node instance for the currently executed test case.
      *
      * @return \PDepend\Source\AST\ASTListExpression

--- a/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithKeyAndShortList.php
+++ b/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithKeyAndShortList.php
@@ -1,0 +1,5 @@
+<?php
+function testForeachStatementWithKeyAndShortList()
+{
+    foreach ($expr as $key => [$a, $b]) {}
+}

--- a/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithShortList.php
+++ b/src/test/resources/files/Source/AST/ASTForeachStatement/testForeachStatementWithShortList.php
@@ -1,0 +1,5 @@
+<?php
+function testForeachStatementWithShortList()
+{
+    foreach ($expr as [$a, $b]) {}
+}

--- a/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithKeys.php
+++ b/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithKeys.php
@@ -1,0 +1,6 @@
+<?php
+function testListExpressionWithKeys()
+{
+    list("a" => $a, "b" => $b) = array("a" => "a", "b" => "b");
+    var_dump( $a, $b );
+}

--- a/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithKeysAndNestedList.php
+++ b/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithKeysAndNestedList.php
@@ -1,0 +1,15 @@
+<?php
+function testListExpressionWithKeysAndNestedList()
+{
+    list('a' => $a, 'b' => list($b, list('c' => $c, 'd' => $d))) = array(
+        'a' => 'a',
+        'b' => array(
+            'b',
+            array(
+                'c' => 'c',
+                'd' => 'd',
+            ),
+        ),
+    );
+    var_dump($a, $b, $c, $d);
+}


### PR DESCRIPTION
#353 

I added partial support for the [short list syntax](https://wiki.php.net/rfc/short_list_syntax) which was introduced in PHP 7.1.

It's only partial support right now, because it does not yet cover assignment operations (`[$a, $b] = $array`). I do not really have an idea on how to properly implement this at the moment (only in a basic manner that does not cover the whole syntax :confused:). However, the short list syntax can be used in foreach statements 

Furthermore, I added support for specifying [keys in list statements](https://wiki.php.net/rfc/list_keys).