### PR TITLE
Clean up PHPDoc and fix some edge cases

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -89,11 +89,15 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     protected $nodeSet = array();
 
     /**
+     * Nodes in which the current analyzed class is used.
+     *
      * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
      */
     private $efferentNodes = array();
 
     /**
+     * Nodes that is used by the current analyzed class.
+     *
      * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
      */
     private $afferentNodes = array();

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -88,8 +88,14 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
 
     protected $nodeSet = array();
 
+    /**
+     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     */
     private $efferentNodes = array();
 
+    /**
+     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     */
     private $afferentNodes = array();
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -142,7 +142,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * node, this method will return an empty <b>array</b>.
      *
      * @param  \PDepend\Source\AST\ASTArtifact $artifact
-     * @return array
+     * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -94,11 +94,15 @@ class DependencyAnalyzer extends AbstractAnalyzer
     protected $nodeSet = array();
 
     /**
+     * Nodes in which the current analyzed dependency is used.
+     *
      * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
      */
     private $efferentNodes = array();
 
     /**
+     * Nodes that is used by the current analyzed node.
+     *
      * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
      */
     private $afferentNodes = array();

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -93,8 +93,14 @@ class DependencyAnalyzer extends AbstractAnalyzer
 
     protected $nodeSet = array();
 
+    /**
+     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     */
     private $efferentNodes = array();
 
+    /**
+     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     */
     private $afferentNodes = array();
 
     /**

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -91,7 +91,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     protected $fileSet = array();
 
     /**
-     * @var \PDepend\Metrics\Analyzer\DependencyAnalyzer
+     * @var \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer|null
      */
     private $dependencyAnalyzer;
 

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -58,7 +58,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var \PDepend\Source\AST\ASTNode
+     * @var \PDepend\Source\AST\ASTNode|null
      */
     protected $parent = null;
 

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -66,7 +66,7 @@ class ASTClassOrInterfaceReference extends ASTType
     /**
      * An already loaded type instance.
      *
-     * @var \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @var \PDepend\Source\AST\AbstractASTClassOrInterface|null
      */
     protected $typeInstance = null;
 

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -124,11 +124,11 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Constructs a new source file instance.
      *
