### PR TITLE
Support PHP 8 match block entries

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 1.0.0
+ */
+
+namespace PDepend\Source\AST;
+
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
+/**
+ * This class represents a block of elements for a match expression.
+ *
+ * <code>
+ * match (4) {
+ *   4.0 => 'Nope',
+ *   "4" => 'Nope',
+ *   4 => "That's it",
+ *   default => thrown new \Exception('quit'),
+ * }
+ * </code>
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.9.0
+ */
+class ASTMatchBlock extends ASTExpression
+{
+    /**
+     * Accept method of the visitor design pattern. This method will be called
+     * by a visitor during tree traversal.
+     *
+     * @param  ASTVisitor $visitor The calling visitor instance.
+     * @param  mixed      $data
+     * @return mixed
+     * @since  0.9.12
+     */
+    public function accept(ASTVisitor $visitor, $data = null)
+    {
+        return $visitor->visitMatchBlock($this, $data);
+    }
+}

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 1.0.0
+ */
+
+namespace PDepend\Source\AST;
+
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
+/**
+ * This class represents a single match key-expression pair.
+ *
+ * <code>
+ * 'foo' => throw new Excetion('foo forbidden'),
+ * default => 'bar',
+ * </code>
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.9.0
+ */
+class ASTMatchEntry extends ASTExpression
+{
+    /**
+     * Accept method of the visitor design pattern. This method will be called
+     * by a visitor during tree traversal.
+     *
+     * @param ASTVisitor $visitor The calling visitor instance.
+     * @param mixed      $data
+     *
+     * @return mixed
+     * @since  0.9.12
+     */
+    public function accept(ASTVisitor $visitor, $data = null)
+    {
+        return $visitor->visitMatchEntry($this, $data);
+    }
+}

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -939,6 +939,32 @@ interface Builder extends \IteratorAggregate
     public function buildAstMatchArgument();
 
     /**
+     * Builds a new argument match expression single-item slot.
+     *
+     * <code>
+     * match($x) {
+     *   "foo" => "bar",
+     * }
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchBlock
+     * @since  2.9.0
+     */
+    public function buildAstMatchBlock();
+
+    /**
+     * Builds a new argument match expression single-item slot.
+     *
+     * <code>
+     * "foo" => "bar",
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @since  2.9.0
+     */
+    public function buildAstMatchEntry();
+
+    /**
      * Builds a new named argument node.
      *
      * <code>

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2684,7 +2684,7 @@ abstract class AbstractPHPParser
         }
 
         if ($exprList instanceof ASTArguments && !$exprList->acceptsMoreArguments()) {
-            $this->throwUnexpectedTokenException();
+            throw $this->getUnexpectedTokenException();
         }
 
         $this->consumeToken(Tokens::T_COMMA);
@@ -3223,12 +3223,18 @@ abstract class AbstractPHPParser
      * Parses the termination token for a statement. This termination token can
      * be a semicolon or a closing php tag.
      *
+     * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
      * @return void
      * @since 0.9.12
      */
-    private function parseStatementTermination()
+    private function parseStatementTermination(array $allowedTerminationTokens = array())
     {
         $this->consumeComments();
+
+        if (in_array($this->tokenizer->peek(), $allowedTerminationTokens, true)) {
+            return;
+        }
+
         if ($this->tokenizer->peek() === Tokens::T_SEMICOLON) {
             $this->consumeToken(Tokens::T_SEMICOLON);
         } else {
@@ -3272,10 +3278,11 @@ abstract class AbstractPHPParser
     /**
      * This method parses a throw-statement.
      *
+     * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
      * @return \PDepend\Source\AST\ASTThrowStatement
      * @since 0.9.12
      */
-    private function parseThrowStatement()
+    private function parseThrowStatement(array $allowedTerminationTokens = array())
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_THROW);
@@ -3283,7 +3290,7 @@ abstract class AbstractPHPParser
         $stmt = $this->builder->buildAstThrowStatement($token->image);
         $stmt->addChild($this->parseExpression());
 
-        $this->parseStatementTermination();
+        $this->parseStatementTermination($allowedTerminationTokens);
 
         return $this->setNodePositionsAndReturn($stmt);
     }
