### PR TITLE
Support PHP 8 Union Type

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents primitive types like integer, float, boolean, string
  * etc.
@@ -68,12 +70,12 @@ class ASTUnionType extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
+     * @param ASTVisitor $visitor
+     * @param mixed      $data
      * @return mixed
      * @since  2.9.0
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitUnionType($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -85,7 +85,7 @@ class ASTUnionType extends ASTType
      */
     public function getImage()
     {
-        return implode('|', array_map(static function ($type) {
+        return implode('|', array_map(function ($type) {
             return $type->getImage();
         }, $this->getChildren()));
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -43,46 +43,25 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
-
 /**
- * Abstract base class for a type node.
+ * This class represents primitive types like integer, float, boolean, string
+ * etc.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.6
  */
-class ASTType extends AbstractASTNode
+class ASTUnionType extends ASTType
 {
     /**
-     * This method will return <b>true</b> when the underlying type is an array.
-     *
-     * @return boolean
-     */
-    public function isArray()
-    {
-        return false;
-    }
-
-    /**
-     * This method will return <b>true</b> when the underlying data type is a
-     * php primitive.
-     *
-     * @return boolean
-     */
-    public function isScalar()
-    {
-        return false;
-    }
-
-    /**
      * This method will return <b>true</b> when this type use union pipe tos specify multiple types.
+     * For this concrete implementation the return value will be always true.
      *
      * @return boolean
      */
     public function isUnion()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -92,10 +71,22 @@ class ASTType extends AbstractASTNode
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @param mixed $data
      * @return mixed
-     * @since 0.9.12
+     * @since  2.9.0
      */
-    public function accept(ASTVisitor $visitor, $data = null)
+    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {
-        return $visitor->visitType($this, $data);
+        return $visitor->visitUnionType($this, $data);
+    }
+
+    /**
+     * Return concatenated allowed types string representation.
+     *
+     * @return string
+     */
+    public function getImage()
+    {
+        return implode('|', array_map(static function ($type) {
+            return $type->getImage();
+        }, $this->getChildren()));
     }
 }

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -956,6 +956,14 @@ interface Builder extends \IteratorAggregate
     public function buildAstScalarType($image);
 
     /**
+     * Builds a new node for the union type.
+     *
+     * @return \PDepend\Source\AST\ASTUnionType
+     * @since  2.9.0
+     */
+    public function buildAstUnionType();
+
+    /**
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1496,6 +1496,17 @@ class PHPBuilder implements Builder
     }
 
     /**
+     * Builds a new node for the union type.
+     *
+     * @return \PDepend\Source\AST\ASTUnionType
+     * @since  1.0.0
+     */
+    public function buildAstUnionType()
+    {
+        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTUnionType');
+    }
+
+    /**
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -114,4 +114,31 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
         return null;
     }
+
+    /**
+     * Parses a type hint that is valid in the supported PHP version.
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     */
+    protected function parseTypeHint()
+    {
+        $types = array(parent::parseTypeHint());
+
+        while ($this->tokenizer->peek() === Tokens::T_BITWISE_OR) {
+            $this->tokenizer->next();
+            $types[] = parent::parseTypeHint();
+        }
+
+        if (count($types) === 1) {
+            return $types[0];
+        }
+
+        $unionType = $this->builder->buildAstUnionType();
+
+        foreach ($types as $type) {
+            $unionType->addChild($type);
+        }
+
+        return $unionType;
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -38,64 +36,45 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.6
  */
 
-namespace PDepend\Source\AST;
+namespace PDepend\Source\Language\PHP\Features\PHP80;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTUnionType;
+use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
- * Abstract base class for a type node.
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.6
+ * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @group unittest
+ * @group php8
  */
-class ASTType extends AbstractASTNode
+class UnionTypesTest extends PHP8ParserVersion80Test
 {
     /**
-     * This method will return <b>true</b> when the underlying type is an array.
-     *
-     * @return boolean
+     * @return void
      */
-    public function isArray()
+    public function testUnionTypes()
     {
-        return false;
-    }
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTFormalParameter $parameter */
+        $parameter =$method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTFormalParameter'
+        );
+        $children = $parameter->getChildren();
 
-    /**
-     * This method will return <b>true</b> when the underlying data type is a
-     * php primitive.
-     *
-     * @return boolean
-     */
-    public function isScalar()
-    {
-        return false;
-    }
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $children[0]);
+        /** @var ASTUnionType $unionType */
+        $unionType = $children[0];
+        $this->assertSame('int|float', $unionType->getImage());
 
-    /**
-     * This method will return <b>true</b> when this type use union pipe tos specify multiple types.
-     *
-     * @return boolean
-     */
-    public function isUnion()
-    {
-        return false;
-    }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitType($this, $data);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $children[1]);
+        /** @var ASTVariableDeclarator $variable */
+        $variable = $children[1];
+        $this->assertSame('$number', $variable->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -62,7 +62,7 @@ class UnionTypesTest extends PHP8ParserVersion80Test
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTFormalParameter $parameter */
-        $parameter =$method->getFirstChildOfType(
+        $parameter = $method->getFirstChildOfType(
             'PDepend\\Source\\AST\\ASTFormalParameter'
         );
         $children = $parameter->getChildren();

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/UnionTypes/testUnionTypes.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/UnionTypes/testUnionTypes.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(int|float $number)
+    {
+        return $number * 4;
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: Fix #495
Breaking change: no

Support PHP 8 Union types

```php
class Number {
  public function __construct(
    int|float $number
  ) {}
}

new Number('NaN'); // TypeError
```

https://www.php.net/releases/8.0/en.php?lang=en#union-types

Depends on #499 to be merged first