### PR TITLE
Allow catch without variable for PHP >= 8.0

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -3401,14 +3401,26 @@ abstract class AbstractPHPParser
         $this->parseCatchExceptionClass($catch);
 
         $this->consumeComments();
-        $catch->addChild($this->parseVariable());
+        $this->parseCatchVariable($catch);
 
-        $this->consumeComments();
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         $catch->addChild($this->parseRegularScope());
 
         return $this->setNodePositionsAndReturn($catch);
+    }
+
+    /**
+     * This method parses assigned variable in catch statement.
+     *
+     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @return void
+     */
+    protected function parseCatchVariable(ASTCatchStatement $stmt)
+    {
+        $stmt->addChild($this->parseVariable());
+
+        $this->consumeComments();
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -45,6 +45,7 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTCallable;
+use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTConstant;
 use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTFormalParameter;
@@ -340,5 +341,18 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         }
 
         return $unionType;
+    }
+
+    /**
+     * This method parses assigned variable in catch statement.
+     *
+     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @return void
+     */
+    protected function parseCatchVariable(ASTCatchStatement $stmt)
+    {
+        if ($this->tokenizer->peek() === Tokens::T_VARIABLE) {
+            parent::parseCatchVariable($stmt);
+        }
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -393,6 +393,15 @@ class PHPParserVersion74Test extends AbstractTest
     }
 
     /**
+     * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
+     * @expectedExceptionMessage Unexpected token: ), line: 8, col: 27
+     */
+    public function testCatchWithoutVariable()
+    {
+        $this->getFirstClassForTestCase();
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -56,6 +56,20 @@ use PDepend\Util\Cache\CacheDriver;
 class PHPParserVersion80Test extends AbstractTest
 {
     /**
+     * testCatchWithoutVariable
+     *
+     * @return void
+     */
+    public function testCatchWithoutVariable()
+    {
+        $catchStatement = $this->getFirstMethodForTestCase()->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTCatchStatement'
+        );
+
+        $this->assertCount(2, $catchStatement->getChildren());
+    }
+
+    /**
      * testFunctionReturnTypeHintStatic
      *
      * @return void

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testCatchWithoutVariable.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testCatchWithoutVariable.php
@@ -1,0 +1,12 @@
+<?php
+class Foo
+{
+    function testCatchWithoutVariable()
+    {
+        try {
+            $a = 1;
+        } catch (Exception) {
+            echo 'Something wrong happened';
+        }
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testCatchWithoutVariable.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testCatchWithoutVariable.php
@@ -1,0 +1,12 @@
+<?php
+class Foo
+{
+    function testCatchWithoutVariable()
+    {
+        try {
+            $a = 1;
+        } catch (Exception) {
+            echo 'Something wrong happened';
+        }
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: Fix #516
Breaking change: no

Enable support for `catch` statements without variable which are now allowed in PHP 8:
```php
try {
  $a = 1;
} catch (Exception /* no variable */) {
  echo 'Something wrong happened';
}
```