@@ -5252,6 +5259,73 @@ abstract class AbstractPHPParser
     }
 
     /**
+     * Parses a single match key.
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     * @since 2.9.0
+     */
+    protected function parseMatchEntryKey()
+    {
+        $this->consumeComments();
+
+        if ($this->tokenizer->peek() === Tokens::T_DEFAULT) {
+            $this->consumeToken(Tokens::T_DEFAULT);
+            $label = $this->builder->buildAstSwitchLabel('default');
+            $label->setDefault();
+
+            return $label;
+        }
+
+        if ($this->isKeyword($this->tokenizer->peek())) {
+            throw $this->getUnexpectedTokenException();
+        }
+
+        return $this->parseExpression();
+    }
+
+    /**
+     * Parses a single match value expression.
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     * @since 2.9.0
+     */
+    protected function parseMatchEntryValue()
+    {
+        $this->consumeComments();
+
+        if ($this->tokenizer->peek() === Tokens::T_THROW) {
+            return $this->parseThrowStatement(array(Tokens::T_COMMA));
+        }
+
+        return $this->parseExpression();
+    }
+
+    /**
+     * Parses a single match entry key-expression pair.
+     *
+     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @since 2.9.0
+     */
+    protected function parseMatchEntry()
+    {
+        $this->consumeComments();
+
+        $this->tokenStack->push();
+
+        $matchEntry = $this->builder->buildAstMatchEntry();
+
+        $matchEntry->addChild($this->parseMatchEntryKey());
+
+        $this->consumeComments();
+        $this->consumeToken(Tokens::T_DOUBLE_ARROW);
+        $this->consumeComments();
+
+        $matchEntry->addChild($this->parseMatchEntryValue());
+
+        return $this->setNodePositionsAndReturn($matchEntry);
+    }
+
+    /**
      * Parses a single array element.
      *
      * An array element can have a simple value, a key/value pair, a value by
@@ -7201,6 +7275,7 @@ abstract class AbstractPHPParser
     }
 
     /**
+     * @param Token|null $token
      * @return UnexpectedTokenException
      */
     protected function getUnexpectedTokenException(Token $token = null)
@@ -7214,10 +7289,11 @@ abstract class AbstractPHPParser
     /**
      * Throws an UnexpectedTokenException
      *
-     * @param \PDepend\Source\Tokenizer\Token $token
+     * @param \PDepend\Source\Tokenizer\Token|null $token
      * @return void
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      * @since 2.2.5
+     * @deprecated 3.0.0 Use throw $this->getUnexpectedTokenException($token) instead
      */
     protected function throwUnexpectedTokenException(Token $token = null)
     {
@@ -7229,6 +7305,6 @@ abstract class AbstractPHPParser
      */
     protected function checkEllipsisInExpressionSupport()
     {
-        $this->throwUnexpectedTokenException();
+        throw $this->getUnexpectedTokenException();
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1469,6 +1469,38 @@ class PHPBuilder implements Builder
     }
 
     /**
+     * Builds a new match block.
+     *
+     * <code>
+     * match($x) {
+     *   "foo" => "bar",
+     * }
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchBlock
+     * @since  2.9.0
+     */
+    public function buildAstMatchBlock()
+    {
+        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchBlock');
+    }
+
+    /**
+     * Builds a new match item.
+     *
+     * <code>
+     * "foo" => "bar",
+     * </code>
+     *
+     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @since  2.9.0
+     */
+    public function buildAstMatchEntry()
+    {
+        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchEntry');
+    }
+
+    /**
      * Builds a new named argument node.
      *
      * <code>

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -183,6 +183,26 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
                 )
             );
 
+            $this->consumeComments();
+            $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN);
+
+            $matchBlock = $this->builder->buildAstMatchBlock();
+
+            while ($this->tokenizer->peek() !== Tokens::T_CURLY_BRACE_CLOSE) {
+                $matchBlock->addChild($this->parseMatchEntry());
+
+                $this->consumeComments();
+
+                if ($this->tokenizer->peek() === Tokens::T_COMMA) {
+                    $this->consumeToken(Tokens::T_COMMA);
+                    $this->consumeComments();
+                }
+            }
+
+            $this->consumeToken(Tokens::T_CURLY_BRACE_CLOSE);
+
+            $function->addChild($matchBlock);
+
             return $function;
         }
 

--- a/src/main/php/PDepend/Source/Tokenizer/Tokens.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokens.php
@@ -66,22 +66,22 @@ interface Tokens
     const T_ABSTRACT = 3;
 
     /**
-     * Marks a curly brace open.
+     * Marks a curly brace open '{'.
      */
     const T_CURLY_BRACE_OPEN = 4;
 
     /**
-     * Marks a curly brace close.
+     * Marks a curly brace close '}'.
      */
     const T_CURLY_BRACE_CLOSE = 5;
 
     /**
-     * Marks a parenthesis open.
+     * Marks a parenthesis open '('.
      */
     const T_PARENTHESIS_OPEN = 6;
 
     /**
-     * Marks a parenthesis close.
+     * Marks a parenthesis close ')'.
      */
     const T_PARENTHESIS_CLOSE = 7;
 
@@ -96,7 +96,7 @@ interface Tokens
     const T_FUNCTION = 9;
 
     /**
-     * Marks a double colon.
+     * Marks a double colon ':'.
      */
     const T_DOUBLE_COLON = 10;
 
@@ -111,7 +111,7 @@ interface Tokens
     const T_DOC_COMMENT = 12;
 
     /**
-     * Marks a semicolon.
+     * Marks a semicolon ';'.
      */
     const T_SEMICOLON = 13;
 


### PR DESCRIPTION
Type: feature
Issue: partial fix for #496
Breaking change: no

Support PHP 8 Match expression (phase 2/2)

```php
echo match (8.0) {
  '8.0' => "Oh no!",
  8.0 => "This is what I expected",
};
//> This is what I expected
```

https://www.php.net/releases/8.0/en.php?lang=en#match-expression

Depends on #499 and #509 to be merged first