### PR TITLE
Fix bool flip in parseEscapedAstLiteralString()

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5388,7 +5388,7 @@ abstract class AbstractPHPParser
         $tokenType = $this->tokenizer->peek();
         while ($tokenType != Tokenizer::T_EOF) {
             if ($tokenType === Tokens::T_BACKSLASH) {
-                $escape != $escape;
+                $escape = !$escape;
                 $image  .= $this->consumeToken(Tokens::T_BACKSLASH)->image;
 
                 $tokenType = $this->tokenizer->peek();


### PR DESCRIPTION
Type: bugfix

Breaking change: no

The inversion of the book was incorrectly done as a comparison