### PR TITLE
Support symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "type": "library",
     "require": {
         "php": ">=5.3.7",
-        "symfony/dependency-injection": "^2.3.0|^3|^4|^5",
-        "symfony/filesystem": "^2.3.0|^3|^4|^5",
-        "symfony/config": "^2.3.0|^3|^4|^5"
+        "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0",
+        "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0",
+        "symfony/config": "^2.3.0|^3|^4|^5|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36|^5.7.27",


### PR DESCRIPTION
Type: feature / refactoring

Allow `^6.0` in Symfony dependencies in `composer.json`.  Still checking if there's any breaking change for this library.