### PR TITLE
Declare accept() in AbstractASTNode

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -156,7 +157,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns all child nodes of this method.
      *
-     * @return ASTNode[]
+     * @return AbstractASTNode[]
      *
      * @since  0.9.8
      */

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -44,7 +44,9 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
 use OutOfBoundsException;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is an abstract base implementation of the ast node interface.
@@ -88,6 +90,11 @@ abstract class AbstractASTNode implements ASTNode
      * @since 0.10.4
      */
     protected $metadata = '::::';
+
+    public function accept(ASTVisitor $visitor, $data = null)
+    {
+        throw new BadMethodCallException('Accept must be overwritten');
+    }
 
     /**
      * Constructs a new ast node instance.

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2425,7 +2425,7 @@ abstract class AbstractPHPParser
      * like {@link ASTInstanceOfExpression} or an object
      * allocation node like {@link ASTAllocationExpression}.
      *
-     * @template T of ASTNode
+     * @template T of AbstractASTNode
      *
      * @param T    $expr
      * @param bool $classRef
@@ -2666,7 +2666,7 @@ abstract class AbstractPHPParser
      * $foo[$bar];
      * </code>
      *
-     * @template T of ASTNode
+     * @template T of AbstractASTNode
      *
      * @param T   $node
      * @param int $closeToken
@@ -5184,7 +5184,7 @@ abstract class AbstractPHPParser
      * This method parses a comma separated list of valid php variables and/or
      * properties and adds them to the given node instance.
      *
-     * @template T of ASTNode
+     * @template T of AbstractASTNode
      *
      * @param T $node The context parent node.
      *
@@ -5861,7 +5861,8 @@ abstract class AbstractPHPParser
      * to consume the stop token. The return value of this method is the prepared
      * input string node.
      * 
-     * @param int $stopToken
+     * @param AbstractASTNode $node
+     * @param int             $stopToken
      *
      * @return ASTNode
      *


### PR DESCRIPTION
Type: refactoring
Breaking change: yes (added `abstract accept()` to `AbstractASTNode`)

`ASTNode` was always assumed to have an `accept()` method, which happens to be true for all our implementations. Instead of replacing all hints for `ASTNode` with a union type of every single implementation I have added it to the `AbstractASTNode` class which all implementations derive from. This is done here instead of the interface, to cause the least amount of backwards comparability issues with other packages that may implement `ASTNode` but not `accept()`.

Considering that anything that didn't implement `accept()` would more then likely have caused a crash I don't think this is big enough of a change that it should not be merged in to the 2.x linage.

This brings us down to just 12 issues.