### PR TITLE
Allow trailing commas in grouped use declarations in PHP 7.2+

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -587,6 +587,10 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         throw $this->getUnexpectedTokenException($this->tokenizer->next());
     }
 
+    /**
+     * use Foo\Bar\{TestA, TestB} is allowed since PHP 7.0
+     * use Foo\Bar\{TestA, TestB,} but trailing comma isn't
+     */
     protected function allowUseGroupDeclarationTrailingComma()
     {
         return false;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -538,12 +538,18 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
                     $this->consumeToken($nextToken);
             }
 
+            if ($this->allowUseGroupDeclarationTrailingComma() &&
+                Tokens::T_CURLY_BRACE_CLOSE === $this->tokenizer->peek()
+            ) {
+                break;
+            }
+
             $subFragments = $this->parseQualifiedNameRaw();
             $this->consumeComments();
 
             $image = $this->parseNamespaceImage($subFragments);
 
-            if (Tokens::T_COMMA != $this->tokenizer->peek()) {
+            if (Tokens::T_COMMA !== $this->tokenizer->peek()) {
                 break;
             }
 
@@ -554,7 +560,9 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
         } while (true);
 
-        $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+        if (isset($image, $subFragments)) {
+            $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+        }
 
         $this->consumeToken(Tokens::T_CURLY_BRACE_CLOSE);
         $this->consumeComments();
@@ -577,5 +585,10 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         }
 
         throw $this->getUnexpectedTokenException($this->tokenizer->next());
+    }
+
+    protected function allowUseGroupDeclarationTrailingComma()
+    {
+        return false;
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -108,7 +108,9 @@ abstract class PHPParserVersion72 extends PHPParserVersion71
             $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
         } while (true);
 
