### PR TITLE
Support PHP 8 nullsafe operator

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -110,6 +110,18 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         $nextTokenType = $this->tokenizer->peek();
 
         switch ($nextTokenType) {
+            case Tokens::T_NULLSAFE_OBJECT_OPERATOR:
+                $token = $this->consumeToken($nextTokenType);
+
+                $expr = $this->builder->buildAstExpression($token->image);
+                $expr->configureLinesAndColumns(
+                    $token->startLine,
+                    $token->endLine,
+                    $token->startColumn,
+                    $token->endColumn
+                );
+
+                return $expr;
         }
 
         return null;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -196,6 +196,10 @@ if (!defined('T_NAME_RELATIVE')) {
     define('T_NAME_RELATIVE', 42313);
 }
 
+if (!defined('T_NULLSAFE_OBJECT_OPERATOR')) {
+    define('T_NULLSAFE_OBJECT_OPERATOR', 42387);
+}
+
 /**
  * This tokenizer uses the internal {@link token_get_all()} function as token stream
  * generator.
@@ -346,6 +350,7 @@ class PHPTokenizerInternal implements FullTokenizer
         T_COALESCE_EQUAL            => Tokens::T_COALESCE_EQUAL,
         // T_DOLLAR_OPEN_CURLY_BRACES  => Tokens::T_CURLY_BRACE_OPEN,
         T_FN                        => Tokens::T_FN,
+        T_NULLSAFE_OBJECT_OPERATOR  => Tokens::T_NULLSAFE_OBJECT_OPERATOR,
     );
 
     /**
@@ -761,7 +766,7 @@ class PHPTokenizerInternal implements FullTokenizer
     {
         $result = array();
 
-        foreach ($tokens as $token) {
+        foreach ($tokens as $index => $token) {
             $temp = (array) $token;
             $temp = $temp[0];
 
@@ -809,6 +814,14 @@ class PHPTokenizerInternal implements FullTokenizer
                 foreach (self::$substituteTokens[$temp] as $token) {
                     $result[] = $token;
                 }
+            } elseif ($temp === '?' && isset($tokens[$index + 1][0]) && $tokens[$index + 1][0] === T_OBJECT_OPERATOR) {
+                $tokens[$index + 1] = array(
+                    T_NULLSAFE_OBJECT_OPERATOR,
+                    '?->',
+                    1,
+                );
+
+                continue;
             } else {
                 $result[] = $token;
             }

--- a/src/main/php/PDepend/Source/Tokenizer/Tokens.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokens.php
@@ -883,6 +883,11 @@ interface Tokens
     const T_COALESCE_EQUAL = 166;
 
     /**
+     * Token that represents the '?->' nullsafe object operator
+     */
+    const T_NULLSAFE_OBJECT_OPERATOR = 387;
+
+    /**
      * Marks any content not between php tags.
      */
     const T_NO_PHP = 255;

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP80;
+
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTVariableDeclarator;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @group unittest
+ * @group php8
+ */
+class NullsafeOperatorTest extends PHP8ParserVersion80Test
+{
+    /**
+     * @return void
+     */
+    public function testNullsafeOperator()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTVariableDeclarator $variable */
+        $variable =$method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+        );
+
+        $this->assertSame('$obj', $variable->getImage());
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -60,7 +60,7 @@ class NullsafeOperatorTest extends PHP8ParserVersion80Test
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTVariableDeclarator $variable */
-        $variable =$method->getFirstChildOfType(
+        $variable = $method->getFirstChildOfType(
             'PDepend\\Source\\AST\\ASTVariableDeclarator'
         );
 

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NullsafeOperator/testNullsafeOperator.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NullsafeOperator/testNullsafeOperator.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar($obj)
+    {
+        return $obj?->prop?->method()?->result;
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: Fix #497
Breaking change: no

Support PHP 8 Nullsafe operator

```php
$country = $session?->user?->getAddress()?->country;
```

https://www.php.net/releases/8.0/en.php?lang=en#nullsafe-operator

Depends on #499 to be merged first