### PR TITLE
Add AbstractPHPParser::parseStaticType and PHPParserVersion80::parseReturnTypeHint

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5800,6 +5800,14 @@ abstract class AbstractPHPParser
     }
 
     /**
+     * @return \PDepend\Source\AST\ASTStaticReference
+     */
+    protected function parseStaticType()
+    {
+        return $this->parseStaticReference($this->consumeToken(Tokens::T_STATIC));
+    }
+
+    /**
      * This method will parse a formal parameter that can optionally be passed
      * by reference.
      *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -189,25 +189,28 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * @return \PDepend\Source\AST\ASTType
      */
+    protected function parseEndReturnTypeHint()
+    {
+        switch ($this->tokenizer->peek()) {
+            case Tokens::T_ARRAY:
+                return $this->parseArrayType();
+            case Tokens::T_SELF:
+                return $this->parseSelfType();
+            case Tokens::T_PARENT:
+                return $this->parseParentType();
+            default:
+                return $this->parseTypeHint();
+        }
+    }
+
+    /**
+     * @return \PDepend\Source\AST\ASTType
+     */
     protected function parseReturnTypeHint()
     {
         $this->consumeComments();
 
-        switch ($tokenType = $this->tokenizer->peek()) {
-            case Tokens::T_ARRAY:
-                $type = $this->parseArrayType();
-                break;
-            case Tokens::T_SELF:
-                $type = $this->parseSelfType();
-                break;
-            case Tokens::T_PARENT:
-                $type = $this->parseParentType();
-                break;
-            default:
-                $type = $this->parseTypeHint();
-                break;
-        }
-        return $type;
+        return $this->parseEndReturnTypeHint();
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -50,6 +50,7 @@ use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\ParserException;
 use PDepend\Source\Parser\UnexpectedTokenException;
@@ -245,6 +246,33 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         $function->addChild($matchBlock);
 
         return $function;
+    }
+
+    /**
+     * @return ASTType
+     */
+    protected function parseReturnTypeHint()
+    {
+        $this->consumeComments();
+
+        switch ($tokenType = $this->tokenizer->peek()) {
+            case Tokens::T_ARRAY:
+                $type = $this->parseArrayType();
+                break;
+            case Tokens::T_SELF:
+                $type = $this->parseSelfType();
+                break;
+            case Tokens::T_PARENT:
+                $type = $this->parseParentType();
+                break;
+            case Tokens::T_STATIC:
+                $type = $this->parseStaticType();
+                break;
+            default:
+                $type = $this->parseTypeHint();
+        }
+
+        return $type;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -251,28 +251,14 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     /**
      * @return ASTType
      */
-    protected function parseReturnTypeHint()
+    protected function parseEndReturnTypeHint()
     {
-        $this->consumeComments();
-
-        switch ($tokenType = $this->tokenizer->peek()) {
-            case Tokens::T_ARRAY:
-                $type = $this->parseArrayType();
-                break;
-            case Tokens::T_SELF:
-                $type = $this->parseSelfType();
-                break;
-            case Tokens::T_PARENT:
-                $type = $this->parseParentType();
-                break;
+        switch ($this->tokenizer->peek()) {
             case Tokens::T_STATIC:
-                $type = $this->parseStaticType();
-                break;
+                return $this->parseStaticType();
             default:
-                $type = $this->parseTypeHint();
+                return parent::parseEndReturnTypeHint();
         }
-
-        return $type;
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -136,6 +136,32 @@ class PHPParserGenericVersion70Test extends AbstractTest
     }
 
     /**
+     * testFunctionReturnTypeHintSelf
+     *
+     * @return void
+     */
+    public function testFunctionReturnTypeHintSelf()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar());
+        $this->assertSame('self', $type->getImage());
+    }
+
+    /**
+     * testFunctionReturnTypeHintParent
+     *
+     * @return void
+     */
+    public function testFunctionReturnTypeHintParent()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar());
+        $this->assertSame('parent', $type->getImage());
+    }
+
+    /**
      * testFunctionReturnTypeHintFloat
      *
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+use PDepend\AbstractTest;
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Util\Cache\CacheDriver;
+
+/**
+ * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion74} class.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion74
+ * @group unittest
+ */
+class PHPParserVersion80Test extends AbstractTest
+{
+    /**
+     * testFunctionReturnTypeHintStatic
+     *
+     * @return void
+     */
+    public function testFunctionReturnTypeHintStatic()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar());
+        $this->assertSame('static', $type->getImage());
+    }
+
+    /**
+     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
+     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Util\Cache\CacheDriver $cache
+     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     */
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    {
+        return $this->getAbstractClassMock(
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion80',
+            array($tokenizer, $builder, $cache)
+        );
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -69,6 +69,32 @@ class PHPParserVersion80Test extends AbstractTest
     }
 
     /**
+     * testFunctionReturnTypeHintNullableStatic
+     *
+     * @return void
+     */
+    public function testFunctionReturnTypeHintNullableStatic()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar());
+        $this->assertSame('static', $type->getImage());
+    }
+
+    /**
+     * testFunctionReturnTypeHintStaticWithComments
+     *
+     * @return void
+     */
+    public function testFunctionReturnTypeHintStaticWithComments()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertFalse($type->isScalar());
+        $this->assertSame('static', $type->getImage());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testFunctionReturnTypeHintParent.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testFunctionReturnTypeHintParent.php
@@ -1,0 +1,8 @@
+<?php
+class Foo extends Bar
+{
+    function testFunctionReturnTypeHintParent(): parent
+    {
+        return new Bar();
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testFunctionReturnTypeHintSelf.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserGenericVersion70/testFunctionReturnTypeHintSelf.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    function testFunctionReturnTypeHintSelf(): self
+    {
+        return $this;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintNullableStatic.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintNullableStatic.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    function testFunctionReturnTypeHintNullableStatic(): ?static
+    {
+        return new static();
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintStatic.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintStatic.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    function testFunctionReturnTypeHintStatic(): static
+    {
+        return new static();
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintStaticWithComments.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionReturnTypeHintStaticWithComments.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    function testFunctionReturnTypeHintStaticWithComments(): ?/* comment */static
+    {
+        return new static();
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: https://github.com/pdepend/pdepend/issues/518
Breaking change: no

<!--
For PHP 8 adds the ability to check the return type of "static".
-->