### PR TITLE
Add named argument value as child to make it discoverable

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -60,11 +60,6 @@ class ASTNamedArgument extends AbstractASTNode
     protected $name;
 
     /**
-     * @var ASTNode
-     */
-    protected $value;
-
-    /**
      * @param string $name
      */
     public function __construct($name, ASTNode $value)
@@ -72,7 +67,7 @@ class ASTNamedArgument extends AbstractASTNode
         parent::__construct();
 
         $this->name = $name;
-        $this->value = $value;
+        $this->addChild($value);
     }
 
     /**
@@ -88,7 +83,7 @@ class ASTNamedArgument extends AbstractASTNode
      */
     public function getValue()
     {
-        return $this->value;
+        return $this->getChild(0);
     }
 
     /**
@@ -96,7 +91,7 @@ class ASTNamedArgument extends AbstractASTNode
      */
     public function getImage()
     {
-        return sprintf('%s: %s', $this->name, $this->value->getImage());
+        return sprintf('%s: %s', $this->name, $this->getChild(0)->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -41,8 +41,10 @@
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamedArgument;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -118,5 +120,59 @@ class NamedArgumentsTest extends PHPParserVersion80Test
 
         $this->assertSame('methods', $argument->getName());
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $argument->getValue());
+    }
+
+    public function testNamedArgumentsFindVariable()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTNamedArgument $namedArgument */
+        $namedArgument = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTNamedArgument'
+        );
+        /** @var ASTVariable[] $variables */
+        $variables = $method->findChildrenOfType(
+            'PDepend\\Source\\AST\\ASTVariable'
+        );
+        $this->assertCount(2, $variables);
+
+        $foundVariable = $namedArgument->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+        $this->assertSame($variables[1], $foundVariable);
+        $this->assertSame('$foo', $foundVariable->getImage());
+        /** @var ASTExpression $expression */
+        $expression = $variables[1]->getParent();
+        /** @var ASTNamedArgument $expression */
+        $expressionParent = $expression->getParent();
+        $this->assertSame($namedArgument, $expressionParent);
+        $this->assertSame(
+            array($variables[1]),
+            $namedArgument->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable')
+        );
+    }
+
+    public function testNamedArgumentsFindDirectVariable()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTNamedArgument $namedArgument */
+        $namedArgument = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTNamedArgument'
+        );
+        /** @var ASTVariable[] $variables */
+        $variables = $method->findChildrenOfType(
+            'PDepend\\Source\\AST\\ASTVariable'
+        );
+        $this->assertCount(2, $variables);
+
+        $foundVariable = $namedArgument->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+        $this->assertSame($variables[1], $foundVariable);
+        $this->assertSame('$foo', $foundVariable->getImage());
+        /** @var ASTNamedArgument $variableParent */
+        $variableParent = $variables[1]->getParent();
+        $this->assertSame($namedArgument, $variableParent);
+        $this->assertSame(
+            array($variables[1]),
+            $namedArgument->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable')
+        );
     }
 }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsFindDirectVariable.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsFindDirectVariable.php
@@ -1,0 +1,10 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        $foo = '-';
+
+        return number_format(5623, thousands_separator: $foo);
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsFindVariable.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NamedArguments/testNamedArgumentsFindVariable.php
@@ -1,0 +1,10 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        $foo = '-';
+
+        return number_format(5623, thousands_separator: ' ' . $foo . ' ');
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix https://github.com/phpmd/phpmd/issues/893
Breaking change: yes (acceptable)

This is breaking for classes that extend `ASTNamedArgument` and use `$this->value` which will be removed. As a semi-private thing, we assume the risk of change is something the developer is aware when entering the protected scope. Also considering, `ASTNamedArgument` class is quite new, risk that users already started to extend it is low while keeping the `$value` property might create pain, storing the value only in `$nodes` is safest.

Thanks to this change, the generic method to scan the tree (`getChild`, `getChildren`, `getFirstChildOfType`, `findChildrenOfType`) will be able to discover the content of the `ASTNamedArgument` value, and `getParent` on the named argument value will return back the `ASTNamedArgument`.