### PR TITLE
Bugfix for PHP 7 and some return types being incorrectly parsed

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5886,15 +5886,8 @@ abstract class AbstractPHPParser
         // Check for fully qualified name
         if ($fragments[0] === '\\') {
             return join('', $fragments);
-        } else {
-            switch (strtolower($fragments[0])) {
-                case 'int':
-                case 'bool':
-                case 'float':
-                case 'string':
-                case 'callable':
-                    return $fragments[0];
-            }
+        } elseif ($this->isScalarOrCallableTypeHint($fragments[0])) {
+            return $fragments[0];
         }
 
         // Search for an use alias
@@ -5971,6 +5964,18 @@ abstract class AbstractPHPParser
         } while ($tokenType === Tokens::T_BACKSLASH);
 
         return $qualifiedName;
+    }
+
+    /**
+     * Determines if the given image is a PHP 7 type hint.
+     *
+     * @param string $image
+     * @return boolean
+     */
+    protected function isScalarOrCallableTypeHint($image)
+    {
+        // Scalar & callable type hints were not present in PHP 5
+        return false;
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
@@ -158,6 +158,17 @@ class PHPParserVersion71Test extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testVoidTypeHintReturnNamespaced()
+    {
+        $type = $this->getFirstFunctionForTestCase()->getReturnType();
+        $this->assertTrue($type->isScalar());
+        $this->assertFalse($type->isArray());
+        $this->assertSame('void', $type->getImage());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion71/testVoidTypeHintReturnNamespaced.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion71/testVoidTypeHintReturnNamespaced.php
@@ -1,0 +1,5 @@
+<?php
+namespace Acme;
+function set($param): void {
+    // do something
+}


### PR DESCRIPTION
Fix for issue #359

Some scalar return types within a namespaced file were resulting in the wrong AST type being constructed.
Code has been slightly refactored because depending on the PHP version will depend on which 'scalar' reserve types are applicable.

Thanks to @emirb for the testcases from closed PR #360
Fixes https://github.com/phpmd/phpmd/issues/464 too AFAIK