### PR TITLE
PHP 8.1 support never return type

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -54,7 +54,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
  */
-class PHPParserGeneric extends PHPParserVersion80
+class PHPParserGeneric extends PHPParserVersion81
 {
     /**
      * Tests if the given token type is a reserved keyword in the supported PHP

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.11
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTCallable;
+use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\AST\State;
+use PDepend\Source\Parser\ParserException;
+use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Tokens;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 8.1.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @since 2.11
+ */
+abstract class PHPParserVersion81 extends PHPParserVersion80
+{
+    /**
+     * Tests if the given image is a PHP 8.1 type hint.
+     *
+     * @param string $image
+     * @return boolean
+     */
+    protected function isScalarOrCallableTypeHint($image)
+    {
+        if (strtolower($image) === 'never') {
+           return true;
+        }
+
+        return parent::isScalarOrCallableTypeHint($image);
+    }
+
+    /**
+     * Parses a scalar type hint or a callable type hint.
+     *
+     * @param string $image
+     * @return \PDepend\Source\AST\ASTType
+     */
+    protected function parseScalarOrCallableTypeHint($image)
+    {
+        if (strtolower($image) === 'never') {
+            return $this->builder->buildAstScalarType($image);
+        }
+
+        return parent::parseScalarOrCallableTypeHint($image);
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP81;
+
+use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTMethod;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ * @group unittest
+ * @group php8
+ */
+class NeverReturnTypeTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testFunctionReturnType()
+    {
+        $type = $this->getFirstFunctionForTestCase()->getReturnType();
+
+        $this->assertTrue($type->isScalar());
+        $this->assertSame('never', $type->getImage());
+    }
+    /**
+     * @return void
+     */
+    public function testMethodReturnType()
+    {
+        $type = $this->getFirstMethodForTestCase()->getReturnType();
+
+        $this->assertTrue($type->isScalar());
+        $this->assertSame('never', $type->getImage());
+    }
+
+    /**
+     * testClosureReturnTypeHintString
+     *
+     * @return void
+     */
+    public function testClosureReturnType()
+    {
+        $type = $this->getFirstClosureForTestCase()->getReturnType();
+
+        $this->assertTrue($type->isScalar());
+        $this->assertSame('never', $type->getImage());
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testClosureReturnType.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testClosureReturnType.php
@@ -1,0 +1,8 @@
+<?php
+function testClosureReturnType() {
+    $x = function() : never {
+        exit;
+    };
+
+    $x();
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testFunctionReturnType.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testFunctionReturnType.php
@@ -1,0 +1,5 @@
+<?php
+function dd(): never
+{
+    exit;
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testMethodReturnType.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/NeverReturnType/testMethodReturnType.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function dd(): never
+    {
+        exit;
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: #556
Breaking change: no

Introduced the new `never` return type introduced in PHP 8.1
RFC: https://wiki.php.net/rfc/noreturn_type

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->