### PR TITLE
Allow trailing commas in isset() and unset()

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2199,9 +2199,11 @@ abstract class AbstractPHPParser
         $startToken = $this->consumeToken(Tokens::T_ISSET);
         $this->consumeComments();
         $this->consumeToken(Tokens::T_PARENTHESIS_OPEN);
+        $this->consumeComments();
 
         $expr = $this->builder->buildAstIssetExpression();
-        $expr = $this->parseVariableList($expr);
+        $expr = $this->parseVariableList($expr, true);
+        $this->consumeComments();
 
         $stopToken = $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
@@ -2213,6 +2215,11 @@ abstract class AbstractPHPParser
         );
 
         return $expr;
+    }
+
+    protected function allowTrailingCommaInSpecialFunctions()
+    {
+        return false;
     }
 
     /**
@@ -3388,9 +3395,11 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_UNSET);
         $this->consumeComments();
         $this->consumeToken(Tokens::T_PARENTHESIS_OPEN);
+        $this->consumeComments();
 
         $stmt = $this->builder->buildAstUnsetStatement();
-        $stmt = $this->parseVariableList($stmt);
+        $stmt = $this->parseVariableList($stmt, true);
+        $this->consumeComments();
 
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
@@ -4894,16 +4903,24 @@ abstract class AbstractPHPParser
      * @return T The prepared entire node.
      * @since 0.9.12
      */
-    private function parseVariableList(ASTNode $node)
+    private function parseVariableList(ASTNode $node, $inCall = false)
     {
         $this->consumeComments();
         while ($this->tokenizer->peek() !== Tokenizer::T_EOF) {
             $node->addChild($this->parseVariableOrConstantOrPrimaryPrefix());
 
             $this->consumeComments();
+
             if ($this->tokenizer->peek() === Tokens::T_COMMA) {
                 $this->consumeToken(Tokens::T_COMMA);
                 $this->consumeComments();
+
+                if ($inCall &&
+                    $this->allowTrailingCommaInSpecialFunctions() &&
+                    $this->tokenizer->peek() === Tokens::T_PARENTHESIS_CLOSE
+                ) {
+                    break;
+                }
             } else {
                 break;
             }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
@@ -52,4 +52,8 @@ namespace PDepend\Source\Language\PHP;
  */
 abstract class PHPParserVersion73 extends PHPParserVersion72
 {
+    protected function allowTrailingCommaInSpecialFunctions()
+    {
+        return true;
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -41,10 +41,8 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTest;
-use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
-use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\Builder\Builder;

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -41,8 +41,10 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\Builder\Builder;
@@ -125,5 +127,14 @@ class PHPParserVersion72Test extends AbstractTest
             'PDepend\\Source\\Language\\PHP\\PHPParserVersion72',
             array($tokenizer, $builder, $cache)
         );
+    }
+
+    /**
+     * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
+     * @expectedExceptionMessage Unexpected token: ), line: 4, col: 14
+     */
+    public function testTrailingCommasInUnsetCall()
+    {
+        $this->parseCodeResourceForTest();
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
@@ -199,6 +199,20 @@ class PHPParserVersion73Test extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testTrailingCommasInUnsetCall()
+    {
+        $functionChildren = $this->getFirstFunctionForTestCase()->getChildren();
+        $statements = $functionChildren[1]->getChildren();
+        /** @var ASTFunctionPostfix[] $calls */
+        $calls = $statements[0]->getChildren();
+
+        $this->assertCount(1, $calls);
+        $this->assertSame('$i', $calls[0]->getImage());
+    }
+
+    /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testTrailingCommasInUnsetCall.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion72/testTrailingCommasInUnsetCall.php
@@ -1,0 +1,5 @@
+<?php
+
+function remove(&$i) {
+    unset($i,);
+}

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion73/testTrailingCommasInUnsetCall.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion73/testTrailingCommasInUnsetCall.php
@@ -1,0 +1,5 @@
+<?php
+
+function remove(&$i) {
+    unset($i,);
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #560
Breaking change: no