### PR TITLE
Start next PHP levels parser inheritance structure

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -54,7 +54,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
  */
-class PHPParserGeneric extends PHPParserVersion71
+class PHPParserGeneric extends PHPParserVersion74
 {
     /**
      * Tests if the given token type is a reserved keyword in the supported PHP

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -53,16 +53,6 @@ use PDepend\Source\Tokenizer\Tokens;
 /**
  * Concrete parser implementation that supports features up to PHP version 7.1.
  *
- * TODO:
- * - void
- *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.void-functions
- * - Class constant visibility
- *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.class-constant-visibility
- * - Multi catch exception handling
- *   http://php.net/manual/en/migration71.new-features.php#migration71.new-features.mulit-catch-exception-handling
- * - see full list
- *   http://php.net/manual/en/migration71.php
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 2.4

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.3
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 7.2.
+ *
+ * TODO: Check or implement features support for:
+ * - New object type
+ *   https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.object-type
+ * - Abstract method overriding
+ *   https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.abstract-method-overriding
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.4
+ */
+abstract class PHPParserVersion72 extends PHPParserVersion71
+{
+}

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.3
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 7.3.
+ *
+ * TODO: Check or implement features support for:
+ * - More Flexible Heredoc and Nowdoc Syntax
+ *   https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc
+ * - Array Destructuring supports Reference Assignments
+ *   https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.destruct-reference
+ * - Instanceof Operator accepts Literals
+ *   https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.instanceof-literals
+ * - Trailing Commas are allowed in Calls
+ *   https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.4
+ */
+abstract class PHPParserVersion73 extends PHPParserVersion72
+{
+}

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.3
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 7.4.
+ *
+ * TODO: Check or implement features support for:
+ * - Typed properties
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties
+ * - Arrow functions
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.arrow-functions
+ * - Limited return type covariance and argument type contravariance
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.type-variance
+ * - Null coalescing assignment operator
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.null-coalescing-assignment-operator
+ * - Unpacking inside arrays
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.unpack-inside-array
+ * - Numeric literal separator
+ *   https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.4
+ */
+abstract class PHPParserVersion74 extends PHPParserVersion73
+{
+}


### PR DESCRIPTION
This is the base structure of PHP 7.2 to 7.4 parser classes with their todo list of features that may impact the parsing of PDepend:

### PHP 7.0
- Tokens: trait, callable, insteadof (allowed as method, constant) (not allowed as class, interface, trait)

### PHP 7.1
All clear

### PHP 7.2
- New object type
https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.object-type
- Abstract method overriding
https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.abstract-method-overriding

### PHP 7.3
- More Flexible Heredoc and Nowdoc Syntax
https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc
- Array Destructuring supports Reference Assignments
https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.destruct-reference
- Instanceof Operator accepts Literals
https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.instanceof-literals
- Trailing Commas are allowed in Calls
https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.trailing-commas

### PHP 7.4
- Typed properties
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties
- Arrow functions
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.arrow-functions
- Limited return type covariance and argument type contravariance
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.type-variance
- Null coalescing assignment operator
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.null-coalescing-assignment-operator
- Unpacking inside arrays
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.unpack-inside-array
- Numeric literal separator
https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.numeric-literal-separator

This could be first merged as it as a TODO list reference, then for each item of each list, we should:
- create an issue/PR (can target php-next-level branch until this PR is merged)
- create a unit test to show how PDepend would be supposed to understand the given syntax (TDD)
- if it's actually properly supported, remove it from the TODO and submit test+toto-removal as ready-to-review PR
- else: mark the test as incomplete `$this->markTestIncomplete('This need to be implemented, your help is welcome, see issue https://github.com/pdepend/pdepend/issues/N');` submit as a pull-request so we can merge it with no risk, then add to the issue: "Make the test xy pass" and propose the issue as a "Good first issue" with a well defined expectations.
