### PR TITLE
Fix #472 Use the current token instead of the first inner one to determine the class start

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -44,6 +44,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -380,9 +381,9 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * @param \PDepend\Source\Tokenizer\Token[] $tokens
      * @return void
      */
-    public function setTokens(array $tokens)
+    public function setTokens(array $tokens, Token $startToken = null)
     {
-        $this->startLine = reset($tokens)->startLine;
+        $this->startLine = ($startToken ?: reset($tokens))->startLine;
         $this->endLine   = end($tokens)->endLine;
 
         $this->cache

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -383,7 +383,11 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function setTokens(array $tokens, Token $startToken = null)
     {
-        $this->startLine = ($startToken ?: reset($tokens))->startLine;
+        if (!$startToken) {
+            $startToken = reset($tokens);
+        }
+
+        $this->startLine = $startToken->startLine;
         $this->endLine   = end($tokens)->endLine;
 
         $this->cache

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -714,11 +714,12 @@ abstract class AbstractPHPParser
      */
     protected function parseClassDeclaration()
     {
+        $startToken = $this->tokenizer->currentToken();
         $this->tokenStack->push();
 
         $class = $this->parseClassSignature();
         $class = $this->parseTypeBody($class);
-        $class->setTokens($this->tokenStack->pop());
+        $class->setTokens($this->tokenStack->pop(), $startToken);
 
         $this->reset();
 
@@ -5883,8 +5884,6 @@ abstract class AbstractPHPParser
             case Tokens::T_ENDFOREACH:
             case Tokens::T_CURLY_BRACE_CLOSE:
                 return null;
-            case Tokens::T_DECLARE:
-                return $this->parseDeclareStatement();
             case Tokens::T_CLOSE_TAG:
                 if (($tokenType = $this->parseNonePhpCode()) === Tokenizer::T_EOF) {
                     return null;

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
@@ -186,6 +186,14 @@ class PHPParserVersion71Test extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testClassStartLine()
+    {
+        $this->assertSame(6, $this->getFirstClassForTestCase()->getStartLine());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion71/testClassStartLine.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion71/testClassStartLine.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Class Foo
+ */
+class Foo
+{
+    // Some
+    // comments
+
+    private const AAA = 'AAA';
+
+    public function test1()
+    {
+    }
+
+    public function test2()
+    {
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #472 Fix phpmd/phpmd#739 ([confirmed](https://github.com/phpmd/phpmd/issues/739#issuecomment-631893513))
Breaking change: no