### PR TITLE
Correct return types in PHPParser

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -161,12 +161,6 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
         }
     }
 
-    /**
-     * Parses a type hint that is valid in the supported PHP version.
-     *
-     * @return \PDepend\Source\AST\ASTNode
-     * @since 1.0.0
-     */
     protected function parseTypeHint()
     {
         switch ($this->tokenizer->peek()) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -329,7 +329,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     }
 
     /**
-     * @return ASTConstant
+     * @return ASTConstant|\PDepend\Source\AST\ASTNamedArgument
      */
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -183,11 +183,6 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         return $this->parseOptionalIndexExpression($node);
     }
 
-    /**
-     * @template T of \PDepend\Source\AST\AbstractASTCallable
-     * @param T $callable
-     * @return T
-     */
     protected function parseCallableDeclarationAddition($callable)
     {
         $this->consumeComments();
@@ -230,12 +225,6 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         return $this->parseEndReturnTypeHint();
     }
 
-    /**
-     * Parses a type hint that is valid in the supported PHP version.
-     *
-     * @return \PDepend\Source\AST\ASTNode
-     * @since 2.3
-     */
     protected function parseTypeHint()
     {
         switch ($this->tokenizer->peek()) {
@@ -350,9 +339,10 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * Attempts to the next sequence of tokens as an anonymous class and adds it to the allocation expression
      *
-     * @param \PDepend\Source\AST\ASTAllocationExpression $allocation
+     * @template T of \PDepend\Source\AST\ASTAllocationExpression
+     * @param T $allocation
      *
-     * @return null|\PDepend\Source\AST\ASTAnonymousClass
+     * @return null|T
      */
     protected function parseAnonymousClassDeclaration(ASTAllocationExpression $allocation)
     {
@@ -412,10 +402,6 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         return $allocation;
     }
 
-    /**
-     * @param \PDepend\Source\AST\ASTNode $node
-     * @return \PDepend\Source\AST\ASTNode
-     */
     protected function parseOptionalMemberPrimaryPrefix(ASTNode $node)
     {
         $this->consumeComments();
@@ -431,10 +417,6 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
         return $node;
     }
 
-    /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return \PDepend\Source\AST\ASTExpression
-     */
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
     {
         $this->consumeComments();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -119,11 +119,6 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         return parent::parseFormalParameterOrTypeHintOrByReference();
     }
 
-    /**
-     * Parses a type hint that is valid in the supported PHP version.
-     *
-     * @return \PDepend\Source\AST\ASTNode
-     */
     protected function parseTypeHint()
     {
         $this->consumeQuestionMark();
@@ -131,13 +126,6 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         return parent::parseTypeHint();
     }
 
-    /**
-     * Override this in later PHPParserVersions as necessary
-     * @param integer $tokenType
-     * @param integer $modifiers
-     * @return \PDepend\Source\AST\ASTConstantDefinition;
-     * @throws UnexpectedTokenException
-     */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
     {
         if ($tokenType == Tokens::T_CONST) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -117,7 +117,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
         $closure = $this->builder->buildAstClosure();
         $closure->setReturnsByReference($this->parseOptionalByReference());
         $closure->addChild($this->parseFormalParameters($closure));
-        $closure = $this->parseCallableDeclarationAddition($closure);
+        $this->parseCallableDeclarationAddition($closure);
 
         $closure->addChild(
             $this->buildReturnStatement(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -139,7 +139,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     /**
      * In this method we implement parsing of PHP 8.0 specific expressions.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     protected function parseExpressionVersion80()
     {
@@ -228,9 +228,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return parent::parseArgumentExpression();
     }
 
-    /**
-     * @return ASTConstant
-     */
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {
         if ($this->tokenizer->peek() === Tokens::T_COLON) {
@@ -245,21 +242,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $constant;
     }
 
-    /**
-     * This method parses a function postfix expression. An object of type
-     * {@link ASTFunctionPostfix} represents any valid php
-     * function call.
-     *
-     * This method will delegate the call to another method that returns a
-     * member primary prefix object when the function postfix expression is
-     * followed by an object operator.
-     *
-     * @param  ASTNode $node This node represents the function
-     *        identifier. An identifier can be a static string, a variable, a
-     *        compound variable or any other valid php function identifier.
-     * @return ASTNode
-     * @throws ParserException
-     */
     protected function parseFunctionPostfix(ASTNode $node)
     {
         if (!($node instanceof ASTIdentifier) || $node->getImageWithoutNamespace() !== 'match') {
@@ -304,9 +286,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $function;
     }
 
-    /**
-     * @return ASTType
-     */
     protected function parseEndReturnTypeHint()
     {
         return $this->parseTypeHint();
@@ -359,11 +338,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $types;
     }
 
-    /**
-     * Parses a type hint that is valid in the supported PHP version.
-     *
-     * @return \PDepend\Source\AST\ASTNode
-     */
     protected function parseTypeHint()
     {
         $this->consumeComments();
@@ -405,10 +379,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         }
     }
 
-    /**
-     * Trailing commas is allowed in closure use list from PHP 8.0
-     * @return false
-     */
     protected function allowTrailingCommaInClosureUseList()
     {
         return true;


### PR DESCRIPTION
Type: documentation update
Breaking change: no

This fixes all incorrect return types for `AbstractPHPParser` and derived classes. For the derived classes this is mostly done by not overwriting the documentation from the parent class and instead simply inherit the correct one.

This solves 30/51 issues reported for PHPStan level 3.

Additional remaining issues
Level 4 issues: 3
Level 5 issues: 21
Level 6 issues: 46
Level 7 issues: 131
Level 8 issues: 197
Level 9 issues: 90
Total: 509