### PR TITLE
Allow "readonly" as part of a class name

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -509,8 +509,10 @@ abstract class AbstractPHPParser
             case Tokens::T_TRAIT_C:
             case Tokens::T_CALLABLE:
             case Tokens::T_INSTEADOF:
+            case Tokens::T_READONLY:
                 return true;
         }
+
         return false;
     }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -76,8 +76,10 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
             case Tokens::T_TRUE:
             case Tokens::T_FALSE:
             case Tokens::T_STRING:
+            case Tokens::T_READONLY:
                 return true;
         }
+
         return false;
     }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -103,6 +103,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
             case Tokens::T_CALLABLE:
             case Tokens::T_INSTEADOF:
             case Tokens::T_NAMESPACE:
+            case Tokens::T_READONLY:
                 return true;
         }
 

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -392,6 +392,11 @@ class PHPParserVersion74Test extends AbstractTest
         $this->assertSame('A', $nodes[1]->getImage());
     }
 
+    public function testReadOnlyNamedImport()
+    {
+        $this->assertFalse($this->parseCodeResourceForTest()->current());
+    }
+
     /**
      * @expectedException \PDepend\Source\Parser\UnexpectedTokenException
      * @expectedExceptionMessage Unexpected token: ), line: 8, col: 27

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testReadOnlyNamedImport.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion74/testReadOnlyNamedImport.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Foo\Bar;
+
+use Somewhere\ReadOnly;


### PR DESCRIPTION
Type: bugfix
Issue: Fix #571
Breaking change: no