### PR TITLE
Update support & contact page

### DIFF
--- a/src/site/rst/support.rst
+++ b/src/site/rst/support.rst
@@ -2,30 +2,21 @@
 Support & Contact
 =================
 
-If you think you found an error or you have an improvment for PHP Depend, you
-can send questions and suggestions to our mailinglist. Or if you are interested
-in helping to improve this software, by writing patches, extensions or just
-providing new ideas, you should feel free to join PHP Depend's `IRC channel`__
-or send a message to the users@pdepend.org mailinglist.
+Support Channel
+===============
 
-__ irc://irc.freenode.net/#pdepend
-
-IRC
-===
-
-- You will always find help on PHP Depend related topics in the `#pdepend`__
-  channel on the `FreeNode`__ network.
-
-__ irc://irc.freenode.net/#pdepend
-__ http://freenode.net
+If you have trouble using PHP Depend, you may find help in our
+`Gitter channel <https://gitter.im/pdepend/community>`_.
 
 Issue-Tracker
 =============
 
-- You can file a ticket in PHP Depend's `Issue tracker`__ when you think you
-  found a bug or you have a feature request for PHP Depend.
-
-__ https://github.com/pdepend/pdepend/issues
+You can file an issue in PHP Depend's
+`issue tracker <https://github.com/pdepend/pdepend/issues>`_ when
+you think you found a bug or you have a feature request for future
+versions of PHP Depend.
+If you can even provide a fix for a bug or provide a new feature,
+please open a `pull request <https://github.com/pdpeend/pdepend/pulls>`_.
 
 For enterprise
 ==============
@@ -33,16 +24,3 @@ For enterprise
 Available as part of the Tidelift Subscription.
 
 The maintainers of PHP Depend and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. `Learn more. <https://tidelift.com/subscription/pkg/packagist-pdepend-pdepend?utm_source=packagist-pdepend-pdepend&utm_medium=referral&utm_campaign=enterprise&utm_term=repo>`_
-
-Commercial support
-==================
-
-There are also companies providing commercial support for PHP Depend:
-
-- `Qafoo GmbH - passion for software quality`__
-
-  Founded by me, the lead developer of PHP Depend, and two friends, Qafoo
-  provides support for PHP Depend and general consulting and training on
-  software quality tools and processes.
-
-__ http://qafoo.com


### PR DESCRIPTION
- Replace mention of IRC channel with Gitter channel
- Update issue tracker
- Remove commercial support through now practially defunct Qafoo

Sync with [PHPMD's Support & Contact page](https://github.com/phpmd/phpmd/blob/630cd42f1157bfd7503d740ea1c66d0e9aa6ae68/src/site/rst/support/index.rst).