### PR TITLE
Support PHP 8 Named arguments

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -91,6 +91,9 @@ class ASTNamedArgument extends AbstractASTNode
         return $this->value;
     }
 
+    /**
+     * @return string
+     */
     public function getImage()
     {
         return sprintf('%s: %s', $this->name, $this->value->getImage());

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -64,6 +64,9 @@ class ASTNamedArgument extends AbstractASTNode
      */
     protected $value;
 
+    /**
+     * @param string $name
+     */
     public function __construct($name, ASTNode $value)
     {
         parent::__construct();

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 0.9.8
+ */
+
+namespace PDepend\Source\AST;
+
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
+/**
+ * This node class encapsultes any expression.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.9.0
+ */
+class ASTNamedArgument extends AbstractASTNode
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var ASTNode
+     */
+    protected $value;
+
+    public function __construct($name, ASTNode $value)
+    {
+        parent::__construct();
+
+        $this->name = $name;
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return ASTNode
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getImage()
+    {
+        return sprintf('%s: %s', $this->name, $this->value->getImage());
+    }
+
+    /**
+     * Accept method of the visitor design pattern. This method will be called
+     * by a visitor during tree traversal.
+     *
+     * @param ASTVisitor $visitor The calling visitor instance.
+     * @param mixed      $data
+     *
+     * @return mixed
+     */
+    public function accept(ASTVisitor $visitor, $data = null)
+    {
+        return $visitor->visitNamedArgument($this, $data);
+    }
+}

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -47,6 +47,7 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -921,6 +922,20 @@ interface Builder extends \IteratorAggregate
      * @since  0.9.6
      */
     public function buildAstArguments();
+
+    /**
+     * Builds a new named argument node.
+     *
+     * <code>
+     * number_format(5623, thousands_separator: ' ')
+     * </code>
+     *
+     * @param string $name
+     * @param ASTNode $value
+     * @return \PDepend\Source\AST\ASTNamedArgument
+     * @since  2.9.0
+     */
+    public function buildAstNamedArgument($name, ASTNode $value);
 
     /**
      * Builds a new array type node.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -51,7 +51,9 @@ use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParentReference;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\Builder\Builder;
@@ -1447,6 +1449,25 @@ class PHPBuilder implements Builder
     public function buildAstArguments()
     {
         return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTArguments');
+    }
+
+    /**
+     * Builds a new named argument node.
+     *
+     * <code>
+     * number_format(5623, thousands_separator: ' ')
+     * </code>
+     *
+     * @param string $name
+     * @param ASTNode $name
+     * @return \PDepend\Source\AST\ASTNamedArgument
+     * @since  2.9.0
+     */
+    public function buildAstNamedArgument($name, ASTNode $value)
+    {
+        Log::debug("Creating: \\PDepend\\Source\\AST\\ASTNamedArgument($name)");
+
+        return new ASTNamedArgument($name, $value);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -326,6 +326,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
         }
     }
 
+    /**
+     * @return ASTConstant
+     */
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {
         return $constant;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -44,6 +44,7 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTConstant;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\FullTokenizer;
@@ -325,6 +326,11 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
         }
     }
 
+    protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
+    {
+        return $constant;
+    }
+
     /**
      * @param \PDepend\Source\AST\ASTArguments $arguments
      * @return \PDepend\Source\AST\ASTArguments
@@ -340,6 +346,10 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
             $this->consumeComments();
             if (null === ($expr = $this->parseOptionalExpression())) {
                 break;
+            }
+
+            if ($expr instanceof ASTConstant) {
+                $expr = $this->parseConstantArgument($expr, $arguments);
             }
 
             $arguments->addChild($expr);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -117,6 +117,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return null;
     }
 
+    /**
+     * @return ASTConstant
+     */
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {
         if ($this->tokenizer->peek() === Tokens::T_COLON) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTConstant;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -113,5 +115,19 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         }
 
         return null;
+    }
+
+    protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
+    {
+        if ($this->tokenizer->peek() === Tokens::T_COLON) {
+            $this->tokenizer->next();
+
+            return $this->builder->buildAstNamedArgument(
+                $constant->getImage(),
+                $this->parseOptionalExpression()
+            );
+        }
+
+        return $constant;
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -61,7 +61,7 @@ class NamedArgumentsTest extends PHP8ParserVersion80Test
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTArguments $arguments */
-        $arguments =$method->getFirstChildOfType(
+        $arguments = $method->getFirstChildOfType(
             'PDepend\\Source\\AST\\ASTArguments'
         );
         $children = $arguments->getChildren();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP80;
+
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamedArgument;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @group unittest
+ * @group php8
+ */
+class NamedArgumentsTest extends PHP8ParserVersion80Test
+{
+    /**
+     * @return void
+     */
+    public function testNamedArguments()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTArguments $arguments */
+        $arguments =$method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTArguments'
+        );
+        $children = $arguments->getChildren();
+
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertSame('5623', $children[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[1]);
+        /** @var ASTNamedArgument $argument */
+        $argument = $children[1];
+        $this->assertSame('thousands_separator', $argument->getName());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $argument->getValue());
+        $this->assertSame("' '", $argument->getValue()->getImage());
+        $this->assertSame("thousands_separator: ' '", $argument->getImage());
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArguments.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArguments.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        return number_format(5623, thousands_separator: ' ');
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: Fix #492
Breaking change: no

Support PHP 8 Named arguments

```php
htmlspecialchars($string, double_encode: false);
```

https://www.php.net/releases/8.0/en.php?lang=en#named-arguments

Depends on #499 to be merged first