### PR TITLE
Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Type: (bugfix / feature / refactoring / documentation update)  
+Issue: #.. the corresponding issue for this PR (if exist)
+Breaking change: yes/no (if yes explain why)
+
+<!--
+Explain what the PR does and also why. If you have parts you are not sure about, please explain. 
+
+Please check this points before submitting your PR.
+ - Add test to cover the changes you made on the code.
+ - If you have a change on the documentation, please link to the page that you change.
+ - If you add a new feature please update the documentation in the same PR.
+ - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
+ - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
+-->


### PR DESCRIPTION
Type: Maintenance support
Issue: none
Breaking change: no

After creating the Issue templates I thought it is a good idea to add a Pull Request template. See https://help.github.com/en/articles/creating-a-pull-request-template-for-your-repository and https://github.blog/2016-02-17-issue-and-pull-request-templates/ for an explanation about the working.

This is in fact a copy of https://github.com/phpmd/phpmd/pull/680