### PR TITLE
Allow null and false in union type for typed properties

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7225,7 +7225,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTType|null
      * @since 0.9.6
      */
-    protected function parseFieldDeclarationType()
+    private function parseFieldDeclarationType()
     {
         // Skip, if ignore annotations is set
         if ($this->ignoreAnnotations === true) {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7225,7 +7225,7 @@ abstract class AbstractPHPParser
      * @return \PDepend\Source\AST\ASTType|null
      * @since 0.9.6
      */
-    private function parseFieldDeclarationType()
+    protected function parseFieldDeclarationType()
     {
         // Skip, if ignore annotations is set
         if ($this->ignoreAnnotations === true) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -57,20 +57,22 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion74 extends PHPParserVersion73
 {
+    protected $possiblePropertyTypes = array(
+        Tokens::T_STRING,
+        Tokens::T_ARRAY,
+        Tokens::T_QUESTION_MARK,
+        Tokens::T_BACKSLASH,
+        Tokens::T_CALLABLE,
+        Tokens::T_SELF,
+    );
+
     protected function parseUnknownDeclaration($tokenType, $modifiers)
     {
         /**
          * Typed properties
          * https://www.php.net/manual/en/migration74.new-features.php#migration74.new-features.core.typed-properties
          */
-        if (in_array($tokenType, array(
-            Tokens::T_STRING,
-            Tokens::T_ARRAY,
-            Tokens::T_QUESTION_MARK,
-            Tokens::T_BACKSLASH,
-            Tokens::T_CALLABLE,
-            Tokens::T_SELF,
-        ))) {
+        if (in_array($tokenType, $this->possiblePropertyTypes, true)) {
             $type = $this->parseTypeHint();
             $declaration = $this->parseFieldDeclaration();
             $declaration->prependChild($type);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -67,6 +67,17 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion80 extends PHPParserVersion74
 {
+    protected $possiblePropertyTypes = array(
+        Tokens::T_STRING,
+        Tokens::T_ARRAY,
+        Tokens::T_QUESTION_MARK,
+        Tokens::T_BACKSLASH,
+        Tokens::T_CALLABLE,
+        Tokens::T_SELF,
+        Tokens::T_NULL,
+        Tokens::T_FALSE,
+    );
+
     /**
      * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
      * name part.

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testNullableTypedProperties.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testNullableTypedProperties.php
@@ -1,0 +1,4 @@
+<?php
+class User {
+    public null|int|float $number;
+}


### PR DESCRIPTION
Type: bugfix
Issue: fix #533
Breaking change: no