### PR TITLE
Don't reset value of ASTFormalParameter::$modifiers when sleep

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -256,4 +256,9 @@ class ASTFormalParameter extends AbstractASTNode
     {
         return ($this->getModifiers() & State::IS_PRIVATE) === State::IS_PRIVATE;
     }
+
+    public function __sleep()
+    {
+        return array_merge(array('modifiers'), parent::__sleep());
+    }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -249,6 +249,7 @@ class ASTFormalParameterTest extends ASTNodeTest
         $param = $this->createNodeInstance();
         $this->assertEquals(
             array(
+                'modifiers',
                 'comment',
                 'metadata',
                 'nodes'


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Don't reset value of ASTFormalParameter::$modifiers when sleep


```php
$param = new ASTFormalParameter();
$param->setModifiers(State::IS_PRIVATE);

// Current Behavior        
var_dump(unserialize(serialize($param))); // ASTFormalParameter::$modifiers => 0

// this PR
var_dump(unserialize(serialize($param))); // ASTFormalParameter::$modifiers => 4
```
