### PR TITLE
(fix): match throw entry may end on curly braces

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5312,7 +5312,7 @@ abstract class AbstractPHPParser
         $this->consumeComments();
 
         if ($this->tokenizer->peek() === Tokens::T_THROW) {
-            return $this->parseThrowStatement(array(Tokens::T_COMMA));
+            return $this->parseThrowStatement(array(Tokens::T_COMMA, Tokens::T_CURLY_BRACE_CLOSE));
         }
 
         return $this->parseExpression();

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpression.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpression.php
@@ -5,7 +5,7 @@ class Foo
         return match($in) {
             'a' => 'A',
             'b' => 'B',
-            default => throw new \InvalidArgumentException("Invalid code [$in]"),
+            default => throw new \InvalidArgumentException("Invalid code [$in]")
         };
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: none
Breaking change: no

When the this code is parsed the following error will be shown.

```php
<?php
class Foo {
    public function bar($in) {
        return match ($in) {
             'a' => 'A',
             'b' => 'B',
             default => throw new \InvalidArgumentException((string) $in)
        };
    }
}
```

Error:

```
Unexpected token: }, line: 8, col: 9, file: /tmp/p.php.
#0 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(7395): PDepend\Source\Parser\UnexpectedTokenException->__construct()
#1 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(7361): PDepend\Source\Language\PHP\AbstractPHPParser->getUnexpectedTokenException()
#2 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(6165): PDepend\Source\Language\PHP\AbstractPHPParser->consumeToken()
#3 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(3249): PDepend\Source\Language\PHP\AbstractPHPParser->parseNonePhpCode()
#4 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(3301): PDepend\Source\Language\PHP\AbstractPHPParser->parseStatementTermination()
#5 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(5315): PDepend\Source\Language\PHP\AbstractPHPParser->parseThrowStatement()
#6 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(5341): PDepend\Source\Language\PHP\AbstractPHPParser->parseMatchEntryValue()
#7 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php(248): PDepend\Source\Language\PHP\AbstractPHPParser->parseMatchEntry()
#8 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(4036): PDepend\Source\Language\PHP\PHPParserVersion80->parseFunctionPostfix()
#9 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(4499): PDepend\Source\Language\PHP\AbstractPHPParser->parseMemberPrefixOrFunctionPostfix()
#10 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(2778): PDepend\Source\Language\PHP\AbstractPHPParser->parseVariableOrConstantOrPrimaryPrefix()
#11 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(3837): PDepend\Source\Language\PHP\AbstractPHPParser->parseOptionalExpression()
#12 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(3855): PDepend\Source\Language\PHP\AbstractPHPParser->buildReturnStatement()
#13 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(6066): PDepend\Source\Language\PHP\AbstractPHPParser->parseReturnStatement()
#14 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(6003): PDepend\Source\Language\PHP\AbstractPHPParser->parseOptionalStatement()
#15 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(1279): PDepend\Source\Language\PHP\AbstractPHPParser->parseScope()
#16 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(1231): PDepend\Source\Language\PHP\AbstractPHPParser->parseCallableDeclaration()
#17 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(988): PDepend\Source\Language\PHP\AbstractPHPParser->parseMethodDeclaration()
#18 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php(87): PDepend\Source\Language\PHP\AbstractPHPParser->parseMethodOrFieldDeclaration()
#19 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(887): PDepend\Source\Language\PHP\PHPParserVersion74->parseMethodOrFieldDeclaration()
#20 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(723): PDepend\Source\Language\PHP\AbstractPHPParser->parseTypeBody()
#21 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(6134): PDepend\Source\Language\PHP\AbstractPHPParser->parseClassDeclaration()
#22 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php(397): PDepend\Source\Language\PHP\AbstractPHPParser->parseOptionalStatement()
#23 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Engine.php(587): PDepend\Source\Language\PHP\AbstractPHPParser->parse()
#24 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/Engine.php(335): PDepend\Engine->performParseProcess()
#25 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/TextUI/Runner.php(314): PDepend\Engine->analyze()
#26 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/TextUI/Command.php(243): PDepend\TextUI\Runner->run()
#27 /home/lucas/workspace/pdepend/pdepend/src/main/php/PDepend/TextUI/Command.php(627): PDepend\TextUI\Command->run()
#28 /home/lucas/workspace/pdepend/pdepend/src/bin/pdepend.php(67): PDepend\TextUI\Command::main()
#29 {main}

```

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->
