### PR TITLE
Support Short List Syntax

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -24,6 +24,7 @@
             </exclude>
         </whitelist>
     </filter>
+
     <logging>
         <log type="coverage-clover" target="clover.xml"/>
     </logging>

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2700,6 +2700,7 @@ abstract class AbstractPHPParser
                     $expressions[] = $this->parseIssetExpression();
                     break;
                 case Tokens::T_LIST:
+                case Tokens::T_SQUARED_BRACKET_OPEN:
                     $expressions[] = $this->parseListExpression();
                     break;
                 case Tokens::T_QUESTION_MARK:

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -55,8 +55,6 @@ use PDepend\Source\Tokenizer\Tokens;
  * TODO:
  * - void
  *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
- * - Symmetric array destructuring
- *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.symmetric-array-destructuring
  * - Class constant visibility
  *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility
  * - Multi catch exception handling

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -70,6 +70,11 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion71 extends PHPParserVersion70
 {
+    protected function isListUnpacking()
+    {
+        return in_array($this->tokenizer->peek(), array(Tokens::T_LIST, Tokens::T_SQUARED_BRACKET_OPEN));
+    }
+
     /**
      * @return \PDepend\Source\AST\ASTType
      */

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -264,6 +264,21 @@ class ASTListExpressionTest extends ASTNodeTest
     }
 
     /**
+     * testListExpressionWithSquaredBrackets
+     *
+     * @return void
+     */
+    public function testListExpressionWithSquaredBrackets()
+    {
+        $parameters = $this->getFirstNodeOfTypeInFunction(
+            $this->getCallingTestMethod(),
+            'PDepend\\Source\\AST\\ASTFormalParameters'
+        );
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $parameters);
+    }
+
+    /**
      * testListExpressionWithCompoundVariable
      *
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
@@ -532,6 +532,27 @@ class PHPParserVersion70Test extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testParseList()
+    {
+        $this->assertNotNull($this->parseCodeResourceForTest());
+    }
+
+    /**
+     * @return void
+     */
+    public function testParseListWithSquaredBrackets()
+    {
+        $this->setExpectedException(
+            '\\PDepend\\Source\\Parser\\UnexpectedTokenException',
+            'Unexpected token: [, line: 2, col: 26, file: '
+        );
+
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
      * Tests that the parser throws an exception when it detects an invalid
      * token in a method or property declaration.
      *

--- a/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithSquaredBrackets.php
+++ b/src/test/resources/files/Source/AST/ASTListExpression/testListExpressionWithSquaredBrackets.php
@@ -1,0 +1,5 @@
+<?php
+function testListExpressionWithSquaredBrackets()
+{
+    [$a, $b] = ["a", "b"];
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParseList.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParseList.php
@@ -1,0 +1,4 @@
+<?php
+foreach ([['a', 'b']] as list($a, $b)) {
+    var_dump($a, $b);
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParseListWithSquaredBrackets.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParseListWithSquaredBrackets.php
@@ -1,0 +1,4 @@
+<?php
+foreach ([['a', 'b']] as [$a, $b]) {
+    var_dump($a, $b);
+}


### PR DESCRIPTION
This PR implements support for keys in list(), which is avaiable as of PHP 7.1, as documented in https://www.php.net/manual/en/migration71.new-features.php#migration71.new-features.support-for-keys-in-list

```php
// list() style
list("id" => $id1, "name" => $name1) = $data[0];

// [] style
["id" => $id1, "name" => $name1] = $data[0];

// list() style
foreach ($data as list("id" => $id, "name" => $name)) {
    // logic here with $id and $name
}

// [] style
foreach ($data as ["id" => $id, "name" => $name]) {
    // logic here with $id and $name
}
```