### PR TITLE
Fix deprecation messages

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -189,7 +189,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string
+     * @return string|null
      */
     public function getComment()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7385,7 +7385,7 @@ abstract class AbstractPHPParser
         }
 
         // Get all @throws Types
-        $throws = $this->parseThrowsAnnotations($callable->getComment());
+        $throws = $callable->getComment() === null ? array() : $this->parseThrowsAnnotations($callable->getComment());
         foreach ($throws as $qualifiedName) {
             $callable->addExceptionClassReference(
                 $this->builder->buildAstClassOrInterfaceReference($qualifiedName)
@@ -7398,7 +7398,7 @@ abstract class AbstractPHPParser
         }
 
         // Get return annotation
-        $qualifiedName = $this->parseReturnAnnotation($callable->getComment());
+        $qualifiedName = $callable->getComment() === null ? null : $this->parseReturnAnnotation($callable->getComment());
         if ($qualifiedName !== null) {
             $callable->setReturnClassReference(
                 $this->builder->buildAstClassOrInterfaceReference($qualifiedName)

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7385,7 +7385,9 @@ abstract class AbstractPHPParser
         }
 
         // Get all @throws Types
-        $throws = $callable->getComment() === null ? array() : $this->parseThrowsAnnotations($callable->getComment());
+        $comment = $callable->getComment();
+        $throws = $comment === null ? array() : $this->parseThrowsAnnotations($comment);
+
         foreach ($throws as $qualifiedName) {
             $callable->addExceptionClassReference(
                 $this->builder->buildAstClassOrInterfaceReference($qualifiedName)
@@ -7398,7 +7400,8 @@ abstract class AbstractPHPParser
         }
 
         // Get return annotation
-        $qualifiedName = $callable->getComment() === null ? null : $this->parseReturnAnnotation($callable->getComment());
+        $qualifiedName = $comment === null ? null : $this->parseReturnAnnotation($comment);
+
         if ($qualifiedName !== null) {
             $callable->setReturnClassReference(
                 $this->builder->buildAstClassOrInterfaceReference($qualifiedName)


### PR DESCRIPTION
Type: bugfix
Breaking change: no

Fix following deprecation messages (running with PHP 8.1)
```
Deprecated: preg_match_all(): Passing null to parameter #2 ($subject) of type string is deprecated in /path/to/vendor/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php on line 7218
Deprecated: preg_match(): Passing null to parameter #2 ($subject) of type string is deprecated in /path/to/vendor/pdepend/pdepend/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php on line 7237
```