### PR TITLE
Fix #491 Support PHP 8 tokens changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,45 +2,46 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.3
-      dist: precise
-      env: DEPENDENCIES=low
-    - php: 5.4
-      dist: trusty
-    - php: 5.4
-      dist: trusty
-      env: DEPENDENCIES=low
-    - php: 5.5
-      dist: trusty
-    - php: 5.5
-      dist: trusty
-      env: DEPENDENCIES=low
-    - php: 5.6
-    - php: 5.6
-      env: DEPENDENCIES=low
-    - php: 7.0
-    - php: 7.0
-      env: DEPENDENCIES=low
-    - php: 7.1
-    - php: 7.1
-      env: DEPENDENCIES=low
-    - php: 7.2
-    # Could be enabled when we'll upgrade PHPUnit
-    # - php: 7.2
-    #   env: DEPENDENCIES=low
-    - php: 7.3
-      env: COVERAGE=true
-    - php: 7.4
-    # Could be enabled when we'll upgrade PHPUnit
-    # - php: 7.3
-    #   env: DEPENDENCIES=low
-    - php: 5.3
-      dist: precise
-      env: BUILD_PHAR=true
-    - php: 7.3
-      env: WEBSITE=true
+    #- php: 5.3
+    #  dist: precise
+    #- php: 5.3
+    #  dist: precise
+    #  env: DEPENDENCIES=low
+    #- php: 5.4
+    #  dist: trusty
+    #- php: 5.4
+    #  dist: trusty
+    #  env: DEPENDENCIES=low
+    #- php: 5.5
+    #  dist: trusty
+    #- php: 5.5
+    #  dist: trusty
+    #  env: DEPENDENCIES=low
+    #- php: 5.6
+    #- php: 5.6
+    #  env: DEPENDENCIES=low
+    #- php: 7.0
+    #- php: 7.0
+    #  env: DEPENDENCIES=low
+    #- php: 7.1
+    #- php: 7.1
+    #  env: DEPENDENCIES=low
+    #- php: 7.2
+    ## Could be enabled when we'll upgrade PHPUnit
+    ## - php: 7.2
+    ##   env: DEPENDENCIES=low
+    #- php: 7.3
+    #  env: COVERAGE=true
+    ## Could be enabled when we'll upgrade PHPUnit
+    ## - php: 7.3
+    ##   env: DEPENDENCIES=low
+    #- php: 7.4
+    - php: nightly
+    #- php: 5.3
+    #  dist: precise
+    #  env: BUILD_PHAR=true
+    #- php: 7.3
+    #  env: WEBSITE=true
   fast_finish: true
 
 sudo: false
@@ -54,7 +55,7 @@ before_script:
   - phpenv config-rm xdebug.ini || echo "XDebug is not enabled"
   - composer self-update
   - if [ "$DEPENDENCIES" = "low" ]; then composer update --prefer-dist --prefer-lowest --prefer-stable; fi
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update --prefer-dist --prefer-stable; fi
+  - if [ "$DEPENDENCIES" != "low" ]; then composer update --prefer-dist --prefer-stable --ignore-platform-reqs; fi
 
 script:
   - if [[ $WEBSITE != 'true' && $BUILD_PHAR != 'true' && $COVERAGE != 'true' ]]; then vendor/bin/phpunit --configuration $TEST_CONFIG --colors; fi

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -118,12 +118,15 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     {
         $parents = array();
         $parent  = $this;
+
         while (is_object($parent = $parent->getParentClass())) {
             if (in_array($parent, $parents, true)) {
                 throw new ASTClassOrInterfaceRecursiveInheritanceException($parent);
             }
+
             $parents[] = $parent;
         }
+
         return $parents;
     }
 
