### PR TITLE
Allow use of trailing comma in closure use list introduced in PHP 8.0

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -6192,6 +6192,11 @@ abstract class AbstractPHPParser
         while ($this->tokenizer->peek() !== Tokenizer::T_EOF) {
             $this->consumeComments();
 
+            if ($this->allowTrailingCommaInClosureUseList() &&
+                $this->tokenizer->peek() === Tokens::T_PARENTHESIS_CLOSE) {
+                break;
+            }
+
             if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
                 $this->consumeToken(Tokens::T_BITWISE_AND);
                 $this->consumeComments();
@@ -6213,6 +6218,15 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         return $closure;
+    }
+
+    /**
+     * Trailing commas is allowed in closure use list from PHP 8.0
+     * @return false
+     */
+    protected function allowTrailingCommaInClosureUseList()
+    {
+        return false;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -355,4 +355,13 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
             parent::parseCatchVariable($stmt);
         }
     }
+
+    /**
+     * Trailing commas is allowed in closure use list from PHP 8.0
+     * @return false
+     */
+    protected function allowTrailingCommaInClosureUseList()
+    {
+        return true;
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -402,6 +402,15 @@ class PHPParserVersion74Test extends AbstractTest
     }
 
     /**
+     * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
+     * @expectedExceptionMessage Unexpected token: ), line: 5, col: 32
+     */
+    public function testTrailingCommaInClosureUseListError()
+    {
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -109,6 +109,14 @@ class PHPParserVersion80Test extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testTrailingCommaInClosureUseList()
+    {
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testTrailingCommaInClosureUseListError.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testTrailingCommaInClosureUseListError.php
@@ -1,0 +1,6 @@
+<?php
+
+function bar() {
+    $a = true;
+    return function () use ($a,) {};
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testTrailingCommaInClosureUseList.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testTrailingCommaInClosureUseList.php
@@ -1,0 +1,6 @@
+<?php
+
+function bar() {
+    $a = true;
+    return function () use ($a,) {};
+}


### PR DESCRIPTION
Type: feature
Issue: N/A
Breaking change: no

This PR adds support for trailing comma in closure use list which was introduced in PHP 8.0. RFC: https://wiki.php.net/rfc/trailing_comma_in_closure_use_list

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->