-        $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+        if (isset($image, $subFragments)) {
+            $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+        }
 
         $this->consumeToken(Tokens::T_CURLY_BRACE_CLOSE);
         $this->consumeComments();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -52,6 +52,9 @@ namespace PDepend\Source\Language\PHP;
  */
 abstract class PHPParserVersion72 extends PHPParserVersion71
 {
+    /**
+     * use Foo\Bar\{TestA, TestB,} trailing comma is supported since PHP 7.2
+     */
     protected function allowUseGroupDeclarationTrailingComma()
     {
         return true;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -97,7 +97,7 @@ abstract class PHPParserVersion72 extends PHPParserVersion71
 
             $image = $this->parseNamespaceImage($subFragments);
 
-            if (Tokens::T_COMMA != $this->tokenizer->peek()) {
+            if (Tokens::T_COMMA !== $this->tokenizer->peek()) {
                 break;
             }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -43,8 +43,6 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\Source\Tokenizer\Tokens;
-
 /**
  * Concrete parser implementation that supports features up to PHP version 7.2.
  *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -88,7 +88,7 @@ abstract class PHPParserVersion72 extends PHPParserVersion71
                     $this->consumeToken($nextToken);
             }
 
-            if (Tokens::T_CURLY_BRACE_CLOSE == $this->tokenizer->peek()) {
+            if (Tokens::T_CURLY_BRACE_CLOSE === $this->tokenizer->peek()) {
                 break;
             }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -54,67 +54,8 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion72 extends PHPParserVersion71
 {
-    /**
-     * @param array<string> $fragments
-     * @return void
-     */
-    protected function parseUseDeclarationForVersion(array $fragments)
+    protected function allowUseGroupDeclarationTrailingComma()
     {
-        if (Tokens::T_CURLY_BRACE_OPEN === $this->tokenizer->peek()) {
-            $this->parseUseDeclarationVersion72($fragments);
-
-            return;
-        }
-
-        parent::parseUseDeclarationForVersion($fragments);
-    }
-
-    /**
-     * @param array<string> $fragments
-     * @return void
-     */
-    protected function parseUseDeclarationVersion72(array $fragments)
-    {
-        $namespacePrefixReplaced = $this->namespacePrefixReplaced;
-
-        $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN);
-        $this->consumeComments();
-
-        do {
-            $nextToken = $this->tokenizer->peek();
-            switch ($nextToken) {
-                case Tokens::T_CONST:
-                case Tokens::T_FUNCTION:
-                    $this->consumeToken($nextToken);
-            }
-
-            if (Tokens::T_CURLY_BRACE_CLOSE === $this->tokenizer->peek()) {
-                break;
-            }
-
-            $subFragments = $this->parseQualifiedNameRaw();
-            $this->consumeComments();
-
-            $image = $this->parseNamespaceImage($subFragments);
-
-            if (Tokens::T_COMMA !== $this->tokenizer->peek()) {
-                break;
-            }
-
-            $this->consumeToken(Tokens::T_COMMA);
-            $this->consumeComments();
-
-            // Add mapping between image and qualified name to symbol table
-            $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
-        } while (true);
-
-        if (isset($image, $subFragments)) {
-            $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
-        }
-
-        $this->consumeToken(Tokens::T_CURLY_BRACE_CLOSE);
-        $this->consumeComments();
-
-        $this->namespacePrefixReplaced = $namespacePrefixReplaced;
+        return true;
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -50,7 +50,7 @@ use PDepend\Source\AST\ASTMethod;
  * @group unittest
  * @group php8
  */
-class AttributeTest extends PHP8ParserVersion80Test
+class AttributeTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -49,11 +49,11 @@ use PDepend\Source\AST\ASTNamedArgument;
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
  * @group unittest
  * @group php8
  */
-class ConstructorPropertyPromotionTest extends PHP8ParserVersion80Test
+class ConstructorPropertyPromotionTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTReturnStatement;
  * @group unittest
  * @group php8
  */
-class MatchExpressionTest extends PHP8ParserVersion80Test
+class MatchExpressionTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTNamedArgument;
  * @group unittest
  * @group php8
  */
-class NamedArgumentsTest extends PHP8ParserVersion80Test
+class NamedArgumentsTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -50,7 +50,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8
  */
-class NullsafeOperatorTest extends PHP8ParserVersion80Test
+class NullsafeOperatorTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80Test.php
@@ -45,10 +45,10 @@ use PDepend\AbstractTest;
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHP8ParserVersion80
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
  * @group unittest
  */
-abstract class PHP8ParserVersion80Test extends AbstractTest
+abstract class PHPParserVersion80Test extends AbstractTest
 {
     protected static function needsPHP80()
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -52,7 +52,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8
  */
-class UnionTypesTest extends PHP8ParserVersion80Test
+class UnionTypesTest extends PHPParserVersion80Test
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -104,6 +104,17 @@ class PHPParserVersion72Test extends AbstractTest
     }
 
     /**
+     * @return \PDepend\Source\AST\ASTNamespace
+     */
+    public function testGroupUseStatementTrailingComma()
+    {
+        $namespaces = $this->parseCodeResourceForTest();
+        $this->assertNotNull($namespaces);
+
+        return $namespaces[0];
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -109,9 +109,8 @@ class PHPParserVersion72Test extends AbstractTest
     public function testGroupUseStatementTrailingComma()
     {
         $namespaces = $this->parseCodeResourceForTest();
-        $this->assertNotNull($namespaces);
-
-        return $namespaces[0];
+        $this->assertGreaterThan(0, count($namespaces));
+        $this->assertContainsOnlyInstancesOf('PDepend\\Source\\AST\\ASTNamespace', $namespaces);
     }
 
     /**

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testGroupUseStatementTrailingComma.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testGroupUseStatementTrailingComma.php
@@ -1,0 +1,9 @@
+<?php
+
+use my\{ClassA, ClassB,};
+use my\{ClassC, ClassD /*, ClassE */,};
+
+class ExtendingClass extends ClassB
+{
+
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #519 
Breaking change: no

Feels like a lot of duplication, but couldn't really figure out a way to insert the early break on T_CURLY_BRACE_CLOSE into the 7.0 parser. I'm also struggling to run the entire testsuite locally, so I don't know what will happen once the GitHub actions run.

(Also I was wrong, trailing commas weren't supported until 7.2)