### PR TITLE
Declare ReturnTypeWillChange on internal overloads

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -111,6 +111,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return integer
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->artifacts);
@@ -121,6 +122,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return T|false
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if ($this->offset >= $this->count) {
@@ -134,6 +136,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->artifacts[$this->offset]->getName();
@@ -144,6 +147,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->offset;
@@ -154,6 +158,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->offset = 0;
@@ -164,6 +169,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return ($this->offset < $this->count);
@@ -179,6 +185,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->artifacts[$offset]);
@@ -193,6 +200,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->artifacts[$offset])) {
@@ -211,6 +219,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \BadMethodCallException('Not supported operation.');
@@ -225,6 +234,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetunset.php
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         throw new \BadMethodCallException('Not supported operation.');


### PR DESCRIPTION
Proposal to add the PHP Attribute `#[\ReturnTypeWillChange]` onto each method that overwrites internal methods for PHP 8.1.

As of PHP 8.1, the return types of these methods must be defined to not be understood as `: mixed`, and be incompatible with internal definition. Due to the fact pDepend must continue to work for PHP >= 5.3.7, we can't add the return type definitions as this is a feature for PHP >= 7. That's why I propose the use of this attribute.

Without this proposal, anyone will get the following deprecation errors when using pDepend on PHP 8.1:
```
Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 182

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 196

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 214

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 228

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 124

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 147

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 137

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 167

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 157

Deprecated: Return type of PDepend\Source\AST\ASTArtifactList::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/vendor/pdepend/pdepend/src/main/php/PDepend/Source/AST/ASTArtifactList.php on line 114
```

Due to the format of PHP Attributes syntax, this edition will have no effect on PHP < 8. On PHP 8.0, the attribute `ReturnTypeWillChange` has no effect. This is only to be compatible with PHP >= 8.1 and PHP < 9.

Type: bugfix
Breaking change: no
