### PR TITLE
Suppress E_NOTICE thrown by unserialize()

### DIFF
--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -200,7 +200,7 @@ class FileCacheDriver implements CacheDriver
     {
         // unserialize() throws E_NOTICE when data is corrupt
         $data = @unserialize($this->read($file));
-        if ($data['hash'] === $hash) {
+        if (isset($data['hash']) && $data['hash'] === $hash) {
             return $data['data'];
         }
         return null;

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -200,7 +200,7 @@ class FileCacheDriver implements CacheDriver
     {
         // unserialize() throws E_NOTICE when data is corrupt
         $data = @unserialize($this->read($file));
-        if (isset($data['hash']) && $data['hash'] === $hash) {
+        if ($data !== false && $data['hash'] === $hash) {
             return $data['data'];
         }
         return null;

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -198,7 +198,8 @@ class FileCacheDriver implements CacheDriver
      */
     protected function restoreFile($file, $hash)
     {
-        $data = unserialize($this->read($file));
+        // unserialize() throws E_NOTICE when data is corrupt
+        $data = @unserialize($this->read($file));
         if ($data['hash'] === $hash) {
             return $data['data'];
         }


### PR DESCRIPTION
Sometimes the cached files might get corrupted and then unserialize() will throw errors like this polluting the output:

```
Notice: unserialize(): Error at offset 0 of 4025 bytes in .../vendor/pdepend/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php on line 201
```

Type: (bugfix)  
Breaking change: no
This doesn't change the value returned by `unserialize()`, it just suppresses the error. 


*Why?*
TLDR: It breaks the json output of phpmd in case cache gets corrupted. And possibly any other scripts that used this as depency.

I ran phpmd on a large project, and pdepend is a depency for it. After some time, my pdepend cache files got corrupted, and because of that a E_NOTICE issue was displayed: 

```
Notice: unserialize(): Error at offset 0 of 4025 bytes in /data/www/Competec/vendor/pdepend/pdepend/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php on line 201
```

This PR should prevent errors from being displayed (=> keeping the phpmd json output valid)