### PR TITLE
Support arrow functions return type hints

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -112,6 +112,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
         $closure = $this->builder->buildAstClosure();
         $closure->setReturnsByReference($this->parseOptionalByReference());
         $closure->addChild($this->parseFormalParameters());
+        $closure = $this->parseCallableDeclarationAddition($closure);
 
         $closure->addChild(
             $this->buildReturnStatement(

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testArrowFunctionsWithReturnType.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testArrowFunctionsWithReturnType.php
@@ -1,0 +1,5 @@
+<?php
+
+function doubleAll(array $numbers): array {
+    return array_map(fn($number): int => $number * 2, $numbers);
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix https://github.com/phpmd/phpmd/issues/731
Breaking change: no

Support typing between `fn()` and `=>`:
```php
$twice = fn(int $number): int => $number * 2;
```