### PR TITLE
Fixes #301: Unexpected token error with invokable

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2399,7 +2399,7 @@ abstract class AbstractPHPParser
      * @throws \PDepend\Source\Parser\TokenStreamEndException
      * @since 0.9.6
      */
-    private function parseBraceExpression(
+    protected function parseBraceExpression(
         ASTNode $node,
         Token $start,
         $closeToken
@@ -3774,7 +3774,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTExpression
      * @since 0.9.8
      */
-    private function parseParenthesisExpression()
+    protected function parseParenthesisExpression()
     {
         $this->tokenStack->push();
         $this->consumeComments();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -243,6 +243,34 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
+     * Parses any expression that is surrounded by an opening and a closing
+     * parenthesis
+     *
+     * @return \PDepend\Source\AST\ASTExpression
+     */
+    protected function parseParenthesisExpression()
+    {
+        $this->tokenStack->push();
+        $this->consumeComments();
+
+        $expr = $this->builder->buildAstExpression();
+        $expr = $this->parseBraceExpression(
+            $expr,
+            $this->consumeToken(Tokens::T_PARENTHESIS_OPEN),
+            Tokens::T_PARENTHESIS_CLOSE
+        );
+        
+        while ($this->tokenizer->peek() === Tokens::T_PARENTHESIS_OPEN) {
+            $function = $this->builder->buildAstFunctionPostfix($expr->getImage());
+            $function->addChild($expr);
+            $function->addChild($this->parseArguments());
+            $expr = $function;
+        }
+        
+        return $this->setNodePositionsAndReturn($expr);
+    }
+
+    /**
      * Tests if the given image is a PHP 7 type hint.
      *
      * @param string $image

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
@@ -560,4 +560,9 @@ class PHPParserVersion70Test extends AbstractTest
             array($tokenizer, $builder, $cache)
         );
     }
+
+    public function testParenthesisAroundCallableParsesArguments()
+    {
+        $this->assertNotNull($this->parseCodeResourceForTest());
+    }
 }

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParenthesisAroundCallableParsesArguments.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion70/testParenthesisAroundCallableParsesArguments.php
@@ -1,0 +1,6 @@
+<?php
+
+function testParenthesisAroundCallableParsesArguments()
+{
+    (($object->callback)(1, 2))(1, 2);
+}


### PR DESCRIPTION
Wrapping a callable in parenthesis stopped the argument list from being
read and caused the argument list to be read as an expression. If the argument list
contained a comma, the unexpected token exception was thrown.