### PR TITLE
Fix const, field, method named readonly

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -442,6 +442,8 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * BuilderContext sensitive alternative mappings.
      *
+     * Re-map based on the previous token
+     *
      * @var array<integer, array>
      */
     protected static $alternativeMap = array(
@@ -545,6 +547,13 @@ class PHPTokenizerInternal implements FullTokenizer
 
         Tokens::T_CLASS => array(
             Tokens::T_DOUBLE_COLON     => Tokens::T_CLASS_FQN,
+        ),
+
+        Tokens::T_READONLY => array(
+            Tokens::T_OBJECT_OPERATOR  => Tokens::T_STRING,
+            Tokens::T_FUNCTION         => Tokens::T_STRING,
+            Tokens::T_CONST            => Tokens::T_STRING,
+            Tokens::T_DOUBLE_COLON     => Tokens::T_STRING,
         ),
     );
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -94,7 +94,35 @@ class ReadonlyPropertiesTest extends AbstractTest
     public function testReadonlyNameUsedElsewhere()
     {
         $class = $this->getFirstClassForTestCase();
+
+        $constant = $class->getChild(0);
+        $this->assertSame('readonly', $constant->getChild(0)->getImage());
+
+        $propertyPostfix = $class->getChild(1);
+        $this->assertSame('$readonly', $propertyPostfix->getChild(1)->getImage());
+
+        $expectedModifiers = ~State::IS_PUBLIC & ~State::IS_READONLY;
+        $this->assertSame(0, ($expectedModifiers & $propertyPostfix->getModifiers()));
+
+        /** @var ASTMethod $constructor */
         $constructor = $class->getMethods()->offsetGet(0);
         $this->assertSame('__construct', $constructor->getName());
+        $constructorNodes = $constructor->getChildren();
+        $assignment = $constructorNodes[1]->getChild(0)->getChild(0);
+
+        $propertyPostfix = $assignment->getChild(0)->getChild(1);
+        self::assertInstanceOf('PDepend\\Source\\AST\\ASTPropertyPostfix', $propertyPostfix);
+        $this->assertSame('readonly', $propertyPostfix->getImage());
+
+        $methodPostfix = $assignment->getChild(1)->getChild(1);
+        self::assertInstanceOf('PDepend\\Source\\AST\\ASTMethodPostfix', $methodPostfix);
+        $this->assertSame('readonly', $methodPostfix->getImage());
+
+        $method = $class->getMethods()->offsetGet(1);
+        $this->assertSame('readonly', $method->getName());
+
+        $methodNodes = $method->getChildren();
+        $constantCall = $methodNodes[1]->getChild(0)->getChild(0);
+        $this->assertSame('readonly', $constantCall->getChild(1)->getImage());
     }
 }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyNameUsedElsewhere.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyNameUsedElsewhere.php
@@ -1,15 +1,17 @@
 <?php
 class Foo
 {
-    public string $readonly;
+    const readonly = 'baz';
+
+    public readonly string $readonly;
 
     public function __construct()
     {
-        $this->readonly = 'foo';
+        $this->readonly = $this->readonly();
     }
 
-    public function readonly($readonly)
+    public function readonly()
     {
-
+        return self::readonly;
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: #566
Breaking change: no

Fix parsing of code with:
- constants named `readonly`
- invoking constants named `readonly`
- calling methods named `readonly`
- calling properties named `readonly`

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->