### PR TITLE
Support PHP 8 Match expression

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -43,28 +43,20 @@
 
 namespace PDepend\Source\AST;
 
-use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
- * This class represents arguments as they are supplied to functions or
- * constructors invocations.
+ * This class represents match expression argument container.
  *
  * <code>
- * //      ------------
- * Foo::bar($x, $y, $z);
- * //      ------------
- *
- * //       ------------
- * $foo->bar($x, $y, $z);
- * //       ------------
+ * match ($x)
  * </code>
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.6
+ * @since 2.9.0
  */
-class ASTArguments extends AbstractASTNode
+class ASTMatchArgument extends ASTArguments
 {
     /**
      * Rather the given arguments list can still take one more argument.
@@ -73,35 +65,20 @@ class ASTArguments extends AbstractASTNode
      */
     public function acceptsMoreArguments()
     {
-        return true;
-    }
-
-    /**
-     * This method adds a new child node to this node instance.
-     *
-     * @param ASTNode $node
-     * @return void
-     */
-    public function addChild(ASTNode $node)
-    {
-        if (!$this->acceptsMoreArguments()) {
-            throw new InvalidArgumentException('No more arguments allowed.');
-        }
-
-        parent::addChild($node);
+        return count($this->getChildren()) < 1;
     }
 
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
+     * @param ASTVisitor $visitor
      * @param mixed $data
      * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {
-        return $visitor->visitArguments($this, $data);
+        return $visitor->visitMatchArgument($this, $data);
     }
 }

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -923,6 +923,18 @@ interface Builder extends \IteratorAggregate
     public function buildAstArguments();
 
     /**
+     * Builds a new argument match expression single-item slot.
+     *
+     * <code>
+     * match($x)
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchArgument
+     * @since  0.9.6
+     */
+    public function buildAstMatchArgument();
+
+    /**
      * Builds a new array type node.
      *
      * @return \PDepend\Source\AST\ASTTypeArray

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2657,19 +2657,40 @@ abstract class AbstractPHPParser
     private function parseExpressionList(ASTNode $exprList)
     {
         $this->consumeComments();
-        while ($expr = $this->parseOptionalExpression()) {
-            $exprList->addChild($expr);
 
-            $this->consumeComments();
-            if (Tokens::T_COMMA === $this->tokenizer->peek()) {
-                $this->consumeToken(Tokens::T_COMMA);
-                $this->consumeComments();
-            } else {
-                break;
-            }
-        }
+        while (
+            ($expr = $this->parseOptionalExpression()) &&
+            $this->addChildToList($exprList, $expr)
+        );
 
         return $exprList;
+    }
+
+    /**
+     * Return true if children remain to be added, false else.
+     *
+     * @param ASTNode $exprList
+     * @param ASTNode $expr
+     * @return bool
+     */
+    protected function addChildToList(ASTNode $exprList, ASTNode $expr)
+    {
+        $exprList->addChild($expr);
+
+        $this->consumeComments();
+
+        if ($this->tokenizer->peek() !== Tokens::T_COMMA) {
+            return false;
+        }
+
+        if ($exprList instanceof ASTArguments && !$exprList->acceptsMoreArguments()) {
+            $this->throwUnexpectedTokenException();
+        }
+
+        $this->consumeToken(Tokens::T_COMMA);
+        $this->consumeComments();
+
+        return true;
     }
 
     /**
@@ -4033,7 +4054,7 @@ abstract class AbstractPHPParser
      * @throws \PDepend\Source\Parser\ParserException
      * @since 0.9.6
      */
