### PR TITLE
Fix #367 Support trait `insteadof` overrides

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -66,14 +66,16 @@ class ASTTraitUseStatement extends ASTStatement
      */
     public function getAllMethods()
     {
-        if (false === is_array($this->allMethods)) {
+        if ($this->allMethods === null) {
             $this->allMethods = array();
+
             foreach ($this->nodes as $node) {
                 if ($node instanceof ASTTraitReference) {
                     $this->collectMethods($node);
                 }
             }
         }
+
         return $this->allMethods;
     }
 
@@ -97,13 +99,16 @@ class ASTTraitUseStatement extends ASTStatement
             if (strtolower($precedence->getImage()) !== $methodName) {
                 continue;
             }
+
             $children = $precedence->getChildren();
+
             for ($i = 1, $count = count($children); $i < $count; ++$i) {
                 if ($methodParent === $children[$i]->getType()) {
                     return true;
                 }
             }
         }
+
         return false;
     }
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -350,6 +350,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
                 throw new ASTTraitMethodCollisionException($method, $this);
             }
         }
+
         return $methods;
     }
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -117,7 +117,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Temporary property that only holds methods during the parsing process.
      *
-     * @var   \PDepend\Source\AST\ASTMethod[]
+     * @var   ASTMethod[]
      * @since 1.0.2
      */
     protected $methods = array();
