### PR TITLE
Supress warning for FilterIterator accept()

### DIFF
--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -68,6 +68,7 @@ class AnalyzerIterator extends \FilterIterator
      *
      * @return boolean
      */
+    #[\ReturnTypeWillChange]
     public function accept()
     {
         return $this->getInnerIterator()->current()->isEnabled();


### PR DESCRIPTION
For the same reason as #576, this attribute should be placed here until the minimum PHP version supported is 7.0.0.

For more details, see #576.

Type: bugfix
Breaking change: no