### PR TITLE
Ignore files in the git export that aren't needed to use the project

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+/scripts export-ignore
+/setup export-ignore
+/src/conf export-ignore
 /src/test export-ignore
 /src/site export-ignore
 .gitattributes export-ignore
@@ -10,3 +13,4 @@ build.xml export-ignore
 phpunit.xml.dist export-ignore
 pdepend.xml.dist export-ignore
 composer.lock export-ignore
+Vagrantfile export-ignore


### PR DESCRIPTION
I noticed that some files where added to the download while not needed.

In this change I add them to the .gitattributes file to ignore it.