### PR TITLE
Fix PHPDoc blocks

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -172,7 +172,7 @@ class Application
     }
 
     /**
-     * @return array<string, array>
+     * @return array<string, array<string, string>>
      */
     private function getAvailableOptionsFor($serviceTag)
     {

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -55,6 +55,9 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
  */
 class Application
 {
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     **/
     private $container;
 
     /**
@@ -64,6 +67,7 @@ class Application
 
     /**
      * @param string $configurationFile
+     * @return void
      */
     public function setConfigurationFile($configurationFile)
     {
@@ -116,6 +120,9 @@ class Application
         return $this->getContainer()->get('pdepend.analyzer_factory');
     }
 
+    /**
+     * @return \Symfony\Component\DependencyInjection\ContainerInterface
+     */
     private function getContainer()
     {
         if ($this->container === null) {
@@ -172,6 +179,7 @@ class Application
     }
 
     /**
+     * @param string $serviceTag
      * @return array<string, array<string, string>>
      */
     private function getAvailableOptionsFor($serviceTag)

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -79,7 +79,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
      * @return void
      */
     public function startParseProcess(Builder $builder)
@@ -90,7 +90,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
      * @return void
      */
     public function endParseProcess(Builder $builder)

--- a/src/main/php/PDepend/DependencyInjection/Compiler/ProcessListenerPass.php
+++ b/src/main/php/PDepend/DependencyInjection/Compiler/ProcessListenerPass.php
@@ -56,6 +56,9 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ProcessListenerPass implements CompilerPassInterface
 {
+    /**
+     * @return void
+     */
     public function process(ContainerBuilder $container)
     {
         $engineDefinition = $container->findDefinition('pdepend.engine');

--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -61,6 +61,9 @@ class Configuration implements ConfigurationInterface
      */
     private $extensions = array();
 
+    /**
+     * @param array<Extension> $extensions
+     */
     public function __construct(array $extensions)
     {
         $this->extensions = $extensions;

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -72,6 +72,7 @@ abstract class Extension
      *
      * @param array            $config    Extension configuration hash (from behat.yml)
      * @param ContainerBuilder $container ContainerBuilder instance
+     * @return void
      */
     public function load(array $config, ContainerBuilder $container)
     {
@@ -94,6 +95,7 @@ abstract class Extension
      * Setups configuration for current extension.
      *
      * @param ArrayNodeDefinition $builder
+     * @return void
      */
     public function getConfig(ArrayNodeDefinition $builder)
     {

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -70,7 +70,7 @@ abstract class Extension
     /**
      * Loads a specific configuration.
      *
-     * @param array            $config    Extension configuration hash (from behat.yml)
+     * @param array<mixed>     $config    Extension configuration hash (from behat.yml)
      * @param ContainerBuilder $container ContainerBuilder instance
      * @return void
      */

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -50,13 +50,16 @@ namespace PDepend\DependencyInjection;
  */
 class ExtensionManager
 {
+    /**
+     * @var array<\PDepend\DependencyInjection\Extension>
+     */
     private $extensions = array();
 
     /**
      * Activate an extension based on a class name.
      *
      * @throws \RuntimeException
-     * @param  string $className
+     * @param  class-string<\PDepend\DependencyInjection\Extension> $className
      * @return void
      */
     public function activateExtension($className)

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -57,6 +57,8 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 class PdependExtension extends SymfonyExtension
 {
     /**
+     * @param array<array<array<array<string>>>> $configs
+     * @return void
      * {@inheritDoc}
      */
     public function load(array $configs, ContainerBuilder $container)
@@ -102,6 +104,10 @@ class PdependExtension extends SymfonyExtension
         $configurationDefinition->setArguments(array($settings));
     }
 
+    /**
+     * @param array<string, array<string, string>> $config
+     * @return \stdClass
+     */
     private function createSettings($config)
     {
         $settings = new \stdClass();

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -65,6 +65,8 @@ class TreeBuilder
      * TreeBuilder constructor.
      *
      * @param string $name
+     *
+     * @return void
      */
     public function __construct($name = 'pdepend')
     {

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -70,16 +70,14 @@ class TreeBuilder
      */
     public function __construct($name = 'pdepend')
     {
-        if (method_exists('Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder', 'root')) {
-            // Symfony < 5
-            $this->treeBuilder = new BaseTreeBuilder();
+        $this->treeBuilder = new BaseTreeBuilder($name);
+        if (!method_exists('Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder', 'getRootNode')) {
+            // Symfony < 4.2
             $this->rootNode = $this->treeBuilder->root($name);
 
             return;
         }
 
-        // Symfony 5+
-        $this->treeBuilder = new BaseTreeBuilder($name);
         $this->rootNode = $this->treeBuilder->getRootNode();
     }
 

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -636,7 +636,7 @@ class Engine
      * This method will create an iterator instance which contains all files
      * that are part of the parsing process.
      *
-     * @return \Iterator
+     * @return \Iterator<int, string>
      */
     private function createFileIterator()
     {

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -117,7 +117,7 @@ class Engine
     /**
      * The used code node builder.
      *
-     * @var \PDepend\Source\Builder\Builder
+     * @var \PDepend\Source\Builder\Builder<\PDepend\Source\AST\ASTNamespace>|null
      */
     private $builder = null;
 
@@ -453,7 +453,7 @@ class Engine
     /**
      * Send the start parsing process event.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<\PDepend\Source\AST\ASTNamespace> $builder The used node builder instance.
      * @return void
      */
     protected function fireStartParseProcess(Builder $builder)
@@ -466,7 +466,7 @@ class Engine
     /**
      * Send the end parsing process event.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<\PDepend\Source\AST\ASTNamespace> $builder The used node builder instance.
      * @return void
      */
     protected function fireEndParseProcess(Builder $builder)

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -694,6 +694,10 @@ class Engine
         return new ArrayIterator(array_values($files));
     }
 
+    /**
+     * @param array<string, mixed> $options
+     * @return \PDepend\Metrics\Analyzer[]
+     */
     private function createAnalyzers($options)
     {
         $analyzers = $this->analyzerFactory->createRequiredForGenerators($this->generators);
@@ -719,6 +723,10 @@ class Engine
         return $analyzers;
     }
 
+    /**
+     * @param string $path
+     * @return bool
+     */
     private function isPhpStream($path)
     {
         return substr($path, 0, strlen($this->phpStreamPrefix)) === $this->phpStreamPrefix;

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -70,7 +70,7 @@ class ExcludePathFilter implements Filter
      * Constructs a new exclude path filter instance and accepts an array of
      * exclude pattern as argument.
      *
-     * @param array $patterns List of exclude file path patterns.
+     * @param array<string> $patterns List of exclude file path patterns.
      */
     public function __construct(array $patterns)
     {

--- a/src/main/php/PDepend/Input/ExtensionFilter.php
+++ b/src/main/php/PDepend/Input/ExtensionFilter.php
@@ -61,7 +61,7 @@ class ExtensionFilter implements Filter
      * Constructs a new file extension filter instance with the given list of
      *  allowed file <b>$extensions</b>.
      *
-     * @param array $extensions List of allowed extension.
+     * @param array<string> $extensions List of allowed extension.
      */
     public function __construct(array $extensions)
     {

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -68,9 +68,9 @@ class Iterator extends \FilterIterator
     /**
      * Constructs a new file filter iterator.
      *
-     * @param \Iterator             $iterator The inner iterator.
-     * @param \PDepend\Input\Filter $filter   The filter object.
-     * @param string                $rootPath Optional root path for the files.
+     * @param \Iterator<\SplFileInfo> $iterator The inner iterator.
+     * @param \PDepend\Input\Filter   $filter   The filter object.
+     * @param string                  $rootPath Optional root path for the files.
      */
     public function __construct(\Iterator $iterator, Filter $filter, $rootPath = null)
     {

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -60,7 +60,7 @@ class Iterator extends \FilterIterator
     /**
      * Optional root path for the files.
      *
-     * @var   string
+     * @var   string|null
      * @since 0.10.0
      */
     protected $rootPath = null;

--- a/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
@@ -82,6 +82,7 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
      *
      * @param array<string, mixed> $options Global option array, every analyzer
      *                                      can extract the required options.
+     * @return void
      */
     public function setOptions(array $options = array())
     {

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -59,14 +59,14 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     /**
      * Collected node metrics
      *
-     * @var array
+     * @var array<string, mixed>
      */
     protected $metrics = null;
 
     /**
      * Metrics restored from the cache. This property is only used temporary.
      *
-     * @var array
+     * @var array<string, mixed>
      */
     private $metricsCached = array();
 

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -90,6 +90,7 @@ interface Analyzer
      * Set global options
      *
      * @param array<string, mixed> $options
+     * @return void
      * @since 2.0.1
      */
     public function setOptions(array $options = array());

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -86,6 +86,9 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      */
     private $nodeMetrics = null;
 
+    /**
+     * @var array<string, ASTNamespace>
+     */
     protected $nodeSet = array();
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -64,7 +64,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * Collected cohesion metrics for classes.
      *
-     * @var array
+     * @var array<string, array<string, integer>>
      */
     private $nodeMetrics = array();
 
@@ -82,7 +82,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * </code>
      *
      * @param  \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array<string, mixed>
+     * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -84,7 +84,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespaces
+     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -155,7 +155,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Provides the project summary metrics as an <b>array</b>.
      *
-     * @return array
+     * @return array<string, integer>
      */
     public function getProjectMetrics()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -92,7 +92,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
     private $nodeMetrics = null;
 
     /**
-     * @var array<string, \PDepend\Source\AST\ASTNamespace>
+     * @var array<string, ASTNamespace>
      */
     protected $nodeSet = array();
 
@@ -315,7 +315,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
             ++$this->nodeMetrics[$id][self::M_NUMBER_OF_CONCRETE_CLASSES];
         }
 
-        
+
         foreach ($type->getDependencies() as $dependency) {
             $this->collectDependencies(
                 $type->getNamespace(),

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -87,7 +87,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * )
      * </code>
      *
-     * @var array<string, array>
+     * @var array<string, array<string, mixed>>
      */
     private $nodeMetrics = null;
 
@@ -161,7 +161,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Returns the statistics for the requested node.
      *
      * @param  \PDepend\Source\AST\AbstractASTArtifact $node
-     * @return array
+     * @return array<string, mixed>
      */
     public function getStats(AbstractASTArtifact $node)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -104,7 +104,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * the requested node, this method will return an empty <b>array</b>.
      *
      * @param \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, integer>
      */
     public function getNodeBasisMetrics(ASTArtifact $artifact)
     {
@@ -121,7 +121,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * node, this method will return an empty <b>array</b>.
      *
      * @param \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, float>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
@@ -377,8 +377,8 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * @see http://www.verifysoft.com/en_halstead_metrics.html
      * @see http://www.grammatech.com/codesonar/workflow-features/halstead
      *
-     * @param array $basis [n1, n2, N1, N2]
-     * @return array
+     * @param array<string, int> $basis [n1, n2, N1, N2]
+     * @return array<string, float>
      */
     public function calculateHalsteadMeasures(array $basis)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -77,7 +77,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespaces
+     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -75,7 +75,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
      * halstead volume & lines of code, all of which we already have analyzers
      * for.
      *
-     * @param array $options
+     * @param array<string, mixed> $options
      */
     public function __construct(array $options = array())
     {
@@ -122,7 +122,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
      * node, this method will return an empty <b>array</b>.
      *
      * @param \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, float>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -89,7 +89,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespaces
+     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -110,7 +110,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * </code>
      *
      * @param  \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, string>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -137,7 +137,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * </code>
      *
      * @param  \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
@@ -159,7 +159,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @return array
+     * @return array<string, integer>
      */
     public function getProjectMetrics()
     {
@@ -414,9 +414,9 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @param  array   $tokens The raw token stream.
-     * @param  boolean $search Optional boolean flag, search start.
-     * @return array
+     * @param  array<integer, \PDepend\Source\Tokenizer\Token> $tokens The raw token stream.
+     * @param  boolean                                         $search Optional boolean flag, search start.
+     * @return array<integer, integer>
      */
     private function linesOfCode(array $tokens, $search = false)
     {

--- a/src/main/php/PDepend/ProcessListener.php
+++ b/src/main/php/PDepend/ProcessListener.php
@@ -59,7 +59,7 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
      * @return void
      */
     public function startParseProcess(Builder $builder);
@@ -67,7 +67,7 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder The used node builder instance.
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
      * @return void
      */
     public function endParseProcess(Builder $builder);

--- a/src/main/php/PDepend/Report/CodeAwareGenerator.php
+++ b/src/main/php/PDepend/Report/CodeAwareGenerator.php
@@ -55,7 +55,7 @@ interface CodeAwareGenerator extends ReportGenerator
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts);

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -79,7 +79,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList
+     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
     protected $code = null;
 
@@ -130,7 +130,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -47,6 +47,7 @@ use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\CodeAwareGenerator;
 use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
+use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
 use PDepend\Util\Utf8Util;
@@ -71,7 +72,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * The context source code.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList
+     * @var \PDepend\Source\AST\ASTArtifactList<AbstractASTArtifact>
      */
     private $code = null;
 
@@ -108,7 +109,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\AbstractASTArtifact> $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<AbstractASTArtifact> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -73,7 +73,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList
+     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
     protected $code = null;
 
@@ -159,7 +159,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -108,14 +108,14 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The Packages dom element.
      *
-     * @var \DOMElement
+     * @var \DOMNode
      */
     protected $packages = null;
 
     /**
      * The Cycles dom element.
      *
-     * @var \DOMElement
+     * @var \DOMNode
      */
     protected $cycles = null;
 

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -260,7 +260,7 @@ class Pyramid implements FileAwareGenerator
     /**
      * Computes the proportions between the given metrics.
      *
-     * @param  array $metrics The aggregated project metrics.
+     * @param  array<string, float> $metrics The aggregated project metrics.
      * @return array<string, float>
      */
     private function computeProportions(array $metrics)

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -79,7 +79,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList
+     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
     protected $code = null;
 
@@ -153,7 +153,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -49,6 +49,8 @@ use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @implements \Iterator<int|string, \PDepend\Source\AST\ASTArtifact>
+ * @implements \ArrayAccess<int|string, \PDepend\Source\AST\ASTArtifact>
  */
 class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
 {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -117,7 +117,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Returns the current node or <b>false</b>
      *
-     * @return \PDepend\Source\AST\ASTArtifact
+     * @return \PDepend\Source\AST\ASTArtifact|false
      */
     public function current()
     {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -49,8 +49,10 @@ use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @implements \Iterator<int|string, \PDepend\Source\AST\ASTArtifact>
- * @implements \ArrayAccess<int|string, \PDepend\Source\AST\ASTArtifact>
+ *
+ * @template T of \PDepend\Source\AST\ASTArtifact
+ * @implements \Iterator<int|string, T>
+ * @implements \ArrayAccess<int|string, T>
  */
 class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
 {
@@ -58,7 +60,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * List of {@link \PDepend\Source\AST\ASTArtifact} objects in
      * this iterator.
      *
-     * @var \PDepend\Source\AST\ASTArtifact[]
+     * @var T[]
      */
     private $artifacts = array();
 
@@ -80,7 +82,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * Constructs a new node iterator from the given {@link \PDepend\Source\AST\ASTArtifact}
      * node array.
      *
-     * @param \PDepend\Source\AST\ASTArtifact[] $artifacts
+     * @param T[] $artifacts
      */
     public function __construct(array $artifacts)
     {
@@ -117,7 +119,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Returns the current node or <b>false</b>
      *
-     * @return \PDepend\Source\AST\ASTArtifact|false
+     * @return T|false
      */
     public function current()
     {
@@ -186,7 +188,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * Offset to retrieve
      *
      * @param  mixed $offset
-     * @return \PDepend\Source\AST\ASTArtifact Can return all value types.
+     * @return T Can return all value types.
      * @throws \OutOfBoundsException
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -50,6 +50,8 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @extends ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>
  */
 class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
 {

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -181,7 +181,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * Setter method for the used parser and token cache.
      *
      * @param  \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\AST\ASTCompilationUnit
+     * @return $this
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -56,7 +56,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var   \PDepend\Util\Cache\CacheDriver
+     * @var   \PDepend\Util\Cache\CacheDriver|null
      * @since 0.10.0
      */
     protected $cache = null;
@@ -64,21 +64,21 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The unique identifier for this function.
      *
-     * @var string
+     * @var string|null
      */
     protected $id = null;
 
     /**
      * The source file name/path.
      *
-     * @var string
+     * @var string|null
      */
     protected $fileName = null;
 
     /**
      * The comment for this type.
      *
-     * @var string
+     * @var string|null
      */
     protected $comment = null;
 
@@ -117,7 +117,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Normalized code in this file.
      *
-     * @var string
+     * @var string|null
      */
     private $source = null;
 
@@ -138,7 +138,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns the physical file name for this object.
      *
-     * @return string
+     * @return string|null
      */
     public function getName()
     {
@@ -148,7 +148,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns the physical file name for this object.
      *
-     * @return string
+     * @return string|null
      */
     public function getFileName()
     {
@@ -158,7 +158,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns a id for this code node.
      *
-     * @return string
+     * @return string|null
      */
     public function getId()
     {
@@ -193,7 +193,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns normalized source code with stripped whitespaces.
      *
-     * @return string
+     * @return string|null
      */
     public function getSource()
     {

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -131,7 +131,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
         if ($fileName && strpos($fileName, 'php://') === 0) {
             $this->fileName = $fileName;
         } elseif ($fileName !== null) {
-            $this->fileName = realpath($fileName);
+            $this->fileName = realpath($fileName) ?: null;
         }
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -81,7 +81,7 @@ class ASTFunction extends AbstractASTCallable
      * Sets the currently active builder context.
      *
      * @param  \PDepend\Source\Builder\BuilderContext $context Current builder context.
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return $this
      * @since  0.10.0
      */
     public function setContext(BuilderContext $context)

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -303,6 +303,7 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * @param boolean $packageAnnotation
+     * @return void
      */
     public function setPackageAnnotation($packageAnnotation)
     {

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -146,7 +146,7 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns an array with all {@link \PDepend\Source\AST\ASTTrait}
      * instances declared in this namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTTrait>
      * @since  1.0.0
      */
     public function getTraits()
@@ -158,7 +158,7 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns an iterator with all {@link \PDepend\Source\AST\ASTClass}
      * instances within this namespace.
      *
-     * @return \PDepend\Source\AST\ASTClass[]
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTClass>
      */
     public function getClasses()
     {
@@ -169,7 +169,7 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns an iterator with all {@link \PDepend\Source\AST\ASTInterface}
      * instances within this namespace.
      *
-     * @return \PDepend\Source\AST\ASTInterface[]
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTInterface>
      */
     public function getInterfaces()
     {
@@ -180,8 +180,9 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns an iterator with all types of the given <b>$className</b> in this
      * namespace.
      *
-     * @param  string $className The class/type we are looking for.
-     * @return \PDepend\Source\AST\ASTArtifactList
+     * @template T of \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @param  class-string<T> $className The class/type we are looking for.
+     * @return \PDepend\Source\AST\ASTArtifactList<T>
      * @since  1.0.0
      */
     private function getTypesOfType($className)
@@ -196,10 +197,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\AbstractASTType} objects in
+     * Returns all {@link \PDepend\Source\AST\AbstractASTClassOrInterface} objects in
      * this namespace.
      *
-     * @return \PDepend\Source\AST\AbstractASTType[]
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>
      */
     public function getTypes()
     {
@@ -209,8 +210,8 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Adds the given type to this namespace and returns the input type instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return \PDepend\Source\AST\AbstractASTType
+     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
      */
     public function addType(AbstractASTType $type)
     {
@@ -234,7 +235,7 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Removes the given type instance from this namespace.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
+     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return void
      */
     public function removeType(AbstractASTType $type)
@@ -251,7 +252,7 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns all {@link \PDepend\Source\AST\ASTFunction} objects in this
      * namespace.
      *
-     * @return \PDepend\Source\AST\ASTFunction[]
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTFunction>
      */
     public function getFunctions()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -122,7 +122,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * instance can store the associated tokens.
      *
      * @param  \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\AST\AbstractASTCallable
+     * @return $this
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -404,7 +404,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an array with all declared static variables.
      *
-     * @return array
+     * @return array<string, mixed>
      * @since  0.9.6
      */
     public function getStaticVariables()

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -183,7 +183,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns an array of references onto the interfaces of this class node.
      *
-     * @return array
+     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference[]
      * @since  0.10.4
      */
     public function getInterfaceReferences()

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -129,7 +129,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * interface instance can store the associated tokens.
      *
      * @param  \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\AST\AbstractASTType
+     * @return $this
      */
     public function setCache(CacheDriver $cache)
     {
@@ -141,7 +141,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Sets the currently active builder context.
      *
      * @param  \PDepend\Source\Builder\BuilderContext $context
-     * @return \PDepend\Source\AST\AbstractASTType
+     * @return $this
      */
     public function setContext(BuilderContext $context)
     {

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -157,8 +157,8 @@ interface ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string $method Name of the called method.
-     * @param array  $args   Array with method argument.
+     * @param string                $method Name of the called method.
+     * @param array<integer, mixed> $args   Array with method argument.
      *
      * @return mixed
      * @since  0.9.12

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -71,7 +71,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Returns an iterator with all registered visit listeners.
      *
-     * @return \Iterator
+     * @return \Iterator<\PDepend\Source\ASTVisitor\ASTVisitListener>
      */
     public function getVisitListeners()
     {
@@ -268,8 +268,8 @@ abstract class AbstractASTVisitor implements ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string $method Name of the called method.
-     * @param array  $args   Array with method argument.
+     * @param string                $method Name of the called method.
+     * @param array<integer, mixed> $args   Array with method argument.
      *
      * @return mixed
      * @since  0.9.12

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -55,6 +55,9 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @template T of mixed
+ * @extends \IteratorAggregate<T>
  */
 interface Builder extends \IteratorAggregate
 {
@@ -67,7 +70,7 @@ interface Builder extends \IteratorAggregate
      * Setter method for the currently used token cache.
      *
      * @param  \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Builder\Builder
+     * @return \PDepend\Source\Builder\Builder<mixed>
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -65,14 +65,14 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * The currently used ast builder.
      *
-     * @var \PDepend\Source\Builder\Builder
+     * @var \PDepend\Source\Builder\Builder<mixed>
      */
     protected static $builder = null;
 
     /**
      * Constructs a new builder context instance.
      *
-     * @param \PDepend\Source\Builder\Builder $builder The currently used ast builder.
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder The currently used ast builder.
      */
     public function __construct(Builder $builder)
     {
@@ -165,7 +165,7 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the currently used builder instance.
      *
-     * @return \PDepend\Source\Builder\Builder
+     * @return \PDepend\Source\Builder\Builder<mixed>
      */
     protected function getBuilder()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1404,7 +1404,7 @@ abstract class AbstractPHPParser
      * {@link \PDepend\Source\AST\ASTTraitReference} class that represents the
      * declaring trait.
      *
-     * @return array
+     * @return array<integer, mixed>
      * @since 1.0.0
      */
     private function parseTraitMethodReference()
@@ -1434,7 +1434,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait adaptation alias statement.
      *
-     * @param array $reference Parsed method reference array.
+     * @param array<integer, mixed> $reference Parsed method reference array.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
      * @since 1.0.0
@@ -1477,7 +1477,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait adaptation precedence statement.
      *
-     * @param  array $reference Parsed method reference array.
+     * @param  array<integer, mixed> $reference Parsed method reference array.
      * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
      * @throws \PDepend\Source\Parser\InvalidStateException
      * @since 1.0.0
@@ -1828,7 +1828,7 @@ abstract class AbstractPHPParser
      * node this can be a {@link \PDepend\Source\AST\ASTPostIncrementExpression} or
      * {@link \PDepend\Source\AST\ASTPostfixExpression}.
      *
-     * @param  array $expressions List of previous parsed expression nodes.
+     * @param  array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
      * @return \PDepend\Source\AST\ASTExpression
      * @since 0.10.0
      */
@@ -1890,7 +1890,7 @@ abstract class AbstractPHPParser
      * node this can be a {@link \PDepend\Source\AST\ASTPostDecrementExpression} or
      * {@link \PDepend\Source\AST\ASTPostfixExpression}.
      *
-     * @param array $expressions List of previous parsed expression nodes.
+     * @param array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
      *
      * @return \PDepend\Source\AST\ASTExpression
      * @since 0.10.0
@@ -6180,7 +6180,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param array $previousElements
+     * @param array<string> $previousElements
      * @return string
      */
     protected function parseQualifiedNameElement(array $previousElements)
@@ -6305,7 +6305,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param array $fragments
+     * @param array<string> $fragments
      * @return void
      */
     protected function parseUseDeclarationForVersion(array $fragments)
@@ -6317,7 +6317,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param array $fragments
+     * @param array<string> $fragments
      * @return string
      */
     protected function parseNamespaceImage(array $fragments)
@@ -6918,7 +6918,7 @@ abstract class AbstractPHPParser
      *
      * @param string $comment The context doc comment block.
      *
-     * @return array
+     * @return array<integer, string>
      */
     private function parseThrowsAnnotations($comment)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1617,6 +1617,7 @@ abstract class AbstractPHPParser
      *
      * @param int                             $tokenType
      * @param \PDepend\Source\Tokenizer\Token $unexpectedToken
+     * @return void
      */
     private function ensureTokenIsListUnpackingOpening($tokenType, $unexpectedToken = null)
     {
@@ -3385,6 +3386,7 @@ abstract class AbstractPHPParser
      * This method parses class references in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @return void
      */
     protected function parseCatchExceptionClass(ASTCatchStatement $stmt)
     {
@@ -5095,6 +5097,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an array structure.
      *
+     * @param boolean $static
      * @return \PDepend\Source\AST\ASTArray
      * @since 1.0.0
      */
@@ -7184,6 +7187,9 @@ abstract class AbstractPHPParser
         throw $this->getUnexpectedTokenException($token);
     }
 
+    /**
+     * @return void
+     */
     protected function checkEllipsisInExpressionSupport()
     {
         $this->throwUnexpectedTokenException();

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -190,7 +190,7 @@ abstract class AbstractPHPParser
     /**
      * The used data structure builder.
      *
-     * @var Builder
+     * @var Builder<mixed>
      */
     protected $builder;
 
@@ -278,7 +278,7 @@ abstract class AbstractPHPParser
      * Constructs a new source parser.
      *
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      */
     public function __construct(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -267,7 +267,7 @@ abstract class AbstractPHPParser
      */
     protected $cache;
 
-    /*
+    /**
      * The used code tokenizer.
      *
      * @var \PDepend\Source\Tokenizer\Tokenizer
@@ -6784,7 +6784,7 @@ abstract class AbstractPHPParser
     /**
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      */
     protected function parseLambdaFunctionDeclaration()

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4604,6 +4604,8 @@ abstract class AbstractPHPParser
                     $this->builder->buildAstConstant($token->image)
                 );
         }
+
+        return null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4581,7 +4581,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a simple PHP constant use and returns a corresponding node.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return \PDepend\Source\AST\ASTNode|null
      * @since 1.0.0
      */
     protected function parseConstant()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -65,6 +65,8 @@ use PDepend\Util\Type;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @implements Builder<\PDepend\Source\AST\ASTNamespace>
  */
 class PHPBuilder implements Builder
 {
@@ -1836,7 +1838,7 @@ class PHPBuilder implements Builder
      * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
     public function getIterator()
     {
@@ -1847,7 +1849,7 @@ class PHPBuilder implements Builder
      * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
     public function getNamespaces()
     {
@@ -1861,7 +1863,7 @@ class PHPBuilder implements Builder
      * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList
+     * @return \PDepend\Source\AST\ASTNamespace[]
      * @since  0.9.12
      */
     private function getPreparedNamespaces()
@@ -2150,10 +2152,12 @@ class PHPBuilder implements Builder
      * Creates a copy of the given input array, but skips all types that do not
      * contain a parent package.
      *
-     * @param array $originalTypes The original types created during the parsing
+     * @template T of \PDepend\Source\AST\AbstractASTType
+     *
+     * @param array<string, array<string, array<int, T>>> $originalTypes The original types created during the parsing
      *        process.
      *
-     * @return array
+     * @return array<string, array<string, array<int, T>>>
      */
     private function copyTypesWithPackage(array $originalTypes)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -110,21 +110,21 @@ class PHPBuilder implements Builder
     /**
      * All generated {@link \PDepend\Source\AST\ASTTrait} objects
      *
-     * @var \PDepend\Source\AST\ASTTrait[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTTrait>>>
      */
     private $traits = array();
 
     /**
      * All generated {@link \PDepend\Source\AST\ASTClass} objects
      *
-     * @var \PDepend\Source\AST\ASTClass[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTClass>>>
      */
     private $classes = array();
 
     /**
      * All generated {@link \PDepend\Source\AST\ASTInterface} instances.
      *
-     * @var \PDepend\Source\AST\ASTInterface[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTInterface>>>
      */
     private $interfaces = array();
 
@@ -152,21 +152,21 @@ class PHPBuilder implements Builder
     /**
      * Cache of all traits created during the regular parsing process.
      *
-     * @var \PDepend\Source\AST\ASTTrait[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTTrait>>>
      */
     private $frozenTraits = array();
 
     /**
      * Cache of all classes created during the regular parsing process.
      *
-     * @var \PDepend\Source\AST\ASTClass[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTClass>>>
      */
     private $frozenClasses = array();
 
     /**
      * Cache of all interfaces created during the regular parsing process.
      *
-     * @var \PDepend\Source\AST\ASTInterface[]
+     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTInterface>>>
      */
     private $frozenInterfaces = array();
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2113,7 +2113,7 @@ class PHPBuilder implements Builder
 
         // Check for exact match and return first matching instance
         if (isset($instances[$caseInsensitiveName][$namespaceName])) {
-            return reset($instances[$caseInsensitiveName][$namespaceName]);
+            return reset($instances[$caseInsensitiveName][$namespaceName]) ?: null;
         }
 
         if (!$this->isDefault($namespaceName)) {
@@ -2121,6 +2121,10 @@ class PHPBuilder implements Builder
         }
 
         $classesOrInterfaces = reset($instances[$caseInsensitiveName]);
+        if (!$classesOrInterfaces) {
+            return null;
+        }
+
         return reset($classesOrInterfaces);
     }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -189,7 +189,7 @@ class PHPBuilder implements Builder
      * Setter method for the currently used token cache.
      *
      * @param  \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\PHPBuilder
+     * @return $this
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2091,7 +2091,7 @@ class PHPBuilder implements Builder
      * best matching instance or <b>null</b> if no match exists.
      *
      * @template T of \PDepend\Source\AST\AbstractASTType
-     * @param  array<string, array<string, array<integer, T>>>  $instances
+     * @param  array<string, array<string, array<string, T>>>  $instances
      * @param  string $qualifiedName
      * @return T|null
      * @since  0.9.5

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -301,7 +301,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     /**
      * In this method we implement parsing of PHP 5.6 specific expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return \PDepend\Source\AST\ASTNode|null
      * @since 2.3
      */
     protected function parseExpressionVersion56()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -323,6 +323,8 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
 
                 return $expr;
         }
+
+        return null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -508,7 +508,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @param array $fragments
+     * @param array<string> $fragments
      * @return void
      */
     protected function parseUseDeclarationForVersion(array $fragments)
@@ -523,7 +523,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @param array $fragments
+     * @param array<string> $fragments
      * @return void
      */
     protected function parseUseDeclarationVersion70(array $fragments)
@@ -566,7 +566,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @param array $previousElements
+     * @param array<string> $previousElements
      * @return string|null
      */
     protected function parseQualifiedNameElement(array $previousElements)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -476,6 +476,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
 
                 return $expr;
         }
+
+        return null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -453,7 +453,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * In this method we implement parsing of PHP 7.0 specific expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return \PDepend\Source\AST\ASTNode|null
      * @since 2.3
      */
     protected function parseExpressionVersion70()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -190,6 +190,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * This method parses class references in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @return void
      */
     protected function parseCatchExceptionClass(ASTCatchStatement $stmt)
     {
@@ -214,6 +215,9 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         return true;
     }
 
+    /**
+     * @return void
+     */
     private function consumeQuestionMark()
     {
         if ($this->tokenizer->peek() === Tokens::T_QUESTION_MARK) {
@@ -221,6 +225,11 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         }
     }
 
+    /**
+     * @param integer $tokenType
+     * @param integer $modifiers
+     * @return integer
+     */
     private function getModifiersForConstantDefinition($tokenType, $modifiers)
     {
         $allowed = State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -126,6 +126,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
     /**
      * Override PHP 7.3 checkEllipsisInExpressionSupport to stop throwing the
      * parsing exception.
+     * @return void
      */
     protected function checkEllipsisInExpressionSupport()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -508,6 +508,9 @@ class PHPTokenizerInternal implements FullTokenizer
         ),
     );
 
+    /**
+     * @var array<integer, array<integer, array<string, string|integer>>>
+     */
     protected static $reductionMap = array(
         Tokens::T_CONCAT => array(
             Tokens::T_CONCAT => array(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -730,9 +730,9 @@ class PHPTokenizerInternal implements FullTokenizer
      * and substitutes some of the tokens with those required by PDepend's
      * parser implementation.
      *
-     * @param array<array> $tokens Unprepared array of php tokens.
+     * @param array<array<integer, integer|string>|string> $tokens Unprepared array of php tokens.
      *
-     * @return array<array>
+     * @return array<array<integer, integer|string>|string>
      */
     private function substituteTokens(array $tokens)
     {
@@ -911,7 +911,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * returns the collected content. The returned value will be null if there
      * was no none php token.
      *
-     * @param array $tokens Reference to the current token stream.
+     * @param array<array<integer, integer|string>|string> $tokens Reference to the current token stream.
      *
      * @return string
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -548,9 +548,9 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * The source file instance.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit
+     * @var \PDepend\Source\AST\ASTCompilationUnit|null
      */
-    protected $sourceFile = '';
+    protected $sourceFile = null;
 
     /**
      * Count of all tokens.
@@ -583,7 +583,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit
+     * @return \PDepend\Source\AST\ASTCompilationUnit|null
      */
     public function getSourceFile()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -916,7 +916,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * @param array<array<integer, integer|string>|string> $tokens Reference to the current token stream.
      *
-     * @return string
+     * @return string|null
      */
     private function consumeNonePhpTokens(array &$tokens)
     {

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -133,7 +133,7 @@ class SymbolTable
      *
      * @throws NoActiveScopeException
      *
-     * @return mixed
+     * @return string|null
      */
     public function lookup($key)
     {

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -63,7 +63,7 @@ interface Tokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return string
+     * @return \PDepend\Source\AST\ASTCompilationUnit|null
      */
     public function getSourceFile();
 

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -332,7 +332,7 @@ class Command
     /**
      * Assign CLI arguments to current runner instance
      *
-     * @return bool
+     * @return void
      */
     protected function assignArguments()
     {

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -629,6 +629,7 @@ class Command
 
     /**
      * @param integer $startTime
+     * @return void
      */
     private function printStatistics($startTime)
     {

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -72,7 +72,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder
      * @return void
      */
     public function startParseProcess(Builder $builder)
@@ -85,7 +85,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder $builder
+     * @param  \PDepend\Source\Builder\Builder<mixed> $builder
      * @return void
      */
     public function endParseProcess(Builder $builder)

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -223,7 +223,7 @@ class Runner
      * Adds a logger or analyzer option.
      *
      * @param string $identifier
-     * @param string|array $value
+     * @param string|array<string> $value
      * @return void
      */
     public function addOption($identifier, $value)

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -124,7 +124,7 @@ class FileCacheDriver implements CacheDriver
      * <em>store()</em>.
      *
      * @param  string $type The name or object type for the next storage method call.
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return $this
      */
     public function type($type)
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -108,7 +108,7 @@ class MemoryCacheDriver implements CacheDriver
      * <em>store()</em>.
      *
      * @param  string $type The name or object type for the next storage method call.
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return $this
      */
     public function type($type)
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -96,7 +96,7 @@ class MemoryCacheDriver implements CacheDriver
      */
     public function __construct()
     {
-        $this->staticId = sha1(uniqid(rand(0, PHP_INT_MAX)));
+        $this->staticId = sha1(uniqid((string)rand(0, PHP_INT_MAX)));
     }
 
     /**

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -66,7 +66,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * The in memory cache.
      *
-     * @var array<string, array>
+     * @var array<string, array<integer, mixed>>
      */
     protected $cache = array();
 
@@ -87,7 +87,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * Global stack, mainly used during testing.
      *
-     * @var array<mixed>
+     * @var array<string, array<integer, mixed>>
      */
     protected static $staticCache = array();
 

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -63,7 +63,7 @@ class Factory
     public function create($pathName)
     {
         $sxml = $this->loadXml($pathName);
-        if ($sxml->project) {
+        if (isset($sxml->project)) {
             return new CloverReport($sxml);
         }
         throw new \RuntimeException('Unsupported coverage report format.');

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -52,6 +52,10 @@ namespace PDepend\Util;
  */
 final class Utf8Util
 {
+    /**
+     * @param string $raw
+     * @return string
+     */
     public static function ensureEncoding($raw)
     {
         $encoding = 'UTF8';

--- a/src/main/php/PDepend/Util/Workarounds.php
+++ b/src/main/php/PDepend/Util/Workarounds.php
@@ -76,7 +76,7 @@ class Workarounds
     /**
      * Returns an array with error messages related to the required workarounds.
      *
-     * @return array
+     * @return array<integer, string>
      */
     public function getRequiredWorkarounds()
     {

--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -909,7 +909,7 @@ abstract class AbstractTest extends TestCase
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -110,7 +110,7 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PHPUnit_Framework_MockObject_MockObject
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
@@ -143,7 +143,7 @@ class PHPParserVersion53Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion54Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion54Test.php
@@ -419,7 +419,7 @@ class PHPParserVersion54Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion55Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion55Test.php
@@ -149,7 +149,7 @@ class PHPParserVersion55Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion56Test.php
@@ -274,7 +274,7 @@ class PHPParserVersion56Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
@@ -631,7 +631,7 @@ class PHPParserVersion70Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
@@ -195,7 +195,7 @@ class PHPParserVersion71Test extends AbstractTest
 
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */

--- a/src/test/resources/files/Metrics/Analyzer/ClassLevelAnalyzer/testGetNodeMetricsForTrait.php
+++ b/src/test/resources/files/Metrics/Analyzer/ClassLevelAnalyzer/testGetNodeMetricsForTrait.php
@@ -17,7 +17,7 @@ trait ProvidesEvents
      * Set the event manager instance used by this context
      *
      * @param  EventCollection $events
-     * @return mixed
+     * @return $this
      */
     public function setEventManager(EventCollection $events)
     {

--- a/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy/testStrategyCountsCorrectTypes.php
+++ b/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy/testStrategyCountsCorrectTypes.php
@@ -9,7 +9,7 @@ class PDepend_CodeRank_ClassA
     /**
      * Method comment.
      *
-     * @return PDepend_CodeRank_ClassA
+     * @return $this
      */
     public function methodA()
     {

--- a/src/test/resources/files/Metrics/Analyzer/CouplingAnalyzer/testGetNodeMetricsForTrait.php
+++ b/src/test/resources/files/Metrics/Analyzer/CouplingAnalyzer/testGetNodeMetricsForTrait.php
@@ -17,7 +17,7 @@ trait ProvidesEvents
      * Set the event manager instance used by this context
      *
      * @param  EventCollection $events
-     * @return mixed
+     * @return $this
      */
     public function setEventManager(EventCollection $events)
     {

--- a/src/test/resources/files/Metrics/Analyzer/CouplingAnalyzer/testGetProjectMetricsForTrait.php
+++ b/src/test/resources/files/Metrics/Analyzer/CouplingAnalyzer/testGetProjectMetricsForTrait.php
@@ -17,7 +17,7 @@ trait ProvidesEvents
      * Set the event manager instance used by this context
      *
      * @param  EventCollection $events
-     * @return mixed
+     * @return $this
      */
     public function setEventManager(EventCollection $events)
     {


### PR DESCRIPTION
Type: PHPDoc fix

Breaking change: no

Changes:
- Fully typing all parameters, parameters, and return types in `src/main`
- `src/main` now again passes PHPStan level 2, and only 382 issues left in total (down from 427)
- Minor edge cases corrected
- Split up chart::close() to make it more readable

Remaining issues at different levels:
2: 1
3: 39
4: 1
5: 17
6: 8
7: 121
8: 195