### PR TITLE
Allow nested arrays in attributes

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -733,7 +733,7 @@ class PHPTokenizerInternal implements FullTokenizer
     public function peekNext()
     {
         $this->tokenize();
-        
+
         $offset = 0;
 
         do {
@@ -848,13 +848,22 @@ class PHPTokenizerInternal implements FullTokenizer
         $result = array();
         $attributeComment = null;
         $attributeCommentLine = null;
+        $brackets = 0;
 
         foreach ($tokens as $index => $token) {
             $temp = (array) $token;
             $temp = $temp[0];
 
             if ($attributeComment) {
+                if ($temp === '[') {
+                    $brackets++;
+                }
+
                 if ($temp === ']') {
+                    $brackets--;
+                }
+
+                if ($brackets <= 0) {
                     $result[] = array(T_COMMENT, "$attributeComment */", $attributeCommentLine);
                     $attributeComment = null;
 
@@ -865,6 +874,7 @@ class PHPTokenizerInternal implements FullTokenizer
             } elseif ($temp === T_ATTRIBUTE) {
                 $attributeComment = '/* @';
                 $attributeCommentLine = $token[2];
+                $brackets = 1;
             } elseif ($temp === T_NAME_QUALIFIED || $temp === T_NAME_FULLY_QUALIFIED) {
                 foreach ($this->splitQualifiedNameToken($token) as $subToken) {
                     $result[] = $subToken;
@@ -1029,7 +1039,7 @@ class PHPTokenizerInternal implements FullTokenizer
                 }
 
                 $startLine += $lines;
-                
+
                 // Store current type
                 if ($type !== Tokens::T_COMMENT && $type !== Tokens::T_DOC_COMMENT) {
                     $previousType = $type;

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -77,4 +77,46 @@ class NamedArgumentsTest extends PHPParserVersion80Test
         $this->assertSame("' '", $argument->getValue()->getImage());
         $this->assertSame("thousands_separator: ' '", $argument->getImage());
     }
+
+    public function testNamedArgumentsWithArrays()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTArguments $arguments */
+        $arguments = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTArguments'
+        );
+        $children = $arguments->getChildren();
+
+        $this->assertCount(4, $children);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertSame("'/thing/{id}'", $children[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[3]);
+        /** @var ASTNamedArgument $argument */
+        $argument = $children[3];
+
+        $this->assertSame('methods', $argument->getName());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $argument->getValue());
+    }
+
+    public function testNamedArgumentsInInstances()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTArguments $arguments */
+        $arguments = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTArguments'
+        );
+        $children = $arguments->getChildren();
+
+        $this->assertCount(4, $children);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertSame("'/thing/{id}'", $children[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[3]);
+        /** @var ASTNamedArgument $argument */
+        $argument = $children[3];
+
+        $this->assertSame('methods', $argument->getName());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $argument->getValue());
+    }
 }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
@@ -14,6 +14,12 @@ class A
         // ...
     }
 
+    #[Bar([']][[]]'])]
+    public function bar()
+    {
+        // ...
+    }
+
     public function b(#[Foo()] $bar)
     {
 

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/Attribute/testAttribute.php
@@ -8,6 +8,12 @@ class Foo
 
 class A
 {
+    #[Route('/thing/{id}', name: 'get_thing_by_id', requirements: ["id" => "\d+"], methods: ['GET'])]
+    public function getById(Request $request): Response
+    {
+        // ...
+    }
+
     public function b(#[Foo()] $bar)
     {
 

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsInInstances.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsInInstances.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        return new Route('/thing/{id}', name: 'get_thing_by_id', requirements: ["id" => "\d+"], methods: ['GET']);
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsWithArrays.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsWithArrays.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        Route('/thing/{id}', name: 'get_thing_by_id', requirements: ["id" => "\d+"], methods: ['GET']);
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #527
Breaking change: no

Allow nested brackets in attributes:

```php
#[Foo(1, ["ignored here ]] "], 2)]
```