### PR TITLE
Cast doc comment in string in parseVarAnnotation

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7260,7 +7260,7 @@ abstract class AbstractPHPParser
      */
     private function parseVarAnnotation($comment)
     {
-        if (preg_match(self::REGEXP_VAR_TYPE, $comment, $match) > 0) {
+        if (preg_match(self::REGEXP_VAR_TYPE, (string) $comment, $match) > 0) {
             $useSymbolTable = $this->useSymbolTable;
 
             return array_map(


### PR DESCRIPTION
Proposal to cast `$comment` argument from `AbstractPHPParser::parseVarAnnotation` method into `string`, as it may be evaluated to `null`. In PHP 8.1, this case brings the following deprecation error: 
```
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php on line 7263
```

Type: bugfix
Breaking change: no