### PR TITLE
Add missing reserved words that are allowed as const name

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -90,12 +90,15 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             case Tokens::T_ENDFOREACH:
             case Tokens::T_ENDIF:
             case Tokens::T_ENDWHILE:
+            case Tokens::T_EMPTY:
+            case Tokens::T_EVAL:
             case Tokens::T_LOGICAL_AND:
             case Tokens::T_GLOBAL:
             case Tokens::T_GOTO:
             case Tokens::T_INSTANCEOF:
             case Tokens::T_INSTEADOF:
             case Tokens::T_INTERFACE:
+            case Tokens::T_ISSET:
             case Tokens::T_NAMESPACE:
             case Tokens::T_NEW:
             case Tokens::T_LOGICAL_OR:
@@ -137,6 +140,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             //case Tokens::T_DIE:
             case Tokens::T_SELF:
             case Tokens::T_PARENT:
+            case Tokens::T_UNSET:
                 return true;
         }
         return parent::isConstantName($tokenType);


### PR DESCRIPTION
Added:
* empty
* eval
* isset
* unset

See: https://www.php.net/manual/en/reserved.keywords.php

Fix for: #354