### PR TITLE
[Github Actions] Skip Imagick install failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,9 @@ jobs:
           coverage: none
 
       - name: Imagick SVG support
-        run: sudo apt-get install libmagickcore-6.q16-3-extra
+        run: |
+          sudo apt-get clean
+          sudo apt-get install libmagickcore-6.q16-3-extra
 
       - name: Cache Composer packages
         id: composer-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,8 @@ jobs:
           coverage: none
 
       - name: Imagick SVG support
-        run: |
-          sudo apt-get clean
-          sudo apt-get install libmagickcore-6.q16-3-extra
+        continue-on-error: true
+        run: sudo apt-get install libmagickcore-6.q16-3-extra
 
       - name: Cache Composer packages
         id: composer-cache


### PR DESCRIPTION
The `apt-get install libmagickcore-6.q16-3-extra` command is just there to increase chances that the SVG test can be ran (not skipped), so we can continue the job if it fails for some reason.