@@ -273,7 +273,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns all {@link \PDepend\Source\AST\ASTMethod} objects in this type.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     public function getMethods()
     {
@@ -296,8 +296,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Adds the given method to this type.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
-     * @return \PDepend\Source\AST\ASTMethod
+     * @param ASTMethod $method
+     * @return ASTMethod
      */
     public function addMethod(ASTMethod $method)
     {
@@ -312,7 +312,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Returns an array with {@link \PDepend\Source\AST\ASTMethod} objects
      * that are imported through traits.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      * @since  1.0.0
      */
     protected function getTraitMethods()
@@ -324,6 +324,14 @@ abstract class AbstractASTType extends AbstractASTArtifact
         );
 
         foreach ($uses as $use) {
+            $priorMethods = array();
+            $precedences = $use->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence');
+
+            /** @var ASTTraitAdaptationPrecedence $precedence */
+            foreach ($precedences as $precedence) {
+                $priorMethods[strtolower($precedence->getImage())] = true;
+            }
+            /** @var ASTMethod $method */
             foreach ($use->getAllMethods() as $method) {
                 foreach ($uses as $use2) {
                     if ($use2->hasExcludeFor($method)) {
@@ -333,7 +341,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
                 $name = strtolower($method->getName());
 
-                if (false === isset($methods[$name])) {
+                if (!isset($methods[$name]) || isset($priorMethods[$name])) {
                     $methods[$name] = $method;
                     continue;
                 }
@@ -451,7 +459,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns a list of all methods provided by this type or one of its parents.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     abstract public function getAllMethods();
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -60,6 +60,8 @@ use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTSwitchStatement;
 use PDepend\Source\AST\ASTTrait;
+use PDepend\Source\AST\ASTTraitAdaptation;
+use PDepend\Source\AST\ASTTraitUseStatement;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableVariable;
@@ -1286,7 +1288,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait use statement.
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
      * @since 1.0.0
      */
     private function parseTraitUseStatement()
@@ -1298,6 +1300,7 @@ abstract class AbstractPHPParser
         $useStatement->addChild($this->parseTraitReference());
 
         $this->consumeComments();
+
         while (Tokens::T_COMMA === $this->tokenizer->peek()) {
             $this->consumeToken(Tokens::T_COMMA);
             $useStatement->addChild($this->parseTraitReference());
@@ -1330,26 +1333,26 @@ abstract class AbstractPHPParser
      * Parses the adaptation list of the given use statement or simply reads
      * the terminating semicolon, when no adaptation list exists.
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $useStatement
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @param ASTTraitUseStatement $useStatement
+     * @return ASTTraitUseStatement
      * @since 1.0.0
      */
-    private function parseOptionalTraitAdaptation(
-        \PDepend\Source\AST\ASTTraitUseStatement $useStatement
-    ) {
+    private function parseOptionalTraitAdaptation(ASTTraitUseStatement $useStatement) {
         $this->consumeComments();
+
         if (Tokens::T_CURLY_BRACE_OPEN === $this->tokenizer->peek()) {
             $useStatement->addChild($this->parseTraitAdaptation());
         } else {
             $this->consumeToken(Tokens::T_SEMICOLON);
         }
+
         return $useStatement;
     }
 
     /**
      * Parses the adaptation expression of a trait use statement.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptation
+     * @return ASTTraitAdaptation
      * @since 1.0.0
      */
     private function parseTraitAdaptation()
@@ -1366,11 +1369,9 @@ abstract class AbstractPHPParser
             $reference = $this->parseTraitMethodReference();
             $this->consumeComments();
 
-            if (Tokens::T_AS === $this->tokenizer->peek()) {
-                $stmt = $this->parseTraitAdaptationAliasStatement($reference);
-            } else {
-                $stmt = $this->parseTraitAdaptationPrecedenceStatement($reference);
-            }
+            $stmt = Tokens::T_AS === $this->tokenizer->peek()
+                ? $this->parseTraitAdaptationAliasStatement($reference)
+                : $this->parseTraitAdaptationPrecedenceStatement($reference);
 
             $this->consumeComments();
             $this->consumeToken(Tokens::T_SEMICOLON);

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -121,6 +121,22 @@ class ASTTraitUseStatementTest extends ASTNodeTest
     }
 
     /**
+     * testTraitUseInsteadOfSelf
+     *
+     * @return void
+     */
+    public function testTraitUseInsteadOfSelf()
+    {
+        /** @var AbstractASTClassOrInterface $class */
+        $class = $this->getFirstClassForTestCase();
+        $getTraitMethods = new \ReflectionMethod($class, 'getTraitMethods');
+        $getTraitMethods->setAccessible(true);
+        $methods = $getTraitMethods->invoke($class);
+
+        $this->assertSame(array('test'), array_keys($methods));
+    }
+
+    /**
      * testGetAllMethodsOnClassWithParentReturnsTraitMethod
      *
      * @return void

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -144,6 +144,26 @@ class ASTTraitUseStatementTest extends ASTNodeTest
     }
 
     /**
+     * testTraitMethodAlias
+     *
+     * @throws ReflectionException
+     *
+     * @return void
+     *
+     * @group issue-154
+     */
+    public function testTraitMethodAlias()
+    {
+        /** @var AbstractASTClassOrInterface $class */
+        $class = $this->getFirstClassForTestCase();
+        $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
+        $getTraitMethods->setAccessible(true);
+        $methods = $getTraitMethods->invoke($class);
+
+        $this->assertSame(array('testa', 'testb'), array_keys($methods));
+    }
+
+    /**
      * testGetAllMethodsOnClassWithParentReturnsTraitMethod
      *
      * @return void

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -43,6 +43,9 @@
 
 namespace PDepend\Source\AST;
 
+use ReflectionException;
+use ReflectionMethod;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitUseStatement} class.
  *
@@ -123,13 +126,17 @@ class ASTTraitUseStatementTest extends ASTNodeTest
     /**
      * testTraitUseInsteadOfSelf
      *
+     * @throws ReflectionException
+     *
      * @return void
+     *
+     * @group issue-154
      */
     public function testTraitUseInsteadOfSelf()
     {
         /** @var AbstractASTClassOrInterface $class */
         $class = $this->getFirstClassForTestCase();
-        $getTraitMethods = new \ReflectionMethod($class, 'getTraitMethods');
+        $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
         $getTraitMethods->setAccessible(true);
         $methods = $getTraitMethods->invoke($class);
 

--- a/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitMethodAlias.php
+++ b/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitMethodAlias.php
@@ -1,0 +1,21 @@
+<?php
+trait A {
+    function test() {
+        echo 'a';
+    }
+}
+
+trait B {
+    function test() {
+        echo 'b';
+    }
+}
+
+class C {
+    use A {
+        test as testA;
+    }
+    use B {
+        test as testB;
+    }
+}

--- a/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitMethodAlias.php
+++ b/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitMethodAlias.php
@@ -18,4 +18,8 @@ class C {
     use B {
         test as testB;
     }
+
+    function test() {
+        echo 'c';
+    }
 }

--- a/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitUseInsteadOfSelf.php
+++ b/src/test/resources/files/Source/AST/ASTTraitUseStatement/testTraitUseInsteadOfSelf.php
@@ -1,0 +1,17 @@
+<?php
+trait A {
+    function test() {
+        echo 'a';
+    }
+}
+
+trait B {
+    use A;
+}
+
+class C {
+    use A;
+    use B {
+        A::test insteadof B;
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #367
Breaking change: no

Support `use B {A::method insteadof B;}` syntax.

This is the test to pass (without breaking other tests) to fix the issue.