### PR TITLE
Allow to omit semi-colon before PHP close tag

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -3192,11 +3192,22 @@ abstract class AbstractPHPParser
     {
         $this->consumeToken($tokenType);
         $this->consumeComments();
+        $this->parseStatementEnd();
+    }
 
-        if ($this->tokenizer->peek() === Tokens::T_SEMICOLON) {
-            $this->consumeToken(Tokens::T_SEMICOLON);
-        } else {
-            $this->parseNonePhpCode();
+    private function parseStatementEnd()
+    {
+        switch ($this->tokenizer->peek()) {
+            case Tokens::T_CLOSE_TAG:
+                return;
+
+            case Tokens::T_SEMICOLON:
+                $this->consumeToken(Tokens::T_SEMICOLON);
+
+                return;
+
+            default:
+                $this->parseNonePhpCode();
         }
     }
 
@@ -3955,11 +3966,7 @@ abstract class AbstractPHPParser
             return;
         }
 
-        if ($this->tokenizer->peek() === Tokens::T_SEMICOLON) {
-            $this->consumeToken(Tokens::T_SEMICOLON);
-        } else {
-            $this->parseNonePhpCode();
-        }
+        $this->parseStatementEnd();
     }
 
     /**

--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -2633,15 +2633,18 @@ abstract class AbstractPHPParser
             $tokens = $this->stripTrailingComments($tokens);
         }
 
-        $end = $tokens[count($tokens) - 1];
-        $start = $tokens[0];
+        $count = count($tokens);
+        if ($count >= 1) {
+            $end = $tokens[$count - 1];
+            $start = $tokens[0];
 
-        $node->configureLinesAndColumns(
-            $start->startLine,
-            $end->endLine,
-            $start->startColumn,
-            $end->endColumn,
-        );
+            $node->configureLinesAndColumns(
+                $start->startLine,
+                $end->endLine,
+                $start->startColumn,
+                $end->endColumn,
+            );
+        }
 
         return $node;
     }
@@ -3069,11 +3072,13 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTStatement
      *
-     * @param T $stmt The owning statement.
+     * @param T   $stmt           The owning statement.
+     * @param int $statementToken The token type of the statement (if, else, for, etc.)
+     *
      * @return T
      * @since 0.9.12
      */
-    private function parseStatementBody(ASTStatement $stmt): ASTStatement
+    private function parseStatementBody(ASTStatement $stmt, int $statementToken): ASTStatement
     {
         $this->consumeComments();
         $tokenType = $this->tokenizer->peek();
@@ -3081,7 +3086,7 @@ abstract class AbstractPHPParser
         if ($tokenType === Tokens::T_CURLY_BRACE_OPEN) {
             $stmt->addChild($this->parseRegularScope());
         } elseif ($tokenType === Tokens::T_COLON) {
-            $stmt->addChild($this->parseAlternativeScope());
+            $stmt->addChild($this->parseAlternativeScope($statementToken));
         } else {
             $stmt->addChild($this->parseStatement());
         }
@@ -3113,16 +3118,18 @@ abstract class AbstractPHPParser
      * Parses the scope of a statement that is surrounded with PHP's alternative
      * syntax for statements.
      *
+     * @param int $statementToken The token type of the statement (if, else, for, etc.)
+     *
      * @since 0.10.0
      */
-    private function parseAlternativeScope(): ASTScopeStatement
+    private function parseAlternativeScope(int $statementToken): ASTScopeStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_COLON);
 
         $scope = $this->parseScopeStatements();
 
-        $this->parseOptionalAlternativeScopeTermination();
+        $this->parseOptionalAlternativeScopeTermination($statementToken);
 
         return $this->setNodePositionsAndReturn($scope);
     }
@@ -3148,11 +3155,21 @@ abstract class AbstractPHPParser
      * Parses the termination of a scope statement that uses PHP's laternative
      * syntax format.
      *
+     * @param int $statementToken The token type of the statement (if, else, for, etc.)
+     *
      * @since 0.10.0
      */
