### PR TITLE
Allow null-safe operator anywhere object operator is allowed

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -283,6 +283,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                  * Class::method or $object->method both only count as 1
                  * identifier, even though they consist of 3 tokens.
                  */
+                case Tokens::T_NULLSAFE_OBJECT_OPERATOR:
                 case Tokens::T_OBJECT_OPERATOR:
                 case Tokens::T_DOUBLE_COLON:
                     // Glue ->/:: and before & after parts together.

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -3945,10 +3945,30 @@ abstract class AbstractPHPParser
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
     {
         $this->consumeComments();
-        if (Tokens::T_OBJECT_OPERATOR === $this->tokenizer->peek()) {
+
+        if ($this->isNextTokenObjectOperator()) {
             return $this->parseMemberPrimaryPrefix($expr->getChild(0));
         }
+
         return $expr;
+    }
+
+    /**
+     * @eturn bool
+     */
+    protected function isNextTokenObjectOperator()
+    {
+        return $this->tokenizer->peek() === Tokens::T_OBJECT_OPERATOR;
+    }
+
+    /**
+     * @return \PDepend\Source\Tokenizer\Token
+     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     */
+    protected function consumeObjectOperatorToken()
+    {
+        return $this->consumeToken(Tokens::T_OBJECT_OPERATOR);
     }
 
     /**
@@ -4132,9 +4152,10 @@ abstract class AbstractPHPParser
     {
         $this->consumeComments();
 
-        if ($this->tokenizer->peek() === Tokens::T_OBJECT_OPERATOR) {
+        if ($this->isNextTokenObjectOperator()) {
             return $this->parseMemberPrimaryPrefix($node);
         }
+
         return $node;
     }
 
@@ -4161,7 +4182,7 @@ abstract class AbstractPHPParser
     protected function parseMemberPrimaryPrefix(ASTNode $node)
     {
         // Consume double colon and optional comments
-        $token = $this->consumeToken(Tokens::T_OBJECT_OPERATOR);
+        $token = $this->consumeObjectOperatorToken();
 
         $prefix = $this->builder->buildAstMemberPrimaryPrefix($token->image);
         $prefix->addChild($node);
@@ -4529,6 +4550,7 @@ abstract class AbstractPHPParser
             case Tokens::T_DOUBLE_COLON:
                 $result = $this->parseStaticMemberPrimaryPrefix($variable);
                 break;
+            case Tokens::T_NULLSAFE_OBJECT_OPERATOR:
             case Tokens::T_OBJECT_OPERATOR:
                 $result = $this->parseMemberPrimaryPrefix($variable);
                 break;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -423,7 +423,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             return $this->parseStaticMemberPrimaryPrefix($node);
         }
 
-        if ($this->tokenizer->peek() === Tokens::T_OBJECT_OPERATOR) {
+        if ($this->isNextTokenObjectOperator()) {
             return $this->parseMemberPrimaryPrefix($node);
         }
 
@@ -442,7 +442,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             return $this->parseStaticMemberPrimaryPrefix($expr->getChild(0));
         }
 
-        if ($this->tokenizer->peek() === Tokens::T_OBJECT_OPERATOR) {
+        if ($this->isNextTokenObjectOperator()) {
             $node = count($expr->getChildren()) === 0 ? $expr : $expr->getChild(0);
             return $this->parseMemberPrimaryPrefix($node);
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -381,6 +381,22 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return true;
     }
 
+    protected function isNextTokenObjectOperator()
+    {
+        return in_array($this->tokenizer->peek(), array(
+            Tokens::T_OBJECT_OPERATOR,
+            Tokens::T_NULLSAFE_OBJECT_OPERATOR,
+        ), true);
+    }
+
+    protected function consumeObjectOperatorToken()
+    {
+        return $this->consumeToken($this->tokenizer->peek() === Tokens::T_NULLSAFE_OBJECT_OPERATOR
+            ? Tokens::T_NULLSAFE_OBJECT_OPERATOR
+            : Tokens::T_OBJECT_OPERATOR
+        );
+    }
+
     protected function parseThrowExpression()
     {
         if ($this->tokenizer->peek() === Tokens::T_THROW) {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -91,6 +91,7 @@ class NullsafeOperatorTest extends PHPParserVersion80Test
             $chain[] = $node->getImage();
         }
 
-        $this->assertSame(array('$this', '->', 'a', '?->', 'b', '->'), $chain);
+        $nullSafe = static::isLowerThanPHP80() ? '->' : '?->';
+        $this->assertSame(array('$this', '->', 'a', $nullSafe, 'b', '->'), $chain);
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -40,6 +40,7 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
+use PDepend\Source\AST\ASTEchoStatement;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
@@ -75,11 +76,21 @@ class NullsafeOperatorTest extends PHPParserVersion80Test
     {
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
-        /** @var ASTVariableDeclarator $variable */
-        $variable = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator'
-        );
+        /** @var ASTEchoStatement $variable */
+        $echo = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTEchoStatement');
+        $chain = array();
+        $node = $echo;
 
-        $this->assertSame('$obj', $variable->getImage());
+        while ($node = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix')) {
+            if ($variable = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable')) {
+                $chain[] = $variable->getImage();
+            } elseif ($property = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTPropertyPostfix')) {
+                $chain[] = $property->getImage();
+            }
+
+            $chain[] = $node->getImage();
+        }
+
+        $this->assertSame(array('$this', '->', 'a', '?->', 'b', '->'), $chain);
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -66,4 +66,20 @@ class NullsafeOperatorTest extends PHPParserVersion80Test
 
         $this->assertSame('$obj', $variable->getImage());
     }
+
+    /**
+     * @return void
+     * @group i
+     */
+    public function testNullsafeOperatorChain()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTVariableDeclarator $variable */
+        $variable = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+        );
+
+        $this->assertSame('$obj', $variable->getImage());
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80Test.php
@@ -52,8 +52,13 @@ abstract class PHPParserVersion80Test extends AbstractTest
 {
     protected static function needsPHP80()
     {
-        if (version_compare(PHP_VERSION, '8.0.0-dev', '<')) {
+        if (static::isLowerThanPHP80()) {
             self::markTestSkipped('Requires at least PHP 8.0');
         }
+    }
+
+    protected static function isLowerThanPHP80()
+    {
+        return version_compare(PHP_VERSION, '8.0.0-dev', '<');
     }
 }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP80/NullsafeOperator/testNullsafeOperatorChain.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP80/NullsafeOperator/testNullsafeOperatorChain.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar()
+    {
+        echo $this->a?->b->c;
+    }
+}


### PR DESCRIPTION
Type: bugfix
Issue: fix #548
Breaking change: no