### PR TITLE
International names support

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -110,7 +110,7 @@ class StrategyFactory
         }
 
         // Prepare identifier
-        $name = ucfirst(strtolower($strategyName));
+        $name = ucfirst(mb_strtolower($strategyName));
 
         $className = "PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\{$name}Strategy";
 

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -89,7 +89,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
      */
     public function __construct($image)
     {
-        parent::__construct(preg_replace('(\s+)', '', strtolower($image)));
+        parent::__construct(preg_replace('(\s+)', '', mb_strtolower($image)));
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -77,7 +77,7 @@ class ASTTrait extends ASTClass
         $methods = $this->getTraitMethods();
 
         foreach ($this->getMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[mb_strtolower($method->getName())] = $method;
         }
 
         return $methods;

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -90,13 +90,13 @@ class ASTTraitUseStatement extends ASTStatement
      */
     public function hasExcludeFor(ASTMethod $method)
     {
-        $methodName   = strtolower($method->getName());
+        $methodName   = mb_strtolower($method->getName());
         $methodParent = $method->getParent();
 
         $precedences = $this->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence');
 
         foreach ($precedences as $precedence) {
-            if (strtolower($precedence->getImage()) !== $methodName) {
+            if (mb_strtolower($precedence->getImage()) !== $methodName) {
                 continue;
             }
 
@@ -139,11 +139,11 @@ class ASTTraitUseStatement extends ASTStatement
      */
     private function getAliasesFor(ASTMethod $method)
     {
-        $name = strtolower($method->getName());
+        $name = mb_strtolower($method->getName());
 
         $newNames = array();
         foreach ($this->getAliases() as $alias) {
-            $name2 = strtolower($alias->getImage());
+            $name2 = mb_strtolower($alias->getImage());
             if ($name2 !== $name) {
                 continue;
             }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -263,7 +263,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         $methods = array();
         foreach ($this->getInterfaces() as $interface) {
             foreach ($interface->getAllMethods() as $method) {
-                $methods[strtolower($method->getName())] = $method;
+                $methods[mb_strtolower($method->getName())] = $method;
             }
         }
 
@@ -274,11 +274,11 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         }
 
         foreach ($this->getTraitMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[mb_strtolower($method->getName())] = $method;
         }
 
         foreach ($this->getMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[mb_strtolower($method->getName())] = $method;
         }
 
         return $methods;

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -329,7 +329,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
             /** @var ASTTraitAdaptationPrecedence $precedence */
             foreach ($precedences as $precedence) {
-                $priorMethods[strtolower($precedence->getImage())] = true;
+                $priorMethods[mb_strtolower($precedence->getImage())] = true;
             }
             /** @var ASTMethod $method */
             foreach ($use->getAllMethods() as $method) {
@@ -339,7 +339,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
                     }
                 }
 
-                $name = strtolower($method->getName());
+                $name = mb_strtolower($method->getName());
 
                 if (!isset($methods[$name]) || isset($priorMethods[$name])) {
                     $methods[$name] = $method;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2100,7 +2100,7 @@ class PHPBuilder implements Builder
         $classOrInterfaceName = $this->extractTypeName($qualifiedName);
         $namespaceName = $this->extractNamespaceName($qualifiedName);
 
-        $caseInsensitiveName = strtolower($classOrInterfaceName);
+        $caseInsensitiveName = mb_strtolower($classOrInterfaceName);
 
         if (!isset($instances[$caseInsensitiveName])) {
             return null;
@@ -2239,7 +2239,7 @@ class PHPBuilder implements Builder
      */
     protected function storeTrait($traitName, $namespaceName, ASTTrait $trait)
     {
-        $traitName = strtolower($traitName);
+        $traitName = mb_strtolower($traitName);
         if (!isset($this->traits[$traitName][$namespaceName])) {
             $this->traits[$traitName][$namespaceName] = array();
         }
@@ -2260,7 +2260,7 @@ class PHPBuilder implements Builder
      */
     protected function storeClass($className, $namespaceName, ASTClass $class)
     {
-        $className = strtolower($className);
+        $className = mb_strtolower($className);
         if (!isset($this->classes[$className][$namespaceName])) {
             $this->classes[$className][$namespaceName] = array();
         }
@@ -2281,7 +2281,7 @@ class PHPBuilder implements Builder
      */
     protected function storeInterface($interfaceName, $namespaceName, ASTInterface $interface)
     {
-        $interfaceName = strtolower($interfaceName);
+        $interfaceName = mb_strtolower($interfaceName);
         if (!isset($this->interfaces[$interfaceName][$namespaceName])) {
             $this->interfaces[$interfaceName][$namespaceName] = array();
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -159,7 +159,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      */
     protected function isScalarOrCallableTypeHint($image)
     {
-        switch (strtolower($image)) {
+        switch (mb_strtolower($image)) {
             case 'iterable':
             case 'void':
                 return true;
@@ -176,7 +176,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      */
     protected function parseScalarOrCallableTypeHint($image)
     {
-        switch (strtolower($image)) {
+        switch (mb_strtolower($image)) {
             case 'void':
                 return $this->builder->buildAstScalarType($image);
             case 'iterable':

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -801,7 +801,7 @@ class PHPTokenizerInternal implements Tokenizer
 
                 $startLine += $lines;
             } else {
-                $value = strtolower($token[1]);
+                $value = mb_strtolower($token[1]);
                 if (isset($literalMap[$value])) {
                     // Fetch literal type
                     $type = $literalMap[$value];

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -170,6 +170,6 @@ class SymbolTable
      */
     private function normalizeKey($key)
     {
-        return strtolower($key);
+        return mb_strtolower($key);
     }
 }

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -98,7 +98,7 @@ class IdBuilder
     {
         return $this->forOffsetItem(
             $type,
-            ltrim(strrchr(strtolower(get_class($type)), '_'), '_')
+            ltrim(strrchr(mb_strtolower(get_class($type)), '_'), '_')
         );
     }
 
@@ -112,7 +112,7 @@ class IdBuilder
     protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
     {
         $fileHash = $artifact->getCompilationUnit()->getId();
-        $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getName()));
+        $itemHash = $this->hash($prefix . ':' . mb_strtolower($artifact->getName()));
 
         $offset = $this->getOffsetInFile($fileHash, $itemHash);
 
@@ -130,7 +130,7 @@ class IdBuilder
         return sprintf(
             '%s-%s',
             $method->getParent()->getId(),
-            $this->hash(strtolower($method->getName()))
+            $this->hash(mb_strtolower($method->getName()))
         );
     }
 

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -61,8 +61,8 @@ class ImageConvert
      */
     public static function convert($input, $output)
     {
-        $inputType  = strtolower(pathinfo($input, PATHINFO_EXTENSION));
-        $outputType = strtolower(pathinfo($output, PATHINFO_EXTENSION));
+        $inputType  = mb_strtolower(pathinfo($input, PATHINFO_EXTENSION));
+        $outputType = mb_strtolower(pathinfo($output, PATHINFO_EXTENSION));
 
         // Check for output file without extension and reuse input type
         if ($outputType === '') {

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -242,7 +242,7 @@ final class Type
         self::initTypeToExtension();
 
         $normalizedName = ltrim($typeName, '\\');
-        $normalizedName = strtolower($normalizedName);
+        $normalizedName = mb_strtolower($normalizedName);
 
         return isset(self::$typeNameToExtension[$normalizedName]);
     }
@@ -260,7 +260,7 @@ final class Type
         self::initTypeToExtension();
 
         $normalizedName = ltrim($typeName, '\\');
-        $normalizedName = strtolower($normalizedName);
+        $normalizedName = mb_strtolower($normalizedName);
         if (isset(self::$typeNameToExtension[$normalizedName])) {
             return self::$typeNameToExtension[$normalizedName];
         }
@@ -294,7 +294,7 @@ final class Type
     public static function isInternalPackage($packageName)
     {
         $packageNames = self::getInternalNamespaces();
-        return isset($packageNames[strtolower($packageName)]);
+        return isset($packageNames[mb_strtolower($packageName)]);
     }
 
     /**
@@ -307,7 +307,7 @@ final class Type
      */
     public static function isScalarType($image)
     {
-        $image = strtolower($image);
+        $image = mb_strtolower($image);
         if (isset(self::$scalarTypes[$image]) === true) {
             return true;
         }
@@ -343,7 +343,7 @@ final class Type
      */
     public static function getPrimitiveType($image)
     {
-        $image = strtolower($image);
+        $image = mb_strtolower($image);
         if (isset(self::$primitiveTypes[$image]) === true) {
             return self::$primitiveTypes[$image];
         }
@@ -369,7 +369,7 @@ final class Type
      */
     public static function isArrayType($image)
     {
-        return (strtolower($image) === 'array');
+        return (mb_strtolower($image) === 'array');
     }
 
     /**

--- a/src/site/config.php
+++ b/src/site/config.php
@@ -115,7 +115,7 @@ return array(
                 $level = $match['level'];
                 $content = $match['content'];
                 // Use content as anchor
-                $hash = preg_replace('/[^a-z0-9]+/', '-', strtolower(trim($match['content'])));
+                $hash = preg_replace('/[^a-z0-9]+/', '-', mb_strtolower(trim($match['content'])));
 
                 return "<a id=\"$hash\"></a>\n<h$level>$content</h$level>";
             }, $content);

--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -731,7 +731,7 @@ abstract class AbstractTest extends TestCase
             array_push($parts, $match[1]);
 
             // TODO: Fix this workaround for the existing lower case directories
-            array_unshift($parts, strtolower(array_shift($parts)));
+            array_unshift($parts, mb_strtolower(array_shift($parts)));
         }
 
         $fileName = substr(join(DIRECTORY_SEPARATOR, $parts), 0, -4) . DIRECTORY_SEPARATOR . $method;
@@ -809,7 +809,7 @@ abstract class AbstractTest extends TestCase
     private static function initVersionCompatibility()
     {
         $reflection = new \ReflectionClass('Iterator');
-        $extension  = strtolower($reflection->getExtensionName());
+        $extension  = mb_strtolower($reflection->getExtensionName());
         $extension  = ($extension === '' ? 'standard' : $extension);
 
         if (defined('CORE_PACKAGE') === false) {
@@ -843,7 +843,7 @@ abstract class AbstractTest extends TestCase
     {
         list($class, $method) = explode('::', $testCase);
 
-        $fileName = substr(strtolower($class), 8, strrpos($class, '\\') - 8);
+        $fileName = substr(mb_strtolower($class), 8, strrpos($class, '\\') - 8);
         $fileName = str_replace('\\', DIRECTORY_SEPARATOR, $fileName) . DIRECTORY_SEPARATOR . $method;
 
         try {

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -95,7 +95,7 @@ class IdBuilderTest extends AbstractTest
                 ->disableOriginalConstructor()
                 ->getMock();
         $unitStub1->method('getFileName')
-                ->willReturn(strtolower(__FILE__));
+                ->willReturn(mb_strtolower(__FILE__));
         $identifier1 = $builder->forFile($unitStub1);
 
         $this->assertNotEquals($identifier0, $identifier1);
@@ -173,7 +173,7 @@ class IdBuilderTest extends AbstractTest
         $class0 = new ASTClass(__FUNCTION__);
         $class0->setCompilationUnit($compilationUnit);
         
-        $class1 = new ASTClass(strtolower(__FUNCTION__));
+        $class1 = new ASTClass(mb_strtolower(__FUNCTION__));
         $class1->setCompilationUnit($compilationUnit);
 
         $builder0 = new IdBuilder();
@@ -198,7 +198,7 @@ class IdBuilderTest extends AbstractTest
         $interface0 = new ASTInterface(__FUNCTION__);
         $interface0->setCompilationUnit($compilationUnit);
 
-        $interface1 = new ASTInterface(strtolower(__FUNCTION__));
+        $interface1 = new ASTInterface(mb_strtolower(__FUNCTION__));
         $interface1->setCompilationUnit($compilationUnit);
 
         $builder0 = new IdBuilder();
@@ -241,7 +241,7 @@ class IdBuilderTest extends AbstractTest
         $function0 = new ASTFunction(__FUNCTION__);
         $function0->setCompilationUnit($compilationUnit);
 
-        $function1 = new ASTFunction(strtolower(__FUNCTION__));
+        $function1 = new ASTFunction(mb_strtolower(__FUNCTION__));
         $function1->setCompilationUnit($compilationUnit);
 
         $builder0 = new IdBuilder();
@@ -328,7 +328,7 @@ class IdBuilderTest extends AbstractTest
         $method0 = new ASTMethod(__FUNCTION__);
         $method0->setParent($class);
 
-        $method1 = new ASTMethod(strtolower(__FUNCTION__));
+        $method1 = new ASTMethod(mb_strtolower(__FUNCTION__));
         $method1->setParent($class);
 
         $builder0 = new IdBuilder();


### PR DESCRIPTION
## Do not merge this as is, we need to figure out how to best handle things in a consistent way to how PHP works

Type: feature  
Breaking change: no

Filenames, namespaces and class names where being handled with functions that aren't safe on non anscii string, but PHP non-anscii names.

mb_* is already used in other parts of the application so this doesn't add new dependencies.