-    private function parseOptionalAlternativeScopeTermination(): void
+    private function parseOptionalAlternativeScopeTermination(int $statementToken): void
     {
         $tokenType = $this->tokenizer->peek();
+
+//        if (in_array($statementToken, array(Tokens::T_IF, Tokens::T_ELSEIF), true) &&
+//            in_array($tokenType, array(Tokens::T_ELSEIF, Tokens::T_ELSE), true)
+//        ) {
+//            $this->consumeComments();
+//            $this->parseStatementEnd();
+//        }
+
         if ($this->isAlternativeScopeTermination($tokenType)) {
             $this->parseAlternativeScopeTermination($tokenType);
         }
@@ -3198,8 +3215,8 @@ abstract class AbstractPHPParser
     private function parseStatementEnd()
     {
         switch ($this->tokenizer->peek()) {
-            case Tokens::T_CLOSE_TAG:
-                return;
+//            case Tokens::T_CLOSE_TAG:
+//                return;
 
             case Tokens::T_SEMICOLON:
                 $this->consumeToken(Tokens::T_SEMICOLON);
@@ -4203,7 +4220,7 @@ abstract class AbstractPHPParser
         $stmt = $this->builder->buildAstIfStatement($token->image);
         $stmt->addChild($this->parseParenthesisExpression());
 
-        $this->parseStatementBody($stmt);
+        $this->parseStatementBody($stmt, Tokens::T_IF);
         $this->parseOptionalElseOrElseIfStatement($stmt);
 
         return $this->setNodePositionsAndReturn($stmt);
@@ -4222,7 +4239,7 @@ abstract class AbstractPHPParser
         $stmt = $this->builder->buildAstElseIfStatement($token->image);
         $stmt->addChild($this->parseParenthesisExpression());
 
-        $this->parseStatementBody($stmt);
+        $this->parseStatementBody($stmt, Tokens::T_ELSEIF);
         $this->parseOptionalElseOrElseIfStatement($stmt);
 
         return $this->setNodePositionsAndReturn($stmt);
@@ -4247,7 +4264,7 @@ abstract class AbstractPHPParser
                 if ($this->tokenizer->peek() === Tokens::T_IF) {
                     $stmt->addChild($this->parseIfStatement());
                 } else {
-                    $this->parseStatementBody($stmt);
+                    $this->parseStatementBody($stmt, Tokens::T_ELSE);
                 }
 
                 break;
@@ -4292,7 +4309,7 @@ abstract class AbstractPHPParser
         }
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
-        return $this->setNodePositionsAndReturn($this->parseStatementBody($stmt));
+        return $this->setNodePositionsAndReturn($this->parseStatementBody($stmt, Tokens::T_FOR));
     }
 
     /**
@@ -4427,7 +4444,7 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         return $this->setNodePositionsAndReturn(
-            $this->parseStatementBody($foreach),
+            $this->parseStatementBody($foreach, Tokens::T_FOREACH),
         );
     }
 
@@ -4445,7 +4462,7 @@ abstract class AbstractPHPParser
         $stmt->addChild($this->parseParenthesisExpression());
 
         return $this->setNodePositionsAndReturn(
-            $this->parseStatementBody($stmt),
+            $this->parseStatementBody($stmt, Tokens::T_WHILE),
         );
     }
 
@@ -4460,7 +4477,7 @@ abstract class AbstractPHPParser
         $token = $this->consumeToken(Tokens::T_DO);
 
         $stmt = $this->builder->buildAstDoWhileStatement($token->image);
-        $stmt = $this->parseStatementBody($stmt);
+        $stmt = $this->parseStatementBody($stmt, Tokens::T_DO);
 
         $this->consumeComments();
         $this->consumeToken(Tokens::T_WHILE);
@@ -4502,7 +4519,7 @@ abstract class AbstractPHPParser
 
         $stmt = $this->builder->buildAstDeclareStatement();
         $stmt = $this->parseDeclareList($stmt);
-        $stmt = $this->parseStatementBody($stmt);
+        $stmt = $this->parseStatementBody($stmt, Tokens::T_DECLARE);
 
         return $this->setNodePositionsAndReturn($stmt);
     }
@@ -7276,7 +7293,9 @@ abstract class AbstractPHPParser
      */
     private function parseNonePhpCode(): int
     {
-        $this->consumeToken(Tokens::T_CLOSE_TAG);
+        if ($this->tokenizer->peek() !== Tokenizer::T_EOF) {
+            $this->consumeToken(Tokens::T_CLOSE_TAG);
+        }
 
         $this->tokenStack->push();
         while (($tokenType = $this->tokenizer->peek()) !== Tokenizer::T_EOF) {

--- a/tests/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -274,6 +274,8 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementTerminatedByPhpCloseTag
+     *
+     * @group end-st
      */
     public function testForStatementTerminatedByPhpCloseTag(): void
     {

--- a/tests/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -250,10 +250,14 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementTerminatedByPhpCloseTag
+     *
+     * @group end-st
      */
     public function testForeachStatementTerminatedByPhpCloseTag(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction();
+        var_dump($stmt->getImage(), $stmt->getStartColumn(), $stmt->getEndColumn());
+        exit;
         static::assertEquals(9, $stmt->getEndColumn());
     }
 

--- a/tests/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -220,6 +220,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementTerminatedByPhpCloseTag
+     *
+     * @group end-st
      */
     public function testSwitchStatementTerminatedByPhpCloseTag(): void
     {

--- a/tests/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -186,6 +186,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementTerminatedByPhpCloseTag
+     *
+     * @group end-st
      */
     public function testWhileStatementTerminatedByPhpCloseTag(): void
     {

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -500,6 +500,10 @@ class PHPParserGenericTest extends AbstractTestCase
         static::assertEmpty($this->parseCodeResourceForTest());
     }
 
+    /**
+     * @group end-st
+     * @group i
+     */
     public function testOptionalSemiColon(): void
     {
         $template = $this->parseCodeResourceForTest();

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -500,6 +500,12 @@ class PHPParserGenericTest extends AbstractTestCase
         static::assertEmpty($this->parseCodeResourceForTest());
     }
 
+    public function testOptionalSemiColon(): void
+    {
+        $template = $this->parseCodeResourceForTest();
+        $this->assertNotNull($template);
+    }
+
     /**
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testOptionalSemiColon.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testOptionalSemiColon.php
@@ -1,0 +1,6 @@
+<?php if (true): ?>
+    <?php if (true): ?>
+    <?php endif ?>
+<?php else: ?>
+<?php endif ?>
+

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testOptionalSemiColon.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testOptionalSemiColon.php
@@ -3,4 +3,3 @@
     <?php endif ?>
 <?php else: ?>
 <?php endif ?>
-


### PR DESCRIPTION
Type: bug
Issue: Fix https://github.com/phpmd/phpmd/issues/892
Breaking change: no