### PR TITLE
Replace xdebug with phpdbg for code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
     # - php: 7.2
     #   env: DEPENDENCIES=low
     - php: 7.3
+      env: COVERAGE=true
     # Could be enabled when we'll upgrade PHPUnit
     # - php: 7.3
     #   env: DEPENDENCIES=low
@@ -47,7 +48,9 @@ env:
   global:
     TEST_CONFIG="phpunit.xml.dist"
 
+
 before_script:
+  - phpenv config-rm xdebug.ini || echo "XDebug is not enabled"
   - composer self-update
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-dist --prefer-lowest --prefer-stable; fi
   - if [ "$DEPENDENCIES" != "low" ]; then composer update --prefer-dist --prefer-stable; fi
@@ -55,8 +58,8 @@ before_script:
 script:
   - |
     if [[ $WEBSITE != 'true' && $BUILD_PHAR != 'true' ]]; then
-      vendor/bin/phpunit --configuration $TEST_CONFIG --colors --coverage-clover=coverage.xml
-      bash <(curl -s https://codecov.io/bash) -f coverage.xml
+      if [ "$COVERAGE" != "true" ]; then vendor/bin/phpunit --configuration $TEST_CONFIG --colors; fi
+      if [ "$COVERAGE" = "true" ]; then phpdbg -qrr vendor/bin/phpunit --configuration $TEST_CONFIG --colors --coverage-clover=coverage.xml; fi
     fi
   - if [[ $WEBSITE = 'true' ]]; then composer build-website; fi
   - |
@@ -68,9 +71,9 @@ script:
 
 after_script:
   - |
-    if [[ $BUILD_PHAR != 'true' ]]; then
-      wget https://scrutinizer-ci.com/ocular.phar
-      php ocular.phar code-coverage:upload --format=php-clover coverage.xml
+    if [[ -f coverage.xml ]]; then
+      bash <(curl -s https://codecov.io/bash) -f coverage.xml
+      wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.xml
     fi
 
 notifications:


### PR DESCRIPTION
Currently it takes 5 hours to run all tests on Travis. Builds for legacy PHP versions take half an hour. More recent versions take 7-12mins to run.

<img width="915" alt="image" src="https://user-images.githubusercontent.com/190447/63469490-3665ef80-c462-11e9-87f1-26181835f97a.png">

<img width="852" alt="image" src="https://user-images.githubusercontent.com/190447/63469757-e20f3f80-c462-11e9-95b1-ff68b2e1476a.png">

By replacing xdebug with phpdbg and only running coverage once, we can easily shave off lots of build time (legacy builds down to 8-10mins).

<img width="909" alt="image" src="https://user-images.githubusercontent.com/190447/63498063-0a2b8c80-c4bd-11e9-8c65-3ce0f7574c10.png">

<img width="846" alt="image" src="https://user-images.githubusercontent.com/190447/63498001-ef591800-c4bc-11e9-85d1-74f981e95ef8.png">


Having so extensive build matrix is another problem I'd like to discuss separately. 