### PR TITLE
PHP 8.1 support final constants

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -95,7 +95,7 @@ class ASTConstantDefinition extends AbstractASTNode
         if (($expected & $modifiers) !== 0) {
             throw new \InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
-                'IS_PUBLIC, IS_PROTECTED and IS_PRIVATE.'
+                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_FINAL.'
             );
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -89,7 +89,8 @@ class ASTConstantDefinition extends AbstractASTNode
     {
         $expected = ~State::IS_PUBLIC
             & ~State::IS_PROTECTED
-            & ~State::IS_PRIVATE;
+            & ~State::IS_PRIVATE
+            & ~State::IS_FINAL;
 
         if (($expected & $modifiers) !== 0) {
             throw new \InvalidArgumentException(

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -348,7 +348,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
                 $image = $declarator->getImage();
                 $value = $declarator->getValue()->getValue();
 
-                $this->constants[$image] = $value;
+                $this->constants[$image] = $declarator;
             }
         }
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -348,7 +348,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
                 $image = $declarator->getImage();
                 $value = $declarator->getValue()->getValue();
 
-                $this->constants[$image] = $declarator;
+                // TODO: think about it :/
+                $this->constants[$image] = $value;
             }
         }
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -75,6 +75,13 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     protected $constants = null;
 
     /**
+     * An <b>array</b> with all constant declarators defined in this class or interface.
+     *
+     * @var array<string, mixed>
+     */
+    protected $constantDeclarators = null;
+
+    /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
      * @return \PDepend\Source\AST\ASTClass|null
@@ -159,7 +166,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a node iterator with all implemented interfaces.
      *
-     * @return ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>
+     * @return ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>|\PDepend\Source\AST\AbstractASTClassOrInterface[]
      * @since  0.9.5
      */
     public function getInterfaces()
@@ -221,6 +228,19 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
             $this->initConstants();
         }
         return $this->constants;
+    }
+
+    /**
+     * Returns an <b>array</b> with all constant declarators defined in this class or interface.
+     *
+     * @return array<string, mixed>
+     */
+    public function getConstantDeclarators()
+    {
+        if ($this->constantDeclarators === null) {
+            $this->initConstantDeclarators();
+        }
+        return $this->constantDeclarators;
     }
 
     /**
@@ -328,14 +348,33 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     private function initConstants()
     {
         $this->constants = array();
+        $declarators = $this->getConstantDeclarators();
+
+        foreach ($declarators as $declarator) {
+            $image = $declarator->getImage();
+            $value = $declarator->getValue()->getValue();
+
+            $this->constants[$image] = $value;
+        }
+    }
+
+    /**
+     * This method initializes the constants defined in this class or interface.
+     *
+     * @return void
+     * @since  0.9.6
+     */
+    private function initConstantDeclarators()
+    {
+        $this->constantDeclarators = array();
         if (($parentClass = $this->getParentClass()) !== null) {
-            $this->constants = $parentClass->getConstants();
+            $this->constantDeclarators = $parentClass->getConstantDeclarators();
         }
 
         foreach ($this->getInterfaces() as $interface) {
-            $this->constants = array_merge(
-                $this->constants,
-                $interface->getConstants()
+            $this->constantDeclarators = array_merge(
+                $this->constantDeclarators,
+                $interface->getConstantDeclarators()
             );
         }
 
@@ -346,10 +385,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
 
             foreach ($declarators as $declarator) {
                 $image = $declarator->getImage();
-                $value = $declarator->getValue()->getValue();
 
-                // TODO: think about it :/
-                $this->constants[$image] = $value;
+                $this->constantDeclarators[$image] = $declarator;
             }
         }
     }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1000,6 +1000,11 @@ abstract class AbstractPHPParser
                     $declaration->setModifiers($modifiers);
 
                     return $declaration;
+                case Tokens::T_CONST:
+                    $declaration = $this->parseConstantDefinition();
+                    $declaration->setModifiers($modifiers);
+
+                    return $declaration;
                 default:
                     return $this->parseUnknownDeclaration($tokenType, $modifiers);
             }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1000,11 +1000,6 @@ abstract class AbstractPHPParser
                     $declaration->setModifiers($modifiers);
 
                     return $declaration;
-                case Tokens::T_CONST:
-                    $declaration = $this->parseConstantDefinition();
-                    $declaration->setModifiers($modifiers);
-
-                    return $declaration;
                 default:
                     return $this->parseUnknownDeclaration($tokenType, $modifiers);
             }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -86,7 +86,7 @@ class ASTConstantDefinitionTest extends ASTNodeTest
         $this->setExpectedException(
             'InvalidArgumentException',
             'Invalid field modifiers given, allowed modifiers are ' .
-            'IS_PUBLIC, IS_PROTECTED and IS_PRIVATE.'
+            'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_FINAL.'
         );
 
         $definition->setModifiers($modifiers);
