### PR TITLE
Set Project Version to 2.6.0

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 project.dir       =
 project.uri       = pdepend.org
 project.name      = pdepend
-project.version   = 2.5.2
+project.version   = 2.6.0
 project.stability = stable
 
 project.pear.uri = pear.example.com


### PR DESCRIPTION
Missing update of the buid.properties to set the version of the new tag (2.6.0).