### PR TITLE
Correct various class types

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -56,7 +56,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 class Application
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface|null
+     * @var \Symfony\Component\DependencyInjection\TaggedContainerInterface|null
      **/
     private $container;
 
@@ -121,7 +121,7 @@ class Application
     }
 
     /**
-     * @return \Symfony\Component\DependencyInjection\ContainerInterface
+     * @return \Symfony\Component\DependencyInjection\TaggedContainerInterface
      */
     private function getContainer()
     {
@@ -133,7 +133,7 @@ class Application
     }
 
     /**
-     * @return \Symfony\Component\DependencyInjection\ContainerInterface
+     * @return \Symfony\Component\DependencyInjection\TaggedContainerInterface
      */
     private function createContainer()
     {

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -65,21 +65,23 @@ class TreeBuilder
      * TreeBuilder constructor.
      *
      * @param string $name
-     *
-     * @return void
      */
     public function __construct($name = 'pdepend')
     {
         $this->treeBuilder = new BaseTreeBuilder($name);
 
-        if (!method_exists('Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder', 'getRootNode')) {
+        if (method_exists($this->treeBuilder, 'getRootNode')) {
+            $this->rootNode = $this->treeBuilder->getRootNode();
+
+            return;
+        }
+
+        if (method_exists($this->treeBuilder, 'root')) {
             // Symfony < 4.2
             $this->rootNode = $this->treeBuilder->root($name);
 
             return;
         }
-
-        $this->rootNode = $this->treeBuilder->getRootNode();
     }
 
     /**

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -117,7 +117,7 @@ class Engine
     /**
      * The used code node builder.
      *
-     * @var \PDepend\Source\Builder\Builder<\PDepend\Source\AST\ASTNamespace>|null
+     * @var PHPBuilder<\PDepend\Source\AST\ASTNamespace>|null
      */
     private $builder = null;
 

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -103,7 +103,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * restored the metrics it will return <b>TRUE</b>, otherwise the return
      * value will be <b>FALSE</b>.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
+     * @param  \PDepend\Source\AST\ASTFunction|\PDepend\Source\AST\ASTMethod|\PDepend\Source\AST\ASTInterface|\PDepend\Source\AST\ASTClass|\PDepend\Source\AST\ASTCompilationUnit $node
      * @return boolean
      */
     protected function restoreFromCache(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -132,7 +132,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Returns an array of all afferent nodes.
      *
      * @param  \PDepend\Source\AST\AbstractASTArtifact $node
-     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     * @return \PDepend\Source\AST\AbstractASTType[]
      */
     public function getAfferents(AbstractASTArtifact $node)
     {
@@ -147,7 +147,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Returns an array of all efferent nodes.
      *
      * @param  \PDepend\Source\AST\AbstractASTArtifact $node
-     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     * @return \PDepend\Source\AST\AbstractASTType[]
      */
     public function getEfferents(AbstractASTArtifact $node)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -88,8 +88,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     private $report = null;
 
     /**
-     *
-     * @var \PDepend\Metrics\Analyzer
+     * @var \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
      */
     private $ccnAnalyzer = null;
 
@@ -132,7 +131,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Adds an analyzer that this analyzer depends on.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer
+     * @param  \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer $analyzer
      * @return void
      */
     public function addAnalyzer(Analyzer $analyzer)
@@ -162,7 +161,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     private function doAnalyze($namespaces)
     {
         $this->metrics = array();
-        
+
         $this->ccnAnalyzer->analyze($namespaces);
 
         $this->fireStartAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -281,8 +281,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a switch label.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param \PDepend\Source\AST\ASTSwitchLabel $node The currently visited node.
+     * @param array<string, integer>             $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      * @since  0.9.8

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -66,9 +66,19 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     const M_MAINTAINABILITY_INDEX = 'mi';
 
     /**
-     * @var AbstractCachingAnalyzer[]
+     * @var CyclomaticComplexityAnalyzer
      */
-    private $analyzers = array();
+    private $analyzersCCN;
+
+    /**
+     * @var HalsteadAnalyzer
+     */
+    private $analyzersHalstead;
+
+    /**
+     * @var NodeLocAnalyzer
+     */
+    private $analyzersLOC;
 
     /**
      * Maintainability index is a combination of cyclomatic complexity,
@@ -81,9 +91,9 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     {
         parent::__construct($options);
 
-        $this->analyzers['ccn'] = new CyclomaticComplexityAnalyzer();
-        $this->analyzers['halstead'] = new HalsteadAnalyzer();
-        $this->analyzers['loc'] = new NodeLocAnalyzer();
+        $this->analyzersCCN = new CyclomaticComplexityAnalyzer();
+        $this->analyzersHalstead = new HalsteadAnalyzer();
+        $this->analyzersLOC = new NodeLocAnalyzer();
     }
 
     /**
@@ -94,11 +104,14 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
      */
     public function analyze($namespaces)
     {
-        // Run CCN, Halstead & LOC analyzers first
-        foreach ($this->analyzers as $analyzer) {
-            $analyzer->setCache($this->getCache());
-            $analyzer->analyze($namespaces);
-        }
+        $this->analyzersCCN->setCache($this->getCache());
+        $this->analyzersCCN->analyze($namespaces);
+
+        $this->analyzersHalstead->setCache($this->getCache());
+        $this->analyzersHalstead->analyze($namespaces);
+
+        $this->analyzersLOC->setCache($this->getCache());
+        $this->analyzersLOC->analyze($namespaces);
 
         if ($this->metrics === null) {
             $this->loadCache();
@@ -186,12 +199,12 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
      */
     public function calculateMaintainabilityIndex(AbstractASTCallable $callable)
     {
-        $cyclomaticComplexity = $this->analyzers['ccn']->getCcn2($callable);
+        $cyclomaticComplexity = $this->analyzersCCN->getCcn2($callable);
 
-        $halstead = $this->analyzers['halstead']->getNodeMetrics($callable);
+        $halstead = $this->analyzersHalstead->getNodeMetrics($callable);
         $halsteadVolume = $halstead[HalsteadAnalyzer::M_HALSTEAD_VOLUME];
 
-        $loc = $this->analyzers['loc']->getNodeMetrics($callable);
+        $loc = $this->analyzersLOC->getNodeMetrics($callable);
         $eloc = $loc[NodeLocAnalyzer::M_EXECUTABLE_LINES_OF_CODE];
 
         $maintainabilityIndex = 171 - 5.2 * log($halsteadVolume) - 0.23 * $cyclomaticComplexity - 16.2 * log($eloc);

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -206,7 +206,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         // Calculate the complexity of the condition
         $parent = $node->getParent()->getChild(0);
         $npath = $this->sumComplexity($parent);
-        
+
         // New PHP 5.3 ifsetor-operator $x ?: $y
         if (count($node->getChildren()) === 1) {
             $npath = MathUtil::mul($npath, '2');
@@ -220,7 +220,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
         // Add 2 for the branching per the NPath spec
         $npath = MathUtil::add($npath, '2');
-        
+
         return MathUtil::mul($npath, $data);
     }
 
@@ -275,8 +275,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(if) = NP(<if-range>) + NP(<expr>) + NP(<else-range> --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param \PDepend\Source\AST\ASTElseIfStatement $node The currently visited node.
+     * @param string                                 $data The previously calculated npath value.
      *
      * @return string
      * @since  0.9.12
@@ -386,8 +386,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(if) = NP(<if-range>) + NP(<expr>) + NP(<else-range> --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param \PDepend\Source\AST\ASTIfStatement $node The currently visited node.
+     * @param string                             $data The previously calculated npath value.
      *
      * @return string
      * @since  0.9.12

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -47,7 +47,7 @@ use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\CodeAwareGenerator;
 use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
-use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
 use PDepend\Util\Utf8Util;
@@ -72,7 +72,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * The context source code.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList<AbstractASTArtifact>
+     * @var \PDepend\Source\AST\ASTArtifactList<ASTNamespace>
      */
     private $code = null;
 
@@ -109,7 +109,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<AbstractASTArtifact> $artifacts
+     * @param  \PDepend\Source\AST\ASTArtifactList<ASTNamespace> $artifacts
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -61,7 +61,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ReportGeneratorFactory
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     * @var \Symfony\Component\DependencyInjection\TaggedContainerInterface
      */
     private $container;
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -192,7 +192,7 @@ abstract class AbstractPHPParser
     /**
      * The used data structure builder.
      *
-     * @var Builder<mixed>
+     * @var PHPBuilder<mixed>
      */
     protected $builder;
 
@@ -280,7 +280,7 @@ abstract class AbstractPHPParser
      * Constructs a new source parser.
      *
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param PHPBuilder<mixed> $builder
      * @param \PDepend\Util\Cache\CacheDriver $cache
      */
     public function __construct(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
@@ -2229,7 +2229,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param boolean $classRef
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference|ASTNode|\PDepend\Source\AST\ASTSelfReference|\PDepend\Source\AST\ASTStaticReference
+     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
      */
     private function parseStandAloneExpressionTypeReference($classRef)
     {
@@ -3470,7 +3470,7 @@ abstract class AbstractPHPParser
             )
         );
     }
-    
+
     /**
      * This method parses a finally-statement.
      *
@@ -7072,7 +7072,7 @@ abstract class AbstractPHPParser
     /**
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return \PDepend\Source\AST\ASTClosure
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      */
     protected function parseLambdaFunctionDeclaration()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1508,7 +1508,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $name
-     * @param ASTNode $name
+     * @param ASTNode $value
      * @return \PDepend\Source\AST\ASTNamedArgument
      * @since  2.9.0
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -184,7 +184,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @template T of \PDepend\Source\AST\ASTCallable
+     * @template T of \PDepend\Source\AST\AbstractASTCallable
      * @param T $callable
      * @return T
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -103,6 +103,9 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
         return $field;
     }
 
+    /**
+     * @return \PDepend\Source\AST\ASTClosure
+     */
     protected function parseLambdaFunctionDeclaration()
     {
         $this->tokenStack->push();

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -208,7 +208,7 @@ class FileCacheDirectory
      * Flushes the cache record for the given file info instance, independent if
      * it is a file, directory or symlink.
      *
-     * @param  \SplFileInfo $file
+     * @param  \DirectoryIterator $file
      * @return void
      */
     protected function flushEntry(\SplFileInfo $file)


### PR DESCRIPTION
Type: documentation update) 
Breaking change: no

This correct the majority of the remaining issues detected by PHPStan at level 2, which do not require ugly code or cause BC issues. Mostly this is cases where a generic class/interface was hinted, but a more specific implementation was assumed by the actual code.