@@ -391,7 +391,6 @@ class ASTConstantDefinitionTest extends ASTNodeTest
     {
         return array(
             array(State::IS_ABSTRACT),
-            array(State::IS_FINAL),
             array(State::IS_STATIC),
             array(
                 State::IS_PRIVATE |
@@ -400,10 +399,6 @@ class ASTConstantDefinitionTest extends ASTNodeTest
             array(
                 State::IS_PROTECTED |
                 State::IS_ABSTRACT
-            ),
-            array(
-                State::IS_PUBLIC |
-                State::IS_FINAL
             ),
             array(
                 State::IS_PUBLIC |

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -58,12 +58,12 @@ class FinalClassConstantTest extends AbstractTest
     public function testFinalClassConstant()
     {
         $class = $this->getFirstClassForTestCase();
-        $constants = $class->getConstants();
+        $constantDeclarators = $class->getConstantDeclarators();
 
-        $constant = $constants['BAR'];
-        $this->assertSame('BAR', $constant->getImage());
+        $constantDeclarator = $constantDeclarators['BAR'];
+        $this->assertSame('BAR', $constantDeclarator->getImage());
 
-        $constantDefinition = $constant->getParent();
+        $constantDefinition = $constantDeclarator->getParent();
         $expectedModifiers = ~State::IS_PRIVATE & ~State::IS_FINAL;
         $this->assertSame(0, ($expectedModifiers & $constantDefinition->getModifiers()));
     }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -50,39 +50,21 @@ use PDepend\Source\AST\State;
  * @group unittest
  * @group php8.1
  */
-class ReadonlyPropertiesTest extends AbstractTest
+class FinalClassConstantTest extends AbstractTest
 {
     /**
      * @return void
      */
-    public function testReadonlyProperty()
+    public function testFinalClassConstant()
     {
         $class = $this->getFirstClassForTestCase();
-        $property = $class->getChild(0);
+        $constants = $class->getConstants();
 
-        $this->assertSame('string', $property->getChild(0)->getImage());
-        $this->assertSame('$bar', $property->getChild(1)->getImage());
+        $constant = $constants['BAR'];
+        $this->assertSame('BAR', $constant->getImage());
 
-        $expectedModifiers = ~State::IS_PUBLIC & ~State::IS_READONLY;
-        $this->assertSame(0, ($expectedModifiers & $property->getModifiers()));
-    }
-
-    /**
-     * @return void
-     */
-    public function testReadonlyPropertyInConstructor()
-    {
-        $class = $this->getFirstClassForTestCase();
-        $constructor = $class->getMethods()->offsetGet(0);
-        $this->assertSame('__construct', $constructor->getName());
-
-        $parameters = $constructor->getParameters();
-        $parameter = $parameters[0];
-
-        $this->assertSame('string', $parameter->getFormalParameter()->getChild(0)->getImage());
-        $this->assertSame('$bar', $parameter->getFormalParameter()->getChild(1)->getImage());
-
-        $expectedModifiers = ~State::IS_PUBLIC & ~State::IS_READONLY;
-        $this->assertSame(0, ($expectedModifiers & $parameter->getFormalParameter()->getModifiers()));
+        $constantDefinition = $constant->getParent();
+        $expectedModifiers = ~State::IS_PRIVATE & ~State::IS_FINAL;
+        $this->assertSame(0, ($expectedModifiers & $constantDefinition->getModifiers()));
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -41,15 +41,13 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\AbstractTest;
-use PDepend\Source\AST\ASTClass;
-use PDepend\Source\AST\ASTMethod;
 
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @group unittest
- * @group php8
+ * @group php8.1
  */
 class NeverReturnTypeTest extends AbstractTest
 {
@@ -63,6 +61,7 @@ class NeverReturnTypeTest extends AbstractTest
         $this->assertTrue($type->isScalar());
         $this->assertSame('never', $type->getImage());
     }
+
     /**
      * @return void
      */
@@ -75,8 +74,6 @@ class NeverReturnTypeTest extends AbstractTest
     }
 
     /**
-     * testClosureReturnTypeHintString
-     *
      * @return void
      */
     public function testClosureReturnType()

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/FinalClassConstant/testFinalClassConstant.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/FinalClassConstant/testFinalClassConstant.php
@@ -1,0 +1,6 @@
+<?php
+
+class Foo
+{
+    final private const BAR = "BAZ";
+}


### PR DESCRIPTION
Type: feature
Issue: #556
Breaking change: no

<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->