### PR TITLE
Allow use of trailing comma in formal parameters list introduced in PHP 8.0

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5607,6 +5607,14 @@ abstract class AbstractPHPParser
         }
 
         while ($tokenType !== Tokenizer::T_EOF) {
+            // check for trailing comma in parameter list
+            $this->consumeComments();
+            $tokenType = $this->tokenizer->peek();
+
+            if ($this->allowTrailingCommaInFormalParametersList() && $tokenType === Tokens::T_PARENTHESIS_CLOSE) {
+                break;
+            }
+
             $formalParameters->addChild(
                 $this->parseFormalParameterOrPrefix($callable)
             );
@@ -5625,6 +5633,15 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         return $this->setNodePositionsAndReturn($formalParameters);
+    }
+
+    /**
+     * use of trailing comma in formal parameters list is allowed since PHP 8.0
+     * example function foo(string $bar, int $baz,)
+     */
+    protected function allowTrailingCommaInFormalParametersList()
+    {
+        return false;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -364,4 +364,13 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     {
         return true;
     }
+
+    /**
+     * use of trailing comma in formal parameters list is allowed since PHP 8.0
+     * example function foo(string $bar, int $baz,)
+     */
+    protected function allowTrailingCommaInFormalParametersList()
+    {
+        return true;
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -411,6 +411,15 @@ class PHPParserVersion74Test extends AbstractTest
     }
 
     /**
+     * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
+     * @expectedExceptionMessage Unexpected token: ), line: 4, col: 43
+     */
+    public function testTrailingCommaInParameterList()
+    {
+        $this->getFirstMethodForTestCase();
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -117,6 +117,18 @@ class PHPParserVersion80Test extends AbstractTest
     }
 
     /**
+     * testTrailingCommaInParameterList
+     *
+     * @return void
+     */
+    public function testTrailingCommaInParameterList()
+    {
+        $method = $this->getFirstMethodForTestCase();
+
+        $this->assertCount(2, $method->getParameters());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testTrailingCommaInParameterList.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testTrailingCommaInParameterList.php
@@ -1,0 +1,5 @@
+<?php
+class Foo
+{
+    function bar(string $foo, string $bar,) {}
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testTrailingCommaInParameterList.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testTrailingCommaInParameterList.php
@@ -1,0 +1,5 @@
+<?php
+class Foo
+{
+    function bar(string $foo, string $bar,) {}
+}


### PR DESCRIPTION
Type: feature
Issue: N/A
Breaking change: no

This PR adds the support for trailing commas in parameter lists introduced in PHP 8.0. Link to RFC: https://wiki.php.net/rfc/trailing_comma_in_parameter_list

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->