### PR TITLE
Declare ReturnTypeWillChange on PHPBuilder::getIterator

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1916,6 +1916,7 @@ class PHPBuilder implements Builder
      *
      * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getNamespaces();


### PR DESCRIPTION
For the same reason as #576, this attribute should be placed here until the minimum PHP version supported by pDepend is 7.0.0.

For more details, please look at #576.

Type: bugfix
Breaking change: no
