### PR TITLE
Allow match to have multiple expressions as key

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5328,7 +5328,16 @@ abstract class AbstractPHPParser
 
         $matchEntry = $this->builder->buildAstMatchEntry();
 
-        $matchEntry->addChild($this->parseMatchEntryKey());
+        do {
+            $matchEntry->addChild($this->parseMatchEntryKey());
+
+            if ($this->tokenizer->peek() === Tokens::T_COMMA) {
+                $this->consumeToken(Tokens::T_COMMA);
+                $this->consumeComments();
+            }
+
+            $type = $this->tokenizer->peek();
+        } while ($type != Tokens::T_DOUBLE_ARROW);
 
         $this->consumeComments();
         $this->consumeToken(Tokens::T_DOUBLE_ARROW);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5330,6 +5330,7 @@ abstract class AbstractPHPParser
 
         do {
             $matchEntry->addChild($this->parseMatchEntryKey());
+            $this->consumeComments();
 
             if ($this->tokenizer->peek() === Tokens::T_COMMA) {
                 $this->consumeToken(Tokens::T_COMMA);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -128,6 +128,83 @@ class MatchExpressionTest extends PHPParserVersion80Test
             return array(get_class($node), $node->getImage());
         }, $new->getChild(1)->getChild(0)->getChildren()));
     }
+    /**
+     * @return void
+     */
+    public function testMatchExpressionWithMultipleKeyExpressions()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTReturnStatement[] $returns */
+        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $match = $returns[0]->getChild(0);
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $match);
+        $this->assertSame('match', $match->getImage());
+        /**
+         * @var array{
+         *     \PDepend\Source\AST\ASTIdentifier,
+         *     \PDepend\Source\AST\ASTMatchArgument,
+         *     \PDepend\Source\AST\ASTMatchBlock,
+         * } $children
+         */
+        $children = $match->getChildren();
+        $this->assertCount(3, $children);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchArgument', $children[1]);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchBlock', $children[2]);
+        $this->assertSame('match', $children[0]->getImage());
+        /** @var \PDepend\Source\AST\ASTVariable[] $arguments */
+        $arguments = $children[1]->getChildren();
+        $this->assertCount(1, $arguments);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $arguments[0]);
+        $this->assertSame('$in', $arguments[0]->getImage());
+        /** @var \PDepend\Source\AST\ASTMatchEntry[] $entries */
+        $entries = $children[2]->getChildren();
+        $this->assertCount(3, $entries);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[0]);
+        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $literals = $entries[0]->getChildren();
+        $this->assertCount(3, $literals);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertSame("'a'", $literals[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertSame("'b'", $literals[1]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[2]);
+        $this->assertSame("'AB'", $literals[2]->getImage());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[1]);
+        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $literals = $entries[1]->getChildren();
+        $this->assertCount(2, $literals);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertSame("1", $literals[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertSame("'One'", $literals[1]->getImage());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[2]);
+        /** @var array{\PDepend\Source\AST\ASTSwitchLabel, \PDepend\Source\AST\ASTThrowStatement} $pair */
+        $pair = $entries[2]->getChildren();
+        $this->assertCount(2, $pair);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $pair[0]);
+        $this->assertSame('default', $pair[0]->getImage());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertSame('throw', $pair[1]->getImage());
+        $this->assertCount(1, $pair[1]->getChildren());
+        $new = $pair[1]->getChild(0);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertSame('new', $new->getImage());
+        $this->assertSame(array('\InvalidArgumentException', ''), array_map(function ($node) {
+            return $node->getImage();
+        }, $new->getChildren()));
+        $this->assertSame(array(
+            array('PDepend\\Source\\AST\\ASTLiteral', 'Invalid code ['),
+            array('PDepend\\Source\\AST\\ASTVariable', '$in'),
+            array('PDepend\\Source\\AST\\ASTLiteral', ']'),
+        ), array_map(function ($node) {
+            return array(get_class($node), $node->getImage());
+        }, $new->getChild(1)->getChild(0)->getChildren()));
+    }
 
     /**
      * @expectedException \PDepend\Source\Parser\UnexpectedTokenException

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -128,6 +128,7 @@ class MatchExpressionTest extends PHPParserVersion80Test
             return array(get_class($node), $node->getImage());
         }, $new->getChild(1)->getChild(0)->getChildren()));
     }
+
     /**
      * @return void
      */

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithMultipleKeyExpressions.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/MatchExpression/testMatchExpressionWithMultipleKeyExpressions.php
@@ -1,0 +1,11 @@
+<?php
+class Foo
+{
+    public function bar($in) {
+        return match($in) {
+            'a', 'b' => 'AB',
+            1 => 'One',
+            default => throw new \InvalidArgumentException("Invalid code [$in]"),
+        };
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: Fix #543 
Breaking change: no

This PR introduces support for allowing multiple expressions as match key.

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->