### PR TITLE
(fix): match expression does not have namespace

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -43,8 +43,6 @@
 
 namespace PDepend\Source\AST;
 
-use function array_pop;
-
 /**
  * This is an abstract base implementation of the ast node interface.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Source\AST;
 
+use function array_pop;
+
 /**
  * This is an abstract base implementation of the ast node interface.
  *
@@ -115,6 +117,18 @@ abstract class AbstractASTNode implements ASTNode
     public function getImage()
     {
         return $this->getMetadata(4);
+    }
+
+    /**
+     * Returns the source image of this ast node without the namespace prefix.
+     *
+     * @return string
+     */
+    public function getImageWithoutNamespace()
+    {
+        $imagePath = explode('\\', $this->getMetadata(4));
+
+        return array_pop($imagePath);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -220,7 +220,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      */
     protected function parseFunctionPostfix(ASTNode $node)
     {
-        if (!($node instanceof ASTIdentifier) || $node->getImage() !== 'match') {
+        if (!($node instanceof ASTIdentifier) || $node->getImageWithoutNamespace() !== 'match') {
             return parent::parseFunctionPostfix($node);
         }
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -72,7 +72,7 @@ class MatchExpressionTest extends PHPParserVersion80Test
     /**
      * @return void
      */
-    private function checkMatchExpression(string $namespacePrefix = null)
+    private function checkMatchExpression($namespacePrefix = null)
     {
         $matchImage = implode('\\', array_filter(array($namespacePrefix, 'match')));
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -74,7 +74,7 @@ class MatchExpressionTest extends PHPParserVersion80Test
      */
     private function checkMatchExpression(string $namespacePrefix = null)
     {
-        $matchImage = implode('\\', array_filter([$namespacePrefix, 'match']));
+        $matchImage = implode('\\', array_filter(array($namespacePrefix, 'match')));
 
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -58,6 +58,24 @@ class MatchExpressionTest extends PHPParserVersion80Test
      */
     public function testMatchExpression()
     {
+        $this->checkMatchExpression();
+    }
+
+    /**
+     * @return void
+     */
+    public function testMatchExpressionWithNamespace()
+    {
+        $this->checkMatchExpression('Baz');
+    }
+
+    /**
+     * @return void
+     */
+    private function checkMatchExpression(string $namespacePrefix = null)
+    {
+        $matchImage = implode('\\', array_filter([$namespacePrefix, 'match']));
+
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
@@ -65,7 +83,8 @@ class MatchExpressionTest extends PHPParserVersion80Test
         $match = $returns[0]->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $match);
-        $this->assertSame('match', $match->getImage());
+        $this->assertSame($matchImage, $match->getImage());
+        $this->assertSame('match', $match->getImageWithoutNamespace());
         /**
          * @var array{
          *     \PDepend\Source\AST\ASTIdentifier,
@@ -78,7 +97,8 @@ class MatchExpressionTest extends PHPParserVersion80Test
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchArgument', $children[1]);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchBlock', $children[2]);
-        $this->assertSame('match', $children[0]->getImage());
+        $this->assertSame($matchImage, $children[0]->getImage());
+        $this->assertSame('match', $children[0]->getImageWithoutNamespace());
         /** @var \PDepend\Source\AST\ASTVariable[] $arguments */
         $arguments = $children[1]->getChildren();
         $this->assertCount(1, $arguments);

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithNamespace.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithNamespace.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Baz;
+
+class Foo
+{
+    public function bar($in) {
+        return match($in) {
+            'a' => 'A',
+            'b' => 'B',
+            default => throw new \InvalidArgumentException("Invalid code [$in]"),
+        };
+    }
+}
+


### PR DESCRIPTION
Type: bugfix
Issue: fix #531
Breaking change: no

The keyword `match` is being treated as if it could have a namespace,
but in PHP 8 you can't use `match` in your code, given it is a reserved
word now.

This fix does keep match as a Tokens::T_STRING, but if the maintainers
prefer that I change it to use a new token id (Tokens::T_MATCH), I can
invest more time to change and fix that way.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->