-    private function parseFunctionPostfix(ASTNode $node)
+    protected function parseFunctionPostfix(ASTNode $node)
     {
         $image = $this->extractPostfixImage($node);
 
@@ -4338,7 +4359,7 @@ abstract class AbstractPHPParser
      * @return string
      * @since 1.0.0
      */
-    private function extractPostfixImage(ASTNode $node)
+    protected function extractPostfixImage(ASTNode $node)
     {
         while ($node instanceof ASTIndexExpression) {
             $node = $node->getChild(0);
@@ -4387,14 +4408,27 @@ abstract class AbstractPHPParser
 
         $this->tokenStack->push();
 
-        $arguments = $this->builder->buildAstArguments();
+        return $this->parseArgumentsParenthesesContent(
+            $this->builder->buildAstArguments()
+        );
+    }
 
+    /**
+     * This method parses the tokens after arguments passed to a function- or method-call.
+     *
+     * @return \PDepend\Source\AST\ASTArguments
+     * @throws \PDepend\Source\Parser\ParserException
+     * @since 0.9.6
+     */
+    protected function parseArgumentsParenthesesContent(ASTArguments $arguments)
+    {
         $this->consumeToken(Tokens::T_PARENTHESIS_OPEN);
         $this->consumeComments();
 
         if (Tokens::T_PARENTHESIS_CLOSE !== $this->tokenizer->peek()) {
             $arguments = $this->parseArgumentList($arguments);
         }
+
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         return $this->setNodePositionsAndReturn($arguments);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2658,10 +2658,9 @@ abstract class AbstractPHPParser
     {
         $this->consumeComments();
 
-        while (
-            ($expr = $this->parseOptionalExpression()) &&
-            $this->addChildToList($exprList, $expr)
-        );
+        do {
+            $expr = $this->parseOptionalExpression();
+        } while ($expr && $this->addChildToList($exprList, $expr));
 
         return $exprList;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1450,6 +1450,21 @@ class PHPBuilder implements Builder
     }
 
     /**
+     * Builds a new argument match expression single-item slot.
+     *
+     * <code>
+     * match($x)
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchArgument
+     * @since  0.9.6
+     */
+    public function buildAstMatchArgument()
+    {
+        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchArgument');
+    }
+
+    /**
      * Builds a new array type node.
      *
      * @return \PDepend\Source\AST\ASTTypeArray

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -338,7 +338,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
                 $this->consumeToken(Tokens::T_ELLIPSIS);
             }
 
-            if (!(($expr = $this->parseOptionalExpression()) && $this->addChildToList($arguments, $expr))) {
+            $expr = $this->parseOptionalExpression();
+
+            if (!$expr || !$this->addChildToList($arguments, $expr)) {
                 break;
             }
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -333,23 +333,13 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     {
         while (true) {
             $this->consumeComments();
+
             if (Tokens::T_ELLIPSIS === $this->tokenizer->peek()) {
                 $this->consumeToken(Tokens::T_ELLIPSIS);
             }
 
-            $this->consumeComments();
-            if (null === ($expr = $this->parseOptionalExpression())) {
+            if (!(($expr = $this->parseOptionalExpression()) && $this->addChildToList($arguments, $expr))) {
                 break;
-            }
-
-            $arguments->addChild($expr);
-
-            $this->consumeComments();
-            if (Tokens::T_COMMA === $this->tokenizer->peek()) {
-                $this->consumeToken(Tokens::T_COMMA);
-                $this->consumeComments();
-
-                continue;
             }
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -43,6 +43,10 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTNode;
+use PDepend\Source\Parser\ParserException;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -90,8 +94,8 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @return ASTNode
+     * @throws UnexpectedTokenException
      */
     protected function parseOptionalExpressionForVersion()
     {
@@ -102,7 +106,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     /**
      * In this method we implement parsing of PHP 8.0 specific expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function parseExpressionVersion80()
     {
@@ -113,5 +117,44 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         }
 
         return null;
+    }
+
+    /**
+     * This method parses a function postfix expression. An object of type
+     * {@link ASTFunctionPostfix} represents any valid php
+     * function call.
+     *
+     * This method will delegate the call to another method that returns a
+     * member primary prefix object when the function postfix expression is
+     * followed by an object operator.
+     *
+     * @param  ASTNode $node This node represents the function
+     *        identifier. An identifier can be a static string, a variable, a
+     *        compound variable or any other valid php function identifier.
+     * @return ASTNode
+     * @throws ParserException
+     */
+    protected function parseFunctionPostfix(ASTNode $node)
+    {
+        if ($node instanceof ASTIdentifier && $node->getImage() === 'match') {
+            $image = $this->extractPostfixImage($node);
+
+            $function = $this->builder->buildAstFunctionPostfix($image);
+            $function->addChild($node);
+
+            $this->consumeComments();
+
+            $this->tokenStack->push();
+
+            $function->addChild(
+                $this->parseArgumentsParenthesesContent(
+                    $this->builder->buildAstMatchArgument()
+                )
+            );
+
+            return $function;
+        }
+
+        return parent::parseFunctionPostfix($node);
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -205,26 +205,25 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      */
     protected function parseFunctionPostfix(ASTNode $node)
     {
-        if ($node instanceof ASTIdentifier && $node->getImage() === 'match') {
-            $image = $this->extractPostfixImage($node);
-
-            $function = $this->builder->buildAstFunctionPostfix($image);
-            $function->addChild($node);
-
-            $this->consumeComments();
-
-            $this->tokenStack->push();
-
-            $function->addChild(
-                $this->parseArgumentsParenthesesContent(
-                    $this->builder->buildAstMatchArgument()
-                )
-            );
-
-            return $function;
+        if (!($node instanceof ASTIdentifier) || $node->getImage() !== 'match') {
+            return parent::parseFunctionPostfix($node);
         }
+        $image = $this->extractPostfixImage($node);
 
-        return parent::parseFunctionPostfix($node);
+        $function = $this->builder->buildAstFunctionPostfix($image);
+        $function->addChild($node);
+
+        $this->consumeComments();
+
+        $this->tokenStack->push();
+
+        $function->addChild(
+            $this->parseArgumentsParenthesesContent(
+                $this->builder->buildAstMatchArgument()
+            )
+        );
+
+        return $function;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -196,6 +196,10 @@ if (!defined('T_NAME_RELATIVE')) {
     define('T_NAME_RELATIVE', 42313);
 }
 
+if (!defined('T_MATCH')) {
+    define('T_MATCH', 42341);
+}
+
 /**
  * This tokenizer uses the internal {@link token_get_all()} function as token stream
  * generator.
@@ -346,6 +350,7 @@ class PHPTokenizerInternal implements FullTokenizer
         T_COALESCE_EQUAL            => Tokens::T_COALESCE_EQUAL,
         // T_DOLLAR_OPEN_CURLY_BRACES  => Tokens::T_CURLY_BRACE_OPEN,
         T_FN                        => Tokens::T_FN,
+        T_MATCH                     => Tokens::T_STRING,
     );
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP80;
+
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTMethod;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @group unittest
+ * @group php8
+ */
+class MatchExpressionTest extends PHP8ParserVersion80Test
+{
+    /**
+     * @return void
+     */
+    public function testMatchExpression()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        $children = $method->getChildren();
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
+
+        /** @var ASTFormalParameters $parametersBag */
+        $parametersBag = $children[0];
+        /** @var ASTFormalParameter[] $parameters */
+        $parameters = $parametersBag->getChildren();
+
+        $this->assertCount(4, $parameters);
+
+        $this->assertTrue($parameters[0]->isPromoted());
+        $this->assertFalse($parameters[0]->isPublic());
+        $this->assertFalse($parameters[0]->isProtected());
+        $this->assertTrue($parameters[0]->isPrivate());
+
+        $this->assertTrue($parameters[1]->isPromoted());
+        $this->assertFalse($parameters[1]->isPublic());
+        $this->assertTrue($parameters[1]->isProtected());
+        $this->assertFalse($parameters[1]->isPrivate());
+
+        $this->assertTrue($parameters[2]->isPromoted());
+        $this->assertTrue($parameters[2]->isPublic());
+        $this->assertFalse($parameters[2]->isProtected());
+        $this->assertFalse($parameters[2]->isPrivate());
+
+        $this->assertFalse($parameters[3]->isPromoted());
+        $this->assertFalse($parameters[3]->isPublic());
+        $this->assertFalse($parameters[3]->isProtected());
+        $this->assertFalse($parameters[3]->isPrivate());
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -62,7 +62,7 @@ class MatchExpressionTest extends PHP8ParserVersion80Test
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTExpression $expression */
-        $expression = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTExpression');
+        $expression = $method->findChildrenOfType('\\PDepend\\Source\\AST\\ASTExpression');
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -40,8 +40,7 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
-use PDepend\Source\AST\ASTFormalParameter;
-use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTMethod;
 
 /**
@@ -58,37 +57,20 @@ class MatchExpressionTest extends PHP8ParserVersion80Test
      */
     public function testMatchExpression()
     {
+        $this->markTestIncomplete('TODO');
+
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
-        $children = $method->getChildren();
+        /** @var ASTExpression $expression */
+        $expression = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTExpression');
+    }
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
-
-        /** @var ASTFormalParameters $parametersBag */
-        $parametersBag = $children[0];
-        /** @var ASTFormalParameter[] $parameters */
-        $parameters = $parametersBag->getChildren();
-
-        $this->assertCount(4, $parameters);
-
-        $this->assertTrue($parameters[0]->isPromoted());
-        $this->assertFalse($parameters[0]->isPublic());
-        $this->assertFalse($parameters[0]->isProtected());
-        $this->assertTrue($parameters[0]->isPrivate());
-
-        $this->assertTrue($parameters[1]->isPromoted());
-        $this->assertFalse($parameters[1]->isPublic());
-        $this->assertTrue($parameters[1]->isProtected());
-        $this->assertFalse($parameters[1]->isPrivate());
-
-        $this->assertTrue($parameters[2]->isPromoted());
-        $this->assertTrue($parameters[2]->isPublic());
-        $this->assertFalse($parameters[2]->isProtected());
-        $this->assertFalse($parameters[2]->isPrivate());
-
-        $this->assertFalse($parameters[3]->isPromoted());
-        $this->assertFalse($parameters[3]->isPublic());
-        $this->assertFalse($parameters[3]->isProtected());
-        $this->assertFalse($parameters[3]->isPrivate());
+    /**
+     * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
+     * @expectedExceptionMessage Unexpected token: ,, line: 5, col: 25
+     */
+    public function testMatchExpressionWithTooManyArguments()
+    {
+        $this->parseCodeResourceForTest();
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -68,6 +68,7 @@ class MatchExpressionTest extends PHP8ParserVersion80Test
     /**
      * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
      * @expectedExceptionMessage Unexpected token: ,, line: 5, col: 25
+     * @return void
      */
     public function testMatchExpressionWithTooManyArguments()
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -57,7 +57,7 @@ class MatchExpressionTest extends PHP8ParserVersion80Test
      */
     public function testMatchExpression()
     {
-        $this->markTestIncomplete('TODO');
+        $this->markTestIncomplete('Implement and test match expression block parsing');
 
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpression.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpression.php
@@ -1,0 +1,11 @@
+<?php
+class Foo
+{
+    public function bar($in) {
+        return match($in) {
+            'a' => 'A',
+            'b' => 'B',
+            default => throw new \InvalidArgumentException("Invalid code [$in]"),
+        };
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithTooManyArguments.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithTooManyArguments.php
@@ -1,0 +1,11 @@
+<?php
+class Foo
+{
+    public function bar($in) {
+        return match($in, 6) {
+            'a' => 'A',
+            'b' => 'B',
+            default => throw new \InvalidArgumentException("Invalid code [$in]"),
+        };
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: partial fix for #496
Breaking change: no

Support PHP 8 Match expression (phase 1)

```php
echo match (8.0) {
  '8.0' => "Oh no!",
  8.0 => "This is what I expected",
};
//> This is what I expected
```

https://www.php.net/releases/8.0/en.php?lang=en#match-expression

Depends on #499 to be merged first

To do in next pull-requests:
#510 Implement match expression block parsing