@@ -169,9 +172,11 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         while (($top = array_pop($stack)) !== null) {
             foreach ($top->interfaceReferences as $interfaceReference) {
                 $interface = $interfaceReference->getType();
+
                 if (in_array($interface, $interfaces, true) === true) {
                     continue;
                 }
+
                 $interfaces[] = $interface;
                 $stack[] = $interface;
             }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -379,9 +379,10 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Sets the tokens for this type.
      *
      * @param \PDepend\Source\Tokenizer\Token[] $tokens
+     * @param Token|null $startToken
      * @return void
      */
-    public function setTokens(array $tokens, Token $startToken = null)
+    public function setTokens(array $tokens, $startToken = null)
     {
         if (!$startToken) {
             $startToken = reset($tokens);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5739,8 +5739,11 @@ abstract class AbstractPHPParser
             case Tokens::T_STRING:
             case Tokens::T_BACKSLASH:
             case Tokens::T_NAMESPACE:
+            // case Tokens::T_CLASS_FQN:
+
                 return true;
         }
+
         return false;
     }
 
@@ -5756,6 +5759,7 @@ abstract class AbstractPHPParser
             case Tokens::T_STRING:
             case Tokens::T_BACKSLASH:
             case Tokens::T_NAMESPACE:
+            case Tokens::T_CLASS:
                 return $this->builder->buildAstClassOrInterfaceReference(
                     $this->parseQualifiedName()
                 );

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -368,11 +368,10 @@ class PHPBuilder implements Builder
      */
     public function getClass($qualifiedName)
     {
-        $class = $this->findClass($qualifiedName);
-        if ($class === null) {
-            $class = $this->buildClassInternal($qualifiedName);
-        }
-        return $class;
+        $qualifiedName = ltrim($qualifiedName, '\\');
+
+        return $this->findClass($qualifiedName)
+            ?: $this->buildClassInternal($qualifiedName);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -54,7 +54,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
  */
-class PHPParserGeneric extends PHPParserVersion74
+class PHPParserGeneric extends PHPParserVersion80
 {
     /**
      * Tests if the given token type is a reserved keyword in the supported PHP
@@ -69,37 +69,6 @@ class PHPParserGeneric extends PHPParserVersion74
         switch ($tokenType) {
             case Tokens::T_CLASS:
             case Tokens::T_INTERFACE:
-                return true;
-        }
-        return false;
-    }
-
-    /**
-     * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
-     * name part.
-     *
-     * @param integer $tokenType The type of a parsed token.
-     *
-     * @return boolean
-     * @since  0.10.6
-     */
-    protected function isClassName($tokenType)
-    {
-        switch ($tokenType) {
-            case Tokens::T_DIR:
-            case Tokens::T_USE:
-            case Tokens::T_GOTO:
-            case Tokens::T_NULL:
-            case Tokens::T_NS_C:
-            case Tokens::T_TRUE:
-            case Tokens::T_CLONE:
-            case Tokens::T_FALSE:
-            case Tokens::T_TRAIT:
-            case Tokens::T_STRING:
-            case Tokens::T_TRAIT_C:
-            case Tokens::T_CALLABLE:
-            case Tokens::T_INSTEADOF:
-            case Tokens::T_NAMESPACE:
                 return true;
         }
         return false;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -219,29 +219,23 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     {
         switch ($this->tokenizer->peek()) {
             case Tokens::T_ARRAY:
-                $type = $this->parseArrayType();
-                break;
+                return $this->parseArrayType();
 
             case Tokens::T_SELF:
-                $type = $this->parseSelfType();
-                break;
+                return $this->parseSelfType();
 
             case Tokens::T_STRING:
             case Tokens::T_BACKSLASH:
             case Tokens::T_NAMESPACE:
                 $name = $this->parseQualifiedName();
 
-                $type = $this->isScalarOrCallableTypeHint($name)
+                return $this->isScalarOrCallableTypeHint($name)
                     ? $this->parseScalarOrCallableTypeHint($name)
                     : $this->builder->buildAstClassOrInterfaceReference($name);
-                break;
 
             default:
-                $type = parent::parseTypeHint();
-                break;
+                return parent::parseTypeHint();
         }
-
-        return $type;
     }
 
     /**
@@ -261,14 +255,14 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             $this->consumeToken(Tokens::T_PARENTHESIS_OPEN),
             Tokens::T_PARENTHESIS_CLOSE
         );
-        
+
         while ($this->tokenizer->peek() === Tokens::T_PARENTHESIS_OPEN) {
             $function = $this->builder->buildAstFunctionPostfix($expr->getImage());
             $function->addChild($expr);
             $function->addChild($this->parseArguments());
             $expr = $function;
         }
-        
+
         return $this->setNodePositionsAndReturn($expr);
     }
 
@@ -341,6 +335,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     protected function parseAnonymousClassDeclaration(ASTAllocationExpression $allocation)
     {
         $this->consumeComments();
+
         if (Tokens::T_CLASS !== $this->tokenizer->peek()) {
             return null;
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -38,47 +38,54 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.5
+ * @since 2.3
  */
 
-namespace PDepend\Source\AST;
+namespace PDepend\Source\Language\PHP;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Tokens;
 
 /**
- * This is a classes only version of the class or interface reference .
+ * Concrete parser implementation that supports features up to PHP version 7.4.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.5
+ * @since 2.4
  */
-class ASTClassReference extends ASTClassOrInterfaceReference
+abstract class PHPParserVersion80 extends PHPParserVersion74
 {
     /**
-     * Returns the concrete type instance associated with with this placeholder.
+     * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
+     * name part.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @param integer $tokenType The type of a parsed token.
+     *
+     * @return boolean
+     * @since  0.10.6
      */
-    public function getType()
+    protected function isClassName($tokenType)
     {
-        if ($this->typeInstance === null) {
-            $this->typeInstance = $this->context->getClass($this->getImage());
+        switch ($tokenType) {
+            case Tokens::T_DIR:
+            case Tokens::T_USE:
+            case Tokens::T_GOTO:
+            case Tokens::T_NULL:
+            case Tokens::T_NS_C:
+            case Tokens::T_TRUE:
+            case Tokens::T_CLONE:
+            case Tokens::T_FALSE:
+            case Tokens::T_TRAIT:
+            case Tokens::T_STRING:
+            case Tokens::T_TRAIT_C:
+            case Tokens::T_CALLABLE:
+            case Tokens::T_INSTEADOF:
+            case Tokens::T_NAMESPACE:
+                return true;
         }
 
-        return $this->typeInstance;
-    }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitClassReference($this, $data);
+        return false;
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -182,6 +182,21 @@ if (!defined('T_COALESCE_EQUAL')) {
 }
 
 /**
+ * Define PHP 8.0 tokens
+ */
+if (!defined('T_NAME_QUALIFIED')) {
+    define('T_NAME_QUALIFIED', 314);
+}
+
+if (!defined('T_NAME_FULLY_QUALIFIED')) {
+    define('T_NAME_FULLY_QUALIFIED', 312);
+}
+
+if (!defined('T_NAME_RELATIVE')) {
+    define('T_NAME_RELATIVE', 313);
+}
+
+/**
  * This tokenizer uses the internal {@link token_get_all()} function as token stream
  * generator.
  *
@@ -275,6 +290,8 @@ class PHPTokenizerInternal implements FullTokenizer
         T_MOD_EQUAL                 => Tokens::T_MOD_EQUAL,
         T_MUL_EQUAL                 => Tokens::T_MUL_EQUAL,
         T_NAMESPACE                 => Tokens::T_NAMESPACE,
+        T_NAME_FULLY_QUALIFIED      => Tokens::T_STRING,
+        T_NAME_QUALIFIED            => Tokens::T_STRING,
         T_XOR_EQUAL                 => Tokens::T_XOR_EQUAL,
         T_INTERFACE                 => Tokens::T_INTERFACE,
         T_BOOL_CAST                 => Tokens::T_BOOL_CAST,
@@ -693,7 +710,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return integer
+     * @return integer|null
      * @since  0.9.12
      */
     public function peekNext()
@@ -703,7 +720,13 @@ class PHPTokenizerInternal implements FullTokenizer
         $offset = 0;
 
         do {
-            $type = $this->tokens[$this->index + ++$offset]->type;
+            $index = $this->index + ++$offset;
+
+            if (!isset($this->tokens[$index])) {
+                return null;
+            }
+
+            $type = $this->tokens[$index]->type;
         } while ($type == Tokens::T_COMMENT || $type == Tokens::T_DOC_COMMENT);
 
         return $type;
@@ -737,10 +760,47 @@ class PHPTokenizerInternal implements FullTokenizer
     private function substituteTokens(array $tokens)
     {
         $result = array();
+
         foreach ($tokens as $token) {
             $temp = (array) $token;
             $temp = $temp[0];
-            if (isset(self::$substituteTokens[$temp])) {
+
+            if ($token[0] === T_NAME_QUALIFIED) {
+                foreach (explode('\\', $token[1]) as $index => $string) {
+                    if ($index) {
+                        $result[] = array(
+                            T_NS_SEPARATOR,
+                            '\\',
+                            $token[2],
+                        );
+                    }
+
+                    $result[] = array(
+                        T_STRING,
+                        $string,
+                        $token[2],
+                    );
+                }
+            } elseif ($token[0] === T_NAME_RELATIVE && preg_match('/^namespace\\\\(.*)$/', $token[1], $match)) {
+                $result[] = array(
+                    T_NAMESPACE,
+                    'namespace',
+                    $token[2],
+                );
+
+                foreach (explode('\\', $match[1]) as $string) {
+                    $result[] = array(
+                        T_NS_SEPARATOR,
+                        '\\',
+                        $token[2],
+                    );
+                    $result[] = array(
+                        T_STRING,
+                        $string,
+                        $token[2],
+                    );
+                }
+            } elseif (isset(self::$substituteTokens[$temp])) {
                 foreach (self::$substituteTokens[$temp] as $token) {
                     $result[] = $token;
                 }
@@ -748,6 +808,7 @@ class PHPTokenizerInternal implements FullTokenizer
                 $result[] = $token;
             }
         }
+
         return $result;
     }
 

--- a/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
+++ b/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
@@ -61,11 +61,12 @@ class UnexpectedTokenException extends TokenException
     public function __construct(Token $token, $fileName)
     {
         $message = sprintf(
-            'Unexpected token: %s, line: %d, col: %d, file: %s.',
+            'Unexpected token: %s, line: %d, col: %d, file: %s.%s',
             $token->image,
             $token->startLine,
             $token->startColumn,
-            $fileName
+            $fileName,
+            "\n".(new \Exception())->getTraceAsString()
         );
 
         parent::__construct($message);

--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -42,6 +42,7 @@
 
 namespace PDepend;
 
+use Exception;
 use PDepend\Input\ExcludePathFilter;
 use PDepend\Input\Iterator;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
@@ -61,6 +62,9 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_Exception;
+use PHPUnit_Framework_TestCase;
+use ReflectionProperty;
 
 /**
  * Abstract test case implementation for the PDepend namespace.
@@ -116,6 +120,26 @@ abstract class AbstractTest extends TestCase
         }
 
         parent::tearDown();
+    }
+
+    /**
+     * Override to run the test and assert its state.
+     *
+     * @return mixed
+     *
+     * @throws Exception|PHPUnit_Framework_Exception
+     */
+    protected function runTest()
+    {
+        $inputReflector = new ReflectionProperty('PHPUnit_Framework_TestCase', 'dependencyInput');
+        $inputReflector->setAccessible(true);
+        $input = $inputReflector->getValue($this);
+
+        if (!empty($input)) {
+            $inputReflector->setValue($this, array_values($input));
+        }
+
+        return parent::runTest();
     }
 
     /**
@@ -546,7 +570,7 @@ abstract class AbstractTest extends TestCase
     {
         $cache = $this->getMockBuilder('\\PDepend\\Util\\Cache\\CacheDriver')
             ->getMock();
-        
+
         return $cache;
     }
 

--- a/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -117,7 +117,7 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTest
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetInterfaces3()
     {
-        $interfaces = $this->parseCodeResourceForTest()
+        $this->parseCodeResourceForTest()
             ->current()
             ->getClasses()
             ->current()

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -65,9 +65,9 @@ class EngineTest extends AbstractTest
     {
         $dir = dirname(__FILE__) . '/foobar';
         $msg = "Invalid directory '{$dir}' added.";
-        
+
         $this->setExpectedException('InvalidArgumentException', $msg);
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($dir);
     }
@@ -96,7 +96,7 @@ class EngineTest extends AbstractTest
 
         $this->assertInstanceOf('Iterator', $engine->analyze());
     }
-    
+
     /**
      * Tests the {@link \PDepend\Engine::analyze()} method and the return
      * value.
@@ -108,22 +108,22 @@ class EngineTest extends AbstractTest
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->addFileFilter(new Input\ExtensionFilter(array('php')));
-        
+
         $metrics = $engine->analyze();
-        
+
         $expected = array(
             'package1'  =>  true,
             'package2'  =>  true,
             'package3'  =>  true
         );
-        
+
         foreach ($metrics as $metric) {
             unset($expected[$metric->getName()]);
         }
-        
+
         $this->assertEquals(0, count($expected));
     }
-    
+
     /**
      * Tests that {@link \PDepend\Engine::analyze()} throws an exception
      * if no source directory was set.
@@ -136,7 +136,7 @@ class EngineTest extends AbstractTest
         $this->setExpectedException('RuntimeException', 'No source directory and file set.');
         $engine->analyze();
     }
-    
+
     /**
      * testAnalyzeReturnsEmptyIteratorWhenNoPackageExists
      *
@@ -147,10 +147,10 @@ class EngineTest extends AbstractTest
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->addFileFilter(new Input\ExtensionFilter(array(__METHOD__)));
-       
+
         $this->assertEquals(0, count($engine->analyze()));
     }
-    
+
     /**
      * Tests that {@link \PDepend\Engine::analyze()} configures the
      * ignore annotations option correct.
@@ -164,12 +164,12 @@ class EngineTest extends AbstractTest
         $engine->addFileFilter(new Input\ExtensionFilter(array('inc')));
         $engine->setWithoutAnnotations();
         $namespaces = $engine->analyze();
-        
+
         $this->assertEquals(2, $namespaces->count());
         $this->assertEquals('pdepend.test', $namespaces->current()->getName());
-        
+
         $function = $namespaces->current()->getFunctions()->current();
-        
+
         $this->assertNotNull($function);
         $this->assertEquals('foo', $function->getName());
         $this->assertEquals(0, $function->getExceptionClasses()->count());
@@ -187,10 +187,10 @@ class EngineTest extends AbstractTest
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->addFileFilter(new Input\ExtensionFilter(array('php')));
         $engine->analyze();
-        
+
         $this->assertEquals(10, $engine->countClasses());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::countClasses()} method fails
      * with an exception if the code was not analyzed before.
@@ -203,12 +203,12 @@ class EngineTest extends AbstractTest
             'RuntimeException',
             'countClasses() doesn\'t work before the source was analyzed.'
         );
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->countClasses();
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::countNamespaces()} method
      * returns the expected number of namespaces.
@@ -220,10 +220,10 @@ class EngineTest extends AbstractTest
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->analyze();
-        
+
         $this->assertEquals(4, $engine->countNamespaces());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::countNamespaces()} method
      * fails with an exception if the code was not analyzed before.
@@ -236,12 +236,12 @@ class EngineTest extends AbstractTest
             'RuntimeException',
             'countNamespaces() doesn\'t work before the source was analyzed.'
         );
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->countNamespaces();
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method
      * returns the expected {@link \PDepend\Source\AST\ASTNamespace} objects.
@@ -253,20 +253,20 @@ class EngineTest extends AbstractTest
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->analyze();
-        
+
         $namespaces = array(
             'package1',
             'package2',
             'package3'
         );
-        
+
         $className = '\\PDepend\\Source\\AST\\ASTNamespace';
-        
+
         foreach ($namespaces as $namespace) {
             $this->assertInstanceOf($className, $engine->getNamespace($namespace));
         }
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method fails
      * with an exception if the code was not analyzed before.
@@ -279,12 +279,12 @@ class EngineTest extends AbstractTest
             'RuntimeException',
             'getNamespace() doesn\'t work before the source was analyzed.'
         );
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->getNamespace('package1');
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method fails
      * with an exception if you request an invalid package.
@@ -297,13 +297,13 @@ class EngineTest extends AbstractTest
             'OutOfBoundsException',
             'Unknown namespace "nspace".'
         );
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->analyze();
         $engine->getNamespace('nspace');
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::getNamespaces()} method
      * returns the expected {@link \PDepend\Source\AST\ASTNamespace} objects
@@ -315,15 +315,15 @@ class EngineTest extends AbstractTest
     {
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
-        
+
         $namespace1 = $engine->analyze();
         $namespace2 = $engine->getNamespaces();
-        
+
         $this->assertNotNull($namespace1);
-        
+
         $this->assertSame($namespace1, $namespace2);
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Engine::getNamespaces()} method
      * fails with an exception if the code was not analyzed before.
@@ -336,7 +336,7 @@ class EngineTest extends AbstractTest
             'RuntimeException',
             'getNamespaces() doesn\'t work before the source was analyzed.'
         );
-        
+
         $engine = $this->createEngineFixture();
         $engine->addDirectory($this->createCodeResourceUriForTest());
         $engine->getNamespaces();
@@ -362,7 +362,7 @@ class EngineTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
-     * @depends PDepend\EngineTest::testSupportForSingleFileIssue90
+     * @depends testSupportForSingleFileIssue90
      */
     public function testSupportForSingleFileIssue90ExpectedNumberOfClasses(ASTNamespace $namespace)
     {
@@ -372,7 +372,7 @@ class EngineTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
-     * @depends PDepend\EngineTest::testSupportForSingleFileIssue90
+     * @depends testSupportForSingleFileIssue90
      */
     public function testSupportForSingleFileIssue90ExpectedNumberOfInterfaces(ASTNamespace $namespace)
     {

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -62,7 +62,7 @@ class AnalyzerIteratorTest extends AbstractTest
      */
     public function testIteratorReturnsEnabledAnalyzerInstances()
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer')
+        $analyzer = $this->getMockBuilder('\\PDepend\\Report\\DummyAnalyzer')
             ->getMock();
         $analyzer->expects($this->exactly(2))
             ->method('isEnabled')
@@ -79,7 +79,7 @@ class AnalyzerIteratorTest extends AbstractTest
      */
     public function testIteratorDoesNotReturnDisabledAnalyzerInstances()
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer')
+        $analyzer = $this->getMockBuilder('\\PDepend\\Report\\DummyAnalyzer')
             ->getMock();
         $analyzer->expects($this->at(0))
             ->method('isEnabled')

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -541,7 +541,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsCorrectFunctionReturnType
+     * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsFunctionReturnTypeToNull($functions)
     {
@@ -560,7 +560,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsCorrectFunctionReturnType
+     * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionTwo($functions)
     {
@@ -579,7 +579,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsCorrectFunctionReturnType
+     * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionThree($functions)
     {
@@ -994,7 +994,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsFileLevelFunctionPackage
+     * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInFirstNamespace($namespaces)
     {
@@ -1005,7 +1005,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsFileLevelFunctionPackage
+     * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInSecondNamespace($namespaces)
     {
@@ -1016,7 +1016,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsFileLevelFunctionPackage
+     * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForFirstFunctionInFirstNamespace($namespaces)
     {
@@ -1028,7 +1028,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsFileLevelFunctionPackage
+     * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForSecondFunctionInFirstNamespace($namespaces)
     {
@@ -1040,7 +1040,7 @@ class ParserTest extends AbstractTest
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
-     * @depends PDepend\ParserTest::testParserSetsFileLevelFunctionPackage
+     * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForFirstFunctionInSecondNamespace($namespaces)
     {

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -136,7 +136,7 @@ class XmlTest extends AbstractTest
     {
         $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerNodeAware')
             ->getMock();
-        
+
         $logger = new Xml();
         $actual = $logger->log($analyzer);
 
@@ -152,7 +152,7 @@ class XmlTest extends AbstractTest
     {
         $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer')
             ->getMock();
-        
+
         $logger = new Xml();
         $actual = $logger->log($analyzer);
 
@@ -187,6 +187,7 @@ class XmlTest extends AbstractTest
      * expected document structure for the source, with applied metrics.
      *
      * @return void
+     * @group i
      */
     public function testXmlLogWithMetrics()
     {


### PR DESCRIPTION
Type: feature
Issue: #491
Breaking change: no

Note: this does not support PHP 8 new features/syntax, this is a support for existing PHP 7 tokens having a different qualification in PHP 8. This aims to enable to run PDepend on PHP 8 but still works only to parse code compatible with PHP 7.