-     * @param string $fileName The source file name/path.
+     * @param string|null $fileName The source file name/path.
      */
     public function __construct($fileName)
     {
-        if (strpos($fileName, 'php://') === 0) {
+        if ($fileName && strpos($fileName, 'php://') === 0) {
             $this->fileName = $fileName;
         } elseif ($fileName !== null) {
             $this->fileName = realpath($fileName);

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -89,7 +89,7 @@ class ASTFieldDeclaration extends AbstractASTNode
             return $this->getChild(0);
         }
 
-        throw new OutOfBoundsException('The parameter does not has a type specification.');
+        throw new OutOfBoundsException('The parameter does not have a type specification.');
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -80,7 +80,7 @@ class ASTFormalParameter extends AbstractASTNode
             return $this->getChild(0);
         }
 
-        throw new OutOfBoundsException('The parameter does not has a type specification.');
+        throw new OutOfBoundsException('The parameter does not have a type specification.');
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -56,7 +56,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The parent namespace for this function.
      *
-     * @var   \PDepend\Source\AST\ASTNamespace
+     * @var   \PDepend\Source\AST\ASTNamespace|null
      * @since 0.10.0
      */
     private $namespace = null;
@@ -64,7 +64,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The currently used builder context.
      *
-     * @var   \PDepend\Source\Builder\BuilderContext
+     * @var   \PDepend\Source\Builder\BuilderContext|null
      * @since 0.10.0
      */
     protected $context = null;
@@ -73,7 +73,7 @@ class ASTFunction extends AbstractASTCallable
      * The name of the parent namespace for this function. We use this property
      * to restore the parent namespace while we unserialize a cached object tree.
      *
-     * @var string
+     * @var string|null
      */
     protected $namespaceName = null;
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -60,7 +60,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * The unique identifier for this function.
      *
-     * @var string
+     * @var string|null
      */
     protected $id = null;
 
@@ -88,7 +88,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * The comment for this type.
      *
-     * @var string
+     * @var string|null
      */
     protected $comment = null;
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -57,7 +57,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The internal used cache instance.
      *
-     * @var   \PDepend\Util\Cache\CacheDriver
+     * @var   \PDepend\Util\Cache\CacheDriver|null
      * @since 0.10.0
      */
     protected $cache = null;
@@ -113,7 +113,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of method/function parameters.
      *
-     * @var \PDepend\Source\AST\ASTParameter[]
+     * @var \PDepend\Source\AST\ASTParameter[]|null
      */
     private $parameters = null;
 
@@ -256,7 +256,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns all {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
      * objects this function depends on.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface[]
+     * @return ASTClassOrInterfaceReferenceIterator
      */
     public function getDependencies()
     {
@@ -352,7 +352,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns an iterator with thrown exception
      * {@link \PDepend\Source\AST\AbstractASTClassOrInterface} instances.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface[]
+     * @return ASTClassOrInterfaceReferenceIterator
      */
     public function getExceptionClasses()
     {
@@ -364,7 +364,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an array with all method/function parameters.
      *
-     * @return \PDepend\Source\AST\ASTParameter[]
+     * @return \PDepend\Source\AST\ASTParameter[]|null
      */
     public function getParameters()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -63,7 +63,7 @@ abstract class AbstractASTNode implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var \PDepend\Source\AST\ASTNode
+     * @var \PDepend\Source\AST\ASTNode|null
      */
     protected $parent = null;
 
@@ -236,7 +236,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the value that was stored under the given index.
      *
      * @param integer $index
-     * @return mixed
+     * @return string
      * @since 0.10.4
      */
     protected function getMetadata($index)

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -58,28 +58,28 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var \PDepend\Util\Cache\CacheDriver|null
      */
     protected $cache = null;
 
     /**
      * The currently used builder context.
      *
-     * @var \PDepend\Source\Builder\BuilderContext
+     * @var \PDepend\Source\Builder\BuilderContext|null
      */
     protected $context = null;
 
     /**
      * The parent namespace for this class.
      *
-     * @var \PDepend\Source\AST\ASTNamespace
+     * @var \PDepend\Source\AST\ASTNamespace|null
      */
     private $namespace = null;
 
     /**
      * An <b>array</b> with all constants defined in this class or interface.
      *
-     * @var array<string, mixed>
+     * @var array<string, mixed>|null
      */
     protected $constants = null;
 
@@ -103,7 +103,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Name of the parent namespace for this class or interface instance. Or
      * <b>NULL</b> when no namespace was specified.
      *
-     * @var string
+     * @var string|null
      */
     protected $namespaceName = null;
 
@@ -117,7 +117,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Temporary property that only holds methods during the parsing process.
      *
-     * @var   ASTMethod[]
+     * @var   ASTMethod[]|null
      * @since 1.0.2
      */
     protected $methods = array();
@@ -273,7 +273,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns all {@link \PDepend\Source\AST\ASTMethod} objects in this type.
      *
-     * @return ASTMethod[]
+     * @return ASTArtifactList<ASTMethod>
      */
     public function getMethods()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -420,7 +420,7 @@ abstract class AbstractPHPParser
      */
     protected function setUpEnvironment()
     {
-        ini_set('xdebug.max_nesting_level', $this->getMaxNestingLevel());
+        ini_set('xdebug.max_nesting_level', (string)$this->getMaxNestingLevel());
 
         $this->useSymbolTable->createScope();
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -169,21 +169,21 @@ abstract class AbstractPHPParser
     /**
      * The name of the last detected namespace.
      *
-     * @var string
+     * @var string|null
      */
     private $namespaceName;
 
     /**
      * Last parsed package tag.
      *
-     * @var string
+     * @var string|null
      */
     private $packageName = Builder::DEFAULT_NAMESPACE;
 
     /**
      * The package defined in the file level comment.
      *
-     * @var string
+     * @var string|null
      */
     private $globalPackageName = Builder::DEFAULT_NAMESPACE;
 
@@ -211,7 +211,7 @@ abstract class AbstractPHPParser
     /**
      * The last parsed doc comment or <b>null</b>.
      *
-     * @var string
+     * @var string|null
      */
     private $docComment;
 
@@ -225,7 +225,7 @@ abstract class AbstractPHPParser
     /**
      * The actually parsed class or interface instance.
      *
-     * @var \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @var \PDepend\Source\AST\AbstractASTClassOrInterface|null
      */
     protected $classOrInterface;
 
@@ -1010,6 +1010,7 @@ abstract class AbstractPHPParser
      * Override this in later PHPParserVersions as necessary
      * @param integer $tokenType
      * @param integer $modifiers
+     * @return \PDepend\Source\AST\ASTConstantDefinition
      * @throws UnexpectedTokenException
      */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
@@ -6843,7 +6844,7 @@ abstract class AbstractPHPParser
      * Extracts the @package information from the given comment.
      *
      * @param string $comment
-     * @return string
+     * @return string|null
      */
     private function parsePackageAnnotation($comment)
     {
@@ -6851,7 +6852,7 @@ abstract class AbstractPHPParser
             $this->packageName = null;
             $this->globalPackageName = null;
 
-            return;
+            return null;
         }
 
         $package = Builder::DEFAULT_NAMESPACE;

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5808,7 +5808,7 @@ abstract class AbstractPHPParser
         if (is_object($token = $this->tokenizer->next())) {
             throw $this->getUnexpectedTokenException($token);
         }
-        throw new TokenStreamEndException($this->compilationUnit->getFileName());
+        throw new TokenStreamEndException($this->tokenizer);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4590,7 +4590,6 @@ abstract class AbstractPHPParser
                 return $this->setNodePositionsAndReturn(
                     $this->builder->buildAstConstant($token->image)
                 );
-                break;
         }
     }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2098,11 +2098,13 @@ class PHPBuilder implements Builder
     protected function findType(array $instances, $qualifiedName)
     {
         $classOrInterfaceName = $this->extractTypeName($qualifiedName);
-        $namespaceName = $this->extractNamespaceName($qualifiedName);
-
         $caseInsensitiveName = strtolower($classOrInterfaceName);
-
         if (!isset($instances[$caseInsensitiveName])) {
+            return null;
+        }
+
+        $namespaceName = $this->extractNamespaceName($qualifiedName);
+        if ($namespaceName === null) {
             return null;
         }
 
@@ -2364,7 +2366,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The qualified PHP 5.3 class identifier.
      *
-     * @return string
+     * @return string|null
      */
     protected function extractNamespaceName($qualifiedName)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -935,7 +935,7 @@ class PHPBuilder implements Builder
      * -------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConditionalExpression
+     * @return \PDepend\Source\AST\ASTPrintExpression
      * @since 2.3
      */
     public function buildAstPrintExpression()

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -87,7 +87,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * Global stack, mainly used during testing.
      *
-     * @var array
+     * @var array<string, array<string, array<integer, mixed>>>
      */
     protected static $staticCache = array();
 

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -53,14 +53,14 @@ class ConfigurationInstance
     /**
      * The unique configuration instance.
      *
-     * @var \PDepend\Util\Configuration
+     * @var \PDepend\Util\Configuration|null
      */
     private static $configuration = null;
 
     /**
      * Returns a configured config instance or <b>null</b>.
      *
-     * @return \PDepend\Util\Configuration
+     * @return \PDepend\Util\Configuration|null
      */
     public static function get()
     {

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -85,7 +85,8 @@ class Factory
         libxml_use_internal_errors($mode);
 
         if ($sxml === false) {
-            throw new \RuntimeException(trim(libxml_get_last_error()->message));
+            $xmlError = libxml_get_last_error();
+            throw new \RuntimeException(trim($xmlError ? $xmlError->message : 'Unknown error'));
         }
         return $sxml;
     }

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -86,7 +86,7 @@ class Factory
 
         if ($sxml === false) {
             $xmlError = libxml_get_last_error();
-            throw new \RuntimeException(trim($xmlError ? $xmlError->message : 'Unknown error'));
+            throw new \RuntimeException($xmlError ? trim($xmlError->message) : 'Unknown error');
         }
         return $sxml;
     }

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -275,10 +275,10 @@ final class Type
     public static function getInternalNamespaces()
     {
         if (self::$internalNamespaces === null) {
-            $extensions = array_values(self::initTypeToExtension());
-            $extensions = array_unique($extensions);
-
-            self::$internalNamespaces = array_combine($extensions, $extensions);
+            self::$internalNamespaces = array();
+            foreach (self::initTypeToExtension() as $namespace) {
+                self::$internalNamespaces[$namespace] = $namespace;
+            }
         }
         return self::$internalNamespaces;
     }

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -54,18 +54,17 @@ final class Utf8Util
 {
     public static function ensureEncoding($raw)
     {
+        $encoding = 'UTF8';
         if (function_exists('mb_detect_encoding')) {
-            $encoding = mb_detect_encoding($raw);
-        } else {
-            $encoding = 'UTF8';
+            $encoding = mb_detect_encoding($raw) ?: $encoding;
         }
 
         $text = '';
         if (function_exists('iconv')) {
-            $text = @iconv($encoding, 'UTF8//IGNORE', $raw);
+            $text = @iconv($encoding, 'UTF8//IGNORE', $raw) ?: '';
         }
 
-        if ('' == $text) {
+        if ($text === '') {
             $text = utf8_encode($raw);
         }
 

--- a/src/main/php/PDepend/Util/Workarounds.php
+++ b/src/main/php/PDepend/Util/Workarounds.php
@@ -59,7 +59,7 @@ class Workarounds
      */
     public function hasSerializeReferenceIssue()
     {
-        return version_compare(phpversion(), '5.4.0', '>') && version_compare(phpversion(), '5.4.5', '<=');
+        return version_compare(PHP_VERSION, '5.4.0', '>') && version_compare(PHP_VERSION, '5.4.5', '<=');
     }
 
     /**
@@ -82,7 +82,7 @@ class Workarounds
     {
         $issues = array();
         if ($this->hasSerializeReferenceIssue()) {
-            $issues[] = 'File cache deactivated due to known serialize() issues in PHP ' . phpversion();
+            $issues[] = 'File cache deactivated due to known serialize() issues in PHP ' . PHP_VERSION;
         }
 
         return $issues;

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -84,7 +84,7 @@ class PHPParserVersion74Test extends AbstractTest
             $message = $exception->getMessage();
         }
 
-        $this->assertSame('The parameter does not has a type specification.', $message);
+        $this->assertSame('The parameter does not have a type specification.', $message);
 
         /** @var array[] $declarations */
         $declarations = array_map(function (ASTFieldDeclaration $child) {


### PR DESCRIPTION
Type: bugfix / documentation

Breaking change: no

More issues found using PHPStand

- Fix a grammatical error in two error messages.
- Fix a chunk of PHPDoc that was incorrect/missing
- Fix some minor issues with string|null|false handling that could have generated notices/warning 
- Fix a couple of edge cases that could lead to empty strings instead of the expected content

Logic change; Utf8Util::ensureEncoding() now always default to `UTF8`, previously if `mb_detect_encoding` was present but failed it would feed `false` to `iconv` resulting it treating the string as `ASCII`.