### PR TITLE
Skip PHP 8 Attributes

### DIFF
--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP80;
+
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTMethod;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @group unittest
+ * @group php8
+ */
+class AttributeTest extends PHP8ParserVersion80Test
+{
+    /**
+     * @return void
+     */
+    public function testAttribute()
+    {
+        self::needsPHP80();
+
+        $types = $this->parseCodeResourceForTest()
+            ->current()
+            ->getTypes();
+        /** @var ASTClass $class */
+        $class = $types[1];
+        $methods = $class->getAllMethods();
+        /** @var ASTMethod $bMethod */
+        $bMethod = $methods['b'];
+        $parameters = $bMethod->getParameters();
+
+        $this->assertSame('$bar', $parameters[0]->getName());
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
@@ -1,0 +1,15 @@
+<?php
+
+#[Attribute]
+class Foo
+{
+
+}
+
+class A
+{
+    public function b(#[Foo()] $bar)
+    {
+
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: #493
Breaking change: no

Skip PHP 8 Attributes

```php
class PostsController
{
    #[Route("/api/posts/{id}", methods: ["GET"])]
    public function get($id) { /* ... */ }
}
```

https://www.php.net/releases/8.0/en.php?lang=en#attributes

This pull-request is not an actual support of PHP 8 Attributes as it does not provide any static structured way to analyze their content. This will just convert them into annotation comments so the parser will not fail when an attribute is inside a line of code.