### PR TITLE
Declare ReturnTypeWillChange on Iterator::accept

### DIFF
--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -85,6 +85,7 @@ class Iterator extends \FilterIterator
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         if ($this->getInnerIterator()->current()->isDir()) {


### PR DESCRIPTION
For the same reason as #576, this attribute should be placed here until the minimum PHP version supported by pDepend is 7.0.0.

For more details, please look at #576.

Type: bugfix
Breaking change: no