### PR TITLE
Check object type support for PHP 7.2

### DIFF
--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -38,22 +36,43 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 2.3
  */
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\AbstractTest;
+
 /**
- * Concrete parser implementation that supports features up to PHP version 7.2.
- *
- * TODO: Check or implement features support for:
- * - Abstract method overriding
- *   https://www.php.net/manual/en/migration72.new-features.php#migration72.new-features.abstract-method-overriding
+ * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion71} class.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 2.4
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
+ * @group unittest
  */
-abstract class PHPParserVersion72 extends PHPParserVersion71
+class PHPParserVersion72Test extends AbstractTest
 {
+    /**
+     * @return void
+     */
+    public function testObjectTypeHintReturn()
+    {
+        $type = $this->getFirstFunctionForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar(), 'object should not be scalar according to https://www.php.net/manual/en/function.is-scalar.php');
+        $this->assertFalse($type->isArray());
+        $this->assertSame('object', $type->getImage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testObjectTypeHintParameter()
+    {
+        $type = $this->getFirstFormalParameterForTestCase()->getType();
+
+        $this->assertFalse($type->isScalar(), 'object should not be scalar according to https://www.php.net/manual/en/function.is-scalar.php');
+        $this->assertFalse($type->isArray());
+        $this->assertSame('object', $type->getImage());
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -43,7 +43,7 @@ namespace PDepend\Source\Language\PHP;
 use PDepend\AbstractTest;
 
 /**
- * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion71} class.
+ * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion72} class.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testObjectTypeHintParameter.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testObjectTypeHintParameter.php
@@ -1,0 +1,4 @@
+<?php
+function displayMyObject(object $value) {
+    echo $value;
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testObjectTypeHintReturn.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testObjectTypeHintReturn.php
@@ -1,0 +1,4 @@
+<?php
+function getMyObject(): object {
+    return (object) [];
+}


### PR DESCRIPTION
This PR proves PDepend support PHP 7.2 object type hint as parameter type and return type and it adds unit test to ensure it cannot be broken by future changes.