### PR TITLE
PHPDoc cleanup

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -43,10 +43,16 @@
 namespace PDepend;
 
 use InvalidArgumentException;
+use PDepend\DependencyInjection\PdependExtension;
+use PDepend\Metrics\AnalyzerFactory;
+use PDepend\Report\ReportGeneratorFactory;
+use PDepend\TextUI\Runner;
+use PDepend\Util\Configuration;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\TaggedContainerInterface;
 
 /**
  * PDepend Application
@@ -57,7 +63,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 class Application
 {
     /**
-     * @var null|\Symfony\Component\DependencyInjection\TaggedContainerInterface
+     * @var null|TaggedContainerInterface
      **/
     private $container;
 
@@ -83,7 +89,7 @@ class Application
     }
 
     /**
-     * @return \PDepend\Util\Configuration
+     * @return Configuration
      */
     public function getConfiguration()
     {
@@ -91,7 +97,7 @@ class Application
     }
 
     /**
-     * @return \PDepend\Engine
+     * @return Engine
      */
     public function getEngine()
     {
@@ -99,7 +105,7 @@ class Application
     }
 
     /**
-     * @return \PDepend\TextUI\Runner
+     * @return Runner
      */
     public function getRunner()
     {
@@ -107,7 +113,7 @@ class Application
     }
 
     /**
-     * @return \PDepend\Report\ReportGeneratorFactory
+     * @return ReportGeneratorFactory
      */
     public function getReportGeneratorFactory()
     {
@@ -115,7 +121,7 @@ class Application
     }
 
     /**
-     * @return \PDepend\Metrics\AnalyzerFactory
+     * @return AnalyzerFactory
      */
     public function getAnalyzerFactory()
     {
@@ -123,7 +129,7 @@ class Application
     }
 
     /**
-     * @return \Symfony\Component\DependencyInjection\TaggedContainerInterface
+     * @return TaggedContainerInterface
      */
     private function getContainer()
     {
@@ -135,11 +141,11 @@ class Application
     }
 
     /**
-     * @return \Symfony\Component\DependencyInjection\TaggedContainerInterface
+     * @return TaggedContainerInterface
      */
     private function createContainer()
     {
-        $extensions = array(new DependencyInjection\PdependExtension());
+        $extensions = array(new PdependExtension());
 
         $container = new ContainerBuilder(new ParameterBag(array()));
         $container->prependExtensionConfig('pdepend', array());

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -42,6 +42,7 @@
 
 namespace PDepend;
 
+use InvalidArgumentException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -56,7 +57,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 class Application
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\TaggedContainerInterface|null
+     * @var null|\Symfony\Component\DependencyInjection\TaggedContainerInterface
      **/
     private $container;
 
@@ -67,12 +68,13 @@ class Application
 
     /**
      * @param string $configurationFile
+     *
      * @return void
      */
     public function setConfigurationFile($configurationFile)
     {
         if (!file_exists($configurationFile)) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('The configuration file "%s" doesn\'t exist.', $configurationFile)
             );
         }
@@ -180,6 +182,7 @@ class Application
 
     /**
      * @param string $serviceTag
+     *
      * @return array<string, array<string, string>>
      */
     private function getAvailableOptionsFor($serviceTag)

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -65,21 +65,22 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Time when it the process has started.
      *
-     * @var integer
+     * @var int
      */
     private $startTime = 0;
 
     /**
      * Number of parsed/analyzed files.
      *
-     * @var integer
+     * @var int
      */
     private $parsedFiles = 0;
 
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     *
      * @return void
      */
     public function startParseProcess(Builder $builder)
@@ -90,7 +91,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     *
      * @return void
      */
     public function endParseProcess(Builder $builder)
@@ -100,7 +102,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts parsing of a new file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function startFileParsing(Tokenizer $tokenizer)
@@ -110,7 +111,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished a file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function endFileParsing(Tokenizer $tokenizer)
@@ -181,7 +181,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts a new analyzer.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     *
      * @return void
      */
     public function startAnalyzer(Analyzer $analyzer)
@@ -191,7 +192,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished one analyzing process.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     *
      * @return void
      */
     public function endAnalyzer(Analyzer $analyzer)

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -79,7 +79,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param Builder<mixed> $builder The used node builder instance.
      *
      * @return void
      */
@@ -91,7 +91,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param Builder<mixed> $builder The used node builder instance.
      *
      * @return void
      */
@@ -181,7 +181,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts a new analyzer.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param Analyzer $analyzer The context analyzer instance.
      *
      * @return void
      */
@@ -192,7 +192,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished one analyzing process.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param Analyzer $analyzer The context analyzer instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -56,6 +56,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  * Copied from Behat
  *
  * @link   https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Extension/Extension.php
+ *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
  */
 abstract class Extension
@@ -72,6 +73,7 @@ abstract class Extension
      *
      * @param array<mixed>     $config    Extension configuration hash (from behat.yml)
      * @param ContainerBuilder $container ContainerBuilder instance
+     *
      * @return void
      */
     public function load(array $config, ContainerBuilder $container)
@@ -94,7 +96,6 @@ abstract class Extension
     /**
      * Setups configuration for current extension.
      *
-     * @param ArrayNodeDefinition $builder
      * @return void
      */
     public function getConfig(ArrayNodeDefinition $builder)

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\DependencyInjection;
 
+use RuntimeException;
+
 /**
  * Manage activation and registration of extensions for PDepend.
  *
@@ -58,14 +60,16 @@ class ExtensionManager
     /**
      * Activate an extension based on a class name.
      *
-     * @throws \RuntimeException
-     * @param  class-string<\PDepend\DependencyInjection\Extension> $className
+     * @param class-string<\PDepend\DependencyInjection\Extension> $className
+     *
+     * @throws RuntimeException
+     *
      * @return void
      */
     public function activateExtension($className)
     {
         if (!class_exists($className)) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf(
                     'Cannot find extension class %s" for PDepend. Maybe the plugin is not installed?',
                     $className
@@ -76,7 +80,7 @@ class ExtensionManager
         $extension = new $className;
 
         if (!($extension instanceof Extension)) {
-            throw new \RuntimeException(
+            throw new RuntimeException(
                 sprintf('Class "%s" is not a valid Extension', $className)
             );
         }

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -53,14 +53,14 @@ use RuntimeException;
 class ExtensionManager
 {
     /**
-     * @var array<\PDepend\DependencyInjection\Extension>
+     * @var array<Extension>
      */
     private $extensions = array();
 
     /**
      * Activate an extension based on a class name.
      *
-     * @param class-string<\PDepend\DependencyInjection\Extension> $className
+     * @param class-string<Extension> $className
      *
      * @throws RuntimeException
      *
@@ -91,7 +91,7 @@ class ExtensionManager
     /**
      * Return all activated extensions.
      *
-     * @return array<\PDepend\DependencyInjection\Extension>
+     * @return array<Extension>
      */
     public function getActivatedExtensions()
     {

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\DependencyInjection;
 
+use stdClass;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension as SymfonyExtension;
@@ -58,6 +59,7 @@ class PdependExtension extends SymfonyExtension
 {
     /**
      * @param array<array<array<array<string>>>> $configs
+     *
      * @return void
      * {@inheritDoc}
      */
@@ -106,22 +108,23 @@ class PdependExtension extends SymfonyExtension
 
     /**
      * @param array<string, array<string, string>> $config
-     * @return \stdClass
+     *
+     * @return stdClass
      */
     private function createSettings($config)
     {
-        $settings = new \stdClass();
+        $settings = new stdClass();
 
-        $settings->cache           = new \stdClass();
+        $settings->cache           = new stdClass();
         $settings->cache->driver = $config['cache']['driver'];
         $settings->cache->location = $config['cache']['location'];
         $settings->cache->ttl = $config['cache']['ttl'];
 
-        $settings->imageConvert             = new \stdClass();
+        $settings->imageConvert             = new stdClass();
         $settings->imageConvert->fontSize   = $config['image_convert']['font_size'];
         $settings->imageConvert->fontFamily = $config['image_convert']['font_family'];
 
-        $settings->parser          = new \stdClass();
+        $settings->parser          = new stdClass();
         $settings->parser->nesting = $config['parser']['nesting'];
 
         return $settings;

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -52,7 +52,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder as BaseTreeBuilder;
 class TreeBuilder
 {
     /**
-     * @var NodeDefinition|ArrayNodeDefinition
+     * @var ArrayNodeDefinition|NodeDefinition
      */
     protected $rootNode;
 

--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -61,7 +61,8 @@ class CompositeFilter implements Filter
     /**
      * Adds a file filter to this composite.
      *
-     * @param  \PDepend\Input\Filter $filter The new filter object.
+     * @param \PDepend\Input\Filter $filter The new filter object.
+     *
      * @return void
      */
     public function append(Filter $filter)
@@ -73,9 +74,10 @@ class CompositeFilter implements Filter
      * Delegates the given <b>$localPath</b> object to all aggregated filters.
      * Returns <b>true</b> if this filter accepts the given path.
      *
-     * @param  string $relative The relative path to the specified root.
-     * @param  string $absolute The absolute path to a source file.
-     * @return boolean
+     * @param string $relative The relative path to the specified root.
+     * @param string $absolute The absolute path to a source file.
+     *
+     * @return bool
      */
     public function accept($relative, $absolute)
     {

--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -52,16 +52,16 @@ namespace PDepend\Input;
 class CompositeFilter implements Filter
 {
     /**
-     * List of aggregated {@link \PDepend\Input\Filter} objects.
+     * List of aggregated {@link Filter} objects.
      *
-     * @var \PDepend\Input\Filter[]
+     * @var Filter[]
      */
     protected $filters = array();
 
     /**
      * Adds a file filter to this composite.
      *
-     * @param \PDepend\Input\Filter $filter The new filter object.
+     * @param Filter $filter The new filter object.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -53,7 +53,8 @@ class ExcludePathFilter implements Filter
     /**
      * Regular expression that should not match against the relative file paths.
      *
-     * @var   string
+     * @var string
+     *
      * @since 0.10.0
      */
     protected $relative = '';
@@ -61,7 +62,8 @@ class ExcludePathFilter implements Filter
     /**
      * Regular expression that should not match against the absolute file paths.
      *
-     * @var   string
+     * @var string
+     *
      * @since 0.10.0
      */
     protected $absolute = '';
@@ -86,7 +88,7 @@ class ExcludePathFilter implements Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      *
-     * @return boolean
+     * @return bool
      */
     public function accept($relative, $absolute)
     {
@@ -99,7 +101,8 @@ class ExcludePathFilter implements Filter
      *
      * @param string $path The absolute path to a source file.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.10.0
      */
     protected function notAbsolute($path)
@@ -113,7 +116,8 @@ class ExcludePathFilter implements Filter
      *
      * @param string $path The relative path to a source file.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.10.0
      */
     protected function notRelative($path)

--- a/src/main/php/PDepend/Input/ExtensionFilter.php
+++ b/src/main/php/PDepend/Input/ExtensionFilter.php
@@ -71,9 +71,10 @@ class ExtensionFilter implements Filter
     /**
      * Returns <b>true</b> if this filter accepts the given paths.
      *
-     * @param  string $relative The relative path to the specified root.
-     * @param  string $absolute The absolute path to a source file.
-     * @return boolean
+     * @param string $relative The relative path to the specified root.
+     * @param string $absolute The absolute path to a source file.
+     *
+     * @return bool
      */
     public function accept($relative, $absolute)
     {

--- a/src/main/php/PDepend/Input/Filter.php
+++ b/src/main/php/PDepend/Input/Filter.php
@@ -53,9 +53,10 @@ interface Filter
     /**
      * Returns <b>true</b> if this filter accepts the given paths.
      *
-     * @param  string $relative The relative path to the specified root.
-     * @param  string $absolute The absolute path to a source file.
-     * @return boolean
+     * @param string $relative The relative path to the specified root.
+     * @param string $absolute The absolute path to a source file.
+     *
+     * @return bool
      */
     public function accept($relative, $absolute);
 }

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -57,7 +57,7 @@ class Iterator extends FilterIterator
     /**
      * The associated filter object.
      *
-     * @var \PDepend\Input\Filter
+     * @var Filter
      */
     protected $filter = null;
 
@@ -74,7 +74,7 @@ class Iterator extends FilterIterator
      * Constructs a new file filter iterator.
      *
      * @param \Iterator<SplFileInfo> $iterator The inner iterator.
-     * @param \PDepend\Input\Filter  $filter   The filter object.
+     * @param Filter                 $filter   The filter object.
      * @param string                 $rootPath Optional root path for the files.
      */
     public function __construct(\Iterator $iterator, Filter $filter, $rootPath = null)

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -42,13 +42,17 @@
 
 namespace PDepend\Input;
 
+use FilterIterator;
+use ReturnTypeWillChange;
+use SplFileInfo;
+
 /**
  * Simple utility filter iterator for php source files.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class Iterator extends \FilterIterator
+class Iterator extends FilterIterator
 {
     /**
      * The associated filter object.
@@ -60,7 +64,8 @@ class Iterator extends \FilterIterator
     /**
      * Optional root path for the files.
      *
-     * @var   string|null
+     * @var null|string
+     *
      * @since 0.10.0
      */
     protected $rootPath = null;
@@ -68,9 +73,9 @@ class Iterator extends \FilterIterator
     /**
      * Constructs a new file filter iterator.
      *
-     * @param \Iterator<\SplFileInfo> $iterator The inner iterator.
-     * @param \PDepend\Input\Filter   $filter   The filter object.
-     * @param string                  $rootPath Optional root path for the files.
+     * @param \Iterator<SplFileInfo> $iterator The inner iterator.
+     * @param \PDepend\Input\Filter  $filter   The filter object.
+     * @param string                 $rootPath Optional root path for the files.
      */
     public function __construct(\Iterator $iterator, Filter $filter, $rootPath = null)
     {
@@ -83,9 +88,9 @@ class Iterator extends \FilterIterator
     /**
      * Returns <b>true</b> if the file name ends with '.php'.
      *
-     * @return boolean
+     * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function accept()
     {
         if ($this->getInnerIterator()->current()->isDir()) {
@@ -98,6 +103,7 @@ class Iterator extends \FilterIterator
      * Returns the full qualified realpath for the currently active file.
      *
      * @return string
+     *
      * @since  0.10.0
      */
     protected function getFullPath()
@@ -110,6 +116,7 @@ class Iterator extends \FilterIterator
      * set. If not, this method returns the absolute file path.
      *
      * @return string
+     *
      * @since  0.10.0
      */
     protected function getLocalPath()

--- a/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
@@ -62,7 +62,7 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
     /**
      * List or registered listeners.
      *
-     * @var \PDepend\Metrics\AnalyzerListener[]
+     * @var AnalyzerListener[]
      */
     private $listeners = array();
 
@@ -93,7 +93,7 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
     /**
      * Adds a listener to this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     * @param AnalyzerListener $listener The listener instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
@@ -82,6 +82,7 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
      *
      * @param array<string, mixed> $options Global option array, every analyzer
      *                                      can extract the required options.
+     *
      * @return void
      */
     public function setOptions(array $options = array())
@@ -92,10 +93,11 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
     /**
      * Adds a listener to this analyzer.
      *
-     * @param  \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     *
      * @return void
      */
-    public function addAnalyzeListener(\PDepend\Metrics\AnalyzerListener $listener)
+    public function addAnalyzeListener(AnalyzerListener $listener)
     {
         if (in_array($listener, $this->listeners, true) === false) {
             $this->listeners[] = $listener;
@@ -110,7 +112,8 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
      * By default all analyzers are enabled. Overwrite this method to provide
      * state based disabling/enabling.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.10
      */
     public function isEnabled()

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -45,6 +45,11 @@
 namespace PDepend\Metrics;
 
 use PDepend\Source\AST\AbstractASTArtifact;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -75,7 +80,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     /**
      * Injected cache driver.
      *
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      */
     private $cache;
 
@@ -92,7 +97,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     /**
      * Getter method for the system wide used cache.
      *
-     * @return \PDepend\Util\Cache\CacheDriver $cache
+     * @return CacheDriver $cache
      */
     public function getCache()
     {
@@ -104,7 +109,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * restored the metrics it will return <b>TRUE</b>, otherwise the return
      * value will be <b>FALSE</b>.
      *
-     * @param \PDepend\Source\AST\ASTClass|\PDepend\Source\AST\ASTCompilationUnit|\PDepend\Source\AST\ASTFunction|\PDepend\Source\AST\ASTInterface|\PDepend\Source\AST\ASTMethod $node
+     * @param ASTClass|ASTCompilationUnit|ASTFunction|ASTInterface|ASTMethod $node
      *
      * @return bool
      */

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -52,6 +53,7 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements AnalyzerCacheAware
@@ -80,7 +82,6 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     /**
      * Setter method for the system wide used cache.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return void
      */
     public function setCache(CacheDriver $cache)
@@ -103,8 +104,9 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * restored the metrics it will return <b>TRUE</b>, otherwise the return
      * value will be <b>FALSE</b>.
      *
-     * @param  \PDepend\Source\AST\ASTFunction|\PDepend\Source\AST\ASTMethod|\PDepend\Source\AST\ASTInterface|\PDepend\Source\AST\ASTClass|\PDepend\Source\AST\ASTCompilationUnit $node
-     * @return boolean
+     * @param \PDepend\Source\AST\ASTClass|\PDepend\Source\AST\ASTCompilationUnit|\PDepend\Source\AST\ASTFunction|\PDepend\Source\AST\ASTInterface|\PDepend\Source\AST\ASTMethod $node
+     *
+     * @return bool
      */
     protected function restoreFromCache(AbstractASTArtifact $node)
     {

--- a/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
@@ -62,7 +62,8 @@ interface AggregateAnalyzer extends Analyzer
     /**
      * Adds a required sub analyzer.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     *
      * @return void
      */
     public function addAnalyzer(Analyzer $analyzer);

--- a/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
@@ -62,7 +62,7 @@ interface AggregateAnalyzer extends Analyzer
     /**
      * Adds a required sub analyzer.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     * @param Analyzer $analyzer The sub analyzer instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Metrics;
 
+use PDepend\Source\AST\ASTNamespace;
+
 /**
  * Base interface for all analyzer implementations.
  *
@@ -61,16 +63,16 @@ interface Analyzer
     /**
      * Adds a listener to this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     * @param AnalyzerListener $listener The listener instance.
      *
      * @return void
      */
     public function addAnalyzeListener(AnalyzerListener $listener);
     
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -42,8 +42,6 @@
 
 namespace PDepend\Metrics;
 
-use PDepend\Source\AST\ASTArtifactList;
-
 /**
  * Base interface for all analyzer implementations.
  *
@@ -63,7 +61,8 @@ interface Analyzer
     /**
      * Adds a listener to this analyzer.
      *
-     * @param  \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
+     *
      * @return void
      */
     public function addAnalyzeListener(AnalyzerListener $listener);
@@ -71,7 +70,8 @@ interface Analyzer
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces);
@@ -81,7 +81,8 @@ interface Analyzer
      * pdepend framework, while an analyzer that does not perform any action
      * for any reason should return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.10
      */
     public function isEnabled();
@@ -90,7 +91,9 @@ interface Analyzer
      * Set global options
      *
      * @param array<string, mixed> $options
+     *
      * @return void
+     *
      * @since 2.0.1
      */
     public function setOptions(array $options = array());

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -45,6 +45,7 @@ namespace PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\AbstractASTType;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
@@ -94,21 +95,21 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Nodes in which the current analyzed class is used.
      *
-     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     * @var array<string, array<int, AbstractASTArtifact>>
      */
     private $efferentNodes = array();
 
     /**
      * Nodes that is used by the current analyzed class.
      *
-     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     * @var array<string, array<int, AbstractASTArtifact>>
      */
     private $afferentNodes = array();
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -132,7 +133,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all afferent nodes.
      *
-     * @return \PDepend\Source\AST\AbstractASTType[]
+     * @return AbstractASTType[]
      */
     public function getAfferents(AbstractASTArtifact $node)
     {
@@ -146,7 +147,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all efferent nodes.
      *
-     * @return \PDepend\Source\AST\AbstractASTType[]
+     * @return AbstractASTType[]
      */
     public function getEfferents(AbstractASTArtifact $node)
     {
@@ -308,7 +309,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Collects a single cycle that is reachable by this namespace. All namespaces
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
-     * @param \PDepend\Source\AST\AbstractASTArtifact[] $list
+     * @param AbstractASTArtifact[] $list
      *
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -108,7 +108,8 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -131,7 +132,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all afferent nodes.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return \PDepend\Source\AST\AbstractASTType[]
      */
     public function getAfferents(AbstractASTArtifact $node)
@@ -146,7 +146,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all efferent nodes.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return \PDepend\Source\AST\AbstractASTType[]
      */
     public function getEfferents(AbstractASTArtifact $node)
@@ -161,7 +160,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -179,7 +177,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)
@@ -198,7 +195,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -211,7 +207,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits an interface node.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -225,7 +220,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Generic visit method for classes and interfaces. Both visit methods
      * delegate calls to this method.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return void
      */
     protected function visitType(AbstractASTClassOrInterface $type)
@@ -243,9 +237,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
 
     /**
      * Collects the dependencies between the two given classes.
-     *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $typeA
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $typeB
      *
      * @return void
      */
@@ -271,7 +262,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Initializes the node metric record for the given <b>$type</b>.
      *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return void
      */
     protected function initTypeMetric(AbstractASTClassOrInterface $type)
@@ -318,10 +308,10 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Collects a single cycle that is reachable by this namespace. All namespaces
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact[] $list
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
-     * @return boolean If this method detects a cycle the return value is <b>true</b>
-     *                 otherwise this method will return <b>false</b>.
+     * @param \PDepend\Source\AST\AbstractASTArtifact[] $list
+     *
+     * @return bool If this method detects a cycle the return value is <b>true</b>
+     *              otherwise this method will return <b>false</b>.
      */
     protected function collectCycle(array &$list, AbstractASTArtifact $node)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -45,6 +45,7 @@ namespace PDepend\Metrics\Analyzer;
 use InvalidArgumentException;
 use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\AggregateAnalyzer;
+use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\AbstractASTType;
@@ -52,6 +53,7 @@ use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
 use RuntimeException;
@@ -106,14 +108,14 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * The internal used cyclomatic complexity analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+     * @var CyclomaticComplexityAnalyzer
      */
     private $cyclomaticAnalyzer = null;
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -155,13 +157,13 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Adds a required sub analyzer.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     * @param Analyzer $analyzer The sub analyzer instance.
      *
      * @return void
      */
-    public function addAnalyzer(\PDepend\Metrics\Analyzer $analyzer)
+    public function addAnalyzer(Analyzer $analyzer)
     {
-        if ($analyzer instanceof \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer) {
+        if ($analyzer instanceof CyclomaticComplexityAnalyzer) {
             $this->cyclomaticAnalyzer = $analyzer;
         } else {
             throw new InvalidArgumentException('CC Analyzer required.');
@@ -327,7 +329,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Variables Inheritance of a class metric, this method only
      * counts protected and public properties of parent classes.
      *
-     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param ASTClass $class The context class instance.
      *
      * @return int
      */
@@ -354,7 +356,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Weight Method Per Class metric, this method only counts
      * protected and public methods of parent classes.
      *
-     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param ASTClass $class The context class instance.
      *
      * @return int
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -42,18 +42,19 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use InvalidArgumentException;
 use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\AggregateAnalyzer;
 use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\AbstractASTType;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
+use RuntimeException;
 
 /**
  * Generates some class level based metrics. This analyzer is based on the
@@ -112,7 +113,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -120,7 +122,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         if ($this->nodeMetrics === null) {
             // First check for the require cc analyzer
             if ($this->cyclomaticAnalyzer === null) {
-                throw new \RuntimeException('Missing required CC analyzer.');
+                throw new RuntimeException('Missing required CC analyzer.');
             }
 
             $this->fireStartAnalyzer();
@@ -153,7 +155,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Adds a required sub analyzer.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The sub analyzer instance.
+     *
      * @return void
      */
     public function addAnalyzer(\PDepend\Metrics\Analyzer $analyzer)
@@ -161,7 +164,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         if ($analyzer instanceof \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer) {
             $this->cyclomaticAnalyzer = $analyzer;
         } else {
-            throw new \InvalidArgumentException('CC Analyzer required.');
+            throw new InvalidArgumentException('CC Analyzer required.');
         }
     }
 
@@ -170,7 +173,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -185,7 +187,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -222,7 +223,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -233,8 +233,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Visits a trait node.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function visitTrait(ASTTrait $trait)
@@ -269,7 +269,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -300,7 +299,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Visits a property node.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function visitProperty(ASTProperty $property)
@@ -329,8 +327,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Variables Inheritance of a class metric, this method only
      * counts protected and public properties of parent classes.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class The context class instance.
-     * @return integer
+     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     *
+     * @return int
      */
     private function calculateVarsi(ASTClass $class)
     {
@@ -355,8 +354,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Weight Method Per Class metric, this method only counts
      * protected and public methods of parent classes.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class The context class instance.
-     * @return integer
+     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     *
+     * @return int
      */
     private function calculateWmciForClass(ASTClass $class)
     {
@@ -380,8 +380,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Calculates the Weight Method Per Class metric for a trait.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
-     * @return integer
+     * @return int
+     *
      * @since  1.0.6
      */
     private function calculateWmciForTrait(ASTTrait $trait)
@@ -392,8 +392,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Calculates the Weight Method Per Class metric.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return integer[]
+     * @return int[]
+     *
      * @since  1.0.6
      */
     private function calculateWmci(AbstractASTType $type)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -46,7 +46,6 @@ use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * Calculates the code rank metric for classes and namespaces.
@@ -117,6 +116,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -168,7 +168,6 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -43,9 +43,11 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractAnalyzer;
+use PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Calculates the code rank metric for classes and namespaces.
@@ -86,7 +88,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * List of node collect strategies.
      *
-     * @var \PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI[]
+     * @var CodeRankStrategyI[]
      */
     private $strategies = array();
 
@@ -113,9 +115,9 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     private $nodeMetrics = null;
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -76,7 +76,6 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
     /**
      * Visits a code class object.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -89,7 +88,6 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -103,7 +101,6 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
      * Generic visitor method for classes and interfaces. Both visit methods
      * delegate calls to this method.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return void
      */
     protected function visitType(AbstractASTClassOrInterface $type)
@@ -133,7 +130,6 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
     /**
      * Initializes the temporary node container for the given <b>$node</b>.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     protected function initNode(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -75,7 +75,6 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -102,8 +101,6 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
      * Extracts the coupling information between the two given types and their
      * parent namespacess.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $dependency
      * @return void
      */
     private function processType(AbstractASTClassOrInterface $type, AbstractASTClassOrInterface $dependency)
@@ -131,7 +128,6 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * Initializes the temporary node container for the given <b>$node</b>.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     private function initNode(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -74,7 +74,6 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * Visits a property node.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function visitProperty(ASTProperty $property)
@@ -113,7 +112,6 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * Initializes the temporary node container for the given <b>$node</b>.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     protected function initNode(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
+use InvalidArgumentException;
+
 /**
  * Factory for the different code rank strategies.
  *
@@ -96,15 +98,17 @@ class StrategyFactory
     /**
      * Creates a code rank strategy for the given identifier.
      *
-     * @param  string $strategyName The strategy identifier.
-     * @return \PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI
-     * @throws \InvalidArgumentException If the given <b>$id</b> is not valid or
+     * @param string $strategyName The strategy identifier.
+     *
+     * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
+     *
+     * @return \PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI
      */
     public function createStrategy($strategyName)
     {
         if (in_array($strategyName, $this->validStrategies) === false) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 sprintf('Cannot load file for identifier "%s".', $strategyName)
             );
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -88,7 +88,7 @@ class StrategyFactory
     /**
      * Creates the default code rank strategy.
      *
-     * @return \PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI
+     * @return CodeRankStrategyI
      */
     public function createDefaultStrategy()
     {
@@ -103,7 +103,7 @@ class StrategyFactory
      * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
      *
-     * @return \PDepend\Metrics\Analyzer\CodeRankAnalyzer\CodeRankStrategyI
+     * @return CodeRankStrategyI
      */
     public function createStrategy($strategyName)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -45,7 +45,6 @@ namespace PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * This analyzer implements several metrics that describe cohesion of classes
@@ -81,7 +80,6 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -45,6 +45,13 @@ namespace PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AbstractAnalyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTProperty;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * This analyzer implements several metrics that describe cohesion of classes
@@ -91,9 +98,9 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -109,7 +116,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     }
 
     /*
-    public function visitProperty(\PDepend\Source\AST\ASTProperty $property)
+    public function visitProperty(ASTProperty $property)
     {
         $this->fireStartProperty($property);
         echo ltrim($property->getName(), '$'), PHP_EOL;
@@ -125,24 +132,24 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         );
         foreach ($prefixes as $prefix) {
             $variable = $prefix->getChild(0);
-            if ($variable instanceof \PDepend\Source\AST\ASTVariable
+            if ($variable instanceof ASTVariable
                 && $variable->isThis()
             ) {
                 echo "\$this->";
-            } elseif ($variable instanceof \PDepend\Source\AST\ASTSelfReference) {
+            } elseif ($variable instanceof ASTSelfReference) {
                 echo "self::";
             } else {
                 continue;
             }
 
             $next = $prefix->getChild(1);
-            if ($next instanceof \PDepend\Source\AST\ASTMemberPrimaryPrefix) {
+            if ($next instanceof ASTMemberPrimaryPrefix) {
                 $next = $next->getChild(0);
             }
 
-            if ($next instanceof \PDepend\Source\AST\ASTPropertyPostfix) {
+            if ($next instanceof ASTPropertyPostfix) {
                 echo $next->getImage(), PHP_EOL;
-            } elseif ($next instanceof \PDepend\Source\AST\ASTMethodPostfix) {
+            } elseif ($next instanceof ASTMethodPostfix) {
                 echo $next->getImage(), '()', PHP_EOL;
             }
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -52,6 +52,7 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTProperty;
 
 /**
@@ -176,9 +177,9 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -194,7 +195,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This method traverses all namespaces in the given iterator and calculates
      * the coupling metrics for them.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      *
@@ -369,7 +370,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Calculates the coupling between the given types.
      *
-     * @param \PDepend\Source\AST\AbstractASTType $coupledType
+     * @param AbstractASTType $coupledType
      *
      * @return void
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\AbstractASTType;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -93,7 +92,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Has this analyzer already processed the source under test?
      *
-     * @var   boolean
+     * @var bool
+     *
      * @since 0.10.2
      */
     private $uninitialized = true;
@@ -101,14 +101,14 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * The number of method or function calls.
      *
-     * @var integer
+     * @var int
      */
     private $calls = 0;
 
     /**
      * Number of fanouts.
      *
-     * @var integer
+     * @var int
      */
     private $fanout = 0;
 
@@ -116,7 +116,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * Temporary map that is used to hold the id combinations of dependee and
      * depender.
      *
-     * @var   array<string, array>
+     * @var array<string, array>
+     *
      * @since 0.10.2
      */
     private $dependencyMap = array();
@@ -125,7 +126,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This array holds a mapping between node identifiers and an array with
      * the node's metrics.
      *
-     * @var   array<string, array>
+     * @var array<string, array>
+     *
      * @since 0.10.2
      */
     private $nodeMetrics = array();
@@ -163,7 +165,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -177,7 +178,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -192,8 +194,10 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This method traverses all namespaces in the given iterator and calculates
      * the coupling metrics for them.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
+     *
      * @since  0.10.2
      */
     private function doAnalyze($namespaces)
@@ -214,6 +218,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * start the object tree traversal.
      *
      * @return void
+     *
      * @since  0.10.2
      */
     private function reset()
@@ -229,6 +234,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * the concrete node metrics.
      *
      * @return void
+     *
      * @since  0.10.2
      */
     private function postProcessTemporaryCouplingMap()
@@ -252,7 +258,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -292,8 +297,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * Visit method for classes that will be called by PDepend during the
      * analysis phase with the current context class.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.10.2
      */
     public function visitClass(ASTClass $class)
@@ -306,8 +311,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * Visit method for interfaces that will be called by PDepend during the
      * analysis phase with the current context interface.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
+     *
      * @since  0.10.2
      */
     public function visitInterface(ASTInterface $interface)
@@ -319,7 +324,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -348,7 +352,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Visits a property node.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function visitProperty(ASTProperty $property)
@@ -366,9 +369,10 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Calculates the coupling between the given types.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $declaringType
-     * @param  \PDepend\Source\AST\AbstractASTType $coupledType
+     * @param \PDepend\Source\AST\AbstractASTType $coupledType
+     *
      * @return void
+     *
      * @since  0.10.2
      */
     private function calculateCoupling(
@@ -405,8 +409,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This method will initialize a temporary coupling container for the given
      * given class or interface instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
      * @return void
+     *
      * @since  0.10.2
      */
     private function initDependencyMap(AbstractASTType $type)
@@ -424,7 +428,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Counts all calls within the given <b>$callable</b>
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     private function countCalls(AbstractASTCallable $callable)

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -95,7 +95,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Returns <b>true</b> when this analyzer is enabled.
      *
-     * @return boolean
+     * @return bool
      */
     public function isEnabled()
     {
@@ -106,7 +106,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      * Returns the calculated metrics for the given node or an empty <b>array</b>
      * when no metrics exist for the given node.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, float>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -131,7 +130,8 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Adds an analyzer that this analyzer depends on.
      *
-     * @param  \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer $analyzer
+     * @param \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer $analyzer
+     *
      * @return void
      */
     public function addAnalyzer(Analyzer $analyzer)
@@ -142,7 +142,8 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -155,7 +156,8 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     private function doAnalyze($namespaces)
@@ -176,7 +178,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Visits the given method.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -189,7 +190,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Visits the given function.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -200,7 +200,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Visits the given callable instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     private function visitCallable(AbstractASTCallable $callable)
@@ -214,7 +213,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Calculates the crap index for the given callable.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return float
      */
     private function calculateCrapIndex(AbstractASTCallable $callable)
@@ -235,7 +233,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Calculates the code coverage for the given callable object.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return float
      */
     private function calculateCoverage(AbstractASTCallable $callable)

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -50,6 +50,9 @@ use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Util\Coverage\Factory;
+use PDepend\Util\Coverage\Report;
 
 /**
  * This analyzer calculates the C.R.A.P. index for methods an functions when a
@@ -83,12 +86,12 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      * The coverage report instance representing the supplied coverage report
      * file.
      *
-     * @var \PDepend\Util\Coverage\Report
+     * @var Report
      */
     private $report = null;
 
     /**
-     * @var \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+     * @var CyclomaticComplexityAnalyzer
      */
     private $ccnAnalyzer = null;
 
@@ -130,7 +133,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Adds an analyzer that this analyzer depends on.
      *
-     * @param \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer $analyzer
+     * @param CyclomaticComplexityAnalyzer $analyzer
      *
      * @return void
      */
@@ -142,7 +145,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -156,7 +159,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -244,7 +247,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      * Returns a previously created report instance or creates a new report
      * instance.
      *
-     * @return \PDepend\Util\Coverage\Report
+     * @return Report
      */
     private function createOrReturnCoverageReport()
     {
@@ -257,11 +260,11 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Creates a new coverage report instance.
      *
-     * @return \PDepend\Util\Coverage\Report
+     * @return Report
      */
     private function createCoverageReport()
     {
-        $factory = new \PDepend\Util\Coverage\Factory();
+        $factory = new Factory();
         return $factory->create($this->options['coverage-report']);
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -50,6 +50,9 @@ use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTSwitchLabel;
 
 /**
  * This class calculates the Cyclomatic Complexity Number(CCN) for the project,
@@ -81,9 +84,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     private $ccn2 = 0;
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -246,8 +249,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a boolean AND-expression.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -262,8 +265,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a boolean OR-expression.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -278,8 +281,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a switch label.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $node The currently visited node.
-     * @param array<string, integer>             $data The previously calculated ccn values.
+     * @param ASTSwitchLabel         $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -297,8 +300,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a catch statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -315,8 +318,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits an elseif statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -333,8 +336,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a for statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -351,8 +354,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a foreach statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -369,8 +372,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits an if statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -387,8 +390,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a logical AND expression.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -403,8 +406,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a logical OR expression.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -419,8 +422,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a ternary operator.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -437,8 +440,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a while-statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
@@ -455,8 +458,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a do/while-statement.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param array<string, integer>      $data The previously calculated ccn values.
+     * @param ASTNode                $node The currently visited node.
+     * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -47,7 +47,6 @@ use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
@@ -70,21 +69,22 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * The project Cyclomatic Complexity Number.
      *
-     * @var integer
+     * @var int
      */
     private $ccn = 0;
 
     /**
      * Extended Cyclomatic Complexity Number(CCN2) for the project.
      *
-     * @var integer
+     * @var int
      */
     private $ccn2 = 0;
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -108,8 +108,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Returns the cyclomatic complexity for the given <b>$node</b> instance.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return integer
+     * @return int
      */
     public function getCcn(ASTArtifact $node)
     {
@@ -124,8 +123,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Returns the extended cyclomatic complexity for the given <b>$node</b>
      * instance.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return integer
+     * @return int
      */
     public function getCcn2(ASTArtifact $node)
     {
@@ -141,7 +139,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -168,7 +165,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -186,7 +182,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -197,7 +192,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -215,8 +209,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits methods, functions or closures and calculated their complexity.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
+     *
      * @since  0.9.8
      */
     public function calculateComplexity(AbstractASTCallable $callable)
@@ -240,6 +234,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param string $nodeId Identifier of the analyzed item.
      *
      * @return void
+     *
      * @since  1.0.0
      */
     private function updateProjectMetrics($nodeId)
@@ -255,6 +250,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitBooleanAndExpression($node, $data)
@@ -270,6 +266,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitBooleanOrExpression($node, $data)
@@ -285,6 +282,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>             $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitSwitchLabel($node, $data)
@@ -303,6 +301,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitCatchStatement($node, $data)
@@ -320,6 +319,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitElseIfStatement($node, $data)
@@ -337,6 +337,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitForStatement($node, $data)
@@ -354,6 +355,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitForeachStatement($node, $data)
@@ -371,6 +373,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitIfStatement($node, $data)
@@ -388,6 +391,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitLogicalAndExpression($node, $data)
@@ -403,6 +407,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitLogicalOrExpression($node, $data)
@@ -418,6 +423,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitConditionalExpression($node, $data)
@@ -435,6 +441,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.8
      */
     public function visitWhileStatement($node, $data)
@@ -452,6 +459,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param array<string, integer>      $data The previously calculated ccn values.
      *
      * @return array<string, integer>
+     *
      * @since  0.9.12
      */
     public function visitDoWhileStatement($node, $data)

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -99,14 +99,14 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Nodes in which the current analyzed dependency is used.
      *
-     * @var array<string, array<integer, \PDepend\Source\AST\ASTNamespace>>
+     * @var array<string, array<int, ASTNamespace>>
      */
     private $efferentNodes = array();
 
     /**
      * Nodes that is used by the current analyzed node.
      *
-     * @var array<string, array<integer, \PDepend\Source\AST\ASTNamespace>>
+     * @var array<string, array<int, ASTNamespace>>
      */
     private $afferentNodes = array();
 
@@ -116,24 +116,24 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * <code>
      * array(
      *     <namespace-id> => array(
-     *         \PDepend\Source\AST\ASTNamespace {},
-     *         \PDepend\Source\AST\ASTNamespace {},
+     *         ASTNamespace {},
+     *         ASTNamespace {},
      *     ),
      *     <namespace-id> => array(
-     *         \PDepend\Source\AST\ASTNamespace {},
-     *         \PDepend\Source\AST\ASTNamespace {},
+     *         ASTNamespace {},
+     *         ASTNamespace {},
      *     ),
      * )
      * </code>
      *
-     * @var array<string, null|array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
+     * @var array<string, null|array<int, AbstractASTArtifact>>
      */
     private $collectedCycles = array();
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -175,7 +175,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all afferent nodes.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     * @return AbstractASTArtifact[]
      */
     public function getAfferents(AbstractASTArtifact $node)
     {
@@ -191,7 +191,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all efferent nodes.
      *
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function getEfferents(AbstractASTArtifact $node)
     {
@@ -208,9 +208,9 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Returns an array of nodes that build a cycle for the requested node or it
      * returns <b>null</b> if no cycle exists .
      *
-     * @param \PDepend\Source\AST\ASTNamespace $node
+     * @param ASTNamespace $node
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact[]
+     * @return AbstractASTArtifact[]
      */
     public function getCycle(AbstractASTArtifact $node)
     {
@@ -457,7 +457,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Collects a single cycle that is reachable by this namespace. All namespaces
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $list
+     * @param ASTNamespace[] $list
      *
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -126,14 +126,15 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * )
      * </code>
      *
-     * @var array<string, array<integer, \PDepend\Source\AST\AbstractASTArtifact>|null>
+     * @var array<string, null|array<integer, \PDepend\Source\AST\AbstractASTArtifact>>
      */
     private $collectedCycles = array();
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -160,7 +161,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns the statistics for the requested node.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return array<string, mixed>
      */
     public function getStats(AbstractASTArtifact $node)
@@ -175,7 +175,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all afferent nodes.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return \PDepend\Source\AST\AbstractASTArtifact[]
      */
     public function getAfferents(AbstractASTArtifact $node)
@@ -192,7 +191,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Returns an array of all efferent nodes.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function getEfferents(AbstractASTArtifact $node)
@@ -210,7 +208,8 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Returns an array of nodes that build a cycle for the requested node or it
      * returns <b>null</b> if no cycle exists .
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $node
+     * @param \PDepend\Source\AST\ASTNamespace $node
+     *
      * @return \PDepend\Source\AST\AbstractASTArtifact[]
      */
     public function getCycle(AbstractASTArtifact $node)
@@ -232,7 +231,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -250,7 +248,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)
@@ -271,7 +268,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -284,7 +280,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Visits an interface node.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -298,7 +293,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Generic visit method for classes and interfaces. Both visit methods
      * delegate calls to this method.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return void
      */
     protected function visitType(AbstractASTClassOrInterface $type)
@@ -331,9 +325,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Collects the dependencies between the two given namespaces.
      *
-     * @param \PDepend\Source\AST\ASTNamespace $namespaceA
-     * @param \PDepend\Source\AST\ASTNamespace $namespaceB
-     *
      * @return void
      */
     private function collectDependencies(ASTNamespace $namespaceA, ASTNamespace $namespaceB)
@@ -357,7 +348,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Initializes the node metric record for the given <b>$namespace</b>.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     protected function initNamespaceMetric(ASTNamespace $namespace)
@@ -467,10 +457,10 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Collects a single cycle that is reachable by this namespace. All namespaces
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $list
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
-     * @return boolean If this method detects a cycle the return value is <b>true</b>
-     *                 otherwise this method will return <b>false</b>.
+     * @param \PDepend\Source\AST\ASTNamespace[] $list
+     *
+     * @return bool If this method detects a cycle the return value is <b>true</b>
+     *              otherwise this method will return <b>false</b>.
      */
     protected function collectCycle(array &$list, ASTNamespace $namespace)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -50,6 +50,7 @@ use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -75,9 +76,9 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
           M_HALSTEAD_CONTENT = 'hi'; // I = (V / D)
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -77,7 +77,8 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -103,7 +104,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * for the given <b>$node</b> (n1, n2, N1, N2). If there are no metrics for
      * the requested node, this method will return an empty <b>array</b>.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, integer>
      */
     public function getNodeBasisMetrics(ASTArtifact $artifact)
@@ -120,7 +120,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, float>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -136,7 +135,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -153,7 +151,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -164,7 +161,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -181,7 +177,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * @see http://www.scribd.com/doc/99533/Halstead-s-Operators-and-Operands-in-C-C-JAVA-by-Indranil-Nandy
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     public function calculateHalsteadBasis(AbstractASTCallable $callable)
@@ -379,6 +374,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * @see http://www.grammatech.com/codesonar/workflow-features/halstead
      *
      * @param array<string, int> $basis [n1, n2, N1, N2]
+     *
      * @return array<string, float>
      */
     public function calculateHalsteadMeasures(array $basis)

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -47,7 +47,6 @@ use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -83,35 +82,35 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Number of all analyzed functions.
      *
-     * @var integer
+     * @var int
      */
     private $fcs = 0;
 
     /**
      * Number of all analyzer methods.
      *
-     * @var integer
+     * @var int
      */
     private $mts = 0;
 
     /**
      * Number of all analyzed classes.
      *
-     * @var integer
+     * @var int
      */
     private $cls = 0;
 
     /**
      * Number of all analyzed abstract classes.
      *
-     * @var integer
+     * @var int
      */
     private $clsa = 0;
 
     /**
      * Number of all analyzed interfaces.
      *
-     * @var integer
+     * @var int
      */
     private $interfs = 0;
 
@@ -154,7 +153,8 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -197,7 +197,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
      * for the given <b>$node</b> instance. If there are no metrics for the
      * requested node, this method will return an empty <b>array</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -211,7 +210,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Calculates metrics for the given <b>$class</b> instance.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -252,7 +250,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Calculates metrics for the given <b>$function</b> instance.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -265,7 +262,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Calculates metrics for the given <b>$interface</b> instance.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -284,7 +280,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -297,7 +292,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Calculates metrics for the given <b>$namespace</b> instance.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -151,9 +151,9 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     private $nodeMetrics = null;
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -48,6 +48,7 @@ use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * This analyzer provides two project related inheritance metrics.
@@ -173,9 +174,9 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -194,7 +195,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * Calculates several inheritance related metrics for the given source
      * namespaces.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -47,7 +47,6 @@ use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 
 /**
@@ -98,7 +97,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * The maximum depth of inheritance tree value within the analyzed source code.
      *
-     * @var integer
+     * @var int
      */
     private $maxDIT = 0;
 
@@ -119,14 +118,14 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Total number of classes.
      *
-     * @var integer
+     * @var int
      */
     private $numberOfClasses = 0;
 
     /**
      * Total number of derived classes.
      *
-     * @var integer
+     * @var int
      */
     private $numberOfDerivedClasses = 0;
 
@@ -142,7 +141,6 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -177,7 +175,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -195,8 +194,10 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * Calculates several inheritance related metrics for the given source
      * namespaces.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
+     *
      * @since  0.9.10
      */
     private function doAnalyze($namespaces)
@@ -216,7 +217,6 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -239,8 +239,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Calculates the number of derived classes.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.9.5
      */
     private function calculateNumberOfDerivedClasses(ASTClass $class)
@@ -262,8 +262,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Calculates the maximum HIT for the given class.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.9.10
      */
     private function calculateDepthOfInheritanceTree(ASTClass $class)
@@ -293,8 +293,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * Calculates two metrics. The number of added methods and the number of
      * overwritten methods.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.9.10
      */
     private function calculateNumberOfAddedAndOverwrittenMethods(ASTClass $class)
@@ -335,8 +335,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Initializes a empty metric container for the given class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.9.10
      */
     private function initNodeMetricsForClass(ASTClass $class)

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -50,6 +50,7 @@ use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * This class calculates the Halstead Complexity Measures for the project,
@@ -97,9 +98,9 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -99,7 +99,8 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -134,7 +135,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, float>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -149,7 +149,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -166,7 +165,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -177,7 +175,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -194,7 +191,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * @see http://blogs.msdn.com/b/codeanalysis/archive/2007/11/20/maintainability-index-range-and-meaning.aspx
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     public function calculateMaintainabilityIndex(AbstractASTCallable $callable)

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -79,7 +79,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -109,7 +110,6 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, string>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -124,7 +124,6 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -135,7 +134,6 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -151,8 +149,6 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
     /**
      * Visits a method node.
-     *
-     * @param \PDepend\Source\AST\ASTMethod $method
      *
      * @return void
      */
@@ -171,8 +167,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * This method will calculate the NPath complexity for the given callable
      * instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
+     *
      * @since  0.9.12
      */
     protected function calculateComplexity(AbstractASTCallable $callable)
@@ -196,9 +192,11 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(?) = NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 2 --
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTNode $node
-     * @param  string                      $data
+     * @param \PDepend\Source\AST\ASTNode $node
+     * @param string                      $data
+     *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitConditionalExpression($node, $data)
@@ -241,6 +239,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitDoWhileStatement($node, $data)
@@ -279,6 +278,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                                 $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitElseIfStatement($node, $data)
@@ -314,6 +314,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitForStatement($node, $data)
@@ -348,6 +349,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitForeachStatement($node, $data)
@@ -390,6 +392,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                             $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitIfStatement($node, $data)
@@ -424,6 +427,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitReturnStatement($node, $data)
@@ -452,6 +456,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitSwitchStatement($node, $data)
@@ -494,6 +499,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitTryStatement($node, $data)
@@ -524,6 +530,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param string                      $data The previously calculated npath value.
      *
      * @return string
+     *
      * @since  0.9.12
      */
     public function visitWhileStatement($node, $data)
@@ -543,7 +550,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
      *
      * @return string
+     *
      * @since  0.9.12
+     *
      * @todo   I don't like this method implementation, it should be possible to
      *       implement this method with more visitor behavior for the boolean
      *       and logical expressions.

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -50,13 +50,17 @@ use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTBooleanAndExpression;
 use PDepend\Source\AST\ASTBooleanOrExpression;
 use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTElseIfStatement;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTIfStatement;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTLogicalAndExpression;
 use PDepend\Source\AST\ASTLogicalOrExpression;
 use PDepend\Source\AST\ASTLogicalXorExpression;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTSwitchLabel;
 use PDepend\Util\MathUtil;
@@ -77,9 +81,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     const M_NPATH_COMPLEXITY = 'npath';
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -192,8 +196,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(?) = NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 2 --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node
-     * @param string                      $data
+     * @param ASTNode $node
+     * @param string  $data
      *
      * @return string
      *
@@ -235,8 +239,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(do) = NP(<do-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -274,8 +278,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(if) = NP(<if-range>) + NP(<expr>) + NP(<else-range> --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTElseIfStatement $node The currently visited node.
-     * @param string                                 $data The previously calculated npath value.
+     * @param ASTElseIfStatement $node The currently visited node.
+     * @param string             $data The previously calculated npath value.
      *
      * @return string
      *
@@ -310,8 +314,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(for) = NP(<for-range>) + NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 1 --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -345,8 +349,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(foreach) = NP(<foreach-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -388,8 +392,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(if) = NP(<if-range>) + NP(<expr>) + NP(<else-range> --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTIfStatement $node The currently visited node.
-     * @param string                             $data The previously calculated npath value.
+     * @param ASTIfStatement $node The currently visited node.
+     * @param string         $data The previously calculated npath value.
      *
      * @return string
      *
@@ -423,8 +427,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(return) = NP(<expr>) --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -452,8 +456,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(switch) = NP(<expr>) + NP(<default-range>) +  NP(<case-range1>) ... --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -495,8 +499,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(try) = NP(<try-range>) + NP(<catch-range1>) + NP(<catch-range2>) ... --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -526,8 +530,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(while) = NP(<while-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
-     * @param string                      $data The previously calculated npath value.
+     * @param ASTNode $node The currently visited node.
+     * @param string  $data The previously calculated npath value.
      *
      * @return string
      *
@@ -547,7 +551,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     /**
      * Calculates the expression sum of the given node.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      *
      * @return string
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -164,9 +164,9 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -47,7 +47,6 @@ use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -75,35 +74,35 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Number Of Packages.
      *
-     * @var integer
+     * @var int
      */
     private $nop = 0;
 
     /**
      * Number Of Classes.
      *
-     * @var integer
+     * @var int
      */
     private $noc = 0;
 
     /**
      * Number Of Interfaces.
      *
-     * @var integer
+     * @var int
      */
     private $noi = 0;
 
     /**
      * Number Of Methods.
      *
-     * @var integer
+     * @var int
      */
     private $nom = 0;
 
     /**
      * Number Of Functions.
      *
-     * @var integer
+     * @var int
      */
     private $nof = 0;
 
@@ -127,7 +126,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -168,7 +166,8 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -190,7 +189,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -221,7 +219,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -240,7 +237,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -271,7 +267,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -296,7 +291,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -52,6 +52,8 @@ use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -167,9 +169,9 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     }
 
     /**
-     * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
+     * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @return void
      */
@@ -411,10 +413,10 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @param array<integer, \PDepend\Source\Tokenizer\Token> $tokens The raw token stream.
-     * @param bool                                            $search Optional boolean flag, search start.
+     * @param array<int, Token> $tokens The raw token stream.
+     * @param bool              $search Optional boolean flag, search start.
      *
-     * @return array<integer, integer>
+     * @return array<int, integer>
      */
     private function linesOfCode(array $tokens, $search = false)
     {
@@ -448,8 +450,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
 
             switch ($token->type) {
                 // These statement are terminated by a semicolon
-                //case \PDepend\Source\Tokenizer\Tokens::T_RETURN:
-                //case \PDepend\Source\Tokenizer\Tokens::T_THROW:
+                //case Tokens::T_RETURN:
+                //case Tokens::T_THROW:
                 case Tokens::T_IF:
                 case Tokens::T_TRY:
                 case Tokens::T_CASE:

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -47,7 +47,6 @@ use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
@@ -108,7 +107,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * Executable lines of code in a class. The method calculation increases
      * this property with each method's ELOC value.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.9.12
      */
     private $classExecutableLines = 0;
@@ -117,7 +117,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * Logical lines of code in a class. The method calculation increases this
      * property with each method's LLOC value.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.9.13
      */
     private $classLogicalLines = 0;
@@ -136,7 +137,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, integer>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -169,7 +169,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     *
      * @return void
      */
     public function analyze($namespaces)
@@ -191,7 +192,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -231,7 +231,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Visits a file node.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
@@ -275,7 +274,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -311,7 +309,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -348,7 +345,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -391,7 +387,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * Updates the project metrics based on the node metrics identifier by the
      * given <b>$id</b>.
      *
-     * @param  string $id The unique identifier of a node.
+     * @param string $id The unique identifier of a node.
+     *
      * @return void
      */
     private function updateProjectMetrics($id)
@@ -414,8 +411,9 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @param  array<integer, \PDepend\Source\Tokenizer\Token> $tokens The raw token stream.
-     * @param  boolean                                         $search Optional boolean flag, search start.
+     * @param array<integer, \PDepend\Source\Tokenizer\Token> $tokens The raw token stream.
+     * @param bool                                            $search Optional boolean flag, search start.
+     *
      * @return array<integer, integer>
      */
     private function linesOfCode(array $tokens, $search = false)

--- a/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
@@ -49,7 +49,7 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * Simple marker interface that is used to mark an analyzer as cache aware. This
  * means that the loading infrastructure code will inject an instance of
- * {@link \PDepend\Util\Cache\CacheDriver} into this analyzer.
+ * {@link CacheDriver} into this analyzer.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -52,6 +53,7 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 interface AnalyzerCacheAware extends Analyzer
@@ -59,7 +61,6 @@ interface AnalyzerCacheAware extends Analyzer
     /**
      * Setter method for the system wide used cache.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return void
      */
     public function setCache(CacheDriver $cache);

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Metrics;
 
+use PDepend\Report\ReportGenerator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -53,7 +54,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class AnalyzerFactory
 {
     /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     * @var ContainerInterface
      */
     private $container;
 
@@ -68,9 +69,9 @@ class AnalyzerFactory
     /**
      * Create and configure all analyzers required for given set of loggers.
      *
-     * @param \PDepend\Report\ReportGenerator[] $generators
+     * @param ReportGenerator[] $generators
      *
-     * @return \PDepend\Metrics\Analyzer[]
+     * @return Analyzer[]
      */
     public function createRequiredForGenerators(array $generators)
     {

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -59,8 +59,6 @@ class AnalyzerFactory
 
     /**
      * Create a new Analyzer Factory
-     *
-     * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
      */
     public function __construct(ContainerInterface $container)
     {
@@ -70,7 +68,8 @@ class AnalyzerFactory
     /**
      * Create and configure all analyzers required for given set of loggers.
      *
-     * @param  \PDepend\Report\ReportGenerator[] $generators
+     * @param \PDepend\Report\ReportGenerator[] $generators
+     *
      * @return \PDepend\Metrics\Analyzer[]
      */
     public function createRequiredForGenerators(array $generators)

--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -38,10 +38,15 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
 
 namespace PDepend\Metrics;
+
+use ArrayIterator;
+use FilterIterator;
+use ReturnTypeWillChange;
 
 /**
  * Filter iterator that only returns enabled {@link \PDepend\Metrics\Analyzer}
@@ -49,9 +54,10 @@ namespace PDepend\Metrics;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
-class AnalyzerIterator extends \FilterIterator
+class AnalyzerIterator extends FilterIterator
 {
     /**
      * Constructs a new iterator instance.
@@ -60,15 +66,15 @@ class AnalyzerIterator extends \FilterIterator
      */
     public function __construct(array $analyzers)
     {
-        parent::__construct(new \ArrayIterator($analyzers));
+        parent::__construct(new ArrayIterator($analyzers));
     }
 
     /**
      * Returns <b>true</b> when the current analyzer instance is enabled.
      *
-     * @return boolean
+     * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function accept()
     {
         return $this->getInnerIterator()->current()->isEnabled();

--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -49,7 +49,7 @@ use FilterIterator;
 use ReturnTypeWillChange;
 
 /**
- * Filter iterator that only returns enabled {@link \PDepend\Metrics\Analyzer}
+ * Filter iterator that only returns enabled {@link Analyzer}
  * instances.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -62,7 +62,7 @@ class AnalyzerIterator extends FilterIterator
     /**
      * Constructs a new iterator instance.
      *
-     * @param \PDepend\Metrics\Analyzer[] $analyzers
+     * @param Analyzer[] $analyzers
      */
     public function __construct(array $analyzers)
     {

--- a/src/main/php/PDepend/Metrics/AnalyzerListener.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerListener.php
@@ -56,7 +56,8 @@ interface AnalyzerListener extends ASTVisitListener
     /**
      * This method is called when the analyzer starts code processing.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     *
      * @return void
      */
     public function startAnalyzer(Analyzer $analyzer);
@@ -64,7 +65,8 @@ interface AnalyzerListener extends ASTVisitListener
     /**
      * This method is called when the analyzer has finished code processing.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     *
      * @return void
      */
     public function endAnalyzer(Analyzer $analyzer);

--- a/src/main/php/PDepend/Metrics/AnalyzerListener.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerListener.php
@@ -56,7 +56,7 @@ interface AnalyzerListener extends ASTVisitListener
     /**
      * This method is called when the analyzer starts code processing.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param Analyzer $analyzer The context analyzer instance.
      *
      * @return void
      */
@@ -65,7 +65,7 @@ interface AnalyzerListener extends ASTVisitListener
     /**
      * This method is called when the analyzer has finished code processing.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The context analyzer instance.
+     * @param Analyzer $analyzer The context analyzer instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/AnalyzerNodeAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerNodeAware.php
@@ -65,7 +65,6 @@ interface AnalyzerNodeAware extends Analyzer
      * )
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact);

--- a/src/main/php/PDepend/ProcessListener.php
+++ b/src/main/php/PDepend/ProcessListener.php
@@ -59,7 +59,7 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param Builder<mixed> $builder The used node builder instance.
      *
      * @return void
      */
@@ -68,7 +68,7 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param Builder<mixed> $builder The used node builder instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/ProcessListener.php
+++ b/src/main/php/PDepend/ProcessListener.php
@@ -59,7 +59,8 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     *
      * @return void
      */
     public function startParseProcess(Builder $builder);
@@ -67,7 +68,8 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder The used node builder instance.
+     *
      * @return void
      */
     public function endParseProcess(Builder $builder);
@@ -75,7 +77,6 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend starts parsing of a new file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function startFileParsing(Tokenizer $tokenizer);
@@ -83,7 +84,6 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
     /**
      * Is called when PDepend has finished a file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function endFileParsing(Tokenizer $tokenizer);

--- a/src/main/php/PDepend/Report/CodeAwareGenerator.php
+++ b/src/main/php/PDepend/Report/CodeAwareGenerator.php
@@ -43,6 +43,7 @@
 namespace PDepend\Report;
 
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * A logger that implements this interface needs the analyzed code structure.
@@ -55,7 +56,7 @@ interface CodeAwareGenerator extends ReportGenerator
     /**
      * Sets the context code nodes.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/CodeAwareGenerator.php
+++ b/src/main/php/PDepend/Report/CodeAwareGenerator.php
@@ -55,7 +55,8 @@ interface CodeAwareGenerator extends ReportGenerator
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     *
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts);

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -78,21 +78,21 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     private $logFile = null;
 
     /**
-     * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
+     * The raw {@link ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
+     * @var ASTArtifactList<ASTNamespace>
      */
     protected $code = null;
 
     /**
      * Set of all analyzed files.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit[]
+     * @var ASTCompilationUnit[]
      */
     protected $fileSet = array();
 
     /**
-     * @var null|\PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
+     * @var null|ClassDependencyAnalyzer
      */
     private $dependencyAnalyzer;
 
@@ -131,7 +131,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      *
      * @return void
      */
@@ -144,7 +144,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -160,7 +160,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      *
      * @return void
      */
@@ -211,8 +211,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param \PDepend\Source\AST\ASTClass $type
-     * @param string                       $typeIdentifier
+     * @param ASTClass $type
+     * @param string   $typeIdentifier
      *
      * @return void
      */
@@ -339,8 +339,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement                             $xml             The parent xml element.
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement         $xml             The parent xml element.
+     * @param ASTCompilationUnit $compilationUnit The code file instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -42,19 +42,20 @@
 
 namespace PDepend\Report\Dependencies;
 
+use DOMDocument;
+use DOMElement;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\Analyzer\ClassDependencyAnalyzer;
 use PDepend\Report\CodeAwareGenerator;
 use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
-use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
@@ -91,14 +92,14 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     protected $fileSet = array();
 
     /**
-     * @var \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer|null
+     * @var null|\PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
      */
     private $dependencyAnalyzer;
 
     /**
      * The internal used xml stack.
      *
-     * @var \DOMElement[]
+     * @var DOMElement[]
      */
     private $xmlStack = array();
 
@@ -130,7 +131,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     *
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)
@@ -142,8 +144,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer)
     {
@@ -157,8 +160,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     *
+     * @return void
      */
     public function close()
     {
@@ -166,7 +170,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             throw new NoLogOutputException($this);
         }
 
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->formatOutput = true;
 
         $dependencies = $dom->createElement('dependencies');
@@ -187,7 +191,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -198,7 +201,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a trait node.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
      */
     public function visitTrait(ASTTrait $trait)
@@ -209,8 +211,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $type
-     * @param  string                       $typeIdentifier
+     * @param \PDepend\Source\AST\ASTClass $type
+     * @param string                       $typeIdentifier
+     *
      * @return void
      */
     private function generateTypeXml(AbstractASTClassOrInterface $type, $typeIdentifier)
@@ -239,7 +242,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -250,7 +252,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -261,7 +262,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)
@@ -298,11 +298,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Aggregates all dependencies for the given <b>$node</b> instance and adds them
      * to the <b>\DOMElement</b>
      *
-     * @param  \DOMElement                             $xml
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
-    protected function writeNodeDependencies(\DOMElement $xml, AbstractASTArtifact $node)
+    protected function writeNodeDependencies(DOMElement $xml, AbstractASTArtifact $node)
     {
         if (!$this->dependencyAnalyzer) {
             return;
@@ -341,11 +339,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param  \DOMElement                            $xml             The parent xml element.
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement                             $xml             The parent xml element.
+     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     *
      * @return void
      */
-    protected function writeFileReference(\DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
+    protected function writeFileReference(DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
     {
         if (in_array($compilationUnit, $this->fileSet, true) === false) {
             $this->fileSet[] = $compilationUnit;

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -42,17 +42,18 @@
 
 namespace PDepend\Report\Jdepend;
 
+use DOMDocument;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\CodeAwareGenerator;
 use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
-use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
-use PDepend\Util\Utf8Util;
 use PDepend\Util\FileUtil;
 use PDepend\Util\ImageConvert;
+use PDepend\Util\Utf8Util;
 
 /**
  * Generates a chart with the aggregated metrics.
@@ -109,7 +110,8 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<ASTNamespace> $artifacts
+     * @param \PDepend\Source\AST\ASTArtifactList<ASTNamespace> $artifacts
+     *
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)
@@ -121,8 +123,9 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer)
     {
@@ -137,8 +140,9 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     *
+     * @return void
      */
     public function close()
     {
@@ -149,7 +153,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
 
         $bias = 0.1;
 
-        $svg = new \DOMDocument('1.0', 'UTF-8');
+        $svg = new DOMDocument('1.0', 'UTF-8');
         $svg->loadXML(file_get_contents(dirname(__FILE__) . '/chart.svg'));
 
         $layer = $svg->getElementById('jdepend.layer');

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -73,14 +73,14 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * The context source code.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList<ASTNamespace>
+     * @var ASTArtifactList<ASTNamespace>
      */
     private $code = null;
 
     /**
      * The context analyzer instance.
      *
-     * @var \PDepend\Metrics\Analyzer\DependencyAnalyzer
+     * @var Analyzer\DependencyAnalyzer
      */
     private $analyzer = null;
 
@@ -110,7 +110,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Sets the context code nodes.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList<ASTNamespace> $artifacts
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      *
      * @return void
      */
@@ -123,7 +123,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -140,7 +140,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -52,6 +52,7 @@ use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\AbstractASTVisitor;
@@ -74,16 +75,16 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     private $logFile = null;
 
     /**
-     * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
+     * The raw {@link ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
+     * @var ASTArtifactList<ASTNamespace>
      */
     protected $code = null;
 
     /**
      * Set of all analyzed files.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit[]
+     * @var ASTCompilationUnit[]
      */
     protected $fileSet = array();
 
@@ -162,7 +163,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      *
      * @return void
      */
@@ -175,7 +176,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -192,7 +193,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Report\Jdepend;
 
+use DOMDocument;
+use DOMElement;
+use DOMNode;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\CodeAwareGenerator;
@@ -108,28 +111,28 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The Packages dom element.
      *
-     * @var \DOMNode
+     * @var DOMNode
      */
     protected $packages = null;
 
     /**
      * The Cycles dom element.
      *
-     * @var \DOMNode
+     * @var DOMNode
      */
     protected $cycles = null;
 
     /**
      * The concrete classes element for the current package.
      *
-     * @var \DOMElement
+     * @var DOMElement
      */
     protected $concreteClasses = null;
 
     /**
      * The abstract classes element for the current package.
      *
-     * @var \DOMElement
+     * @var DOMElement
      */
     protected $abstractClasses = null;
 
@@ -159,7 +162,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     *
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)
@@ -171,8 +175,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer)
     {
@@ -187,8 +192,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     *
+     * @return void
      */
     public function close()
     {
@@ -197,7 +203,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             throw new NoLogOutputException($this);
         }
 
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
 
         $dom->formatOutput = true;
 
@@ -218,7 +224,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -247,7 +252,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -272,7 +276,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a package node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)

--- a/src/main/php/PDepend/Report/NoLogOutputException.php
+++ b/src/main/php/PDepend/Report/NoLogOutputException.php
@@ -55,8 +55,6 @@ class NoLogOutputException extends LogicException
 {
     /**
      * Creates a new log target exception for the given log instance.
-     *
-     * @param \PDepend\Report\ReportGenerator $logger
      */
     public function __construct(ReportGenerator $logger)
     {

--- a/src/main/php/PDepend/Report/NoLogOutputException.php
+++ b/src/main/php/PDepend/Report/NoLogOutputException.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Report;
 
+use LogicException;
+
 /**
  * This type of exception is thrown, if a required log target/log file wasn't
  * configured for the current logger instance.
@@ -49,7 +51,7 @@ namespace PDepend\Report;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class NoLogOutputException extends \LogicException
+class NoLogOutputException extends LogicException
 {
     /**
      * Creates a new log target exception for the given log instance.

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -76,35 +76,35 @@ class Pyramid implements FileAwareGenerator
     /**
      * The used coupling analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\CouplingAnalyzer
+     * @var CouplingAnalyzer
      */
     private $coupling = null;
 
     /**
      * The used cyclomatic complexity analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+     * @var CyclomaticComplexityAnalyzer
      */
     private $cyclomaticComplexity = null;
 
     /**
      * The used inheritance analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\InheritanceAnalyzer
+     * @var InheritanceAnalyzer
      */
     private $inheritance = null;
 
     /**
      * The used node count analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\NodeCountAnalyzer
+     * @var NodeCountAnalyzer
      */
     private $nodeCount = null;
 
     /**
      * The used node loc analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\NodeLocAnalyzer
+     * @var NodeLocAnalyzer
      */
     private $nodeLoc = null;
 
@@ -158,7 +158,7 @@ class Pyramid implements FileAwareGenerator
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -183,7 +183,7 @@ class Pyramid implements FileAwareGenerator
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException
+     * @throws NoLogOutputException
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Report\Overview;
 
+use DOMDocument;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\Analyzer\CouplingAnalyzer;
 use PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer;
@@ -52,6 +53,7 @@ use PDepend\Report\FileAwareGenerator;
 use PDepend\Report\NoLogOutputException;
 use PDepend\Util\FileUtil;
 use PDepend\Util\ImageConvert;
+use RuntimeException;
 
 /**
  * This logger generates a system overview pyramid, as described in the book
@@ -156,8 +158,9 @@ class Pyramid implements FileAwareGenerator
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer)
     {
@@ -180,8 +183,9 @@ class Pyramid implements FileAwareGenerator
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException
+     *
+     * @return void
      */
     public function close()
     {
@@ -193,7 +197,7 @@ class Pyramid implements FileAwareGenerator
         $metrics     = $this->collectMetrics();
         $proportions = $this->computeProportions($metrics);
 
-        $svg = new \DOMDocument('1.0', 'UTF-8');
+        $svg = new DOMDocument('1.0', 'UTF-8');
         $svg->loadXML(file_get_contents(dirname(__FILE__) . '/pyramid.svg'));
 
         $items = array_merge($metrics, $proportions);
@@ -231,9 +235,10 @@ class Pyramid implements FileAwareGenerator
      * If no threshold is defined for the given name, this method will return
      * <b>null</b>.
      *
-     * @param  string $name  The metric/field identfier.
-     * @param  mixed  $value The metric/field value.
-     * @return string|null
+     * @param string $name  The metric/field identfier.
+     * @param mixed  $value The metric/field value.
+     *
+     * @return null|string
      */
     private function computeThreshold($name, $value)
     {
@@ -260,7 +265,8 @@ class Pyramid implements FileAwareGenerator
     /**
      * Computes the proportions between the given metrics.
      *
-     * @param  array<string, float> $metrics The aggregated project metrics.
+     * @param array<string, float> $metrics The aggregated project metrics.
+     *
      * @return array<string, float>
      */
     private function computeProportions(array $metrics)
@@ -291,25 +297,26 @@ class Pyramid implements FileAwareGenerator
     /**
      * Aggregates the required metrics from the registered analyzers.
      *
+     * @throws RuntimeException If one of the required analyzers isn't set.
+     *
      * @return array<string, mixed>
-     * @throws \RuntimeException If one of the required analyzers isn't set.
      */
     private function collectMetrics()
     {
         if ($this->coupling === null) {
-            throw new \RuntimeException('Missing Coupling analyzer.');
+            throw new RuntimeException('Missing Coupling analyzer.');
         }
         if ($this->cyclomaticComplexity === null) {
-            throw new \RuntimeException('Missing Cyclomatic Complexity analyzer.');
+            throw new RuntimeException('Missing Cyclomatic Complexity analyzer.');
         }
         if ($this->inheritance === null) {
-            throw new \RuntimeException('Missing Inheritance analyzer.');
+            throw new RuntimeException('Missing Inheritance analyzer.');
         }
         if ($this->nodeCount === null) {
-            throw new \RuntimeException('Missing Node Count analyzer.');
+            throw new RuntimeException('Missing Node Count analyzer.');
         }
         if ($this->nodeLoc === null) {
-            throw new \RuntimeException('Missing Node LOC analyzer.');
+            throw new RuntimeException('Missing Node LOC analyzer.');
         }
 
         $coupling    = $this->coupling->getProjectMetrics();

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -56,7 +56,7 @@ interface ReportGenerator
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -65,7 +65,7 @@ interface ReportGenerator
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -56,16 +56,18 @@ interface ReportGenerator
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer);
     
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     *
+     * @return void
      */
     public function close();
     

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Report;
 
+use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -74,10 +75,12 @@ class ReportGeneratorFactory
      * Creates a new generator or returns an existing instance for the given
      * <b>$identifier</b>.
      *
-     * @param  string $identifier The generator identifier.
-     * @param  string $fileName   The log output file name.
+     * @param string $identifier The generator identifier.
+     * @param string $fileName   The log output file name.
+     *
+     * @throws RuntimeException
+     *
      * @return \PDepend\Report\ReportGenerator
-     * @throws \RuntimeException
      */
     public function createGenerator($identifier, $fileName)
     {
@@ -95,7 +98,7 @@ class ReportGeneratorFactory
             }
 
             if (!$logger) {
-                throw new \RuntimeException(sprintf('Unknown generator with identifier "%s".', $identifier));
+                throw new RuntimeException(sprintf('Unknown generator with identifier "%s".', $identifier));
             }
 
             // TODO: Refactor this into an external log configurator or a similar

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -80,7 +80,7 @@ class ReportGeneratorFactory
      *
      * @throws RuntimeException
      *
-     * @return \PDepend\Report\ReportGenerator
+     * @return ReportGenerator
      */
     public function createGenerator($identifier, $fileName)
     {
@@ -115,7 +115,7 @@ class ReportGeneratorFactory
     /**
      * Set of created logger instances.
      *
-     * @var \PDepend\Report\ReportGenerator[]
+     * @var ReportGenerator[]
      */
     protected $instances = array();
 }

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Report\Summary;
 
+use DOMDocument;
+use DOMElement;
 use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
@@ -109,7 +111,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * The internal used xml stack.
      *
-     * @var \DOMElement[]
+     * @var DOMElement[]
      */
     private $xmlStack = array();
 
@@ -153,7 +155,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     *
      * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts)
@@ -165,8 +168,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     *
+     * @return bool
      */
     public function log(Analyzer $analyzer)
     {
@@ -187,8 +191,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @return void
      * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     *
+     * @return void
      */
     public function close()
     {
@@ -196,7 +201,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             throw new NoLogOutputException($this);
         }
 
-        $dom = new \DOMDocument('1.0', 'UTF-8');
+        $dom = new DOMDocument('1.0', 'UTF-8');
 
         $dom->formatOutput = true;
 
@@ -237,6 +242,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Returns an array with all collected project metrics.
      *
      * @return array<string, mixed>
+     *
      * @since  0.9.10
      */
     private function getProjectMetrics()
@@ -256,7 +262,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -267,7 +272,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a trait node.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
      */
     public function visitTrait(ASTTrait $trait)
@@ -278,8 +282,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $type
-     * @param  string                       $typeIdentifier
+     * @param string $typeIdentifier
+     *
      * @return void
      */
     private function generateTypeXml(ASTClass $type, $typeIdentifier)
@@ -321,7 +325,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -347,7 +350,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -358,7 +360,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -383,7 +384,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)
@@ -422,11 +422,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Aggregates all metrics for the given <b>$node</b> instance and adds them
      * to the <b>\DOMElement</b>
      *
-     * @param  \DOMElement                             $xml
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
-    protected function writeNodeMetrics(\DOMElement $xml, AbstractASTArtifact $node)
+    protected function writeNodeMetrics(DOMElement $xml, AbstractASTArtifact $node)
     {
         $metrics = array();
         foreach ($this->nodeAwareAnalyzers as $analyzer) {
@@ -447,11 +445,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param  \DOMElement                            $xml             The parent xml element.
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement                             $xml             The parent xml element.
+     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     *
      * @return void
      */
-    protected function writeFileReference(\DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
+    protected function writeFileReference(DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
     {
         if (in_array($compilationUnit, $this->fileSet, true) === false) {
             $this->fileSet[] = $compilationUnit;

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -79,32 +79,32 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     private $logFile = null;
 
     /**
-     * The raw {@link \PDepend\Source\AST\ASTNamespace} instances.
+     * The raw {@link ASTNamespace} instances.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
+     * @var ASTArtifactList<ASTNamespace>
      */
     protected $code = null;
 
     /**
      * Set of all analyzed files.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit[]
+     * @var ASTCompilationUnit[]
      */
     protected $fileSet = array();
 
     /**
      * List of all analyzers that implement the node aware interface
-     * {@link \PDepend\Metrics\AnalyzerNodeAware}.
+     * {@link AnalyzerNodeAware}.
      *
-     * @var \PDepend\Metrics\AnalyzerNodeAware[]
+     * @var AnalyzerNodeAware[]
      */
     private $nodeAwareAnalyzers = array();
 
     /**
      * List of all analyzers that implement the node aware interface
-     * {@link \PDepend\Metrics\AnalyzerProjectAware}.
+     * {@link AnalyzerProjectAware}.
      *
-     * @var \PDepend\Metrics\AnalyzerProjectAware[]
+     * @var AnalyzerProjectAware[]
      */
     private $projectAwareAnalyzers = array();
 
@@ -155,7 +155,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Sets the context code nodes.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace> $artifacts
+     * @param ASTArtifactList<ASTNamespace> $artifacts
      *
      * @return void
      */
@@ -168,7 +168,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      *
      * @return bool
      */
@@ -191,7 +191,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Closes the logger process and writes the output file.
      *
-     * @throws \PDepend\Report\NoLogOutputException If the no log target exists.
+     * @throws NoLogOutputException If the no log target exists.
      *
      * @return void
      */
@@ -445,8 +445,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement                             $xml             The parent xml element.
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement         $xml             The parent xml element.
+     * @param ASTCompilationUnit $compilationUnit The code file instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -63,6 +64,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTAllocationExpression extends AbstractASTNode
@@ -71,9 +73,6 @@ class ASTAllocationExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 class ASTAnonymousClass extends ASTClass implements ASTNode
@@ -58,7 +60,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var \PDepend\Source\AST\ASTNode|null
+     * @var null|\PDepend\Source\AST\ASTNode
      */
     protected $parent = null;
 
@@ -68,12 +70,14 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * image in a colon separated string.
      *
      * @var string
+     *
      * @since 0.10.4
      */
     protected $metadata = ':::';
 
     /**
      * @param string $image
+     *
      * @return void
      */
     public function setImage($image)
@@ -94,7 +98,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the start line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartLine()
     {
@@ -104,7 +108,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the start column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartColumn()
     {
@@ -114,7 +118,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the end line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndLine()
     {
@@ -124,7 +128,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the end column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndColumn()
     {
@@ -135,11 +139,13 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * For better performance we have moved the single setter methods for the
      * node columns and lines into this configure method.
      *
-     * @param integer $startLine
-     * @param integer $endLine
-     * @param integer $startColumn
-     * @param integer $endColumn
+     * @param int $startLine
+     * @param int $endLine
+     * @param int $startColumn
+     * @param int $endColumn
+     *
      * @return void
+     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns($startLine, $endLine, $startColumn, $endColumn)
@@ -165,6 +171,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Sets the parent node of this node.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function setParent(ASTNode $node)
@@ -177,6 +184,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * of <b>$parentType</b>.
      *
      * @param string $parentType
+     *
      * @return \PDepend\Source\AST\ASTNode[]
      */
     public function getParentsOfType($parentType)
@@ -197,6 +205,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * This method adds a new child node at the first position of the children.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function prependChild(ASTNode $node)
@@ -209,7 +218,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAnonymous()
     {
@@ -217,9 +226,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     }
 
     /**
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return integer
+     * @return int
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {
@@ -232,6 +239,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array
+     *
      * @since 0.10.0
      */
     public function __sleep()
@@ -261,8 +269,10 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @param integer $index
-     * @return integer
+     * @param int $index
+     *
+     * @return int
+     *
      * @since 0.10.4
      */
     protected function getMetadataInteger($index)
@@ -274,9 +284,11 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Stores an integer value under the given index in the internally used data
      * string.
      *
-     * @param integer $index
-     * @param integer $value
+     * @param int $index
+     * @param int $value
+     *
      * @return void
+     *
      * @since 0.10.4
      */
     protected function setMetadataInteger($index, $value)
@@ -287,8 +299,8 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the value that was stored under the given index.
      *
-     * @param integer $index
-     * @return mixed
+     * @param int $index
+     *
      * @since 0.10.4
      */
     protected function getMetadata($index)
@@ -301,9 +313,10 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param integer $index
-     * @param mixed $value
+     * @param int $index
+     *
      * @return void
+     *
      * @since 0.10.4
      */
     protected function setMetadata($index, $value)
@@ -317,7 +330,8 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.10.4
      */
     protected function getMetadataSize()

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -60,7 +60,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var null|\PDepend\Source\AST\ASTNode
+     * @var null|ASTNode
      */
     protected $parent = null;
 
@@ -160,7 +160,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function getParent()
     {
@@ -169,8 +169,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
 
     /**
      * Sets the parent node of this node.
-     *
-     * @param \PDepend\Source\AST\ASTNode $node
      *
      * @return void
      */
@@ -185,7 +183,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      *
      * @param string $parentType
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getParentsOfType($parentType)
     {
@@ -203,8 +201,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
 
     /**
      * This method adds a new child node at the first position of the children.
-     *
-     * @param \PDepend\Source\AST\ASTNode $node
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -62,6 +63,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTArguments extends AbstractASTNode
@@ -79,7 +81,6 @@ class ASTArguments extends AbstractASTNode
     /**
      * This method adds a new child node to this node instance.
      *
-     * @param ASTNode $node
      * @return void
      */
     public function addChild(ASTNode $node)
@@ -95,9 +96,6 @@ class ASTArguments extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents an array expression.
  *
@@ -62,17 +64,17 @@ namespace PDepend\Source\AST;
  *
  * @since 1.0.0
  */
-class ASTArray extends \PDepend\Source\AST\ASTExpression
+class ASTArray extends ASTExpression
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitArray($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -58,6 +59,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTArray extends \PDepend\Source\AST\ASTExpression
@@ -66,9 +68,8 @@ class ASTArray extends \PDepend\Source\AST\ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param  mixed                                 $data
-     * @return mixed
+     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     *
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -58,6 +59,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
@@ -66,7 +68,7 @@ class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
      * This method will return <b>true</b> when the element value is passed by
      * reference.
      *
-     * @return boolean
+     * @return bool
      */
     public function isByReference()
     {
@@ -86,7 +88,8 @@ class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.4
      * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
      */
@@ -100,9 +103,7 @@ class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a single array element expression.
  *
@@ -62,7 +64,7 @@ namespace PDepend\Source\AST;
  *
  * @since 1.0.0
  */
-class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
+class ASTArrayElement extends ASTExpression
 {
     /**
      * This method will return <b>true</b> when the element value is passed by
@@ -91,7 +93,7 @@ class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
      * @return int
      *
      * @since  0.10.4
-     * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
+     * @see    ASTNode#getMetadataSize()
      */
     protected function getMetadataSize()
     {
@@ -102,11 +104,11 @@ class ASTArrayElement extends \PDepend\Source\AST\ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitArrayElement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -60,6 +61,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTArrayIndexExpression extends ASTIndexExpression
@@ -68,9 +70,8 @@ class ASTArrayIndexExpression extends ASTIndexExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param  mixed                                 $data
-     * @return mixed
+     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     *
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -70,7 +70,7 @@ class ASTArrayIndexExpression extends ASTIndexExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -56,6 +56,7 @@ interface ASTArtifact /* extends ASTNode */
      * Returns the artifact name.
      *
      * @return string
+     *
      * @deprecated Use getImage() inherit from ASTNode class.
      */
     public function getName();
@@ -70,7 +71,6 @@ interface ASTArtifact /* extends ASTNode */
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor);

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -56,14 +56,14 @@ use ReturnTypeWillChange;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @template T of \PDepend\Source\AST\ASTArtifact
+ * @template T of ASTArtifact
  * @implements \Iterator<int|string, T>
  * @implements \ArrayAccess<int|string, T>
  */
 class ASTArtifactList implements ArrayAccess, Iterator, Countable
 {
     /**
-     * List of {@link \PDepend\Source\AST\ASTArtifact} objects in
+     * List of {@link ASTArtifact} objects in
      * this iterator.
      *
      * @var T[]
@@ -85,7 +85,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     private $offset = 0;
 
     /**
-     * Constructs a new node iterator from the given {@link \PDepend\Source\AST\ASTArtifact}
+     * Constructs a new node iterator from the given {@link ASTArtifact}
      * node array.
      *
      * @param T[] $artifacts
@@ -112,7 +112,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     }
 
     /**
-     * Returns the number of {@link \PDepend\Source\AST\ASTArtifact}
+     * Returns the number of {@link ASTArtifact}
      * objects in this iterator.
      *
      * @return int
@@ -138,7 +138,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     }
 
     /**
-     * Returns the name of the current {@link \PDepend\Source\AST\ASTArtifact}.
+     * Returns the name of the current {@link ASTArtifact}.
      *
      * @return string
      */
@@ -149,7 +149,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     }
 
     /**
-     * Moves the internal pointer to the next {@link \PDepend\Source\AST\ASTArtifact}.
+     * Moves the internal pointer to the next {@link ASTArtifact}.
      *
      * @return void
      */
@@ -171,7 +171,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     }
 
     /**
-     * Returns <b>true</b> while there is a next {@link \PDepend\Source\AST\ASTArtifact}.
+     * Returns <b>true</b> while there is a next {@link ASTArtifact}.
      *
      * @return bool
      */

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -42,7 +42,13 @@
 
 namespace PDepend\Source\AST;
 
+use ArrayAccess;
+use BadMethodCallException;
+use Countable;
+use Iterator;
+use OutOfBoundsException;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
+use ReturnTypeWillChange;
 
 /**
  * Iterator for code nodes.
@@ -54,7 +60,7 @@ use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
  * @implements \Iterator<int|string, T>
  * @implements \ArrayAccess<int|string, T>
  */
-class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
+class ASTArtifactList implements ArrayAccess, Iterator, Countable
 {
     /**
      * List of {@link \PDepend\Source\AST\ASTArtifact} objects in
@@ -67,14 +73,14 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Total number of available nodes.
      *
-     * @var integer
+     * @var int
      */
     private $count = 0;
 
     /**
      * Current internal offset.
      *
-     * @var integer
+     * @var int
      */
     private $offset = 0;
 
@@ -109,9 +115,9 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      * Returns the number of {@link \PDepend\Source\AST\ASTArtifact}
      * objects in this iterator.
      *
-     * @return integer
+     * @return int
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function count()
     {
         return count($this->artifacts);
@@ -120,9 +126,9 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Returns the current node or <b>false</b>
      *
-     * @return T|false
+     * @return false|T
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function current()
     {
         if ($this->offset >= $this->count) {
@@ -136,7 +142,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return string
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->artifacts[$this->offset]->getName();
@@ -147,7 +153,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function next()
     {
         ++$this->offset;
@@ -158,7 +164,7 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @return void
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function rewind()
     {
         $this->offset = 0;
@@ -167,9 +173,9 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Returns <b>true</b> while there is a next {@link \PDepend\Source\AST\ASTArtifact}.
      *
-     * @return boolean
+     * @return bool
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function valid()
     {
         return ($this->offset < $this->count);
@@ -180,12 +186,13 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
      *
      * @param mixed $offset An offset to check for.
      *
-     * @return boolean Returns true on success or false on failure. The return
-     *                 value will be casted to boolean if non-boolean was returned.
+     * @return bool Returns true on success or false on failure. The return
+     *              value will be casted to boolean if non-boolean was returned.
+     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->artifacts[$offset]);
@@ -194,49 +201,58 @@ class ASTArtifactList implements \ArrayAccess, \Iterator, \Countable
     /**
      * Offset to retrieve
      *
-     * @param  mixed $offset
+     * @param mixed $offset
+     *
+     * @throws OutOfBoundsException
+     *
      * @return T Can return all value types.
-     * @throws \OutOfBoundsException
+     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->artifacts[$offset])) {
             return $this->artifacts[$offset];
         }
-        throw new \OutOfBoundsException("The offset {$offset} does not exist.");
+        throw new OutOfBoundsException("The offset {$offset} does not exist.");
     }
 
     /**
      * Offset to set
      *
-     * @param  mixed $offset
-     * @param  mixed $value
+     * @param mixed $offset
+     * @param mixed $value
+     *
+     * @throws BadMethodCallException
+     *
      * @return void
-     * @throws \BadMethodCallException
+     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
-        throw new \BadMethodCallException('Not supported operation.');
+        throw new BadMethodCallException('Not supported operation.');
     }
 
     /**
      * Offset to unset
      *
-     * @param  mixed $offset
+     * @param mixed $offset
+     *
+     * @throws BadMethodCallException
+     *
      * @return void
-     * @throws \BadMethodCallException
+     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetunset.php
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
-        throw new \BadMethodCallException('Not supported operation.');
+        throw new BadMethodCallException('Not supported operation.');
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
@@ -45,7 +45,7 @@ namespace PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTArtifact;
 
 /**
- * Base interface for {@link \PDepend\Source\AST\ASTArtifactList} filters.
+ * Base interface for {@link ASTArtifactList} filters.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
@@ -56,8 +56,7 @@ interface ArtifactFilter
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return boolean
+     * @return bool
      */
     public function accept(ASTArtifact $node);
 }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -58,14 +58,14 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * Singleton instance of this filter.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
+     * @var CollectionArtifactFilter
      */
     private static $instance = null;
 
     /**
      * Singleton method for this filter class.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
+     * @return CollectionArtifactFilter
      */
     public static function getInstance()
     {
@@ -87,14 +87,14 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * An optional configured filter instance.
      *
-     * @var \PDepend\Source\AST\ASTArtifactList\ArtifactFilter
+     * @var ArtifactFilter
      */
     private $filter = null;
 
     /**
      * Sets the used filter instance.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList\ArtifactFilter $filter
+     * @param ArtifactFilter $filter
      *
      * @return void
      *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -94,8 +94,10 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * Sets the used filter instance.
      *
-     * @param  \PDepend\Source\AST\ASTArtifactList\ArtifactFilter $filter
+     * @param \PDepend\Source\AST\ASTArtifactList\ArtifactFilter $filter
+     *
      * @return void
+     *
      * @since  0.9.12
      */
     public function setFilter(ArtifactFilter $filter = null)
@@ -107,8 +109,7 @@ final class CollectionArtifactFilter implements ArtifactFilter
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return boolean
+     * @return bool
      */
     public function accept(ASTArtifact $node)
     {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
@@ -56,8 +56,7 @@ class NullArtifactFilter implements ArtifactFilter
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return boolean
+     * @return bool
      */
     public function accept(ASTArtifact $node)
     {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -86,8 +86,8 @@ class PackageArtifactFilter implements ArtifactFilter
     {
         $namespace = null;
         // NOTE: This looks a little bit ugly and it seems better to exclude
-        //       \PDepend\Source\AST\ASTMethod and \PDepend\Source\AST\ASTProperty,
-        //       but when PDepend supports more node types, this could produce errors.
+        //       ASTMethod and ASTProperty, but when PDepend supports more node
+        //       types, this could produce errors.
         if ($node instanceof AbstractASTClassOrInterface) {
             $namespace = $node->getNamespace()->getName();
         } elseif ($node instanceof ASTFunction) {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -80,8 +80,7 @@ class PackageArtifactFilter implements ArtifactFilter
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
      *
-     * @param  \PDepend\Source\AST\ASTArtifact $node
-     * @return boolean
+     * @return bool
      */
     public function accept(ASTArtifact $node)
     {

--- a/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
@@ -56,9 +56,6 @@ class ASTAssignmentExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTBooleanAndExpression extends AbstractASTNode
@@ -58,9 +60,6 @@ class ASTBooleanAndExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTBooleanOrExpression extends AbstractASTNode
@@ -58,9 +60,6 @@ class ASTBooleanOrExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a break-statement.
  *
@@ -66,17 +68,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTBreakStatement extends \PDepend\Source\AST\ASTStatement
+class ASTBreakStatement extends ASTStatement
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitBreakStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTBreakStatement extends \PDepend\Source\AST\ASTStatement
@@ -71,9 +73,7 @@ class ASTBreakStatement extends \PDepend\Source\AST\ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -51,7 +51,7 @@ namespace PDepend\Source\AST;
 interface ASTCallable
 {
     /**
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     public function getReturnType();
 }

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a cast-expression node.
  *
@@ -82,7 +84,7 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.15
  */
-class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
+class ASTCastExpression extends ASTUnaryExpression
 {
     /**
      * Constructs a new cast-expression node.
@@ -171,9 +173,9 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitCastExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.15
  */
 
@@ -78,6 +79,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.15
  */
 class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
@@ -95,7 +97,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents an array cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isArray()
     {
@@ -105,7 +107,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents an object cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isObject()
     {
@@ -115,7 +117,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents a boolean cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isBoolean()
     {
@@ -125,7 +127,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents an integer cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isInteger()
     {
@@ -135,7 +137,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents a float cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isFloat()
     {
@@ -148,7 +150,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents a string cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isString()
     {
@@ -158,7 +160,7 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
     /**
      * Returns <b>true</b> when this node represents an unset cast-expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isUnset()
     {
@@ -170,9 +172,6 @@ class ASTCastExpression extends \PDepend\Source\AST\ASTUnaryExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -55,9 +55,7 @@ class ASTCatchStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a catch-statement.
  *
@@ -54,11 +56,11 @@ class ASTCatchStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitCatchStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -57,7 +57,7 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * List of associated properties.
      *
-     * @var \PDepend\Source\AST\ASTProperty[]
+     * @var ASTProperty[]
      */
     private $properties = null;
 
@@ -95,7 +95,7 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Returns all properties for this class.
      *
-     * @return \PDepend\Source\AST\ASTProperty[]
+     * @return ASTProperty[]
      */
     public function getProperties()
     {
@@ -121,8 +121,6 @@ class ASTClass extends AbstractASTClassOrInterface
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTType $type
      *
      * @return bool
      */

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
+use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
@@ -62,7 +64,7 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAbstract()
     {
@@ -72,7 +74,7 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * This method will return <b>true</b> when this class is declared as final.
      *
-     * @return boolean
+     * @return bool
      */
     public function isFinal()
     {
@@ -83,7 +85,7 @@ class ASTClass extends AbstractASTClassOrInterface
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAnonymous()
     {
@@ -120,8 +122,9 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return boolean
+     * @param \PDepend\Source\AST\AbstractASTType $type
+     *
+     * @return bool
      */
     public function isSubtypeOf(AbstractASTType $type)
     {
@@ -145,7 +148,8 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -160,16 +164,19 @@ class ASTClass extends AbstractASTClassOrInterface
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param  integer $modifiers
+     * @param int $modifiers
+     *
+     * @throws BadMethodCallException
+     * @throws InvalidArgumentException
+     *
      * @return void
-     * @throws \BadMethodCallException
-     * @throws \InvalidArgumentException
+     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers)
     {
         if ($this->modifiers !== 0) {
-            throw new \BadMethodCallException(
+            throw new BadMethodCallException(
                 'Cannot overwrite previously set class modifiers.'
             );
         }
@@ -179,7 +186,7 @@ class ASTClass extends AbstractASTClassOrInterface
                   & ~State::IS_FINAL;
 
         if (($expected & $modifiers) !== 0) {
-            throw new \InvalidArgumentException('Invalid class modifier given.');
+            throw new InvalidArgumentException('Invalid class modifier given.');
         }
 
         $this->modifiers = $modifiers;
@@ -188,7 +195,6 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -203,6 +209,7 @@ class ASTClass extends AbstractASTClassOrInterface
      * context.
      *
      * @return void
+     *
      * @since  0.10.0
      */
     public function __wakeup()

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.0.0
  */
 
@@ -60,6 +61,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.0.0
  */
 class ASTClassFqnPostfix extends AbstractASTNode
@@ -69,9 +71,7 @@ class ASTClassFqnPostfix extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -70,7 +70,7 @@ class ASTClassFqnPostfix extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -59,8 +59,6 @@ class ASTClassOrInterfaceRecursiveInheritanceException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
      */
     public function __construct(AbstractASTClassOrInterface $type)
     {

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -38,10 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
 namespace PDepend\Source\AST;
+
+use RuntimeException;
 
 /**
  * This type of exception will be thrown when an inheritance hierarchy is
@@ -49,9 +52,10 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
-class ASTClassOrInterfaceRecursiveInheritanceException extends \RuntimeException
+class ASTClassOrInterfaceRecursiveInheritanceException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 
@@ -52,6 +53,7 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 class ASTClassOrInterfaceReference extends ASTType
@@ -66,15 +68,14 @@ class ASTClassOrInterfaceReference extends ASTType
     /**
      * An already loaded type instance.
      *
-     * @var \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     * @var null|\PDepend\Source\AST\AbstractASTClassOrInterface
      */
     protected $typeInstance = null;
 
     /**
      * Constructs a new type holder instance.
      *
-     * @param \PDepend\Source\Builder\BuilderContext $context
-     * @param string                                 $qualifiedName
+     * @param string $qualifiedName
      */
     public function __construct(BuilderContext $context, $qualifiedName)
     {
@@ -102,9 +103,6 @@ class ASTClassOrInterfaceReference extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)
@@ -117,6 +115,7 @@ class ASTClassOrInterfaceReference extends ASTType
      * be cached for this node instance.
      *
      * @return array
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -61,14 +61,14 @@ class ASTClassOrInterfaceReference extends ASTType
     /**
      * The global AST builder context.
      *
-     * @var \PDepend\Source\Builder\BuilderContext
+     * @var BuilderContext
      */
     protected $context = null;
 
     /**
      * An already loaded type instance.
      *
-     * @var null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @var null|AbstractASTClassOrInterface
      */
     protected $typeInstance = null;
 
@@ -87,7 +87,7 @@ class ASTClassOrInterfaceReference extends ASTType
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     public function getType()
     {

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -44,22 +44,21 @@ namespace PDepend\Source\AST;
 
 /**
  * This is a special implementation of the node iterator that will translate
- * a list of given {@link \PDepend\Source\AST\ASTClassOrInterfaceReference} holders
- * into a list of unique {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
+ * a list of given {@link ASTClassOrInterfaceReference} holders
+ * into a list of unique {@link AbstractASTClassOrInterface}
  * instances.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @extends ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>
+ * @extends ASTArtifactList<AbstractASTClassOrInterface>
  */
 class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
 {
     /**
      * Constructs a new reference iterator instance.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference[] $references List of
-     *                                                                       references to concrete type instances.
+     * @param ASTClassOrInterfaceReference[] $references List of references to concrete type instances.
      */
     public function __construct(array $references)
     {
@@ -67,12 +66,12 @@ class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
     }
 
     /**
-     * This method creates a set of {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
+     * This method creates a set of {@link AbstractASTClassOrInterface}
      * objects from the given reference array.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference[] $references
+     * @param ASTClassOrInterfaceReference[] $references
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface[]
+     * @return AbstractASTClassOrInterface[]
      */
     protected function createClassesAndInterfaces(array $references)
     {

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -59,7 +59,7 @@ class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
      * Constructs a new reference iterator instance.
      *
      * @param \PDepend\Source\AST\ASTClassOrInterfaceReference[] $references List of
-     *        references to concrete type instances.
+     *                                                                       references to concrete type instances.
      */
     public function __construct(array $references)
     {
@@ -70,7 +70,8 @@ class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
      * This method creates a set of {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
      * objects from the given reference array.
      *
-     * @param  \PDepend\Source\AST\ASTClassOrInterfaceReference[] $references
+     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference[] $references
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface[]
      */
     protected function createClassesAndInterfaces(array $references)

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -59,7 +59,7 @@ class ASTClassReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     public function getType()
     {

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 class ASTClassReference extends ASTClassOrInterfaceReference
@@ -72,9 +74,6 @@ class ASTClassReference extends ASTClassOrInterfaceReference
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a clone-expression.
  *
@@ -52,17 +54,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTCloneExpression extends \PDepend\Source\AST\ASTExpression
+class ASTCloneExpression extends ASTExpression
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitCloneExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTCloneExpression extends \PDepend\Source\AST\ASTExpression
@@ -57,9 +59,7 @@ class ASTCloneExpression extends \PDepend\Source\AST\ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,12 +49,13 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTClosure extends AbstractASTNode implements ASTCallable
 {
     /**
-     * @return \PDepend\Source\AST\ASTType|null
+     * @return null|\PDepend\Source\AST\ASTType
      */
     public function getReturnType()
     {
@@ -69,7 +71,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * This method will return <b>true</b> when this closure returns by
      * reference.
      *
-     * @return boolean
+     * @return bool
      */
     public function returnsByReference()
     {
@@ -79,7 +81,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     /**
      * This method can be used to flag this closure as returns by reference.
      *
-     * @param boolean $returnsReference Does this closure return by reference?
+     * @param bool $returnsReference Does this closure return by reference?
      *
      * @return void
      */
@@ -108,7 +110,8 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * }
      * </code>
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  1.0.0
      */
     public function isStatic()
@@ -119,9 +122,10 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     /**
      * This method can be used to flag this closure instance as static.
      *
-     * @param boolean $static Whether this closure is static or not.
+     * @param bool $static Whether this closure is static or not.
      *
      * @return void
+     *
      * @since  1.0.0
      */
     public function setStatic($static)
@@ -134,9 +138,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
@@ -147,7 +149,8 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since  1.0.0
      * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
      */

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a closure-expression.
  *
@@ -55,7 +57,7 @@ namespace PDepend\Source\AST;
 class ASTClosure extends AbstractASTNode implements ASTCallable
 {
     /**
-     * @return null|\PDepend\Source\AST\ASTType
+     * @return null|ASTType
      */
     public function getReturnType()
     {
@@ -137,11 +139,11 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitClosure($this, $data);
     }
@@ -152,7 +154,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * @return int
      *
      * @since  1.0.0
-     * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
+     * @see    ASTNode#getMetadataSize()
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTComment.php
+++ b/src/main/php/PDepend/Source/AST/ASTComment.php
@@ -56,9 +56,6 @@ class ASTComment extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -56,7 +56,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var   \PDepend\Util\Cache\CacheDriver|null
+     * @var null|\PDepend\Util\Cache\CacheDriver
+     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -64,28 +65,29 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The unique identifier for this function.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $id = null;
 
     /**
      * The source file name/path.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $fileName = null;
 
     /**
      * The comment for this type.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $comment = null;
 
     /**
      * The files start line. This property must always have the value <em>1</em>.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.10.0
      */
     protected $startLine = 0;
@@ -93,7 +95,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The files end line.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.10.0
      */
     protected $endLine = 0;
@@ -101,7 +104,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * List of classes, interfaces and functions that parsed from this file.
      *
-     * @var   \PDepend\Source\AST\AbstractASTArtifact[]
+     * @var \PDepend\Source\AST\AbstractASTArtifact[]
+     *
      * @since 0.10.0
      */
     protected $childNodes = array();
@@ -109,7 +113,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Was this file instance restored from the cache?
      *
-     * @var   boolean
+     * @var bool
+     *
      * @since 0.10.0
      */
     protected $cached = false;
@@ -117,14 +122,14 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Normalized code in this file.
      *
-     * @var string|null
+     * @var null|string
      */
     private $source = null;
 
     /**
      * Constructs a new source file instance.
      *
-     * @param string|null $fileName The source file name/path.
+     * @param null|string $fileName The source file name/path.
      */
     public function __construct($fileName)
     {
@@ -138,7 +143,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns the physical file name for this object.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getName()
     {
@@ -148,7 +153,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns the physical file name for this object.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getFileName()
     {
@@ -158,7 +163,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns a id for this code node.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getId()
     {
@@ -168,8 +173,10 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Sets the unique identifier for this file instance.
      *
-     * @param  string $id Identifier for this file.
+     * @param string $id Identifier for this file.
+     *
      * @return void
+     *
      * @since  0.9.12
      */
     public function setId($id)
@@ -180,8 +187,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Setter method for the used parser and token cache.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return $this
+     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -193,7 +200,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns normalized source code with stripped whitespaces.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getSource()
     {
@@ -230,8 +237,10 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Adds a source item that was parsed from this source file.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $artifact
+     * @param \PDepend\Source\AST\AbstractASTArtifact $artifact
+     *
      * @return void
+     *
      * @since  0.10.0
      */
     public function addChild(AbstractASTArtifact $artifact)
@@ -244,7 +253,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * this value must always be <em>1</em>, while it can be <em>0</em> for a
      * not existing dummy file.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.0
      */
     public function getStartLine()
@@ -260,7 +270,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * this value must always be greater <em>0</em>, while it can be <em>0</em>
      * for a not existing dummy file.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.0
      */
     public function getEndLine()
@@ -276,7 +287,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * from the cache and not currently parsed. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.10.0
      */
     public function isCached()
@@ -287,7 +299,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -301,6 +312,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * array with those property names that should be serialized.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -323,6 +335,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * in this source file and this file instance.
      *
      * @return void
+     *
      * @since  0.10.0
      * @see    \PDepend\Source\AST\ASTCompilationUnit::$childNodes
      */
@@ -371,7 +384,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * PHP version < 5.3 where cyclic references can not be resolved
      * automatically by PHP's garbage collector.
      *
-     * @return     void
+     * @return void
+     *
      * @since  0.9.12
      * @deprecated Since 0.10.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\ASTVisitor\ASTVisitor;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -56,7 +57,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var null|\PDepend\Util\Cache\CacheDriver
+     * @var null|CacheDriver
      *
      * @since 0.10.0
      */
@@ -104,7 +105,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * List of classes, interfaces and functions that parsed from this file.
      *
-     * @var \PDepend\Source\AST\AbstractASTArtifact[]
+     * @var AbstractASTArtifact[]
      *
      * @since 0.10.0
      */
@@ -211,7 +212,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns an <b>array</b> with all tokens within this file.
      *
-     * @return array<\PDepend\Source\Tokenizer\Token>
+     * @return array<Token>
      */
     public function getTokens()
     {
@@ -223,7 +224,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Sets the tokens for this file.
      *
-     * @param array<\PDepend\Source\Tokenizer\Token> $tokens The generated tokens.
+     * @param array<Token> $tokens The generated tokens.
      *
      * @return void
      */
@@ -236,8 +237,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
 
     /**
      * Adds a source item that was parsed from this source file.
-     *
-     * @param \PDepend\Source\AST\AbstractASTArtifact $artifact
      *
      * @return void
      *
@@ -337,7 +336,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * @return void
      *
      * @since  0.10.0
-     * @see    \PDepend\Source\AST\ASTCompilationUnit::$childNodes
+     * @see    ASTCompilationUnit::$childNodes
      */
     public function __wakeup()
     {

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -38,10 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
 namespace PDepend\Source\AST;
+
+use RuntimeException;
 
 /**
  * This type of exception will be thrown when the source file of a code object
@@ -49,9 +52,10 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
-class ASTCompilationUnitNotFoundException extends \RuntimeException
+class ASTCompilationUnitNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -59,8 +59,6 @@ class ASTCompilationUnitNotFoundException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTArtifact $owner
      */
     public function __construct(AbstractASTArtifact $owner)
     {

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -64,6 +65,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTCompoundExpression extends AbstractASTNode
@@ -72,9 +74,6 @@ class ASTCompoundExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -60,6 +61,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTCompoundVariable extends AbstractASTNode
@@ -68,9 +70,6 @@ class ASTCompoundVariable extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -56,6 +57,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTConditionalExpression extends AbstractASTNode
@@ -64,9 +66,6 @@ class ASTConditionalExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTConstant.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstant.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTConstant extends AbstractASTNode
@@ -58,9 +60,6 @@ class ASTConstant extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -84,14 +84,14 @@ class ASTConstantDeclarator extends AbstractASTNode
     /**
      * The initial declaration value for this node or <b>null</b>.
      *
-     * @var \PDepend\Source\AST\ASTValue|null
+     * @var null|\PDepend\Source\AST\ASTValue
      */
     protected $value = null;
 
     /**
      * Returns the initial declaration value for this node.
      *
-     * @return \PDepend\Source\AST\ASTValue|null
+     * @return null|\PDepend\Source\AST\ASTValue
      */
     public function getValue()
     {
@@ -101,7 +101,8 @@ class ASTConstantDeclarator extends AbstractASTNode
     /**
      * Sets the declared default value for this constant node.
      *
-     * @param  \PDepend\Source\AST\ASTValue|null $value
+     * @param null|\PDepend\Source\AST\ASTValue $value
+     *
      * @return void
      */
     public function setValue(ASTValue $value = null)
@@ -113,9 +114,6 @@ class ASTConstantDeclarator extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -84,14 +84,14 @@ class ASTConstantDeclarator extends AbstractASTNode
     /**
      * The initial declaration value for this node or <b>null</b>.
      *
-     * @var null|\PDepend\Source\AST\ASTValue
+     * @var null|ASTValue
      */
     protected $value = null;
 
     /**
      * Returns the initial declaration value for this node.
      *
-     * @return null|\PDepend\Source\AST\ASTValue
+     * @return null|ASTValue
      */
     public function getValue()
     {
@@ -100,8 +100,6 @@ class ASTConstantDeclarator extends AbstractASTNode
 
     /**
      * Sets the declared default value for this constant node.
-     *
-     * @param null|\PDepend\Source\AST\ASTValue $value
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -155,7 +155,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * @return int
      *
      * @since  0.10.4
-     * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
+     * @see    ASTNode#getMetadataSize()
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
@@ -66,7 +67,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
      *
-     * @return integer
+     * @return int
      */
     public function getModifiers()
     {
@@ -80,10 +81,11 @@ class ASTConstantDefinition extends AbstractASTNode
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param integer $modifiers The declared modifiers for this node.
+     * @param int $modifiers The declared modifiers for this node.
+     *
+     * @throws InvalidArgumentException If the given modifier contains unexpected values.
      *
      * @return void
-     * @throws \InvalidArgumentException If the given modifier contains unexpected values.
      */
     public function setModifiers($modifiers)
     {
@@ -93,7 +95,7 @@ class ASTConstantDefinition extends AbstractASTNode
             & ~State::IS_FINAL;
 
         if (($expected & $modifiers) !== 0) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
                 'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_FINAL.'
             );
@@ -106,7 +108,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPublic()
     {
@@ -117,7 +119,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProtected()
     {
@@ -128,7 +130,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPrivate()
     {
@@ -139,9 +141,6 @@ class ASTConstantDefinition extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)
@@ -153,7 +152,8 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.4
      * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
      */

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -55,6 +56,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTConstantPostfix extends AbstractASTNode
@@ -63,9 +65,6 @@ class ASTConstantPostfix extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTContinueStatement extends \PDepend\Source\AST\ASTStatement
@@ -71,9 +73,7 @@ class ASTContinueStatement extends \PDepend\Source\AST\ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a continue-statement.
  *
@@ -66,17 +68,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTContinueStatement extends \PDepend\Source\AST\ASTStatement
+class ASTContinueStatement extends ASTStatement
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitContinueStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -66,6 +67,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
@@ -104,10 +106,6 @@ class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed                                 $data
-     *
-     * @return mixed
      * @since  0.10.0
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
@@ -121,6 +119,7 @@ class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a declare-statement.
  *
@@ -70,19 +72,19 @@ namespace PDepend\Source\AST;
  *
  * @since 0.10.0
  */
-class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
+class ASTDeclareStatement extends ASTStatement
 {
     /**
      * The parsed declare values.
      *
-     * @var \PDepend\Source\AST\ASTValue[]
+     * @var ASTValue[]
      */
     protected $values = array();
 
     /**
      * Returns all values/parameters for this declare statement.
      *
-     * @return \PDepend\Source\AST\ASTValue[]
+     * @return ASTValue[]
      */
     public function getValues()
     {
@@ -92,8 +94,7 @@ class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
     /**
      * Adds a parameter/value for this declare-statement.
      *
-     * @param string                       $name
-     * @param \PDepend\Source\AST\ASTValue $value
+     * @param string $name
      *
      * @return void
      */
@@ -108,7 +109,7 @@ class ASTDeclareStatement extends \PDepend\Source\AST\ASTStatement
      *
      * @since  0.10.0
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitDeclareStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTDoWhileStatement extends \PDepend\Source\AST\ASTStatement
@@ -57,9 +59,7 @@ class ASTDoWhileStatement extends \PDepend\Source\AST\ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a do/while-statement.
  *
@@ -52,17 +54,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTDoWhileStatement extends \PDepend\Source\AST\ASTStatement
+class ASTDoWhileStatement extends ASTStatement
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitDoWhileStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents an echo-statement.
  *
@@ -52,17 +54,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTEchoStatement extends \PDepend\Source\AST\ASTStatement
+class ASTEchoStatement extends ASTStatement
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitEchoStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTEchoStatement extends \PDepend\Source\AST\ASTStatement
@@ -57,9 +59,7 @@ class ASTEchoStatement extends \PDepend\Source\AST\ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents an elseif-statement.
  *
@@ -52,7 +54,7 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTElseIfStatement extends \PDepend\Source\AST\ASTStatement
+class ASTElseIfStatement extends ASTStatement
 {
     /**
      * Returns <b>true</b> when this <b>elseif</b>-statement is followed by an
@@ -74,11 +76,11 @@ class ASTElseIfStatement extends \PDepend\Source\AST\ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitElseIfStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTElseIfStatement extends \PDepend\Source\AST\ASTStatement
@@ -56,7 +58,8 @@ class ASTElseIfStatement extends \PDepend\Source\AST\ASTStatement
      * Returns <b>true</b> when this <b>elseif</b>-statement is followed by an
      * <b>else</b>-statement.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.12
      */
     public function hasElse()
@@ -72,9 +75,7 @@ class ASTElseIfStatement extends \PDepend\Source\AST\ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents an eval-expression.
  *
@@ -52,17 +54,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTEvalExpression extends \PDepend\Source\AST\ASTExpression
+class ASTEvalExpression extends ASTExpression
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitEvalExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTEvalExpression extends \PDepend\Source\AST\ASTExpression
@@ -57,9 +59,7 @@ class ASTEvalExpression extends \PDepend\Source\AST\ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents an exit-expression.
  *
@@ -52,17 +54,17 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTExitExpression extends \PDepend\Source\AST\ASTExpression
+class ASTExitExpression extends ASTExpression
 {
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitExitExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTExitExpression extends \PDepend\Source\AST\ASTExpression
@@ -57,9 +59,7 @@ class ASTExitExpression extends \PDepend\Source\AST\ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTExpression extends AbstractASTNode
@@ -57,9 +59,7 @@ class ASTExpression extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class encapsultes any expression.
  *
@@ -58,11 +60,11 @@ class ASTExpression extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -46,6 +46,7 @@ namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a field or property declaration of a class.
@@ -84,7 +85,7 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns the type of this parameter.
      *
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     public function getType()
     {
@@ -185,11 +186,11 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitFieldDeclaration($this, $data);
     }
@@ -200,7 +201,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * @return int
      *
      * @since  0.10.4
-     * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
+     * @see    ASTNode#getMetadataSize()
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -38,11 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
 
 /**
@@ -64,6 +66,7 @@ use OutOfBoundsException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTFieldDeclaration extends AbstractASTNode
@@ -71,7 +74,7 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Checks if this parameter has a type.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasType()
     {
@@ -96,7 +99,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
      *
-     * @return integer
+     * @return int
      */
     public function getModifiers()
     {
@@ -110,10 +113,11 @@ class ASTFieldDeclaration extends AbstractASTNode
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param integer $modifiers The declared modifiers for this node.
+     * @param int $modifiers The declared modifiers for this node.
+     *
+     * @throws InvalidArgumentException If the given modifier contains unexpected values.
      *
      * @return void
-     * @throws \InvalidArgumentException If the given modifier contains unexpected values.
      */
     public function setModifiers($modifiers)
     {
@@ -124,7 +128,7 @@ class ASTFieldDeclaration extends AbstractASTNode
                   & ~State::IS_READONLY;
 
         if (($expected & $modifiers) !== 0) {
-            throw new \InvalidArgumentException(
+            throw new InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
                 'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_STATIC.'
             );
@@ -137,7 +141,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPublic()
     {
@@ -148,7 +152,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProtected()
     {
@@ -159,7 +163,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPrivate()
     {
@@ -170,7 +174,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Returns <b>true</b> when this node is declared as static, otherwise
      * the returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStatic()
     {
@@ -182,9 +186,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
@@ -195,7 +197,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.4
      * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
      */

--- a/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
@@ -55,10 +55,6 @@ class ASTFinallyStatement extends ASTStatement
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represent the init part of a for-statement.
  *
@@ -60,11 +62,11 @@ class ASTForInit extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitForInit($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -61,9 +61,7 @@ class ASTForInit extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTForStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTForStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a for-statement.
  *
@@ -58,11 +60,11 @@ class ASTForStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitForStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -54,6 +55,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTForUpdate extends AbstractASTNode
@@ -63,9 +65,7 @@ class ASTForUpdate extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represent the update part of a for-statement.
  *
@@ -64,11 +66,11 @@ class ASTForUpdate extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitForUpdate($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTForeachStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTForeachStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a foreach-statement.
  *
@@ -58,11 +60,11 @@ class ASTForeachStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitForeachStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -57,6 +58,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTFormalParameter extends AbstractASTNode
@@ -64,14 +66,14 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Defined modifiers for this property node.
      *
-     * @var integer
+     * @var int
      */
     protected $modifiers = 0;
 
     /**
      * Checks if this parameter has a type.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasType()
     {
@@ -96,7 +98,8 @@ class ASTFormalParameter extends AbstractASTNode
      * This method will return <b>true</b> when the parameter is declared as a
      * variable argument list <b>...</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 2.0.7
      */
     public function isVariableArgList()
@@ -119,7 +122,7 @@ class ASTFormalParameter extends AbstractASTNode
      * This method will return <b>true</b> when the parameter is passed by
      * reference.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPassedByReference()
     {
@@ -140,9 +143,8 @@ class ASTFormalParameter extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  ASTVisitor $visitor The calling visitor instance.
-     * @param  mixed      $data
-     * @return mixed
+     * @param ASTVisitor $visitor The calling visitor instance.
+     *
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)
@@ -153,7 +155,8 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.10.4
      * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
      */
@@ -165,7 +168,8 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -180,10 +184,13 @@ class ASTFormalParameter extends AbstractASTNode
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param  integer $modifiers
-     * @return void
+     * @param int $modifiers
+     *
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
+     *
+     * @return void
+     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers)
@@ -212,7 +219,7 @@ class ASTFormalParameter extends AbstractASTNode
      *
      * Can happen only on constructor promotion property.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPromoted()
     {
@@ -225,7 +232,7 @@ class ASTFormalParameter extends AbstractASTNode
      *
      * Can happen only on constructor promotion property.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPublic()
     {
@@ -238,7 +245,7 @@ class ASTFormalParameter extends AbstractASTNode
      *
      * Can happen only on constructor promotion property.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProtected()
     {
@@ -251,7 +258,7 @@ class ASTFormalParameter extends AbstractASTNode
      *
      * Can happen only on constructor promotion property.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPrivate()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -158,7 +158,7 @@ class ASTFormalParameter extends AbstractASTNode
      * @return int
      *
      * @since  0.10.4
-     * @see    \PDepend\Source\AST\ASTNode#getMetadataSize()
+     * @see    ASTNode#getMetadataSize()
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -67,6 +68,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTFormalParameters extends AbstractASTNode
@@ -75,9 +77,8 @@ class ASTFormalParameters extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param  mixed                                 $data
-     * @return mixed
+     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     *
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -77,7 +77,7 @@ class ASTFormalParameters extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -56,7 +56,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The parent namespace for this function.
      *
-     * @var null|\PDepend\Source\AST\ASTNamespace
+     * @var null|ASTNamespace
      *
      * @since 0.10.0
      */
@@ -65,7 +65,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The currently used builder context.
      *
-     * @var null|\PDepend\Source\Builder\BuilderContext
+     * @var null|BuilderContext
      *
      * @since 0.10.0
      */
@@ -82,7 +82,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * Sets the currently active builder context.
      *
-     * @param \PDepend\Source\Builder\BuilderContext $context Current builder context.
+     * @param BuilderContext $context Current builder context.
      *
      * @return $this
      *
@@ -97,7 +97,7 @@ class ASTFunction extends AbstractASTCallable
     /**
      * Returns the parent namespace for this function.
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function getNamespace()
     {
@@ -106,8 +106,6 @@ class ASTFunction extends AbstractASTCallable
 
     /**
      * Sets the parent namespace for this function.
-     *
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -56,7 +56,8 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The parent namespace for this function.
      *
-     * @var   \PDepend\Source\AST\ASTNamespace|null
+     * @var null|\PDepend\Source\AST\ASTNamespace
+     *
      * @since 0.10.0
      */
     private $namespace = null;
@@ -64,7 +65,8 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The currently used builder context.
      *
-     * @var   \PDepend\Source\Builder\BuilderContext|null
+     * @var null|\PDepend\Source\Builder\BuilderContext
+     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -73,15 +75,17 @@ class ASTFunction extends AbstractASTCallable
      * The name of the parent namespace for this function. We use this property
      * to restore the parent namespace while we unserialize a cached object tree.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $namespaceName = null;
 
     /**
      * Sets the currently active builder context.
      *
-     * @param  \PDepend\Source\Builder\BuilderContext $context Current builder context.
+     * @param \PDepend\Source\Builder\BuilderContext $context Current builder context.
+     *
      * @return $this
+     *
      * @since  0.10.0
      */
     public function setContext(BuilderContext $context)
@@ -103,7 +107,8 @@ class ASTFunction extends AbstractASTCallable
     /**
      * Sets the parent namespace for this function.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
+     * @param \PDepend\Source\AST\ASTNamespace $namespace
+     *
      * @return void
      */
     public function setNamespace(ASTNamespace $namespace)
@@ -116,6 +121,7 @@ class ASTFunction extends AbstractASTCallable
      * Resets the namespace associated with this function node.
      *
      * @return void
+     *
      * @since  0.10.2
      */
     public function unsetNamespace()
@@ -129,6 +135,7 @@ class ASTFunction extends AbstractASTCallable
      * function does not belong to a namespace.
      *
      * @return string
+     *
      * @since  0.10.0
      */
     public function getNamespaceName()
@@ -139,7 +146,6 @@ class ASTFunction extends AbstractASTCallable
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -153,6 +159,7 @@ class ASTFunction extends AbstractASTCallable
      * cached for all function instances.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -167,6 +174,7 @@ class ASTFunction extends AbstractASTCallable
      * context.
      *
      * @return void
+     *
      * @since  0.10.0
      */
     public function __wakeup()

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a function postfix expression.
  *
@@ -68,11 +70,11 @@ class ASTFunctionPostfix extends ASTInvocation
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitFunctionPostfix($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -58,6 +59,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTFunctionPostfix extends ASTInvocation
@@ -67,9 +69,7 @@ class ASTFunctionPostfix extends ASTInvocation
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTGlobalStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTGlobalStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a global-statement.
  *
@@ -58,11 +60,11 @@ class ASTGlobalStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitGlobalStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a goto-statement.
  *
@@ -58,11 +60,11 @@ class ASTGotoStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitGotoStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTGotoStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTGotoStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a here-/nowdoc node.
  *
@@ -77,9 +79,9 @@ class ASTHeredoc extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitHeredoc($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTHeredoc extends ASTExpression
@@ -76,9 +78,6 @@ class ASTHeredoc extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -49,6 +50,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTIdentifier extends ASTExpression
@@ -58,9 +60,7 @@ class ASTIdentifier extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * A static identifier as it can be used to access a function, method, constant
  * or property.
@@ -59,11 +61,11 @@ class ASTIdentifier extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitIdentifier($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTIfStatement extends ASTStatement
@@ -56,7 +58,8 @@ class ASTIfStatement extends ASTStatement
      * Returns <b>true</b> when this <b>if</b>-statement is followed by an
      * <b>else</b>-statement.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.12
      */
     public function hasElse()
@@ -69,9 +72,7 @@ class ASTIfStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents an if-statement.
  *
@@ -71,11 +73,11 @@ class ASTIfStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitIfStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a <b>include</b>- or <b>include_once</b>-expression.
  *
@@ -85,9 +87,9 @@ class ASTIncludeExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitIncludeExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTIncludeExpression extends ASTExpression
@@ -55,14 +57,14 @@ class ASTIncludeExpression extends ASTExpression
     /**
      * Does this node represent a <b>include_once</b>-expression?
      *
-     * @var boolean
+     * @var bool
      */
     protected $once = false;
 
     /**
      * Does this node represent a <b>include_once</b>-expression?
      *
-     * @return boolean
+     * @return bool
      */
     public function isOnce()
     {
@@ -84,9 +86,6 @@ class ASTIncludeExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {
@@ -99,6 +98,7 @@ class ASTIncludeExpression extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 abstract class ASTIndexExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTInstanceOfExpression extends ASTExpression
@@ -57,9 +59,7 @@ class ASTInstanceOfExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents an instanceof expression node.
  *
@@ -58,11 +60,11 @@ class ASTInstanceOfExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitInstanceOfExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
@@ -56,14 +57,14 @@ class ASTInterface extends AbstractASTClassOrInterface
      * The modifiers for this interface instance, by default an interface is
      * always abstract.
      *
-     * @var integer
+     * @var int
      */
     protected $modifiers = State::IS_IMPLICIT_ABSTRACT;
 
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAbstract()
     {
@@ -73,14 +74,17 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * Sets a reference onto the parent class of this class node.
      *
-     * @param  \PDepend\Source\AST\ASTClassReference $classReference
+     * @param \PDepend\Source\AST\ASTClassReference $classReference
+     *
+     * @throws BadMethodCallException
+     *
      * @return void
-     * @throws \BadMethodCallException
+     *
      * @since  0.9.5
      */
-    public function setParentClassReference(\PDepend\Source\AST\ASTClassReference $classReference)
+    public function setParentClassReference(ASTClassReference $classReference)
     {
-        throw new \BadMethodCallException(
+        throw new BadMethodCallException(
             'Unsupported method ' . __METHOD__ . '() called.'
         );
     }
@@ -88,8 +92,9 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return boolean
+     * @param \PDepend\Source\AST\AbstractASTType $type
+     *
+     * @return bool
      */
     public function isSubtypeOf(AbstractASTType $type)
     {
@@ -108,7 +113,8 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -119,7 +125,6 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -134,6 +139,7 @@ class ASTInterface extends AbstractASTClassOrInterface
      * context.
      *
      * @return void
+     *
      * @since  0.10.0
      */
     public function __wakeup()

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -74,8 +74,6 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * Sets a reference onto the parent class of this class node.
      *
-     * @param \PDepend\Source\AST\ASTClassReference $classReference
-     *
      * @throws BadMethodCallException
      *
      * @return void
@@ -91,8 +89,6 @@ class ASTInterface extends AbstractASTClassOrInterface
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTType $type
      *
      * @return bool
      */

--- a/src/main/php/PDepend/Source/AST/ASTInvocation.php
+++ b/src/main/php/PDepend/Source/AST/ASTInvocation.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 abstract class ASTInvocation extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTIssetExpression extends ASTExpression
@@ -58,9 +60,6 @@ class ASTIssetExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTLabelStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTLabelStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a label-statement.
  *
@@ -58,11 +60,11 @@ class ASTLabelStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitLabelStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTListExpression extends ASTExpression
@@ -57,9 +59,7 @@ class ASTListExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a list-expression.
  *
@@ -58,11 +60,11 @@ class ASTListExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitListExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a literal node.
  *
@@ -58,11 +60,11 @@ class ASTLiteral extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitLiteral($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTLiteral extends AbstractASTNode
@@ -57,9 +59,7 @@ class ASTLiteral extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTLogicalAndExpression extends ASTExpression
@@ -57,9 +59,7 @@ class ASTLogicalAndExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a logical <b>and</b>-expression.
  *
@@ -58,11 +60,11 @@ class ASTLogicalAndExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitLogicalAndExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a logical <b>or</b>-expression.
  *
@@ -58,11 +60,11 @@ class ASTLogicalOrExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitLogicalOrExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTLogicalOrExpression extends ASTExpression
@@ -57,9 +59,7 @@ class ASTLogicalOrExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a logical <b>xor</b>-expression.
  *
@@ -58,11 +60,11 @@ class ASTLogicalXorExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitLogicalXorExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTLogicalXorExpression extends ASTExpression
@@ -57,9 +59,7 @@ class ASTLogicalXorExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -54,6 +55,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.9.0
  */
 class ASTMatchArgument extends ASTArguments
@@ -72,9 +74,6 @@ class ASTMatchArgument extends ASTArguments
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -59,6 +60,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.9.0
  */
 class ASTMatchBlock extends ASTExpression
@@ -67,9 +69,8 @@ class ASTMatchBlock extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  ASTVisitor $visitor The calling visitor instance.
-     * @param  mixed      $data
-     * @return mixed
+     * @param ASTVisitor $visitor The calling visitor instance.
+     *
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -55,6 +56,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.9.0
  */
 class ASTMatchEntry extends ASTExpression
@@ -64,9 +66,7 @@ class ASTMatchEntry extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param ASTVisitor $visitor The calling visitor instance.
-     * @param mixed      $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -67,6 +68,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTMemberPrimaryPrefix extends AbstractASTNode
@@ -75,7 +77,7 @@ class ASTMemberPrimaryPrefix extends AbstractASTNode
      * Returns <b>true</b> when this member primary prefix represents a static
      * property or method access.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStatic()
     {
@@ -87,9 +89,7 @@ class ASTMemberPrimaryPrefix extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * Primary prefix expression as it is used to access class or interface members
  * like methods, properties and constants.
@@ -88,11 +90,11 @@ class ASTMemberPrimaryPrefix extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitMemberPrimaryPrefix($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
@@ -62,7 +63,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Defined modifiers for this property node.
      *
-     * @var integer
+     * @var int
      */
     protected $modifiers = 0;
 
@@ -70,7 +71,8 @@ class ASTMethod extends AbstractASTCallable
      * This method returns a OR combined integer of the declared modifiers for
      * this method.
      *
-     * @return integer
+     * @return int
+     *
      * @since  1.0.0
      */
     public function getModifiers()
@@ -85,9 +87,12 @@ class ASTMethod extends AbstractASTCallable
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param  integer $modifiers
+     * @param int $modifiers
+     *
+     * @throws InvalidArgumentException If the given modifier contains unexpected values.
+     *
      * @return void
-     * @throws \InvalidArgumentException If the given modifier contains unexpected values.
+     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers)
@@ -100,7 +105,7 @@ class ASTMethod extends AbstractASTCallable
                   & ~State::IS_FINAL;
 
         if (($expected & $modifiers) !== 0) {
-            throw new \InvalidArgumentException('Invalid method modifier given.');
+            throw new InvalidArgumentException('Invalid method modifier given.');
         }
 
         $this->modifiers = $modifiers;
@@ -109,7 +114,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> if this is an abstract method.
      *
-     * @return boolean
+     * @return bool
      */
     public function isAbstract()
     {
@@ -120,7 +125,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPublic()
     {
@@ -131,7 +136,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProtected()
     {
@@ -142,7 +147,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPrivate()
     {
@@ -153,7 +158,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns <b>true</b> when this node is declared as static, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStatic()
     {
@@ -164,7 +169,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns <b>true</b> when this node is declared as final, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isFinal()
     {
@@ -174,7 +179,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the parent type object or <b>null</b>
      *
-     * @return \PDepend\Source\AST\AbstractASTType|null
+     * @return null|\PDepend\Source\AST\AbstractASTType
      */
     public function getParent()
     {
@@ -184,7 +189,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Sets the parent type object.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType|null $parent
+     * @param null|\PDepend\Source\AST\AbstractASTType $parent
+     *
      * @return void
      */
     public function setParent(AbstractASTType $parent = null)
@@ -195,8 +201,10 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the source file where this method was declared.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit
      * @throws \PDepend\Source\AST\ASTCompilationUnitNotFoundException When no parent was set.
+     *
+     * @return \PDepend\Source\AST\ASTCompilationUnit
+     *
      * @since  0.10.0
      */
     public function getCompilationUnit()
@@ -211,7 +219,6 @@ class ASTMethod extends AbstractASTCallable
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -225,6 +232,7 @@ class ASTMethod extends AbstractASTCallable
      * cached for method instances.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -56,7 +56,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * The parent type object.
      *
-     * @var \PDepend\Source\AST\AbstractASTType
+     * @var AbstractASTType
      */
     protected $parent = null;
 
@@ -179,7 +179,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the parent type object or <b>null</b>
      *
-     * @return null|\PDepend\Source\AST\AbstractASTType
+     * @return null|AbstractASTType
      */
     public function getParent()
     {
@@ -188,8 +188,6 @@ class ASTMethod extends AbstractASTCallable
 
     /**
      * Sets the parent type object.
-     *
-     * @param null|\PDepend\Source\AST\AbstractASTType $parent
      *
      * @return void
      */
@@ -201,9 +199,9 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the source file where this method was declared.
      *
-     * @throws \PDepend\Source\AST\ASTCompilationUnitNotFoundException When no parent was set.
+     * @throws ASTCompilationUnitNotFoundException When no parent was set.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit
+     * @return ASTCompilationUnit
      *
      * @since  0.10.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -58,6 +59,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTMethodPostfix extends ASTInvocation
@@ -67,9 +69,7 @@ class ASTMethodPostfix extends ASTInvocation
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a method postfix expression..
  *
@@ -68,11 +70,11 @@ class ASTMethodPostfix extends ASTInvocation
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitMethodPostfix($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.9.0
  */
 class ASTNamedArgument extends AbstractASTNode
@@ -99,9 +101,6 @@ class ASTNamedArgument extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param ASTVisitor $visitor The calling visitor instance.
-     * @param mixed      $data
-     *
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -78,12 +78,12 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Does this namespace contain user defined functions, classes or interfaces?
      *
-     * @var boolean
+     * @var bool
      */
     private $userDefined = null;
 
     /**
-     * @var boolean
+     * @var bool
      */
     protected $packageAnnotation = false;
 
@@ -113,7 +113,8 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>class/method</b> is user defined. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.10
      */
     public function isUserDefined()
@@ -129,7 +130,8 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>class/method</b> is user defined. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.10
      */
     private function checkUserDefined()
@@ -147,6 +149,7 @@ class ASTNamespace extends AbstractASTArtifact
      * instances declared in this namespace.
      *
      * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTTrait>
+     *
      * @since  1.0.0
      */
     public function getTraits()
@@ -181,8 +184,11 @@ class ASTNamespace extends AbstractASTArtifact
      * namespace.
      *
      * @template T of \PDepend\Source\AST\AbstractASTClassOrInterface
-     * @param  class-string<T> $className The class/type we are looking for.
+     *
+     * @param class-string<T> $className The class/type we are looking for.
+     *
      * @return \PDepend\Source\AST\ASTArtifactList<T>
+     *
      * @since  1.0.0
      */
     private function getTypesOfType($className)
@@ -210,7 +216,8 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Adds the given type to this namespace and returns the input type instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
      */
     public function addType(AbstractASTType $type)
@@ -235,7 +242,8 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Removes the given type instance from this namespace.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     *
      * @return void
      */
     public function removeType(AbstractASTType $type)
@@ -262,7 +270,8 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Adds the given function to this namespace and returns the input instance.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
+     * @param \PDepend\Source\AST\ASTFunction $function
+     *
      * @return \PDepend\Source\AST\ASTFunction
      */
     public function addFunction(ASTFunction $function)
@@ -281,7 +290,8 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Removes the given function from this namespace.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
+     * @param \PDepend\Source\AST\ASTFunction $function
+     *
      * @return void
      */
     public function removeFunction(ASTFunction $function)
@@ -295,7 +305,7 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isPackageAnnotation()
     {
@@ -303,7 +313,8 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * @param boolean $packageAnnotation
+     * @param bool $packageAnnotation
+     *
      * @return void
      */
     public function setPackageAnnotation($packageAnnotation)
@@ -314,7 +325,6 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -60,18 +60,18 @@ class ASTNamespace extends AbstractASTArtifact
     protected $id = null;
 
     /**
-     * List of all {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
+     * List of all {@link AbstractASTClassOrInterface}
      * objects for this namespace.
      *
-     * @var \PDepend\Source\AST\AbstractASTClassOrInterface[]
+     * @var AbstractASTClassOrInterface[]
      */
     protected $types = array();
 
     /**
-     * List of all standalone {@link \PDepend\Source\AST\ASTFunction} objects
+     * List of all standalone {@link ASTFunction} objects
      * in this namespace.
      *
-     * @var \PDepend\Source\AST\ASTFunction[]
+     * @var ASTFunction[]
      */
     protected $functions = array();
 
@@ -145,10 +145,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns an array with all {@link \PDepend\Source\AST\ASTTrait}
+     * Returns an array with all {@link ASTTrait}
      * instances declared in this namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTTrait>
+     * @return ASTArtifactList<ASTTrait>
      *
      * @since  1.0.0
      */
@@ -158,10 +158,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns an iterator with all {@link \PDepend\Source\AST\ASTClass}
+     * Returns an iterator with all {@link ASTClass}
      * instances within this namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTClass>
+     * @return ASTArtifactList<ASTClass>
      */
     public function getClasses()
     {
@@ -169,10 +169,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns an iterator with all {@link \PDepend\Source\AST\ASTInterface}
+     * Returns an iterator with all {@link ASTInterface}
      * instances within this namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTInterface>
+     * @return ASTArtifactList<ASTInterface>
      */
     public function getInterfaces()
     {
@@ -183,11 +183,11 @@ class ASTNamespace extends AbstractASTArtifact
      * Returns an iterator with all types of the given <b>$className</b> in this
      * namespace.
      *
-     * @template T of \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @template T of AbstractASTClassOrInterface
      *
      * @param class-string<T> $className The class/type we are looking for.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<T>
+     * @return ASTArtifactList<T>
      *
      * @since  1.0.0
      */
@@ -203,10 +203,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\AbstractASTClassOrInterface} objects in
+     * Returns all {@link AbstractASTClassOrInterface} objects in
      * this namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>
+     * @return ASTArtifactList<AbstractASTClassOrInterface>
      */
     public function getTypes()
     {
@@ -216,9 +216,9 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Adds the given type to this namespace and returns the input type instance.
      *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @param AbstractASTClassOrInterface $type
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     public function addType(AbstractASTType $type)
     {
@@ -242,7 +242,7 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Removes the given type instance from this namespace.
      *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
+     * @param AbstractASTClassOrInterface $type
      *
      * @return void
      */
@@ -257,10 +257,10 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\ASTFunction} objects in this
+     * Returns all {@link ASTFunction} objects in this
      * namespace.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTFunction>
+     * @return ASTArtifactList<ASTFunction>
      */
     public function getFunctions()
     {
@@ -270,9 +270,7 @@ class ASTNamespace extends AbstractASTArtifact
     /**
      * Adds the given function to this namespace and returns the input instance.
      *
-     * @param \PDepend\Source\AST\ASTFunction $function
-     *
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return ASTFunction
      */
     public function addFunction(ASTFunction $function)
     {
@@ -289,8 +287,6 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * Removes the given function from this namespace.
-     *
-     * @param \PDepend\Source\AST\ASTFunction $function
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -98,14 +98,14 @@ interface ASTNode
      *
      * @throws OutOfBoundsException When no node exists at the given index.
      *
-     * @return \PDepend\Source\AST\AbstractASTNode
+     * @return AbstractASTNode
      */
     public function getChild($index);
 
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getChildren();
 
@@ -114,7 +114,7 @@ interface ASTNode
      * instance of the given <b>$targetType</b>. The returned value will be
      * <b>null</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType
      *
@@ -127,7 +127,7 @@ interface ASTNode
      * instance of the given <b>$targetType</b>. The returned value will be
      * an empty <b>array</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
      * @param T[]             $results    Already found node instances. This parameter
@@ -141,14 +141,12 @@ interface ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function getParent();
 
     /**
      * Sets the parent node of this node.
-     *
-     * @param \PDepend\Source\AST\ASTNode $node
      *
      * @return void
      */
@@ -160,7 +158,7 @@ interface ASTNode
      *
      * @param string $parentType
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getParentsOfType($parentType);
 

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -38,16 +38,20 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
 namespace PDepend\Source\AST;
+
+use OutOfBoundsException;
 
 /**
  * This is an abstract base implementation of the ast node interface.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 interface ASTNode
@@ -62,37 +66,39 @@ interface ASTNode
     /**
      * Returns the start line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartLine();
 
     /**
      * Returns the start column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartColumn();
 
     /**
      * Returns the end line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndLine();
 
     /**
      * Returns the end column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndColumn();
 
     /**
      * Returns the node instance for the given index or throws an exception.
      *
-     * @param integer $index
-     * @return \PDepend\Source\AST\ASTNode
-     * @throws \OutOfBoundsException When no node exists at the given index.
+     * @param int $index
+     *
+     * @throws OutOfBoundsException When no node exists at the given index.
+     *
+     * @return \PDepend\Source\AST\AbstractASTNode
      */
     public function getChild($index);
 
@@ -109,8 +115,10 @@ interface ASTNode
      * <b>null</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType
-     * @return T|null
+     *
+     * @return null|T
      */
     public function getFirstChildOfType($targetType);
 
@@ -120,9 +128,11 @@ interface ASTNode
      * an empty <b>array</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType Searched class or interface type.
-     * @param T[]             $results Already found node instances. This parameter
-     *        is only for internal usage.
+     * @param T[]             $results    Already found node instances. This parameter
+     *                                    is only for internal usage.
+     *
      * @return T[]
      */
     public function findChildrenOfType($targetType, array &$results = array());
@@ -139,6 +149,7 @@ interface ASTNode
      * Sets the parent node of this node.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function setParent(ASTNode $node);
@@ -148,6 +159,7 @@ interface ASTNode
      * of <b>$parentType</b>.
      *
      * @param string $parentType
+     *
      * @return \PDepend\Source\AST\ASTNode[]
      */
     public function getParentsOfType($parentType);
@@ -173,11 +185,13 @@ interface ASTNode
      * For better performance we have moved the single setter methods for the
      * node columns and lines into this configure method.
      *
-     * @param integer $startLine
-     * @param integer $endLine
-     * @param integer $startColumn
-     * @param integer $endColumn
+     * @param int $startLine
+     * @param int $endLine
+     * @param int $startColumn
+     * @param int $endColumn
+     *
      * @return void
+     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns($startLine, $endLine, $startColumn, $endColumn);

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -52,7 +52,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  * <?php
  * class Builder
  * {
- *     public function buildNode($name, $line, \PDepend\Source\AST\ASTCompilationUnit $unit) {
+ *     public function buildNode($name, $line, ASTCompilationUnit $unit) {
  *     }
  * }
  *
@@ -68,7 +68,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * The parent function or method instance.
      *
-     * @var \PDepend\Source\AST\AbstractASTCallable
+     * @var AbstractASTCallable
      */
     private $declaringFunction = null;
 
@@ -96,7 +96,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * The wrapped variable declarator instance.
      *
-     * @var \PDepend\Source\AST\ASTVariableDeclarator
+     * @var ASTVariableDeclarator
      */
     private $variableDeclarator = null;
 
@@ -146,7 +146,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Returns the parent function or method instance or <b>null</b>
      *
-     * @return \PDepend\Source\AST\AbstractASTCallable
+     * @return AbstractASTCallable
      *
      * @since  0.9.5
      */
@@ -157,8 +157,6 @@ class ASTParameter extends AbstractASTArtifact
 
     /**
      * Sets the parent function or method object.
-     *
-     * @param \PDepend\Source\AST\AbstractASTCallable $function
      *
      * @return void
      *
@@ -175,7 +173,7 @@ class ASTParameter extends AbstractASTArtifact
      *
      * @todo Review this for refactoring, maybe create a empty getParent()?
      *
-     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return null|AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -213,7 +211,7 @@ class ASTParameter extends AbstractASTArtifact
      * Returns the class type of this parameter. This method will return
      * <b>null</b> for all scalar type, only classes or interfaces are used.
      *
-     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return null|AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -252,7 +250,7 @@ class ASTParameter extends AbstractASTArtifact
     public function isArray()
     {
         $node = $this->formalParameter->getChild(0);
-        return ($node instanceof \PDepend\Source\AST\ASTTypeArray);
+        return ($node instanceof ASTTypeArray);
     }
 
     /**
@@ -328,7 +326,7 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return the declared default value for this parameter.
      * Please note that this method will return <b>null</b> when no default
      * value was declared, therefore you should combine calls to this method and
-     * {@link \PDepend\Source\AST\ASTParameter::isDefaultValueAvailable()} to
+     * {@link ASTParameter::isDefaultValueAvailable()} to
      * detect a NULL-value.
      *
      * @since  0.9.5

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -75,14 +75,14 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * The parameter position.
      *
-     * @var integer
+     * @var int
      */
     private $position = 0;
 
     /**
      * Is this parameter optional or mandatory?
      *
-     * @var boolean
+     * @var bool
      */
     private $optional = false;
 
@@ -102,8 +102,6 @@ class ASTParameter extends AbstractASTArtifact
 
     /**
      * Constructs a new parameter instance for the given AST node.
-     *
-     * @param ASTFormalParameter $formalParameter
      */
     public function __construct(ASTFormalParameter $formalParameter)
     {
@@ -128,7 +126,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Returns the line number where the item declaration can be found.
      *
-     * @return integer
+     * @return int
      */
     public function getStartLine()
     {
@@ -138,7 +136,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Returns the line number where the item declaration ends.
      *
-     * @return integer The last source line for this item.
+     * @return int The last source line for this item.
      */
     public function getEndLine()
     {
@@ -149,6 +147,7 @@ class ASTParameter extends AbstractASTArtifact
      * Returns the parent function or method instance or <b>null</b>
      *
      * @return \PDepend\Source\AST\AbstractASTCallable
+     *
      * @since  0.9.5
      */
     public function getDeclaringFunction()
@@ -159,8 +158,10 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Sets the parent function or method object.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $function
+     * @param \PDepend\Source\AST\AbstractASTCallable $function
+     *
      * @return void
+     *
      * @since  0.9.5
      */
     public function setDeclaringFunction(AbstractASTCallable $function)
@@ -173,7 +174,9 @@ class ASTParameter extends AbstractASTArtifact
      * The returned value will be <b>null</b> if the parent is a function.
      *
      * @todo Review this for refactoring, maybe create a empty getParent()?
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     *
+     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getDeclaringClass()
@@ -187,7 +190,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Returns the parameter position in the method/function signature.
      *
-     * @return integer
+     * @return int
      */
     public function getPosition()
     {
@@ -197,7 +200,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Sets the parameter position in the method/function signature.
      *
-     * @param integer $position The parameter position.
+     * @param int $position The parameter position.
      *
      * @return void
      */
@@ -210,7 +213,8 @@ class ASTParameter extends AbstractASTArtifact
      * Returns the class type of this parameter. This method will return
      * <b>null</b> for all scalar type, only classes or interfaces are used.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getClass()
@@ -228,7 +232,8 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return <b>true</b> when the parameter is passed by
      * reference.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function isPassedByReference()
@@ -240,7 +245,8 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return <b>true</b> when the parameter was declared with
      * the array type hint, otherwise the it will return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function isArray()
@@ -254,7 +260,8 @@ class ASTParameter extends AbstractASTArtifact
      * scalar or it is an <b>array</b> or type explicit declared with a default
      * value <b>null</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function allowsNull()
@@ -274,7 +281,8 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return <b>true</b> when this parameter is optional and
      * can be left blank on invocation.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function isOptional()
@@ -287,10 +295,11 @@ class ASTParameter extends AbstractASTArtifact
      * parameter is only optional when it has a default value an no following
      * parameter has no default value.
      *
-     * @param boolean $optional Boolean flag that marks this parameter a
-     *                          optional or not.
+     * @param bool $optional Boolean flag that marks this parameter a
+     *                       optional or not.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     public function setOptional($optional)
@@ -302,7 +311,8 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return <b>true</b> when the parameter declaration
      * contains a default value.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function isDefaultValueAvailable()
@@ -321,7 +331,6 @@ class ASTParameter extends AbstractASTArtifact
      * {@link \PDepend\Source\AST\ASTParameter::isDefaultValueAvailable()} to
      * detect a NULL-value.
      *
-     * @return mixed
      * @since  0.9.5
      */
     public function getDefaultValue()
@@ -334,7 +343,6 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -51,6 +52,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 final class ASTParentReference extends ASTClassOrInterfaceReference
@@ -71,7 +73,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * Constructs a new type holder instance.
      *
      * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $reference The type
-     *        instance that reference the concrete target of self.
+     *                                                                    instance that reference the concrete target of self.
      *
      * @todo Call parent constructor, otherwise this could cause bad side effects.
      */
@@ -84,6 +86,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * Returns the visual representation for this node type.
      *
      * @return string
+     *
      * @since  0.10.4
      */
     public function getImage()
@@ -105,9 +108,6 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)
@@ -121,6 +121,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -65,15 +65,14 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     /**
      * The wrapped reference node.
      *
-     * @var \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @var ASTClassOrInterfaceReference
      */
     protected $reference = null;
 
     /**
      * Constructs a new type holder instance.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $reference The type
-     *                                                                    instance that reference the concrete target of self.
+     * @param ASTClassOrInterfaceReference $reference The type instance that reference the concrete target of self.
      *
      * @todo Call parent constructor, otherwise this could cause bad side effects.
      */
@@ -97,7 +96,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     public function getType()
     {

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class ASTPostfixExpression extends ASTExpression
@@ -57,10 +59,6 @@ class ASTPostfixExpression extends ASTExpression
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class ASTPreDecrementExpression extends ASTUnaryExpression
@@ -57,10 +59,6 @@ class ASTPreDecrementExpression extends ASTUnaryExpression
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class ASTPreIncrementExpression extends ASTUnaryExpression
@@ -57,10 +59,6 @@ class ASTPreIncrementExpression extends ASTUnaryExpression
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
@@ -49,6 +49,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 class ASTPrintExpression extends ASTExpression
@@ -64,10 +65,6 @@ class ASTPrintExpression extends ASTExpression
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -62,7 +62,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * The wrapped field declaration instance.
      *
-     * @var   \PDepend\Source\AST\ASTFieldDeclaration
+     * @var \PDepend\Source\AST\ASTFieldDeclaration
+     *
      * @since 0.9.6
      */
     private $fieldDeclaration = null;
@@ -70,7 +71,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * The wrapped variable declarator instance.
      *
-     * @var   \PDepend\Source\AST\ASTVariableDeclarator
+     * @var \PDepend\Source\AST\ASTVariableDeclarator
+     *
      * @since 0.9.6
      */
     private $variableDeclarator = null;
@@ -80,13 +82,13 @@ class ASTProperty extends AbstractASTArtifact
      * declarator.
      *
      * @param \PDepend\Source\AST\ASTFieldDeclaration   $fieldDeclaration   The context
-     *        field declaration where this property was declared in the source.
+     *                                                                      field declaration where this property was declared in the source.
      * @param \PDepend\Source\AST\ASTVariableDeclarator $variableDeclarator The context
-     *        variable declarator for this property instance.
+     *                                                                      variable declarator for this property instance.
      */
     public function __construct(
-        \PDepend\Source\AST\ASTFieldDeclaration $fieldDeclaration,
-        \PDepend\Source\AST\ASTVariableDeclarator $variableDeclarator
+        ASTFieldDeclaration $fieldDeclaration,
+        ASTVariableDeclarator $variableDeclarator
     ) {
         $this->fieldDeclaration   = $fieldDeclaration;
         $this->variableDeclarator = $variableDeclarator;
@@ -108,7 +110,8 @@ class ASTProperty extends AbstractASTArtifact
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.6
      */
     public function getModifiers()
@@ -120,7 +123,7 @@ class ASTProperty extends AbstractASTArtifact
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPublic()
     {
@@ -131,7 +134,7 @@ class ASTProperty extends AbstractASTArtifact
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isProtected()
     {
@@ -142,7 +145,7 @@ class ASTProperty extends AbstractASTArtifact
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isPrivate()
     {
@@ -153,7 +156,7 @@ class ASTProperty extends AbstractASTArtifact
      * Returns <b>true</b> when this node is declared as static, otherwise
      * the returned value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isStatic()
     {
@@ -164,7 +167,8 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return <b>true</b> when this property doc comment
      * contains an array type hint, otherwise the it will return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public function isArray()
@@ -182,7 +186,8 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return <b>true</b> when this property doc comment
      * contains a primitive type hint, otherwise the it will return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public function isScalar()
@@ -200,7 +205,8 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the type of this property. This method will return <b>null</b>
      * for all scalar type, only class properties will have a type.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getClass()
@@ -227,7 +233,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the line number where the property declaration can be found.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.6
      */
     public function getStartLine()
@@ -238,7 +245,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the column number where the property declaration starts.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.8
      */
     public function getStartColumn()
@@ -249,7 +257,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the line number where the property declaration ends.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.6
      */
     public function getEndLine()
@@ -260,7 +269,8 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the column number where the property declaration ends.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.8
      */
     public function getEndColumn()
@@ -272,6 +282,7 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return the class where this property was declared.
      *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.6
      */
     public function getDeclaringClass()
@@ -282,8 +293,10 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Sets the declaring class object.
      *
-     * @param  \PDepend\Source\AST\ASTClass $declaringClass
+     * @param \PDepend\Source\AST\ASTClass $declaringClass
+     *
      * @return void
+     *
      * @since  0.9.6
      */
     public function setDeclaringClass(ASTClass $declaringClass)
@@ -295,7 +308,8 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return <b>true</b> when the parameter declaration
      * contains a default value.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public function isDefaultValueAvailable()
@@ -311,7 +325,6 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return the default value for this property instance or
      * <b>null</b> when this property was only declared and not initialized.
      *
-     * @return mixed
      * @since  0.9.6
      */
     public function getDefaultValue()
@@ -326,7 +339,6 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)
@@ -338,6 +350,7 @@ class ASTProperty extends AbstractASTArtifact
      * This method returns a string representation of this parameter.
      *
      * @return string
+     *
      * @since  0.9.6
      */
     public function __toString()

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -62,7 +62,7 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * The wrapped field declaration instance.
      *
-     * @var \PDepend\Source\AST\ASTFieldDeclaration
+     * @var ASTFieldDeclaration
      *
      * @since 0.9.6
      */
@@ -71,7 +71,7 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * The wrapped variable declarator instance.
      *
-     * @var \PDepend\Source\AST\ASTVariableDeclarator
+     * @var ASTVariableDeclarator
      *
      * @since 0.9.6
      */
@@ -81,10 +81,8 @@ class ASTProperty extends AbstractASTArtifact
      * Constructs a new item for the given field declaration and variable
      * declarator.
      *
-     * @param \PDepend\Source\AST\ASTFieldDeclaration   $fieldDeclaration   The context
-     *                                                                      field declaration where this property was declared in the source.
-     * @param \PDepend\Source\AST\ASTVariableDeclarator $variableDeclarator The context
-     *                                                                      variable declarator for this property instance.
+     * @param ASTFieldDeclaration   $fieldDeclaration   The context field declaration where this property was declared in the source.
+     * @param ASTVariableDeclarator $variableDeclarator The context variable declarator for this property instance.
      */
     public function __construct(
         ASTFieldDeclaration $fieldDeclaration,
@@ -205,7 +203,7 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the type of this property. This method will return <b>null</b>
      * for all scalar type, only class properties will have a type.
      *
-     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return null|AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -281,7 +279,7 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * This method will return the class where this property was declared.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      *
      * @since  0.9.6
      */
@@ -292,8 +290,6 @@ class ASTProperty extends AbstractASTArtifact
 
     /**
      * Sets the declaring class object.
-     *
-     * @param \PDepend\Source\AST\ASTClass $declaringClass
      *
      * @return void
      *

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a property postfix expression..
  *
@@ -72,11 +74,11 @@ class ASTPropertyPostfix extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitPropertyPostfix($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTPropertyPostfix extends AbstractASTNode
@@ -71,9 +73,7 @@ class ASTPropertyPostfix extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTRequireExpression extends ASTExpression
@@ -55,14 +57,14 @@ class ASTRequireExpression extends ASTExpression
     /**
      * Does this node represent a <b>require_once</b>-expression?
      *
-     * @var boolean
+     * @var bool
      */
     protected $once = false;
 
     /**
      * Does this node represent a <b>require_once</b>-expression?
      *
-     * @return boolean
+     * @return bool
      */
     public function isOnce()
     {
@@ -84,9 +86,6 @@ class ASTRequireExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {
@@ -99,6 +98,7 @@ class ASTRequireExpression extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a <b>require</b>- or <b>require_once</b>-expression.
  *
@@ -85,9 +87,9 @@ class ASTRequireExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitRequireExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a return statement node.
  *
@@ -72,11 +74,11 @@ class ASTReturnStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitReturnStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTReturnStatement extends ASTStatement
@@ -71,9 +73,7 @@ class ASTReturnStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -49,6 +50,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTScalarType extends ASTType
@@ -57,7 +59,7 @@ class ASTScalarType extends ASTType
      * This method will return <b>true</b> when this type is a php primitive.
      * For this concrete implementation the return value will be always true.
      *
-     * @return boolean
+     * @return bool
      */
     public function isScalar()
     {
@@ -67,7 +69,7 @@ class ASTScalarType extends ASTType
     /**
      * This method will return <b>true</b> when this type is exactly null.
      *
-     * @return boolean
+     * @return bool
      */
     public function isNull()
     {
@@ -77,7 +79,7 @@ class ASTScalarType extends ASTType
     /**
      * This method will return <b>true</b> when this type is exactly false.
      *
-     * @return boolean
+     * @return bool
      */
     public function isFalse()
     {
@@ -88,9 +90,6 @@ class ASTScalarType extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents primitive types like integer, float, boolean, string
  * etc.
@@ -92,7 +94,7 @@ class ASTScalarType extends ASTType
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitScalarType($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTScope extends AbstractASTNode
@@ -57,9 +59,7 @@ class ASTScope extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a method/function scope.
  *
@@ -58,11 +60,11 @@ class ASTScope extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitScope($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a program scope statement.
  *
@@ -58,11 +60,11 @@ class ASTScopeStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitScopeStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTScopeStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTScopeStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -66,7 +66,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * The currently used builder context.
      *
-     * @var \PDepend\Source\Builder\BuilderContext
+     * @var BuilderContext
      *
      * @since 0.10.0
      */
@@ -85,8 +85,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
 
     /**
      * Constructs a new type holder instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $target
      */
     public function __construct(BuilderContext $context, AbstractASTClassOrInterface $target)
     {
@@ -109,7 +107,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * Returns the class or interface instance that this node instance represents.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      *
      * @since  0.10.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -52,6 +53,7 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTSelfReference extends ASTClassOrInterfaceReference
@@ -64,7 +66,8 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * The currently used builder context.
      *
-     * @var   \PDepend\Source\Builder\BuilderContext
+     * @var \PDepend\Source\Builder\BuilderContext
+     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -72,8 +75,10 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * The full qualified class name, including the namespace or namespace name.
      *
-     * @var   string
+     * @var string
+     *
      * @since 0.10.0
+     *
      * @todo  To reduce memory usage, move property into new metadata string
      */
     protected $qualifiedName = null;
@@ -81,7 +86,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * Constructs a new type holder instance.
      *
-     * @param \PDepend\Source\Builder\BuilderContext          $context
      * @param \PDepend\Source\AST\AbstractASTClassOrInterface $target
      */
     public function __construct(BuilderContext $context, AbstractASTClassOrInterface $target)
@@ -94,6 +98,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * Returns the visual representation for this node type.
      *
      * @return string
+     *
      * @since  0.10.4
      */
     public function getImage()
@@ -105,6 +110,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * Returns the class or interface instance that this node instance represents.
      *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.10.0
      */
     public function getType()
@@ -122,6 +128,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * array with those property names that should be serialized for this class.
      *
      * @return array
+     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -136,9 +143,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.1
  */
 class ASTShiftLeftExpression extends ASTExpression
@@ -72,9 +74,6 @@ class ASTShiftLeftExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class encapsultes a shift left expression.
  *
@@ -73,9 +75,9 @@ class ASTShiftLeftExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitShiftLeftExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class encapsultes a shift right expression.
  *
@@ -73,9 +75,9 @@ class ASTShiftRightExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitShiftRightExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.1
  */
 class ASTShiftRightExpression extends ASTExpression
@@ -72,9 +74,6 @@ class ASTShiftRightExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This is node represents a single statement.
  *
@@ -58,11 +60,11 @@ class ASTStatement extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTStatement extends AbstractASTNode
@@ -57,9 +59,7 @@ class ASTStatement extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This is a special reference container that is used whenever the keyword
  * <b>static</b> is used to reference a class or interface.
@@ -76,11 +78,11 @@ class ASTStaticReference extends ASTSelfReference
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitStaticReference($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -49,6 +50,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTStaticReference extends ASTSelfReference
@@ -62,6 +64,7 @@ class ASTStaticReference extends ASTSelfReference
      * Returns the visual representation for this node type.
      *
      * @return string
+     *
      * @since  0.10.4
      */
     public function getImage()
@@ -74,9 +77,7 @@ class ASTStaticReference extends ASTSelfReference
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a static variable declaration.
  *
@@ -72,11 +74,11 @@ class ASTStaticVariableDeclaration extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitStaticVariableDeclaration($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTStaticVariableDeclaration extends ASTExpression
@@ -71,9 +73,7 @@ class ASTStaticVariableDeclaration extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -44,13 +44,15 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents PHP strings that can embed various other expressions.
  *
  * <code>
  * $string = "Manuel $Pichler <{$email}>";
  *
- * // \PDepend\Source\AST\ASTString
+ * // ASTString
  * // |-- ASTLiteral             -  "Manuel ")
  * // |-- ASTVariable            -  $Pichler
  * // |-- ASTLiteral             -  " <"
@@ -70,11 +72,11 @@ class ASTString extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitString($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
 
@@ -60,6 +61,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
 class ASTString extends AbstractASTNode
@@ -69,9 +71,7 @@ class ASTString extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -56,6 +57,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTStringIndexExpression extends ASTIndexExpression
@@ -63,10 +65,6 @@ class ASTStringIndexExpression extends ASTIndexExpression
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a switch-label.
  *
@@ -85,11 +87,11 @@ class ASTSwitchLabel extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitSwitchLabel($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTSwitchLabel extends AbstractASTNode
@@ -55,14 +57,14 @@ class ASTSwitchLabel extends AbstractASTNode
     /**
      * Is this switch label the default label?
      *
-     * @var boolean
+     * @var bool
      */
     protected $default = false;
 
     /**
      * Returns <b>true</b> when this node is the default label.
      *
-     * @return boolean
+     * @return bool
      */
     public function isDefault()
     {
@@ -84,9 +86,7 @@ class ASTSwitchLabel extends AbstractASTNode
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
@@ -100,6 +100,7 @@ class ASTSwitchLabel extends AbstractASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -55,9 +55,7 @@ class ASTSwitchStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a switch statement.
  *
@@ -54,11 +56,11 @@ class ASTSwitchStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitSwitchStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTThrowStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTThrowStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a throw-statement.
  *
@@ -58,11 +60,11 @@ class ASTThrowStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitThrowStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -59,7 +59,7 @@ class ASTTrait extends ASTClass
     /**
      * Returns all properties for this class.
      *
-     * @return \PDepend\Source\AST\ASTProperty[]
+     * @return ASTProperty[]
      *
      * @since  1.0.6
      *
@@ -71,10 +71,10 @@ class ASTTrait extends ASTClass
     }
 
     /**
-     * Returns an array with {@link \PDepend\Source\AST\ASTMethod} objects
+     * Returns an array with {@link ASTMethod} objects
      * that are implemented or imported by this trait.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     public function getAllMethods()
     {
@@ -89,8 +89,6 @@ class ASTTrait extends ASTClass
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTType $type
      *
      * @return bool
      *

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTrait extends ASTClass
@@ -58,7 +60,9 @@ class ASTTrait extends ASTClass
      * Returns all properties for this class.
      *
      * @return \PDepend\Source\AST\ASTProperty[]
+     *
      * @since  1.0.6
+     *
      * @todo   Return properties declared by a trait.
      */
     public function getProperties()
@@ -86,8 +90,10 @@ class ASTTrait extends ASTClass
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return boolean
+     * @param \PDepend\Source\AST\AbstractASTType $type
+     *
+     * @return bool
+     *
      * @todo   Should we handle trait subtypes?
      */
     public function isSubtypeOf(AbstractASTType $type)
@@ -98,7 +104,6 @@ class ASTTrait extends ASTClass
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
      * @return void
      */
     public function accept(ASTVisitor $visitor)

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTraitAdaptation extends ASTScope
@@ -57,10 +59,6 @@ class ASTTraitAdaptation extends ASTScope
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a trait adaptation alias.
  *
@@ -130,9 +132,9 @@ class ASTTraitAdaptationAlias extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitTraitAdaptationAlias($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTraitAdaptationAlias extends ASTStatement
@@ -62,14 +64,14 @@ class ASTTraitAdaptationAlias extends ASTStatement
     /**
      * The new method modifier for the imported method.
      *
-     * @var integer
+     * @var int
      */
     protected $newModifier = -1;
 
     /**
      * Sets the new method modifier.
      *
-     * @param integer $newModifier The new method modifier.
+     * @param int $newModifier The new method modifier.
      *
      * @return void
      */
@@ -82,7 +84,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      * Returns the new method modifier or <b>-1</b> when this alias does not
      * specify a new method modifier.
      *
-     * @return integer
+     * @return int
      */
     public function getNewModifier()
     {
@@ -129,9 +131,6 @@ class ASTTraitAdaptationAlias extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTraitAdaptationPrecedence extends ASTStatement
@@ -57,10 +59,6 @@ class ASTTraitAdaptationPrecedence extends ASTStatement
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -7,10 +7,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
 namespace PDepend\Source\AST;
+
+use RuntimeException;
 
 /**
  * This type of exception will be thrown when a trait related method collision
@@ -18,9 +21,10 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
-class ASTTraitMethodCollisionException extends \RuntimeException
+class ASTTraitMethodCollisionException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -28,9 +28,6 @@ class ASTTraitMethodCollisionException extends RuntimeException
 {
     /**
      * Constructs a new exception instance.
-     *
-     * @param \PDepend\Source\AST\ASTMethod       $method
-     * @param \PDepend\Source\AST\AbstractASTType $type
      */
     public function __construct(ASTMethod $method, AbstractASTType $type)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -59,7 +59,7 @@ class ASTTraitReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return \PDepend\Source\AST\AbstractASTType
+     * @return AbstractASTType
      */
     public function getType()
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTraitReference extends ASTClassOrInterfaceReference
@@ -71,9 +73,6 @@ class ASTTraitReference extends ASTClassOrInterfaceReference
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,12 +51,13 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTraitUseStatement extends ASTStatement
 {
     /**
-     * @var \PDepend\Source\AST\ASTMethod[]|null
+     * @var null|\PDepend\Source\AST\ASTMethod[]
      */
     private $allMethods;
 
@@ -85,8 +87,9 @@ class ASTTraitUseStatement extends ASTStatement
      * if the given <b>$method</b> is excluded, otherwise the return value of
      * this method will be <b>false</b>.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
-     * @return boolean
+     * @param \PDepend\Source\AST\ASTMethod $method
+     *
+     * @return bool
      */
     public function hasExcludeFor(ASTMethod $method)
     {
@@ -134,7 +137,8 @@ class ASTTraitUseStatement extends ASTStatement
      * alias exists for the given method, this method will simply return the
      * an <b>array</b> with the original method.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
+     * @param \PDepend\Source\AST\ASTMethod $method
+     *
      * @return \PDepend\Source\AST\ASTMethod[]
      */
     private function getAliasesFor(ASTMethod $method)
@@ -203,10 +207,6 @@ class ASTTraitUseStatement extends ASTStatement
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
-     *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param  mixed                                 $data
-     * @return mixed
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -57,14 +57,14 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
 class ASTTraitUseStatement extends ASTStatement
 {
     /**
-     * @var null|\PDepend\Source\AST\ASTMethod[]
+     * @var null|ASTMethod[]
      */
     private $allMethods;
 
     /**
      * Returns an array with all aliased or directly imported methods.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     public function getAllMethods()
     {
@@ -82,12 +82,10 @@ class ASTTraitUseStatement extends ASTStatement
     }
 
     /**
-     * This method tests if the given {@link \PDepend\Source\AST\ASTMethod} is excluded
+     * This method tests if the given {@link ASTMethod} is excluded
      * by precedence statement in this use statement. It will return <b>true</b>
      * if the given <b>$method</b> is excluded, otherwise the return value of
      * this method will be <b>false</b>.
-     *
-     * @param \PDepend\Source\AST\ASTMethod $method
      *
      * @return bool
      */
@@ -117,9 +115,9 @@ class ASTTraitUseStatement extends ASTStatement
 
     /**
      * Collects all directly defined methods or method aliases for the given
-     * {@link \PDepend\Source\AST\ASTTraitReference}
+     * {@link ASTTraitReference}
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference Context trait reference.
+     * @param ASTTraitReference $reference Context trait reference.
      *
      * @return void
      */
@@ -137,9 +135,7 @@ class ASTTraitUseStatement extends ASTStatement
      * alias exists for the given method, this method will simply return the
      * an <b>array</b> with the original method.
      *
-     * @param \PDepend\Source\AST\ASTMethod $method
-     *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     private function getAliasesFor(ASTMethod $method)
     {
@@ -197,7 +193,7 @@ class ASTTraitUseStatement extends ASTStatement
      * Returns an <b>array</b> with all alias statements declared in this use
      * statement.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias[]
+     * @return ASTTraitAdaptationAlias[]
      */
     private function getAliases()
     {

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node class represents a try-statement.
  *
@@ -58,11 +60,11 @@ class ASTTryStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitTryStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTTryStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTTryStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTType extends AbstractASTNode
@@ -57,7 +59,7 @@ class ASTType extends AbstractASTNode
     /**
      * This method will return <b>true</b> when the underlying type is an array.
      *
-     * @return boolean
+     * @return bool
      */
     public function isArray()
     {
@@ -68,7 +70,7 @@ class ASTType extends AbstractASTNode
      * This method will return <b>true</b> when the underlying data type is a
      * php primitive.
      *
-     * @return boolean
+     * @return bool
      */
     public function isScalar()
     {
@@ -78,7 +80,7 @@ class ASTType extends AbstractASTNode
     /**
      * This method will return <b>true</b> when this type use union pipe tos specify multiple types.
      *
-     * @return boolean
+     * @return bool
      */
     public function isUnion()
     {
@@ -89,9 +91,6 @@ class ASTType extends AbstractASTNode
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor
-     * @param mixed $data
-     * @return mixed
      * @since 0.9.12
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents an array type node.
  *
@@ -83,11 +85,11 @@ class ASTTypeArray extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitTypeArray($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTTypeArray extends ASTType
@@ -70,7 +72,7 @@ class ASTTypeArray extends ASTType
      * For this concrete type implementation the returned value will be always
      * <b>true</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isArray()
     {
@@ -82,9 +84,7 @@ class ASTTypeArray extends ASTType
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 class ASTTypeCallable extends ASTType
@@ -70,9 +72,6 @@ class ASTTypeCallable extends ASTType
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
-     *
-     * @return mixed
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a callable type node.
  *
@@ -71,9 +73,9 @@ class ASTTypeCallable extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitTypeCallable($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents an array type node.
  *
@@ -83,11 +85,11 @@ class ASTTypeIterable extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitTypeIterable($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.5.1
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.5.1
  */
 class ASTTypeIterable extends ASTType
@@ -70,7 +72,7 @@ class ASTTypeIterable extends ASTType
      * For this concrete type implementation the returned value will be always
      * <b>true</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isArray()
     {
@@ -82,9 +84,7 @@ class ASTTypeIterable extends ASTType
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents an unary expression node.
  *
@@ -72,11 +74,11 @@ class ASTUnaryExpression extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitUnaryExpression($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.11
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.11
  */
 class ASTUnaryExpression extends ASTExpression
@@ -71,9 +73,7 @@ class ASTUnaryExpression extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -51,6 +52,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTUnionType extends ASTType
@@ -59,7 +61,7 @@ class ASTUnionType extends ASTType
      * This method will return <b>true</b> when this type use union pipe tos specify multiple types.
      * For this concrete implementation the return value will be always true.
      *
-     * @return boolean
+     * @return bool
      */
     public function isUnion()
     {
@@ -70,9 +72,6 @@ class ASTUnionType extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param ASTVisitor $visitor
-     * @param mixed      $data
-     * @return mixed
      * @since  2.9.0
      */
     public function accept(ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a unset-statement node.
  *
@@ -58,11 +60,11 @@ class ASTUnsetStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitUnsetStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class ASTUnsetStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTUnsetStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 
@@ -50,6 +51,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.5
  */
 class ASTValue
@@ -57,21 +59,17 @@ class ASTValue
     /**
      * Boolean flag that is <b>true</b> when a PHP-value was set.
      *
-     * @var boolean
+     * @var bool
      */
     private $valueAvailable = false;
 
     /**
      * The parsed PHP-value,
-     *
-     * @var mixed
      */
     private $value = null;
 
     /**
      * This method will return the parsed PHP value.
-     *
-     * @return mixed
      */
     public function getValue()
     {
@@ -98,7 +96,7 @@ class ASTValue
     /**
      * This method will return <b>true</b> when the PHP-value is already set.
      *
-     * @return boolean
+     * @return bool
      */
     public function isValueAvailable()
     {

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -54,6 +55,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTVariable extends ASTExpression
@@ -62,7 +64,8 @@ class ASTVariable extends ASTExpression
      * This method will return <b>true</b> when this variable instance represents
      * the <b>$this</b> scope of a class instance.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.10.0
      */
     public function isThis()
@@ -75,9 +78,7 @@ class ASTVariable extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a variable node.
  *
@@ -77,11 +79,11 @@ class ASTVariable extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitVariable($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This node type represents a variable declarator. A variable declarator always
  * contains a variable name and it can optionally provide a variable default
@@ -59,7 +61,7 @@ class ASTVariableDeclarator extends ASTExpression
     /**
      * The initial declaration value for this node or <b>null</b>.
      *
-     * @var null|\PDepend\Source\AST\ASTValue
+     * @var null|ASTValue
      */
     protected $value = null;
 
@@ -67,7 +69,7 @@ class ASTVariableDeclarator extends ASTExpression
      * Returns the initial declaration value for this node or <b>null</b> when
      * no default value exists.
      *
-     * @return null|\PDepend\Source\AST\ASTValue
+     * @return null|ASTValue
      */
     public function getValue()
     {
@@ -76,8 +78,6 @@ class ASTVariableDeclarator extends ASTExpression
 
     /**
      * Sets the declared default value for this variable node.
-     *
-     * @param \PDepend\Source\AST\ASTValue $value
      *
      * @return void
      */
@@ -90,11 +90,11 @@ class ASTVariableDeclarator extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitVariableDeclarator($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -50,6 +51,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTVariableDeclarator extends ASTExpression
@@ -57,7 +59,7 @@ class ASTVariableDeclarator extends ASTExpression
     /**
      * The initial declaration value for this node or <b>null</b>.
      *
-     * @var \PDepend\Source\AST\ASTValue|null
+     * @var null|\PDepend\Source\AST\ASTValue
      */
     protected $value = null;
 
@@ -65,7 +67,7 @@ class ASTVariableDeclarator extends ASTExpression
      * Returns the initial declaration value for this node or <b>null</b> when
      * no default value exists.
      *
-     * @return \PDepend\Source\AST\ASTValue|null
+     * @return null|\PDepend\Source\AST\ASTValue
      */
     public function getValue()
     {
@@ -89,9 +91,7 @@ class ASTVariableDeclarator extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
@@ -105,6 +105,7 @@ class ASTVariableDeclarator extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class ASTVariableVariable extends ASTExpression
@@ -71,9 +73,7 @@ class ASTVariableVariable extends ASTExpression
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a variable variable node.
  *
@@ -72,11 +74,11 @@ class ASTVariableVariable extends ASTExpression
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitVariableVariable($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a while-statement.
  *
@@ -58,11 +60,11 @@ class ASTWhileStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitWhileStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 class ASTWhileStatement extends ASTStatement
@@ -57,9 +59,7 @@ class ASTWhileStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -44,6 +44,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * This class represents a yield statement node.
  *
@@ -72,11 +74,11 @@ class ASTYieldStatement extends ASTStatement
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
+     * @param ASTVisitor $visitor The calling visitor instance.
      *
      * @since  0.9.12
      */
-    public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = null)
     {
         return $visitor->visitYieldStatement($this, $data);
     }

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -62,6 +63,7 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since @TODO
  */
 class ASTYieldStatement extends ASTStatement
@@ -71,9 +73,7 @@ class ASTYieldStatement extends ASTStatement
      * by a visitor during tree traversal.
      *
      * @param \PDepend\Source\ASTVisitor\ASTVisitor $visitor The calling visitor instance.
-     * @param mixed                                 $data
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function accept(\PDepend\Source\ASTVisitor\ASTVisitor $visitor, $data = null)

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -81,7 +81,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * The source file for this item.
      *
-     * @var null|\PDepend\Source\AST\ASTCompilationUnit
+     * @var null|ASTCompilationUnit
      */
     protected $compilationUnit = null;
 
@@ -168,7 +168,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Returns the source file for this item.
      *
-     * @return null|\PDepend\Source\AST\ASTCompilationUnit
+     * @return null|ASTCompilationUnit
      */
     public function getCompilationUnit()
     {
@@ -177,8 +177,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Sets the source file for this item.
-     *
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -60,35 +60,35 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * The unique identifier for this function.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $id = null;
 
     /**
      * The line number where the item declaration starts.
      *
-     * @var integer
+     * @var int
      */
     protected $startLine = 0;
 
     /**
      * The line number where the item declaration ends.
      *
-     * @var integer
+     * @var int
      */
     protected $endLine = 0;
 
     /**
      * The source file for this item.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit|null
+     * @var null|\PDepend\Source\AST\ASTCompilationUnit
      */
     protected $compilationUnit = null;
 
     /**
      * The comment for this type.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $comment = null;
 
@@ -128,6 +128,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * @param string $name The item name.
      *
      * @return void
+     *
      * @since  1.0.0
      */
     public function setName($name)
@@ -153,8 +154,10 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Sets the unique identifier for this node instance.
      *
-     * @param  string $id Identifier for this node.
+     * @param string $id Identifier for this node.
+     *
      * @return void
+     *
      * @since  0.9.12
      */
     public function setId($id)
@@ -165,7 +168,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Returns the source file for this item.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit|null
+     * @return null|\PDepend\Source\AST\ASTCompilationUnit
      */
     public function getCompilationUnit()
     {
@@ -175,7 +178,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Sets the source file for this item.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
+     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
+     *
      * @return void
      */
     public function setCompilationUnit(ASTCompilationUnit $compilationUnit)
@@ -189,7 +193,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string|null
+     * @return null|string
      */
     public function getComment()
     {
@@ -200,6 +204,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Sets the raw doc comment for this node.
      *
      * @param string $comment
+     *
      * @return void
      */
     public function setComment($comment)
@@ -210,7 +215,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Returns the line number where the class or interface declaration starts.
      *
-     * @return integer
+     * @return int
      */
     public function getStartLine()
     {
@@ -220,7 +225,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Returns the line number where the class or interface declaration ends.
      *
-     * @return integer
+     * @return int
      */
     public function getEndLine()
     {
@@ -233,6 +238,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Returns the doc comment for this item or <b>null</b>.
      *
      * @return string
+     *
      * @deprecated Use getComment() inherit from ASTNode instead.
      */
     public function getDocComment()
@@ -244,7 +250,9 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Sets the doc comment for this item.
      *
      * @param string $docComment
+     *
      * @return void
+     *
      * @deprecated Use setComment() inherit from ASTNode instead.
      */
     public function setDocComment($docComment)

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -57,7 +57,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The internal used cache instance.
      *
-     * @var   \PDepend\Util\Cache\CacheDriver|null
+     * @var null|\PDepend\Util\Cache\CacheDriver
+     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -66,7 +67,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * A reference instance for the return value of this callable. By
      * default and for any scalar type this property is <b>null</b>.
      *
-     * @var   \PDepend\Source\AST\ASTClassOrInterfaceReference|null
+     * @var null|\PDepend\Source\AST\ASTClassOrInterfaceReference
+     *
      * @since 0.9.5
      */
     protected $returnClassReference = null;
@@ -74,7 +76,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of all exceptions classes referenced by this callable.
      *
-     * @var   \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     * @var \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     *
      * @since 0.9.5
      */
     protected $exceptionClassReferences = array();
@@ -82,14 +85,15 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Does this callable return a value by reference?
      *
-     * @var boolean
+     * @var bool
      */
     protected $returnsReference = false;
 
     /**
      * List of all parsed child nodes.
      *
-     * @var   \PDepend\Source\AST\ASTNode[]
+     * @var \PDepend\Source\AST\ASTNode[]
+     *
      * @since 0.9.6
      */
     protected $nodes = array();
@@ -97,7 +101,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The start line number of the method or function declaration.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.9.12
      */
     protected $startLine = 0;
@@ -105,7 +110,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The end line number of the method or function declaration.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.9.12
      */
     protected $endLine = 0;
@@ -113,7 +119,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of method/function parameters.
      *
-     * @var \PDepend\Source\AST\ASTParameter[]|null
+     * @var null|\PDepend\Source\AST\ASTParameter[]
      */
     private $parameters = null;
 
@@ -121,8 +127,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Setter method for the currently used token cache, where this callable
      * instance can store the associated tokens.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return $this
+     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -138,6 +144,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      *
      * @return void
      * @access private
+     *
      * @since  0.9.6
      */
     public function addChild(ASTNode $node)
@@ -149,6 +156,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns all child nodes of this method.
      *
      * @return \PDepend\Source\AST\ASTNode[]
+     *
      * @since  0.9.8
      */
     public function getChildren()
@@ -162,10 +170,12 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * <b>null</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType Searched class or interface type.
      *
-     * @return T|null
+     * @return null|T
      * @access private
+     *
      * @since  0.9.6
      */
     public function getFirstChildOfType($targetType)
@@ -185,11 +195,13 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Will find all children for the given type.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType Searched class or interface type.
      * @param T[]             $results    The found children.
      *
      * @return T[]
      * @access private
+     *
      * @since  0.9.6
      */
     public function findChildrenOfType($targetType, array &$results = array())
@@ -235,7 +247,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns the line number where the callable declaration starts.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.6
      */
     public function getStartLine()
@@ -246,7 +259,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns the line number where the callable declaration ends.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.6
      */
     public function getEndLine()
@@ -274,7 +288,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * the return value of this callable. The returned value will be <b>null</b>
      * if there is no return value or the return value is scalat.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getReturnClass()
@@ -292,7 +307,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Tests if this callable has a return class and return <b>true</b> if it is
      * configured.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 2.2.4
      */
     public function hasReturnClass()
@@ -307,7 +323,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTType|null
+     * @return null|\PDepend\Source\AST\ASTType
      */
     public function getReturnType()
     {
@@ -324,9 +340,10 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * function return type.
      *
      * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference Holder
-     *        instance for the declared function return type.
+     *                                                                         instance for the declared function return type.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     public function setReturnClassReference(ASTClassOrInterfaceReference $classReference)
@@ -339,13 +356,14 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * this callable.
      *
      * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference A
-     *        reference instance for a thrown exception.
+     *                                                                         reference instance for a thrown exception.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     public function addExceptionClassReference(
-        \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference
+        ASTClassOrInterfaceReference $classReference
     ) {
         $this->exceptionClassReferences[] = $classReference;
     }
@@ -366,7 +384,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an array with all method/function parameters.
      *
-     * @return \PDepend\Source\AST\ASTParameter[]|null
+     * @return null|\PDepend\Source\AST\ASTParameter[]
      */
     public function getParameters()
     {
@@ -380,7 +398,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * This method will return <b>true</b> when this method returns a value by
      * reference, otherwise the return value will be <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.5
      */
     public function returnsReference()
@@ -394,6 +413,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * a value by reference.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     public function setReturnsReference()
@@ -405,6 +425,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns an array with all declared static variables.
      *
      * @return array<string, mixed>
+     *
      * @since  0.9.6
      */
     public function getStaticVariables()
@@ -436,7 +457,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * restored from the cache and not currently parsed. Otherwise this method
      * will return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.10.0
      */
     public function isCached()
@@ -448,6 +470,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * This method will initialize the <b>$_parameters</b> property.
      *
      * @return void
+     *
      * @since  0.9.6
      */
     private function initParameters()
@@ -487,6 +510,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * cached for all callable instances.
      *
      * @return array
+     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -514,6 +538,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * automatically by PHP's garbage collector.
      *
      * @return void
+     *
      * @since  0.9.12
      */
     public function free()

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -57,7 +58,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The internal used cache instance.
      *
-     * @var null|\PDepend\Util\Cache\CacheDriver
+     * @var null|CacheDriver
      *
      * @since 0.10.0
      */
@@ -67,7 +68,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * A reference instance for the return value of this callable. By
      * default and for any scalar type this property is <b>null</b>.
      *
-     * @var null|\PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @var null|ASTClassOrInterfaceReference
      *
      * @since 0.9.5
      */
@@ -76,7 +77,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of all exceptions classes referenced by this callable.
      *
-     * @var \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     * @var ASTClassOrInterfaceReference[]
      *
      * @since 0.9.5
      */
@@ -92,7 +93,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of all parsed child nodes.
      *
-     * @var \PDepend\Source\AST\ASTNode[]
+     * @var ASTNode[]
      *
      * @since 0.9.6
      */
@@ -119,7 +120,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * List of method/function parameters.
      *
-     * @var null|\PDepend\Source\AST\ASTParameter[]
+     * @var null|ASTParameter[]
      */
     private $parameters = null;
 
@@ -140,7 +141,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Adds a parsed child node to this node.
      *
-     * @param \PDepend\Source\AST\ASTNode $node A parsed child node instance.
+     * @param ASTNode $node A parsed child node instance.
      *
      * @return void
      * @access private
@@ -155,7 +156,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns all child nodes of this method.
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      *
      * @since  0.9.8
      */
@@ -169,7 +170,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * instance of the given <b>$targetType</b>. The returned value will be
      * <b>null</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
      *
@@ -194,7 +195,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Will find all children for the given type.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
      * @param T[]             $results    The found children.
@@ -230,7 +231,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Sets the tokens found in the function body.
      *
-     * @param \PDepend\Source\Tokenizer\Token[] $tokens The body tokens.
+     * @param Token[] $tokens The body tokens.
      *
      * @return void
      */
@@ -269,7 +270,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
+     * Returns all {@link AbstractASTClassOrInterface}
      * objects this function depends on.
      *
      * @return ASTClassOrInterfaceReferenceIterator
@@ -288,7 +289,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * the return value of this callable. The returned value will be <b>null</b>
      * if there is no return value or the return value is scalat.
      *
-     * @return null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return null|AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -323,7 +324,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     }
 
     /**
-     * @return null|\PDepend\Source\AST\ASTType
+     * @return null|ASTType
      */
     public function getReturnType()
     {
@@ -339,8 +340,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * This method can be used to set a reference instance for the declared
      * function return type.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference Holder
-     *                                                                         instance for the declared function return type.
+     * @param ASTClassOrInterfaceReference $classReference Holder instance for the declared function return type.
      *
      * @return void
      *
@@ -355,8 +355,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Adds a reference holder for a thrown exception class or interface to
      * this callable.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference A
-     *                                                                         reference instance for a thrown exception.
+     * @param ASTClassOrInterfaceReference $classReference A reference instance for a thrown exception.
      *
      * @return void
      *
@@ -370,7 +369,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
 
     /**
      * Returns an iterator with thrown exception
-     * {@link \PDepend\Source\AST\AbstractASTClassOrInterface} instances.
+     * {@link AbstractASTClassOrInterface} instances.
      *
      * @return ASTClassOrInterfaceReferenceIterator
      */
@@ -384,7 +383,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an array with all method/function parameters.
      *
-     * @return null|\PDepend\Source\AST\ASTParameter[]
+     * @return null|ASTParameter[]
      */
     public function getParameters()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -55,7 +55,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * The parent for this class node.
      *
-     * @var   \PDepend\Source\AST\ASTClassReference|null
+     * @var null|\PDepend\Source\AST\ASTClassReference
+     *
      * @since 0.9.5
      */
     protected $parentClassReference = null;
@@ -84,8 +85,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
-     * @return \PDepend\Source\AST\ASTClass|null
      * @throws \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
+     *
+     * @return null|\PDepend\Source\AST\ASTClass
      */
     public function getParentClass()
     {
@@ -117,8 +119,10 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * direct parent of this class is the first element in the returned array
      * and parent of this parent the second element and so on.
      *
-     * @return \PDepend\Source\AST\ASTClass[]
      * @throws \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
+     *
+     * @return \PDepend\Source\AST\ASTClass[]
+     *
      * @since  1.0.0
      */
     public function getParentClasses()
@@ -140,7 +144,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a reference onto the parent class of this class node or <b>null</b>.
      *
-     * @return \PDepend\Source\AST\ASTClassReference|null
+     * @return null|\PDepend\Source\AST\ASTClassReference
+     *
      * @since  0.9.5
      */
     public function getParentClassReference()
@@ -152,9 +157,10 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Sets a reference onto the parent class of this class node.
      *
      * @param \PDepend\Source\AST\ASTClassReference $classReference Reference to the
-     *        declared parent class.
+     *                                                              declared parent class.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     public function setParentClassReference(ASTClassReference $classReference)
@@ -167,6 +173,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns a node iterator with all implemented interfaces.
      *
      * @return ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>|\PDepend\Source\AST\AbstractASTClassOrInterface[]
+     *
      * @since  0.9.5
      */
     public function getInterfaces()
@@ -196,6 +203,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns an array of references onto the interfaces of this class node.
      *
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     *
      * @since  0.10.4
      */
     public function getInterfaceReferences()
@@ -206,8 +214,10 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Adds a interface reference node.
      *
-     * @param  \PDepend\Source\AST\ASTClassOrInterfaceReference $interfaceReference
+     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $interfaceReference
+     *
      * @return void
+     *
      * @since  0.9.5
      */
     public function addInterfaceReference(ASTClassOrInterfaceReference $interfaceReference)
@@ -249,7 +259,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @param string $name Name of the searched constant.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public function hasConstant($name)
@@ -266,7 +277,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @param string $name Name of the searched constant.
      *
-     * @return mixed
      * @since  0.9.6
      */
     public function getConstant($name)
@@ -281,6 +291,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns a list of all methods provided by this type or one of its parents.
      *
      * @return \PDepend\Source\AST\ASTMethod[]
+     *
      * @since  0.9.10
      */
     public function getAllMethods()
@@ -328,14 +339,14 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
      *
-     * @return boolean
+     * @return bool
      */
     abstract public function isAbstract();
 
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return integer
+     * @return int
      */
     abstract public function getModifiers();
 
@@ -343,6 +354,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * This method initializes the constants defined in this class or interface.
      *
      * @return void
+     *
      * @since  0.9.6
      */
     private function initConstants()
@@ -362,6 +374,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * This method initializes the constants defined in this class or interface.
      *
      * @return void
+     *
      * @since  0.9.6
      */
     private function initConstantDeclarators()
@@ -398,6 +411,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * interface instance.
      *
      * @return array
+     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -55,7 +55,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * The parent for this class node.
      *
-     * @var null|\PDepend\Source\AST\ASTClassReference
+     * @var null|ASTClassReference
      *
      * @since 0.9.5
      */
@@ -64,7 +64,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * List of all interfaces implemented/extended by the this type.
      *
-     * @var \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     * @var ASTClassOrInterfaceReference[]
      */
     protected $interfaceReferences = array();
 
@@ -85,9 +85,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
-     * @throws \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      *
-     * @return null|\PDepend\Source\AST\ASTClass
+     * @return null|ASTClass
      */
     public function getParentClass()
     {
@@ -119,9 +119,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * direct parent of this class is the first element in the returned array
      * and parent of this parent the second element and so on.
      *
-     * @throws \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      *
-     * @return \PDepend\Source\AST\ASTClass[]
+     * @return ASTClass[]
      *
      * @since  1.0.0
      */
@@ -144,7 +144,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a reference onto the parent class of this class node or <b>null</b>.
      *
-     * @return null|\PDepend\Source\AST\ASTClassReference
+     * @return null|ASTClassReference
      *
      * @since  0.9.5
      */
@@ -156,8 +156,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Sets a reference onto the parent class of this class node.
      *
-     * @param \PDepend\Source\AST\ASTClassReference $classReference Reference to the
-     *                                                              declared parent class.
+     * @param ASTClassReference $classReference Reference to the declared parent class.
      *
      * @return void
      *
@@ -172,7 +171,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a node iterator with all implemented interfaces.
      *
-     * @return ASTArtifactList<\PDepend\Source\AST\AbstractASTClassOrInterface>|\PDepend\Source\AST\AbstractASTClassOrInterface[]
+     * @return AbstractASTClassOrInterface[]|ASTArtifactList<AbstractASTClassOrInterface>
      *
      * @since  0.9.5
      */
@@ -202,7 +201,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns an array of references onto the interfaces of this class node.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference[]
+     * @return ASTClassOrInterfaceReference[]
      *
      * @since  0.10.4
      */
@@ -213,8 +212,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
 
     /**
      * Adds a interface reference node.
-     *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $interfaceReference
      *
      * @return void
      *
@@ -290,7 +287,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a list of all methods provided by this type or one of its parents.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      *
      * @since  0.9.10
      */
@@ -321,7 +318,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\AbstractASTClassOrInterface}
+     * Returns all {@link AbstractASTClassOrInterface}
      * objects this type depends on.
      *
      * @return ASTClassOrInterfaceReferenceIterator

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -59,7 +59,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Parsed child nodes of this node.
      *
-     * @var \PDepend\Source\AST\ASTNode[]
+     * @var ASTNode[]
      */
     protected $nodes = array();
 
@@ -67,7 +67,7 @@ abstract class AbstractASTNode implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var null|\PDepend\Source\AST\ASTNode
+     * @var null|ASTNode
      */
     protected $parent = null;
 
@@ -312,7 +312,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @throws OutOfBoundsException When no node exists at the given index.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function getChild($index)
     {
@@ -331,7 +331,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getChildren()
     {
@@ -343,7 +343,7 @@ abstract class AbstractASTNode implements ASTNode
      * instance of the given <b>$targetType</b>. The returned value will be
      * <b>null</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType
      *
@@ -367,7 +367,7 @@ abstract class AbstractASTNode implements ASTNode
      * instance of the given <b>$targetType</b>. The returned value will be
      * an empty <b>array</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
      * @param T[]             $results    Already found node instances. This parameter
@@ -389,8 +389,6 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method adds a new child node at the first position of the children.
      *
-     * @param \PDepend\Source\AST\ASTNode $node
-     *
      * @return void
      */
     public function prependChild(ASTNode $node)
@@ -401,8 +399,6 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * This method adds a new child node to this node instance.
-     *
-     * @param \PDepend\Source\AST\ASTNode $node
      *
      * @return void
      */
@@ -416,7 +412,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function getParent()
     {
@@ -429,7 +425,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param string $parentType
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getParentsOfType($parentType)
     {
@@ -447,8 +443,6 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Sets the parent node of this node.
-     *
-     * @param \PDepend\Source\AST\ASTNode $node
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -38,16 +38,20 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
 namespace PDepend\Source\AST;
+
+use OutOfBoundsException;
 
 /**
  * This is an abstract base implementation of the ast node interface.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 abstract class AbstractASTNode implements ASTNode
@@ -63,7 +67,7 @@ abstract class AbstractASTNode implements ASTNode
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
      *
-     * @var \PDepend\Source\AST\ASTNode|null
+     * @var null|\PDepend\Source\AST\ASTNode
      */
     protected $parent = null;
 
@@ -80,6 +84,7 @@ abstract class AbstractASTNode implements ASTNode
      * image in a colon seperated string.
      *
      * @var string
+     *
      * @since 0.10.4
      */
     protected $metadata = '::::';
@@ -100,6 +105,7 @@ abstract class AbstractASTNode implements ASTNode
      * Sets the image for this ast node.
      *
      * @param string $image
+     *
      * @return void
      */
     public function setImage($image)
@@ -132,7 +138,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the start line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartLine()
     {
@@ -142,7 +148,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the start column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getStartColumn()
     {
@@ -152,7 +158,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the end line for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndLine()
     {
@@ -162,7 +168,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the end column for this ast node.
      *
-     * @return integer
+     * @return int
      */
     public function getEndColumn()
     {
@@ -173,11 +179,13 @@ abstract class AbstractASTNode implements ASTNode
      * For better performance we have moved the single setter methods for the
      * node columns and lines into this configure method.
      *
-     * @param integer $startLine
-     * @param integer $endLine
-     * @param integer $startColumn
-     * @param integer $endColumn
+     * @param int $startLine
+     * @param int $endLine
+     * @param int $startColumn
+     * @param int $endColumn
+     *
      * @return void
+     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns(
@@ -195,8 +203,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @param integer $index
-     * @return integer
+     * @param int $index
+     *
+     * @return int
+     *
      * @since 0.10.4
      */
     protected function getMetadataInteger($index)
@@ -208,9 +218,11 @@ abstract class AbstractASTNode implements ASTNode
      * Stores an integer value under the given index in the internally used data
      * string.
      *
-     * @param integer $index
-     * @param integer $value
+     * @param int $index
+     * @param int $value
+     *
      * @return void
+     *
      * @since 0.10.4
      */
     protected function setMetadataInteger($index, $value)
@@ -221,8 +233,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns a boolean value that was stored under the given index.
      *
-     * @param integer $index
-     * @return boolean
+     * @param int $index
+     *
+     * @return bool
+     *
      * @since 0.10.4
      */
     protected function getMetadataBoolean($index)
@@ -234,9 +248,11 @@ abstract class AbstractASTNode implements ASTNode
      * Stores a boolean value under the given index in the internally used data
      * string.
      *
-     * @param integer $index
-     * @param boolean $value
+     * @param int  $index
+     * @param bool $value
+     *
      * @return void
+     *
      * @since 0.10.4
      */
     protected function setMetadataBoolean($index, $value)
@@ -247,8 +263,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the value that was stored under the given index.
      *
-     * @param integer $index
+     * @param int $index
+     *
      * @return string
+     *
      * @since 0.10.4
      */
     protected function getMetadata($index)
@@ -261,9 +279,10 @@ abstract class AbstractASTNode implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param integer $index
-     * @param mixed $value
+     * @param int $index
+     *
      * @return void
+     *
      * @since 0.10.4
      */
     protected function setMetadata($index, $value)
@@ -277,7 +296,8 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.10.4
      */
     protected function getMetadataSize()
@@ -288,16 +308,18 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the node instance for the given index or throws an exception.
      *
-     * @param integer $index
+     * @param int $index
+     *
+     * @throws OutOfBoundsException When no node exists at the given index.
+     *
      * @return \PDepend\Source\AST\ASTNode
-     * @throws \OutOfBoundsException When no node exists at the given index.
      */
     public function getChild($index)
     {
         if (isset($this->nodes[$index])) {
             return $this->nodes[$index];
         }
-        throw new \OutOfBoundsException(
+        throw new OutOfBoundsException(
             sprintf(
                 'No node found at index %d in node of type: %s',
                 $index,
@@ -322,8 +344,10 @@ abstract class AbstractASTNode implements ASTNode
      * <b>null</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType
-     * @return T|null
+     *
+     * @return null|T
      */
     public function getFirstChildOfType($targetType)
     {
@@ -344,9 +368,11 @@ abstract class AbstractASTNode implements ASTNode
      * an empty <b>array</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType Searched class or interface type.
      * @param T[]             $results    Already found node instances. This parameter
-     *        is only for internal usage.
+     *                                    is only for internal usage.
+     *
      * @return T[]
      */
     public function findChildrenOfType($targetType, array &$results = array())
@@ -364,6 +390,7 @@ abstract class AbstractASTNode implements ASTNode
      * This method adds a new child node at the first position of the children.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function prependChild(ASTNode $node)
@@ -376,6 +403,7 @@ abstract class AbstractASTNode implements ASTNode
      * This method adds a new child node to this node instance.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function addChild(ASTNode $node)
@@ -400,6 +428,7 @@ abstract class AbstractASTNode implements ASTNode
      * of <b>$parentType</b>.
      *
      * @param string $parentType
+     *
      * @return \PDepend\Source\AST\ASTNode[]
      */
     public function getParentsOfType($parentType)
@@ -420,6 +449,7 @@ abstract class AbstractASTNode implements ASTNode
      * Sets the parent node of this node.
      *
      * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      */
     public function setParent(ASTNode $node)
@@ -456,6 +486,7 @@ abstract class AbstractASTNode implements ASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array
+     *
      * @since 0.10.0
      */
     public function __sleep()
@@ -474,6 +505,7 @@ abstract class AbstractASTNode implements ASTNode
      * node's children.
      *
      * @return void
+     *
      * @since 0.10.0
      */
     public function __wakeup()

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -62,21 +62,21 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var null|\PDepend\Util\Cache\CacheDriver
+     * @var null|CacheDriver
      */
     protected $cache = null;
 
     /**
      * The currently used builder context.
      *
-     * @var null|\PDepend\Source\Builder\BuilderContext
+     * @var null|BuilderContext
      */
     protected $context = null;
 
     /**
      * The parent namespace for this class.
      *
-     * @var null|\PDepend\Source\AST\ASTNamespace
+     * @var null|ASTNamespace
      */
     private $namespace = null;
 
@@ -99,7 +99,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * List of all parsed child nodes.
      *
-     * @var \PDepend\Source\AST\ASTNode[]
+     * @var ASTNode[]
      */
     protected $nodes = array();
 
@@ -154,8 +154,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Adds a parsed child node to this node.
      *
-     * @param \PDepend\Source\AST\ASTNode $node
-     *
      * @return void
      * @access private
      */
@@ -171,7 +169,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @throws OutOfBoundsException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function getChild($index)
     {
@@ -190,7 +188,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns all child nodes of this class.
      *
-     * @return \PDepend\Source\AST\ASTNode[]
+     * @return ASTNode[]
      */
     public function getChildren()
     {
@@ -202,7 +200,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * instance of the given <b>$targetType</b>. The returned value will be
      * <b>null</b> if no child exists for that.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
      *
@@ -234,7 +232,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Will find all children for the given type.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $targetType The target class or interface type.
      * @param T[]             $results    The found children.
@@ -283,7 +281,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     }
 
     /**
-     * Returns all {@link \PDepend\Source\AST\ASTMethod} objects in this type.
+     * Returns all {@link ASTMethod} objects in this type.
      *
      * @return ASTArtifactList<ASTMethod>
      */
@@ -320,7 +318,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     }
 
     /**
-     * Returns an array with {@link \PDepend\Source\AST\ASTMethod} objects
+     * Returns an array with {@link ASTMethod} objects
      * that are imported through traits.
      *
      * @return ASTMethod[]
@@ -377,7 +375,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns an <b>array</b> with all tokens within this type.
      *
-     * @return \PDepend\Source\Tokenizer\Token[]
+     * @return Token[]
      */
     public function getTokens()
     {
@@ -389,7 +387,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Sets the tokens for this type.
      *
-     * @param \PDepend\Source\Tokenizer\Token[] $tokens
+     * @param Token[] $tokens
      *
      * @return void
      */
@@ -431,7 +429,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns the parent namespace for this class.
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function getNamespace()
     {
@@ -440,8 +438,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
     /**
      * Sets the parent namespace for this type.
-     *
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
      *
      * @return void
      */
@@ -484,8 +480,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Checks that this user type is a subtype of the given <b>$type</b>
      * instance.
-     *
-     * @param \PDepend\Source\AST\AbstractASTType $type
      *
      * @return bool
      *

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -38,11 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
 namespace PDepend\Source\AST;
 
+use OutOfBoundsException;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
@@ -52,6 +54,7 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 abstract class AbstractASTType extends AbstractASTArtifact
@@ -59,28 +62,28 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var \PDepend\Util\Cache\CacheDriver|null
+     * @var null|\PDepend\Util\Cache\CacheDriver
      */
     protected $cache = null;
 
     /**
      * The currently used builder context.
      *
-     * @var \PDepend\Source\Builder\BuilderContext|null
+     * @var null|\PDepend\Source\Builder\BuilderContext
      */
     protected $context = null;
 
     /**
      * The parent namespace for this class.
      *
-     * @var \PDepend\Source\AST\ASTNamespace|null
+     * @var null|\PDepend\Source\AST\ASTNamespace
      */
     private $namespace = null;
 
     /**
      * An <b>array</b> with all constants defined in this class or interface.
      *
-     * @var array<string, mixed>|null
+     * @var null|array<string, mixed>
      */
     protected $constants = null;
 
@@ -89,7 +92,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * The parser marks all classes and interfaces as user defined that have a
      * source file and were part of parsing process.
      *
-     * @var boolean
+     * @var bool
      */
     protected $userDefined = false;
 
@@ -104,21 +107,22 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Name of the parent namespace for this class or interface instance. Or
      * <b>NULL</b> when no namespace was specified.
      *
-     * @var string|null
+     * @var null|string
      */
     protected $namespaceName = null;
 
     /**
      * The modifiers for this class instance.
      *
-     * @var integer
+     * @var int
      */
     protected $modifiers = 0;
 
     /**
      * Temporary property that only holds methods during the parsing process.
      *
-     * @var   ASTMethod[]|null
+     * @var null|ASTMethod[]
+     *
      * @since 1.0.2
      */
     protected $methods = array();
@@ -128,7 +132,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Setter method for the currently used token cache, where this class or
      * interface instance can store the associated tokens.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return $this
      */
     public function setCache(CacheDriver $cache)
@@ -140,7 +143,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Sets the currently active builder context.
      *
-     * @param  \PDepend\Source\Builder\BuilderContext $context
      * @return $this
      */
     public function setContext(BuilderContext $context)
@@ -152,7 +154,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Adds a parsed child node to this node.
      *
-     * @param  \PDepend\Source\AST\ASTNode $node
+     * @param \PDepend\Source\AST\ASTNode $node
+     *
      * @return void
      * @access private
      */
@@ -164,16 +167,18 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns the child at the given index.
      *
-     * @param  integer $index
+     * @param int $index
+     *
+     * @throws OutOfBoundsException
+     *
      * @return \PDepend\Source\AST\ASTNode
-     * @throws \OutOfBoundsException
      */
     public function getChild($index)
     {
         if (isset($this->nodes[$index])) {
             return $this->nodes[$index];
         }
-        throw new \OutOfBoundsException(
+        throw new OutOfBoundsException(
             sprintf(
                 'No node found at index %d in node of type: %s',
                 $index,
@@ -198,10 +203,12 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * <b>null</b> if no child exists for that.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType Searched class or interface type.
      *
-     * @return T|null
+     * @return null|T
      * @access private
+     *
      * @todo   Refactor $_methods property to getAllMethods() when it exists.
      */
     public function getFirstChildOfType($targetType)
@@ -228,11 +235,13 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Will find all children for the given type.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $targetType The target class or interface type.
      * @param T[]             $results    The found children.
      *
      * @return T[]
      * @access private
+     *
      * @todo   Refactor $_methods property to getAllMethods() when it exists.
      */
     public function findChildrenOfType($targetType, array &$results = array())
@@ -255,7 +264,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * This method will return <b>true</b> when this type has a declaration in
      * the analyzed source files.
      *
-     * @return boolean
+     * @return bool
      */
     public function isUserDefined()
     {
@@ -299,7 +308,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Adds the given method to this type.
      *
-     * @param ASTMethod $method
      * @return ASTMethod
      */
     public function addMethod(ASTMethod $method)
@@ -316,6 +324,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * that are imported through traits.
      *
      * @return ASTMethod[]
+     *
      * @since  1.0.0
      */
     protected function getTraitMethods()
@@ -381,7 +390,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Sets the tokens for this type.
      *
      * @param \PDepend\Source\Tokenizer\Token[] $tokens
-     * @param Token|null $startToken
+     *
      * @return void
      */
     public function setTokens(array $tokens, Token $startToken = null)
@@ -432,7 +441,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Sets the parent namespace for this type.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
+     * @param \PDepend\Source\AST\ASTNamespace $namespace
+     *
      * @return void
      */
     public function setNamespace(ASTNamespace $namespace)
@@ -457,7 +467,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * was restored from the cache and not currently parsed. Otherwise this
      * method will return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
      */
     public function isCached()
     {
@@ -475,8 +485,10 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Checks that this user type is a subtype of the given <b>$type</b>
      * instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
-     * @return boolean
+     * @param \PDepend\Source\AST\AbstractASTType $type
+     *
+     * @return bool
+     *
      * @since  1.0.6
      */
     abstract public function isSubtypeOf(AbstractASTType $type);

--- a/src/main/php/PDepend/Source/AST/State.php
+++ b/src/main/php/PDepend/Source/AST/State.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Source\AST;
 
+use ReflectionClass;
+use ReflectionMethod;
+
 /**
  * Holds constants with internal state constants
  *
@@ -53,42 +56,42 @@ interface State
     /**
      * Marks a class or interface as implicit abstract.
      */
-    const IS_IMPLICIT_ABSTRACT = \ReflectionClass::IS_IMPLICIT_ABSTRACT;
+    const IS_IMPLICIT_ABSTRACT = ReflectionClass::IS_IMPLICIT_ABSTRACT;
 
     /**
      * Marks a class or interface as explicit abstract.
      */
-    const IS_EXPLICIT_ABSTRACT = \ReflectionClass::IS_EXPLICIT_ABSTRACT;
+    const IS_EXPLICIT_ABSTRACT = ReflectionClass::IS_EXPLICIT_ABSTRACT;
 
     /**
      * Marks a node as public.
      */
-    const IS_PUBLIC = \ReflectionMethod::IS_PUBLIC;
+    const IS_PUBLIC = ReflectionMethod::IS_PUBLIC;
 
     /**
      * Marks a node as protected.
      */
-    const IS_PROTECTED = \ReflectionMethod::IS_PROTECTED;
+    const IS_PROTECTED = ReflectionMethod::IS_PROTECTED;
 
     /**
      * Marks a node as private.
      */
-    const IS_PRIVATE = \ReflectionMethod::IS_PRIVATE;
+    const IS_PRIVATE = ReflectionMethod::IS_PRIVATE;
 
     /**
      * Marks a node as abstract.
      */
-    const IS_ABSTRACT = \ReflectionMethod::IS_ABSTRACT;
+    const IS_ABSTRACT = ReflectionMethod::IS_ABSTRACT;
 
     /**
      * Marks a node as final.
      */
-    const IS_FINAL = \ReflectionMethod::IS_FINAL;
+    const IS_FINAL = ReflectionMethod::IS_FINAL;
 
     /**
      * Marks a node as static.
      */
-    const IS_STATIC = \ReflectionMethod::IS_STATIC;
+    const IS_STATIC = ReflectionMethod::IS_STATIC;
 
     /**
      * Marks a node as readonly.

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
@@ -63,7 +63,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new class instance.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     *
      * @return void
      */
     public function startVisitClass(ASTClass $class);
@@ -71,7 +72,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a class instance.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     *
      * @return void
      */
     public function endVisitClass(ASTClass $class);
@@ -79,8 +81,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new trait instance.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function startVisitTrait(ASTTrait $trait);
@@ -88,8 +90,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a trait instance.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function endVisitTrait(ASTTrait $trait);
@@ -97,7 +99,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new file instance.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     *
      * @return void
      */
     public function startVisitFile(ASTCompilationUnit $compilationUnit);
@@ -105,7 +108,8 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a file instance.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     *
      * @return void
      */
     public function endVisitFile(ASTCompilationUnit $compilationUnit);
@@ -113,7 +117,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new function instance.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function startVisitFunction(ASTFunction $function);
@@ -121,7 +124,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a function instance.
      *
-     * @param  ASTFunction $function
      * @return void
      */
     public function endVisitFunction(ASTFunction $function);
@@ -129,7 +131,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new interface instance.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function startVisitInterface(ASTInterface $interface);
@@ -137,7 +138,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with an interface instance.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function endVisitInterface(ASTInterface $interface);
@@ -145,7 +145,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new method instance.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function startVisitMethod(ASTMethod $method);
@@ -153,7 +152,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a method instance.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function endVisitMethod(ASTMethod $method);
@@ -161,7 +159,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new namespace instance.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function startVisitNamespace(ASTNamespace $namespace);
@@ -169,7 +166,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a namespace instance.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function endVisitNamespace(ASTNamespace $namespace);
@@ -177,7 +173,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new parameter instance.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function startVisitParameter(ASTParameter $parameter);
@@ -185,7 +180,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a parameter instance.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function endVisitParameter(ASTParameter $parameter);
@@ -193,7 +187,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new property instance.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function startVisitProperty(ASTProperty $property);
@@ -201,7 +194,6 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a property instance.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function endVisitProperty(ASTProperty $property);

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
@@ -63,7 +63,7 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new class instance.
      *
-     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param ASTClass $class The context class instance.
      *
      * @return void
      */
@@ -72,7 +72,7 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a class instance.
      *
-     * @param \PDepend\Source\AST\ASTClass $class The context class instance.
+     * @param ASTClass $class The context class instance.
      *
      * @return void
      */
@@ -99,7 +99,7 @@ interface ASTVisitListener
     /**
      * Is called when the visitor starts a new file instance.
      *
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     * @param ASTCompilationUnit $compilationUnit The context file instance.
      *
      * @return void
      */
@@ -108,7 +108,7 @@ interface ASTVisitListener
     /**
      * Is called when the visitor ends with a file instance.
      *
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit The context file instance.
+     * @param ASTCompilationUnit $compilationUnit The context file instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -62,7 +62,9 @@ interface ASTVisitor
 {
     /**
      * Adds a new listener to this node visitor.
+     *
      * @param \PDepend\Source\ASTVisitor\ASTVisitListener $listener
+     *
      * @return void
      */
     public function addVisitListener(ASTVisitListener $listener);
@@ -70,7 +72,6 @@ interface ASTVisitor
     /**
      * Visits a class node.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class);
@@ -78,8 +79,8 @@ interface ASTVisitor
     /**
      * Visits a trait node.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function visitTrait(ASTTrait $trait);
@@ -87,7 +88,6 @@ interface ASTVisitor
     /**
      * Visits a file node.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     public function visitCompilationUnit(ASTCompilationUnit $compilationUnit);
@@ -95,7 +95,6 @@ interface ASTVisitor
     /**
      * Visits a function node.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function);
@@ -103,7 +102,6 @@ interface ASTVisitor
     /**
      * Visits a code interface object.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface);
@@ -111,7 +109,6 @@ interface ASTVisitor
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method);
@@ -119,7 +116,6 @@ interface ASTVisitor
     /**
      * Visits a namespace node.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace);
@@ -127,7 +123,6 @@ interface ASTVisitor
     /**
      * Visits a parameter node.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function visitParameter(ASTParameter $parameter);
@@ -135,7 +130,6 @@ interface ASTVisitor
     /**
      * Visits a property node.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function visitProperty(ASTProperty $property);
@@ -160,7 +154,6 @@ interface ASTVisitor
      * @param string                $method Name of the called method.
      * @param array<integer, mixed> $args   Array with method argument.
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function __call($method, $args);

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -63,8 +63,6 @@ interface ASTVisitor
     /**
      * Adds a new listener to this node visitor.
      *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitListener $listener
-     *
      * @return void
      */
     public function addVisitListener(ASTVisitListener $listener);
@@ -151,8 +149,8 @@ interface ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string                $method Name of the called method.
-     * @param array<integer, mixed> $args   Array with method argument.
+     * @param string            $method Name of the called method.
+     * @param array<int, mixed> $args   Array with method argument.
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
@@ -65,7 +65,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new class instance.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function startVisitClass(ASTClass $class)
@@ -76,7 +75,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a class instance.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function endVisitClass(ASTClass $class)
@@ -87,8 +85,8 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new trait instance.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function startVisitTrait(ASTTrait $trait)
@@ -99,8 +97,8 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a trait instance.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function endVisitTrait(ASTTrait $trait)
@@ -111,7 +109,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new file instance.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     public function startVisitFile(ASTCompilationUnit $compilationUnit)
@@ -122,7 +119,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a file instance.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     public function endVisitFile(ASTCompilationUnit $compilationUnit)
@@ -133,7 +129,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new function instance.
      *
-     * @param  ASTFunction $function
      * @return void
      */
     public function startVisitFunction(ASTFunction $function)
@@ -144,7 +139,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a function instance.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function endVisitFunction(ASTFunction $function)
@@ -155,7 +149,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new interface instance.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function startVisitInterface(ASTInterface $interface)
@@ -166,7 +159,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with an interface instance.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function endVisitInterface(ASTInterface $interface)
@@ -177,7 +169,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new method instance.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function startVisitMethod(ASTMethod $method)
@@ -188,7 +179,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a method instance.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function endVisitMethod(ASTMethod $method)
@@ -199,7 +189,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new namespace instance.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function startVisitNamespace(ASTNamespace $namespace)
@@ -210,7 +199,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a namespace instance.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     public function endVisitNamespace(ASTNamespace $namespace)
@@ -221,7 +209,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new parameter instance.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function startVisitParameter(ASTParameter $parameter)
@@ -232,7 +219,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a parameter instance.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function endVisitParameter(ASTParameter $parameter)
@@ -243,7 +229,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor starts a new property instance.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function startVisitProperty(ASTProperty $property)
@@ -254,7 +239,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Is called when the visitor ends with a property instance.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function endVisitProperty(ASTProperty $property)
@@ -265,7 +249,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Generic notification method that is called for every node start.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     protected function startVisitNode(AbstractASTArtifact $node)
@@ -275,7 +258,6 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Generic notification method that is called when the node processing ends.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     protected function endVisitNode(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -67,14 +67,14 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * List of all registered listeners.
      *
-     * @var \PDepend\Source\ASTVisitor\ASTVisitListener[]
+     * @var ASTVisitListener[]
      */
     private $listeners = array();
 
     /**
      * Returns an iterator with all registered visit listeners.
      *
-     * @return Iterator<\PDepend\Source\ASTVisitor\ASTVisitListener>
+     * @return Iterator<ASTVisitListener>
      */
     public function getVisitListeners()
     {
@@ -83,8 +83,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
 
     /**
      * Adds a new listener to this node visitor.
-     *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitListener $listener
      *
      * @return void
      */
@@ -264,8 +262,8 @@ abstract class AbstractASTVisitor implements ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string                $method Name of the called method.
-     * @param array<integer, mixed> $args   Array with method argument.
+     * @param string            $method Name of the called method.
+     * @param array<int, mixed> $args   Array with method argument.
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\ASTVisitor;
 
+use ArrayIterator;
+use Iterator;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
@@ -51,6 +53,7 @@ use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
+use RuntimeException;
 
 /**
  * This abstract visitor implementation provides a default traversal algorithm
@@ -71,17 +74,18 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Returns an iterator with all registered visit listeners.
      *
-     * @return \Iterator<\PDepend\Source\ASTVisitor\ASTVisitListener>
+     * @return Iterator<\PDepend\Source\ASTVisitor\ASTVisitListener>
      */
     public function getVisitListeners()
     {
-        return new \ArrayIterator($this->listeners);
+        return new ArrayIterator($this->listeners);
     }
 
     /**
      * Adds a new listener to this node visitor.
      *
-     * @param  \PDepend\Source\ASTVisitor\ASTVisitListener $listener
+     * @param \PDepend\Source\ASTVisitor\ASTVisitListener $listener
+     *
      * @return void
      */
     public function addVisitListener(ASTVisitListener $listener)
@@ -94,7 +98,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a class node.
      *
-     * @param  ASTClass $class
      * @return void
      */
     public function visitClass(ASTClass $class)
@@ -116,8 +119,8 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a trait node.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function visitTrait(ASTTrait $trait)
@@ -136,7 +139,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a file node.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
@@ -148,7 +150,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a function node.
      *
-     * @param  ASTFunction $function
      * @return void
      */
     public function visitFunction(ASTFunction $function)
@@ -167,7 +168,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a code interface object.
      *
-     * @param  ASTInterface $interface
      * @return void
      */
     public function visitInterface(ASTInterface $interface)
@@ -186,7 +186,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a method node.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     public function visitMethod(ASTMethod $method)
@@ -203,7 +202,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a namespace node.
      *
-     * @param  ASTNamespace $namespace
      * @return void
      */
     public function visitNamespace(ASTNamespace $namespace)
@@ -229,7 +227,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a parameter node.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     public function visitParameter(ASTParameter $parameter)
@@ -241,7 +238,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Visits a property node.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     public function visitProperty(ASTProperty $property)
@@ -271,13 +267,12 @@ abstract class AbstractASTVisitor implements ASTVisitor
      * @param string                $method Name of the called method.
      * @param array<integer, mixed> $args   Array with method argument.
      *
-     * @return mixed
      * @since  0.9.12
      */
     public function __call($method, $args)
     {
         if (!isset($args[1])) {
-            throw new \RuntimeException("No node to visit provided for $method.");
+            throw new RuntimeException("No node to visit provided for $method.");
         }
 
         $value = $args[1];
@@ -290,7 +285,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start class event.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     protected function fireStartClass(ASTClass $class)
@@ -303,7 +297,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end class event.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     protected function fireEndClass(ASTClass $class)
@@ -316,7 +309,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start trait event.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
      */
     protected function fireStartTrait(ASTTrait $trait)
@@ -329,7 +321,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end trait event.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
      */
     protected function fireEndTrait(ASTTrait $trait)
@@ -342,7 +333,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start file event.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     protected function fireStartFile(ASTCompilationUnit $compilationUnit)
@@ -355,7 +345,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end file event.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return void
      */
     protected function fireEndFile(ASTCompilationUnit $compilationUnit)
@@ -368,7 +357,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start function event.
      *
-     * @param  ASTFunction $function
      * @return void
      */
     protected function fireStartFunction(ASTFunction $function)
@@ -381,7 +369,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end function event.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     protected function fireEndFunction(ASTFunction $function)
@@ -394,7 +381,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start interface event.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     protected function fireStartInterface(ASTInterface $interface)
@@ -407,7 +393,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end interface event.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     protected function fireEndInterface(ASTInterface $interface)
@@ -420,7 +405,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start method event.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     protected function fireStartMethod(ASTMethod $method)
@@ -433,7 +417,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end method event.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return void
      */
     protected function fireEndMethod(ASTMethod $method)
@@ -446,7 +429,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start namespace event.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     protected function fireStartNamespace(ASTNamespace $namespace)
@@ -459,7 +441,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end namespace event.
      *
-     * @param  \PDepend\Source\AST\ASTNamespace $namespace
      * @return void
      */
     protected function fireEndNamespace(ASTNamespace $namespace)
@@ -472,7 +453,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start parameter event.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     protected function fireStartParameter(ASTParameter $parameter)
@@ -485,7 +465,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a end parameter event.
      *
-     * @param  \PDepend\Source\AST\ASTParameter $parameter
      * @return void
      */
     protected function fireEndParameter(ASTParameter $parameter)
@@ -498,7 +477,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends a start property event.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     protected function fireStartProperty(ASTProperty $property)
@@ -511,7 +489,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     /**
      * Sends an end property event.
      *
-     * @param  \PDepend\Source\AST\ASTProperty $property
      * @return void
      */
     protected function fireEndProperty(ASTProperty $property)

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -44,12 +44,114 @@ namespace PDepend\Source\Builder;
 
 use IteratorAggregate;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTAnonymousClass;
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTBooleanAndExpression;
+use PDepend\Source\AST\ASTBooleanOrExpression;
+use PDepend\Source\AST\ASTBreakStatement;
+use PDepend\Source\AST\ASTCastExpression;
+use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassFqnPostfix;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTClassReference;
+use PDepend\Source\AST\ASTCloneExpression;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTComment;
+use PDepend\Source\AST\ASTCompoundExpression;
+use PDepend\Source\AST\ASTCompoundVariable;
+use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTConstantPostfix;
+use PDepend\Source\AST\ASTContinueStatement;
+use PDepend\Source\AST\ASTDeclareStatement;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTEchoStatement;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTEvalExpression;
+use PDepend\Source\AST\ASTExitExpression;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTFinallyStatement;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForInit;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTForStatement;
+use PDepend\Source\AST\ASTForUpdate;
 use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTGlobalStatement;
+use PDepend\Source\AST\ASTGotoStatement;
+use PDepend\Source\AST\ASTHeredoc;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTIfStatement;
+use PDepend\Source\AST\ASTIncludeExpression;
+use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTIssetExpression;
+use PDepend\Source\AST\ASTLabelStatement;
+use PDepend\Source\AST\ASTListExpression;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTLogicalAndExpression;
+use PDepend\Source\AST\ASTLogicalOrExpression;
+use PDepend\Source\AST\ASTLogicalXorExpression;
+use PDepend\Source\AST\ASTMatchArgument;
+use PDepend\Source\AST\ASTMatchBlock;
+use PDepend\Source\AST\ASTMatchEntry;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTNamedArgument;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTPostfixExpression;
+use PDepend\Source\AST\ASTPreDecrementExpression;
+use PDepend\Source\AST\ASTPreIncrementExpression;
+use PDepend\Source\AST\ASTPrintExpression;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTRequireExpression;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTScope;
+use PDepend\Source\AST\ASTScopeStatement;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTShiftLeftExpression;
+use PDepend\Source\AST\ASTShiftRightExpression;
+use PDepend\Source\AST\ASTStatement;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTStaticVariableDeclaration;
+use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTStringIndexExpression;
+use PDepend\Source\AST\ASTSwitchLabel;
+use PDepend\Source\AST\ASTSwitchStatement;
+use PDepend\Source\AST\ASTThrowStatement;
 use PDepend\Source\AST\ASTTrait;
+use PDepend\Source\AST\ASTTraitAdaptation;
+use PDepend\Source\AST\ASTTraitAdaptationAlias;
+use PDepend\Source\AST\ASTTraitAdaptationPrecedence;
+use PDepend\Source\AST\ASTTraitReference;
+use PDepend\Source\AST\ASTTraitUseStatement;
+use PDepend\Source\AST\ASTTryStatement;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\AST\ASTTypeIterable;
+use PDepend\Source\AST\ASTUnaryExpression;
+use PDepend\Source\AST\ASTUnionType;
+use PDepend\Source\AST\ASTUnsetStatement;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\AST\ASTVariableVariable;
+use PDepend\Source\AST\ASTWhileStatement;
+use PDepend\Source\AST\ASTYieldStatement;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -71,7 +173,7 @@ interface Builder extends IteratorAggregate
     /**
      * Setter method for the currently used token cache.
      *
-     * @return \PDepend\Source\Builder\Builder<mixed>
+     * @return Builder<mixed>
      *
      * @since  0.10.0
      */
@@ -88,12 +190,12 @@ interface Builder extends IteratorAggregate
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
+     * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -104,7 +206,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName The qualified name of the referenced type.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      *
      * @since  0.9.5
      */
@@ -115,7 +217,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  1.0.0
      */
@@ -132,12 +234,12 @@ interface Builder extends IteratorAggregate
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTTrait}
+     * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  1.0.0
      */
@@ -148,25 +250,25 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     public function buildClass($qualifiedName);
 
     /**
      * Builds an anonymous class instance.
      *
-     * @return \PDepend\Source\AST\ASTAnonymousClass
+     * @return ASTAnonymousClass
      */
     public function buildAnonymousClass();
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
+     * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      *
      * @since  0.9.5
      */
@@ -186,7 +288,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName The qualified name of the referenced type.
      *
-     * @return \PDepend\Source\AST\ASTClassReference
+     * @return ASTClassReference
      *
      * @since  0.9.5
      */
@@ -197,7 +299,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     public function buildInterface($qualifiedName);
 
@@ -212,12 +314,12 @@ interface Builder extends IteratorAggregate
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTInterface}
+     * qualified name. It will create a new {@link ASTInterface}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      *
      * @since  0.9.5
      */
@@ -228,7 +330,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function buildNamespace($name);
 
@@ -237,7 +339,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     public function buildMethod($name);
 
@@ -246,14 +348,14 @@ interface Builder extends IteratorAggregate
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return ASTFunction
      */
     public function buildFunction($name);
 
     /**
      * Builds a new self reference instance.
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      *
      * @since  0.9.6
      */
@@ -262,10 +364,9 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new parent reference instance.
      *
-     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $reference The type
-     *                                                                    instance that reference the concrete target of parent.
+     * @param ASTClassOrInterfaceReference $reference The type instance that reference the concrete target of parent.
      *
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @return ASTParentReference
      *
      * @since  0.9.6
      */
@@ -274,7 +375,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new static reference instance.
      *
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      *
      * @since  0.9.6
      */
@@ -283,7 +384,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new field declaration node.
      *
-     * @return \PDepend\Source\AST\ASTFieldDeclaration
+     * @return ASTFieldDeclaration
      *
      * @since  0.9.6
      */
@@ -294,7 +395,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the variable declarator.
      *
-     * @return \PDepend\Source\AST\ASTVariableDeclarator
+     * @return ASTVariableDeclarator
      *
      * @since  0.9.6
      */
@@ -305,7 +406,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the constant.
      *
-     * @return \PDepend\Source\AST\ASTConstant
+     * @return ASTConstant
      *
      * @since  0.9.6
      */
@@ -316,7 +417,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the variable.
      *
-     * @return \PDepend\Source\AST\ASTVariable
+     * @return ASTVariable
      *
      * @since  0.9.6
      */
@@ -327,7 +428,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the variable variable.
      *
-     * @return \PDepend\Source\AST\ASTVariableVariable
+     * @return ASTVariableVariable
      *
      * @since  0.9.6
      */
@@ -338,7 +439,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the compound variable.
      *
-     * @return \PDepend\Source\AST\ASTCompoundVariable
+     * @return ASTCompoundVariable
      *
      * @since  0.9.6
      */
@@ -347,7 +448,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new compound expression node.
      *
-     * @return \PDepend\Source\AST\ASTCompoundExpression
+     * @return ASTCompoundExpression
      *
      * @since  0.9.6
      */
@@ -358,7 +459,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the static declaration.
      *
-     * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     * @return ASTStaticVariableDeclaration
      *
      * @since  0.9.6
      */
@@ -367,7 +468,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new closure node.
      *
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      *
      * @since  0.9.12
      */
@@ -376,7 +477,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new formal parameters node.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameters
+     * @return ASTFormalParameters
      *
      * @since  0.9.6
      */
@@ -385,7 +486,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new formal parameter node.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since  0.9.6
      */
@@ -396,7 +497,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.9.8
      */
@@ -407,7 +508,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The assignment operator.
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
      *
      * @since  0.9.8
      */
@@ -418,7 +519,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTAllocationExpression
+     * @return ASTAllocationExpression
      *
      * @since  0.9.6
      */
@@ -429,7 +530,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTEvalExpression
+     * @return ASTEvalExpression
      *
      * @since  0.9.12
      */
@@ -440,7 +541,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
      *
      * @since  0.9.12
      */
@@ -451,7 +552,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTCloneExpression
+     * @return ASTCloneExpression
      *
      * @since  0.9.12
      */
@@ -462,7 +563,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
      *
      * @since  0.9.12
      */
@@ -471,7 +572,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new include- or include_once-expression.
      *
-     * @return \PDepend\Source\AST\ASTIncludeExpression
+     * @return ASTIncludeExpression
      *
      * @since  0.9.12
      */
@@ -480,7 +581,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new require- or require_once-expression.
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
      *
      * @since  0.9.12
      */
@@ -489,7 +590,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new array-expression node.
      *
-     * @return \PDepend\Source\AST\ASTArrayIndexExpression
+     * @return ASTArrayIndexExpression
      *
      * @since  0.9.12
      */
@@ -504,7 +605,7 @@ interface Builder extends IteratorAggregate
      * //     --------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
      *
      * @since  0.9.12
      */
@@ -515,7 +616,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     * @return ASTInstanceOfExpression
      *
      * @since  0.9.6
      */
@@ -536,7 +637,7 @@ interface Builder extends IteratorAggregate
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTIssetExpression
+     * @return ASTIssetExpression
      *
      * @since  0.9.12
      */
@@ -551,7 +652,7 @@ interface Builder extends IteratorAggregate
      *         --------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConditionalExpression
+     * @return ASTConditionalExpression
      *
      * @since  0.9.8
      */
@@ -566,7 +667,7 @@ interface Builder extends IteratorAggregate
      * -------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTPrintExpression
+     * @return ASTPrintExpression
      *
      * @since 2.3
      */
@@ -575,7 +676,7 @@ interface Builder extends IteratorAggregate
     /**
      * Build a new shift left expression.
      *
-     * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     * @return ASTShiftLeftExpression
      *
      * @since  1.0.1
      */
@@ -584,7 +685,7 @@ interface Builder extends IteratorAggregate
     /**
      * Build a new shift right expression.
      *
-     * @return \PDepend\Source\AST\ASTShiftRightExpression
+     * @return ASTShiftRightExpression
      *
      * @since  1.0.1
      */
@@ -593,7 +694,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new boolean and-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     * @return ASTBooleanAndExpression
      *
      * @since  0.9.8
      */
@@ -602,7 +703,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new boolean or-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     * @return ASTBooleanOrExpression
      *
      * @since  0.9.8
      */
@@ -611,7 +712,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new logical <b>and</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     * @return ASTLogicalAndExpression
      *
      * @since  0.9.8
      */
@@ -620,7 +721,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new logical <b>or</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     * @return ASTLogicalOrExpression
      *
      * @since  0.9.8
      */
@@ -629,7 +730,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new logical <b>xor</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     * @return ASTLogicalXorExpression
      *
      * @since  0.9.8
      */
@@ -638,7 +739,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new trait use-statement node.
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
      *
      * @since  1.0.0
      */
@@ -647,7 +748,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new trait adaptation scope.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptation
+     * @return ASTTraitAdaptation
      *
      * @since  1.0.0
      */
@@ -658,7 +759,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The trait method name.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     * @return ASTTraitAdaptationAlias
      *
      * @since  1.0.0
      */
@@ -669,7 +770,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The trait method name.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @return ASTTraitAdaptationPrecedence
      *
      * @since  1.0.0
      */
@@ -680,7 +781,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $qualifiedName The full qualified trait name.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      *
      * @since  1.0.0
      */
@@ -689,7 +790,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new switch-statement-node.
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
      *
      * @since  0.9.8
      */
@@ -700,7 +801,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this label.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      *
      * @since  0.9.8
      */
@@ -711,7 +812,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTCatchStatement
+     * @return ASTCatchStatement
      *
      * @since  0.9.8
      */
@@ -720,7 +821,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new finally-statement node.
      *
-     * @return \PDepend\Source\AST\ASTFinallyStatement
+     * @return ASTFinallyStatement
      *
      * @since  2.0.0
      */
@@ -731,7 +832,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTIfStatement
+     * @return ASTIfStatement
      *
      * @since  0.9.8
      */
@@ -742,7 +843,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTElseIfStatement
+     * @return ASTElseIfStatement
      *
      * @since  0.9.8
      */
@@ -753,7 +854,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTForStatement
+     * @return ASTForStatement
      *
      * @since  0.9.8
      */
@@ -768,7 +869,7 @@ interface Builder extends IteratorAggregate
      *      ------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForInit
+     * @return ASTForInit
      *
      * @since  0.9.8
      */
@@ -783,7 +884,7 @@ interface Builder extends IteratorAggregate
      *                                        -------------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForUpdate
+     * @return ASTForUpdate
      *
      * @since  0.9.12
      */
@@ -794,7 +895,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTForeachStatement
+     * @return ASTForeachStatement
      *
      * @since  0.9.8
      */
@@ -805,7 +906,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
      *
      * @since  0.9.8
      */
@@ -816,7 +917,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTDoWhileStatement
+     * @return ASTDoWhileStatement
      *
      * @since  0.9.12
      */
@@ -843,7 +944,7 @@ interface Builder extends IteratorAggregate
      * -----------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTDeclareStatement
+     * @return ASTDeclareStatement
      *
      * @since  0.10.0
      */
@@ -872,7 +973,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      *
      * @since  0.9.6
      */
@@ -883,7 +984,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The image of this identifier.
      *
-     * @return \PDepend\Source\AST\ASTIdentifier
+     * @return ASTIdentifier
      *
      * @since  0.9.6
      */
@@ -904,7 +1005,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @return ASTFunctionPostfix
      *
      * @since  0.9.6
      */
@@ -925,7 +1026,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTMethodPostfix
+     * @return ASTMethodPostfix
      *
      * @since  0.9.6
      */
@@ -942,7 +1043,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantPostfix
+     * @return ASTConstantPostfix
      *
      * @since  0.9.6
      */
@@ -963,7 +1064,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      *
      * @since  0.9.6
      */
@@ -982,7 +1083,7 @@ interface Builder extends IteratorAggregate
      * //       -----
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      *
      * @since  2.0.0
      */
@@ -1001,7 +1102,7 @@ interface Builder extends IteratorAggregate
      * //       ------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      *
      * @since  0.9.6
      */
@@ -1014,7 +1115,7 @@ interface Builder extends IteratorAggregate
      * match($x)
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchArgument
+     * @return ASTMatchArgument
      *
      * @since  0.9.6
      */
@@ -1029,7 +1130,7 @@ interface Builder extends IteratorAggregate
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchBlock
+     * @return ASTMatchBlock
      *
      * @since  2.9.0
      */
@@ -1042,7 +1143,7 @@ interface Builder extends IteratorAggregate
      * "foo" => "bar",
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @return ASTMatchEntry
      *
      * @since  2.9.0
      */
@@ -1057,7 +1158,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTNamedArgument
+     * @return ASTNamedArgument
      *
      * @since  2.9.0
      */
@@ -1066,7 +1167,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new array type node.
      *
-     * @return \PDepend\Source\AST\ASTTypeArray
+     * @return ASTTypeArray
      *
      * @since  0.9.6
      */
@@ -1075,7 +1176,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new node for the callable type.
      *
-     * @return \PDepend\Source\AST\ASTTypeCallable
+     * @return ASTTypeCallable
      *
      * @since  1.0.0
      */
@@ -1084,7 +1185,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new node for the iterable type.
      *
-     * @return \PDepend\Source\AST\ASTTypeIterable
+     * @return ASTTypeIterable
      *
      * @since  2.5.1
      */
@@ -1095,7 +1196,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTScalarType
+     * @return ASTScalarType
      *
      * @since  0.9.6
      */
@@ -1104,7 +1205,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new node for the union type.
      *
-     * @return \PDepend\Source\AST\ASTUnionType
+     * @return ASTUnionType
      *
      * @since  2.9.0
      */
@@ -1115,7 +1216,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source image for the literal node.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      *
      * @since  0.9.6
      */
@@ -1127,7 +1228,7 @@ interface Builder extends IteratorAggregate
      * <code>
      * $string = "Manuel $Pichler <{$email}>";
      *
-     * // \PDepend\Source\AST\ASTString
+     * // ASTString
      * // |-- ASTLiteral             -  "Manuel ")
      * // |-- ASTVariable            -  $Pichler
      * // |-- ASTLiteral             -  " <"
@@ -1136,7 +1237,7 @@ interface Builder extends IteratorAggregate
      * // |-- ASTLiteral             -  ">"
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTString
+     * @return ASTString
      *
      * @since  0.9.10
      */
@@ -1145,7 +1246,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new php array node.
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since  1.0.0
      */
@@ -1154,7 +1255,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new array element node.
      *
-     * @return \PDepend\Source\AST\ASTArrayElement
+     * @return ASTArrayElement
      *
      * @since  1.0.0
      */
@@ -1163,7 +1264,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new heredoc node.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      *
      * @since  0.9.12
      */
@@ -1183,7 +1284,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
      *
      * @since  0.9.6
      */
@@ -1222,7 +1323,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantDeclarator
+     * @return ASTConstantDeclarator
      *
      * @since  0.9.6
      */
@@ -1233,7 +1334,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $cdata The comment text.
      *
-     * @return \PDepend\Source\AST\ASTComment
+     * @return ASTComment
      *
      * @since  0.9.8
      */
@@ -1244,7 +1345,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The unary expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      *
      * @since  0.9.11
      */
@@ -1255,7 +1356,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The cast-expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTCastExpression
+     * @return ASTCastExpression
      *
      * @since  0.10.0
      */
@@ -1266,7 +1367,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The postfix-expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTPostfixExpression
+     * @return ASTPostfixExpression
      *
      * @since  0.10.0
      */
@@ -1275,7 +1376,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new pre-increment-expression node instance.
      *
-     * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     * @return ASTPreIncrementExpression
      *
      * @since  0.10.0
      */
@@ -1284,7 +1385,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new pre-decrement-expression node instance.
      *
-     * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     * @return ASTPreDecrementExpression
      *
      * @since  0.10.0
      */
@@ -1293,7 +1394,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new function/method scope instance.
      *
-     * @return \PDepend\Source\AST\ASTScope
+     * @return ASTScope
      *
      * @since  0.9.12
      */
@@ -1302,7 +1403,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new statement instance.
      *
-     * @return \PDepend\Source\AST\ASTStatement
+     * @return ASTStatement
      *
      * @since  0.9.12
      */
@@ -1313,7 +1414,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
      *
      * @since  0.9.12
      */
@@ -1324,7 +1425,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTBreakStatement
+     * @return ASTBreakStatement
      *
      * @since  0.9.12
      */
@@ -1335,7 +1436,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTContinueStatement
+     * @return ASTContinueStatement
      *
      * @since  0.9.12
      */
@@ -1344,7 +1445,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new scope-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      *
      * @since  0.9.12
      */
@@ -1355,7 +1456,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTTryStatement
+     * @return ASTTryStatement
      *
      * @since  0.9.12
      */
@@ -1366,7 +1467,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
      *
      * @since  0.9.12
      */
@@ -1377,7 +1478,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTGotoStatement
+     * @return ASTGotoStatement
      *
      * @since  0.9.12
      */
@@ -1388,7 +1489,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTLabelStatement
+     * @return ASTLabelStatement
      *
      * @since  0.9.12
      */
@@ -1397,7 +1498,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new global-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTGlobalStatement
+     * @return ASTGlobalStatement
      *
      * @since  0.9.12
      */
@@ -1406,7 +1507,7 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new unset-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTUnsetStatement
+     * @return ASTUnsetStatement
      *
      * @since  0.9.12
      */
@@ -1417,7 +1518,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTEchoStatement
+     * @return ASTEchoStatement
      *
      * @since  0.9.12
      */
@@ -1428,7 +1529,7 @@ interface Builder extends IteratorAggregate
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     * @return ASTYieldStatement
      *
      * @since  $version$
      */

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\Builder;
 
+use IteratorAggregate;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
@@ -60,7 +61,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @template T of mixed
  * @extends \IteratorAggregate<T>
  */
-interface Builder extends \IteratorAggregate
+interface Builder extends IteratorAggregate
 {
     /**
      * The default package name.
@@ -70,8 +71,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Setter method for the currently used token cache.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Builder\Builder<mixed>
+     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache);
@@ -79,8 +80,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Restores a function within the internal type scope.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreFunction(ASTFunction $function);
@@ -90,8 +91,10 @@ interface Builder extends \IteratorAggregate
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getClassOrInterface($qualifiedName);
@@ -102,6 +105,7 @@ interface Builder extends \IteratorAggregate
      * @param string $qualifiedName The qualified name of the referenced type.
      *
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     *
      * @since  0.9.5
      */
     public function buildAstClassOrInterfaceReference($qualifiedName);
@@ -109,8 +113,10 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new php trait instance.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  1.0.0
      */
     public function buildTrait($qualifiedName);
@@ -118,8 +124,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Restores an existing trait instance within the context of this builder.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function restoreTrait(ASTTrait $trait);
@@ -129,8 +135,10 @@ interface Builder extends \IteratorAggregate
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTTrait}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName);
@@ -138,7 +146,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new code class instance.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTClass
      */
     public function buildClass($qualifiedName);
@@ -155,8 +164,10 @@ interface Builder extends \IteratorAggregate
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTClass
+     *
      * @since  0.9.5
      */
     public function getClass($qualifiedName);
@@ -164,8 +175,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Restores an existing class instance within the context of this builder.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreClass(ASTClass $class);
@@ -173,8 +184,10 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new code type reference instance.
      *
-     * @param  string $qualifiedName The qualified name of the referenced type.
+     * @param string $qualifiedName The qualified name of the referenced type.
+     *
      * @return \PDepend\Source\AST\ASTClassReference
+     *
      * @since  0.9.5
      */
     public function buildAstClassReference($qualifiedName);
@@ -182,7 +195,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new new interface instance.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTInterface
      */
     public function buildInterface($qualifiedName);
@@ -190,8 +204,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Restores an existing interface instance within the context of this builder.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreInterface(ASTInterface $interface);
@@ -201,8 +215,10 @@ interface Builder extends \IteratorAggregate
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTInterface}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName The full qualified type identifier.
+     * @param string $qualifiedName The full qualified type identifier.
+     *
      * @return \PDepend\Source\AST\ASTInterface
+     *
      * @since  0.9.5
      */
     public function getInterface($qualifiedName);
@@ -210,7 +226,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new namespace instance.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return \PDepend\Source\AST\ASTNamespace
      */
     public function buildNamespace($name);
@@ -218,7 +235,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new method instance.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return \PDepend\Source\AST\ASTMethod
      */
     public function buildMethod($name);
@@ -226,7 +244,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new function instance.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return \PDepend\Source\AST\ASTFunction
      */
     public function buildFunction($name);
@@ -234,8 +253,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new self reference instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return \PDepend\Source\AST\ASTSelfReference
+     *
      * @since  0.9.6
      */
     public function buildAstSelfReference(AbstractASTClassOrInterface $type);
@@ -243,9 +262,11 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new parent reference instance.
      *
-     * @param  \PDepend\Source\AST\ASTClassOrInterfaceReference $reference The type
-     *        instance that reference the concrete target of parent.
+     * @param \PDepend\Source\AST\ASTClassOrInterfaceReference $reference The type
+     *                                                                    instance that reference the concrete target of parent.
+     *
      * @return \PDepend\Source\AST\ASTParentReference
+     *
      * @since  0.9.6
      */
     public function buildAstParentReference(ASTClassOrInterfaceReference $reference);
@@ -253,8 +274,8 @@ interface Builder extends \IteratorAggregate
     /**
      * Builds a new static reference instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $owner
      * @return \PDepend\Source\AST\ASTStaticReference
+     *
      * @since  0.9.6
      */
     public function buildAstStaticReference(AbstractASTClassOrInterface $owner);
@@ -263,6 +284,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new field declaration node.
      *
      * @return \PDepend\Source\AST\ASTFieldDeclaration
+     *
      * @since  0.9.6
      */
     public function buildAstFieldDeclaration();
@@ -273,6 +295,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the variable declarator.
      *
      * @return \PDepend\Source\AST\ASTVariableDeclarator
+     *
      * @since  0.9.6
      */
     public function buildAstVariableDeclarator($image);
@@ -283,6 +306,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the constant.
      *
      * @return \PDepend\Source\AST\ASTConstant
+     *
      * @since  0.9.6
      */
     public function buildAstConstant($image);
@@ -293,6 +317,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the variable.
      *
      * @return \PDepend\Source\AST\ASTVariable
+     *
      * @since  0.9.6
      */
     public function buildAstVariable($image);
@@ -303,6 +328,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the variable variable.
      *
      * @return \PDepend\Source\AST\ASTVariableVariable
+     *
      * @since  0.9.6
      */
     public function buildAstVariableVariable($image);
@@ -313,6 +339,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the compound variable.
      *
      * @return \PDepend\Source\AST\ASTCompoundVariable
+     *
      * @since  0.9.6
      */
     public function buildAstCompoundVariable($image);
@@ -321,6 +348,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new compound expression node.
      *
      * @return \PDepend\Source\AST\ASTCompoundExpression
+     *
      * @since  0.9.6
      */
     public function buildAstCompoundExpression();
@@ -331,6 +359,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the static declaration.
      *
      * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     *
      * @since  0.9.6
      */
     public function buildAstStaticVariableDeclaration($image);
@@ -339,6 +368,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new closure node.
      *
      * @return \PDepend\Source\AST\ASTClosure
+     *
      * @since  0.9.12
      */
     public function buildAstClosure();
@@ -347,6 +377,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new formal parameters node.
      *
      * @return \PDepend\Source\AST\ASTFormalParameters
+     *
      * @since  0.9.6
      */
     public function buildAstFormalParameters();
@@ -355,6 +386,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new formal parameter node.
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since  0.9.6
      */
     public function buildAstFormalParameter();
@@ -363,7 +395,9 @@ interface Builder extends \IteratorAggregate
      * Builds a new expression node.
      *
      * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.8
      */
     public function buildAstExpression($image = null);
@@ -374,6 +408,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The assignment operator.
      *
      * @return \PDepend\Source\AST\ASTAssignmentExpression
+     *
      * @since  0.9.8
      */
     public function buildAstAssignmentExpression($image);
@@ -384,6 +419,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTAllocationExpression
+     *
      * @since  0.9.6
      */
     public function buildAstAllocationExpression($image);
@@ -394,6 +430,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTEvalExpression
+     *
      * @since  0.9.12
      */
     public function buildAstEvalExpression($image);
@@ -404,6 +441,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTExitExpression
+     *
      * @since  0.9.12
      */
     public function buildAstExitExpression($image);
@@ -414,6 +452,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTCloneExpression
+     *
      * @since  0.9.12
      */
     public function buildAstCloneExpression($image);
@@ -424,6 +463,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTListExpression
+     *
      * @since  0.9.12
      */
     public function buildAstListExpression($image);
@@ -432,6 +472,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new include- or include_once-expression.
      *
      * @return \PDepend\Source\AST\ASTIncludeExpression
+     *
      * @since  0.9.12
      */
     public function buildAstIncludeExpression();
@@ -440,6 +481,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new require- or require_once-expression.
      *
      * @return \PDepend\Source\AST\ASTRequireExpression
+     *
      * @since  0.9.12
      */
     public function buildAstRequireExpression();
@@ -448,6 +490,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new array-expression node.
      *
      * @return \PDepend\Source\AST\ASTArrayIndexExpression
+     *
      * @since  0.9.12
      */
     public function buildAstArrayIndexExpression();
@@ -462,6 +505,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTStringIndexExpression
+     *
      * @since  0.9.12
      */
     public function buildAstStringIndexExpression();
@@ -472,6 +516,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     *
      * @since  0.9.6
      */
     public function buildAstInstanceOfExpression($image);
@@ -492,6 +537,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTIssetExpression
+     *
      * @since  0.9.12
      */
     public function buildAstIssetExpression();
@@ -506,6 +552,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTConditionalExpression
+     *
      * @since  0.9.8
      */
     public function buildAstConditionalExpression();
@@ -520,6 +567,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTPrintExpression
+     *
      * @since 2.3
      */
     public function buildAstPrintExpression();
@@ -528,6 +576,7 @@ interface Builder extends \IteratorAggregate
      * Build a new shift left expression.
      *
      * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     *
      * @since  1.0.1
      */
     public function buildAstShiftLeftExpression();
@@ -536,6 +585,7 @@ interface Builder extends \IteratorAggregate
      * Build a new shift right expression.
      *
      * @return \PDepend\Source\AST\ASTShiftRightExpression
+     *
      * @since  1.0.1
      */
     public function buildAstShiftRightExpression();
@@ -544,6 +594,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new boolean and-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     *
      * @since  0.9.8
      */
     public function buildAstBooleanAndExpression();
@@ -552,6 +603,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new boolean or-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     *
      * @since  0.9.8
      */
     public function buildAstBooleanOrExpression();
@@ -560,6 +612,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new logical <b>and</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalAndExpression();
@@ -568,6 +621,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new logical <b>or</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalOrExpression();
@@ -576,6 +630,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new logical <b>xor</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalXorExpression();
@@ -584,6 +639,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new trait use-statement node.
      *
      * @return \PDepend\Source\AST\ASTTraitUseStatement
+     *
      * @since  1.0.0
      */
     public function buildAstTraitUseStatement();
@@ -592,6 +648,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new trait adaptation scope.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptation
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptation();
@@ -602,6 +659,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The trait method name.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationAlias($image);
@@ -612,6 +670,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The trait method name.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationPrecedence($image);
@@ -622,6 +681,7 @@ interface Builder extends \IteratorAggregate
      * @param string $qualifiedName The full qualified trait name.
      *
      * @return \PDepend\Source\AST\ASTTraitReference
+     *
      * @since  1.0.0
      */
     public function buildAstTraitReference($qualifiedName);
@@ -630,6 +690,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new switch-statement-node.
      *
      * @return \PDepend\Source\AST\ASTSwitchStatement
+     *
      * @since  0.9.8
      */
     public function buildAstSwitchStatement();
@@ -640,6 +701,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this label.
      *
      * @return \PDepend\Source\AST\ASTSwitchLabel
+     *
      * @since  0.9.8
      */
     public function buildAstSwitchLabel($image);
@@ -650,6 +712,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTCatchStatement
+     *
      * @since  0.9.8
      */
     public function buildAstCatchStatement($image);
@@ -658,6 +721,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new finally-statement node.
      *
      * @return \PDepend\Source\AST\ASTFinallyStatement
+     *
      * @since  2.0.0
      */
     public function buildAstFinallyStatement();
@@ -668,6 +732,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTIfStatement
+     *
      * @since  0.9.8
      */
     public function buildAstIfStatement($image);
@@ -678,6 +743,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTElseIfStatement
+     *
      * @since  0.9.8
      */
     public function buildAstElseIfStatement($image);
@@ -688,6 +754,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTForStatement
+     *
      * @since  0.9.8
      */
     public function buildAstForStatement($image);
@@ -702,6 +769,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTForInit
+     *
      * @since  0.9.8
      */
     public function buildAstForInit();
@@ -716,6 +784,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTForUpdate
+     *
      * @since  0.9.12
      */
     public function buildAstForUpdate();
@@ -726,6 +795,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTForeachStatement
+     *
      * @since  0.9.8
      */
     public function buildAstForeachStatement($image);
@@ -736,6 +806,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTWhileStatement
+     *
      * @since  0.9.8
      */
     public function buildAstWhileStatement($image);
@@ -746,6 +817,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTDoWhileStatement
+     *
      * @since  0.9.12
      */
     public function buildAstDoWhileStatement($image);
@@ -772,6 +844,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTDeclareStatement
+     *
      * @since  0.10.0
      */
     public function buildAstDeclareStatement();
@@ -800,6 +873,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     *
      * @since  0.9.6
      */
     public function buildAstMemberPrimaryPrefix($image);
@@ -810,6 +884,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The image of this identifier.
      *
      * @return \PDepend\Source\AST\ASTIdentifier
+     *
      * @since  0.9.6
      */
     public function buildAstIdentifier($image);
@@ -830,6 +905,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTFunctionPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstFunctionPostfix($image);
@@ -850,6 +926,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTMethodPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstMethodPostfix($image);
@@ -866,6 +943,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTConstantPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstConstantPostfix($image);
@@ -886,6 +964,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTPropertyPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstPropertyPostfix($image);
@@ -904,6 +983,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     *
      * @since  2.0.0
      */
     public function buildAstClassFqnPostfix();
@@ -922,6 +1002,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTArguments
+     *
      * @since  0.9.6
      */
     public function buildAstArguments();
@@ -934,6 +1015,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchArgument
+     *
      * @since  0.9.6
      */
     public function buildAstMatchArgument();
@@ -948,6 +1030,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchBlock
+     *
      * @since  2.9.0
      */
     public function buildAstMatchBlock();
@@ -960,6 +1043,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchEntry
+     *
      * @since  2.9.0
      */
     public function buildAstMatchEntry();
@@ -972,8 +1056,9 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @param string $name
-     * @param ASTNode $value
+     *
      * @return \PDepend\Source\AST\ASTNamedArgument
+     *
      * @since  2.9.0
      */
     public function buildAstNamedArgument($name, ASTNode $value);
@@ -982,6 +1067,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new array type node.
      *
      * @return \PDepend\Source\AST\ASTTypeArray
+     *
      * @since  0.9.6
      */
     public function buildAstTypeArray();
@@ -990,6 +1076,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new node for the callable type.
      *
      * @return \PDepend\Source\AST\ASTTypeCallable
+     *
      * @since  1.0.0
      */
     public function buildAstTypeCallable();
@@ -998,6 +1085,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new node for the iterable type.
      *
      * @return \PDepend\Source\AST\ASTTypeIterable
+     *
      * @since  2.5.1
      */
     public function buildAstTypeIterable();
@@ -1006,7 +1094,9 @@ interface Builder extends \IteratorAggregate
      * Builds a new primitive type node.
      *
      * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTScalarType
+     *
      * @since  0.9.6
      */
     public function buildAstScalarType($image);
@@ -1015,6 +1105,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new node for the union type.
      *
      * @return \PDepend\Source\AST\ASTUnionType
+     *
      * @since  2.9.0
      */
     public function buildAstUnionType();
@@ -1025,6 +1116,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source image for the literal node.
      *
      * @return \PDepend\Source\AST\ASTLiteral
+     *
      * @since  0.9.6
      */
     public function buildAstLiteral($image);
@@ -1045,6 +1137,7 @@ interface Builder extends \IteratorAggregate
      * </code>
      *
      * @return \PDepend\Source\AST\ASTString
+     *
      * @since  0.9.10
      */
     public function buildAstString();
@@ -1053,6 +1146,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new php array node.
      *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since  1.0.0
      */
     public function buildAstArray();
@@ -1061,6 +1155,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new array element node.
      *
      * @return \PDepend\Source\AST\ASTArrayElement
+     *
      * @since  1.0.0
      */
     public function buildAstArrayElement();
@@ -1069,6 +1164,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new heredoc node.
      *
      * @return \PDepend\Source\AST\ASTHeredoc
+     *
      * @since  0.9.12
      */
     public function buildAstHeredoc();
@@ -1088,6 +1184,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTConstantDefinition
+     *
      * @since  0.9.6
      */
     public function buildAstConstantDefinition($image);
@@ -1126,6 +1223,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTConstantDeclarator
+     *
      * @since  0.9.6
      */
     public function buildAstConstantDeclarator($image);
@@ -1136,6 +1234,7 @@ interface Builder extends \IteratorAggregate
      * @param string $cdata The comment text.
      *
      * @return \PDepend\Source\AST\ASTComment
+     *
      * @since  0.9.8
      */
     public function buildAstComment($cdata);
@@ -1146,6 +1245,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The unary expression image/character.
      *
      * @return \PDepend\Source\AST\ASTUnaryExpression
+     *
      * @since  0.9.11
      */
     public function buildAstUnaryExpression($image);
@@ -1156,6 +1256,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The cast-expression image/character.
      *
      * @return \PDepend\Source\AST\ASTCastExpression
+     *
      * @since  0.10.0
      */
     public function buildAstCastExpression($image);
@@ -1166,6 +1267,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The postfix-expression image/character.
      *
      * @return \PDepend\Source\AST\ASTPostfixExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPostfixExpression($image);
@@ -1174,6 +1276,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new pre-increment-expression node instance.
      *
      * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPreIncrementExpression();
@@ -1182,6 +1285,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new pre-decrement-expression node instance.
      *
      * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPreDecrementExpression();
@@ -1190,6 +1294,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new function/method scope instance.
      *
      * @return \PDepend\Source\AST\ASTScope
+     *
      * @since  0.9.12
      */
     public function buildAstScope();
@@ -1198,6 +1303,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new statement instance.
      *
      * @return \PDepend\Source\AST\ASTStatement
+     *
      * @since  0.9.12
      */
     public function buildAstStatement();
@@ -1208,6 +1314,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTReturnStatement
+     *
      * @since  0.9.12
      */
     public function buildAstReturnStatement($image);
@@ -1218,6 +1325,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTBreakStatement
+     *
      * @since  0.9.12
      */
     public function buildAstBreakStatement($image);
@@ -1228,6 +1336,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTContinueStatement
+     *
      * @since  0.9.12
      */
     public function buildAstContinueStatement($image);
@@ -1236,6 +1345,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new scope-statement instance.
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
+     *
      * @since  0.9.12
      */
     public function buildAstScopeStatement();
@@ -1246,6 +1356,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTTryStatement
+     *
      * @since  0.9.12
      */
     public function buildAstTryStatement($image);
@@ -1256,6 +1367,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTThrowStatement
+     *
      * @since  0.9.12
      */
     public function buildAstThrowStatement($image);
@@ -1266,6 +1378,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTGotoStatement
+     *
      * @since  0.9.12
      */
     public function buildAstGotoStatement($image);
@@ -1276,6 +1389,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTLabelStatement
+     *
      * @since  0.9.12
      */
     public function buildAstLabelStatement($image);
@@ -1284,6 +1398,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new global-statement instance.
      *
      * @return \PDepend\Source\AST\ASTGlobalStatement
+     *
      * @since  0.9.12
      */
     public function buildAstGlobalStatement();
@@ -1292,6 +1407,7 @@ interface Builder extends \IteratorAggregate
      * Builds a new unset-statement instance.
      *
      * @return \PDepend\Source\AST\ASTUnsetStatement
+     *
      * @since  0.9.12
      */
     public function buildAstUnsetStatement();
@@ -1302,6 +1418,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTEchoStatement
+     *
      * @since  0.9.12
      */
     public function buildAstEchoStatement($image);
@@ -1312,6 +1429,7 @@ interface Builder extends \IteratorAggregate
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTYieldStatement
+     *
      * @since  $version$
      */
     public function buildAstYieldStatement($image);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -53,6 +54,7 @@ use PDepend\Source\AST\ASTTrait;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 interface BuilderContext
@@ -61,7 +63,6 @@ interface BuilderContext
      * This method can be used to register an existing function in the current
      * application context.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function registerFunction(ASTFunction $function);
@@ -70,8 +71,8 @@ interface BuilderContext
      * This method can be used to register an existing trait in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function registerTrait(ASTTrait $trait);
@@ -80,7 +81,6 @@ interface BuilderContext
      * This method can be used to register an existing class in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
      */
     public function registerClass(ASTClass $class);
@@ -89,7 +89,6 @@ interface BuilderContext
      * This method can be used to register an existing interface in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function registerInterface(ASTInterface $interface);
@@ -97,8 +96,10 @@ interface BuilderContext
     /**
      * Returns the trait instance for the given qualified name.
      *
-     * @param  string $qualifiedName Full qualified trait name.
+     * @param string $qualifiedName Full qualified trait name.
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName);
@@ -106,7 +107,8 @@ interface BuilderContext
     /**
      * Returns the class instance for the given qualified name.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTClass
      */
     public function getClass($qualifiedName);
@@ -114,7 +116,8 @@ interface BuilderContext
     /**
      * Returns a class or an interface instance for the given qualified name.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Builder;
 
+use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -98,7 +99,7 @@ interface BuilderContext
      *
      * @param string $qualifiedName Full qualified trait name.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  1.0.0
      */
@@ -109,7 +110,7 @@ interface BuilderContext
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     public function getClass($qualifiedName);
 
@@ -118,7 +119,7 @@ interface BuilderContext
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName);
 }

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Builder\BuilderContext;
 
+use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -67,14 +68,14 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * The currently used ast builder.
      *
-     * @var \PDepend\Source\Builder\Builder<mixed>
+     * @var Builder<mixed>
      */
     protected static $builder = null;
 
     /**
      * Constructs a new builder context instance.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder The currently used ast builder.
+     * @param Builder<mixed> $builder The currently used ast builder.
      */
     public function __construct(Builder $builder)
     {
@@ -109,7 +110,7 @@ class GlobalBuilderContext implements BuilderContext
      * This method can be used to register an existing class in the current
      * class context.
      *
-     * @param \PDepend\Source\AST\ASTClass $class The class instance.
+     * @param ASTClass $class The class instance.
      *
      * @return void
      */
@@ -134,7 +135,7 @@ class GlobalBuilderContext implements BuilderContext
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  1.0.0
      */
@@ -148,7 +149,7 @@ class GlobalBuilderContext implements BuilderContext
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     public function getClass($qualifiedName)
     {
@@ -160,7 +161,7 @@ class GlobalBuilderContext implements BuilderContext
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName)
     {
@@ -170,7 +171,7 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the currently used builder instance.
      *
-     * @return \PDepend\Source\Builder\Builder<mixed>
+     * @return Builder<mixed>
      */
     protected function getBuilder()
     {

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -58,6 +59,7 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class GlobalBuilderContext implements BuilderContext
@@ -83,7 +85,6 @@ class GlobalBuilderContext implements BuilderContext
      * This method can be used to register an existing function in the current
      * application context.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
      */
     public function registerFunction(ASTFunction $function)
@@ -95,8 +96,8 @@ class GlobalBuilderContext implements BuilderContext
      * This method can be used to register an existing trait in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  1.0.0
      */
     public function registerTrait(ASTTrait $trait)
@@ -108,7 +109,8 @@ class GlobalBuilderContext implements BuilderContext
      * This method can be used to register an existing class in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class The class instance.
+     * @param \PDepend\Source\AST\ASTClass $class The class instance.
+     *
      * @return void
      */
     public function registerClass(ASTClass $class)
@@ -120,7 +122,6 @@ class GlobalBuilderContext implements BuilderContext
      * This method can be used to register an existing interface in the current
      * class context.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
      */
     public function registerInterface(ASTInterface $interface)
@@ -131,8 +132,10 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the trait instance for the given qualified name.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName)
@@ -143,7 +146,8 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the class instance for the given qualified name.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTClass
      */
     public function getClass($qualifiedName)
@@ -154,7 +158,8 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns a class or an interface instance for the given qualified name.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName)

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -44,40 +44,124 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTBooleanAndExpression;
+use PDepend\Source\AST\ASTBooleanOrExpression;
+use PDepend\Source\AST\ASTBreakStatement;
 use PDepend\Source\AST\ASTCallable;
+use PDepend\Source\AST\ASTCastExpression;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassFqnPostfix;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTCloneExpression;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTComment;
+use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTCompoundExpression;
 use PDepend\Source\AST\ASTCompoundVariable;
+use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTContinueStatement;
 use PDepend\Source\AST\ASTDeclareStatement;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTEchoStatement;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTEvalExpression;
+use PDepend\Source\AST\ASTExitExpression;
 use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTFinallyStatement;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForInit;
 use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTForStatement;
+use PDepend\Source\AST\ASTForUpdate;
+use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTGlobalStatement;
+use PDepend\Source\AST\ASTGotoStatement;
+use PDepend\Source\AST\ASTHeredoc;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTIfStatement;
+use PDepend\Source\AST\ASTIncludeExpression;
 use PDepend\Source\AST\ASTIndexExpression;
+use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTIssetExpression;
+use PDepend\Source\AST\ASTLabelStatement;
+use PDepend\Source\AST\ASTListExpression;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTLogicalAndExpression;
+use PDepend\Source\AST\ASTLogicalOrExpression;
+use PDepend\Source\AST\ASTLogicalXorExpression;
+use PDepend\Source\AST\ASTMatchEntry;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTPostDecrementExpression;
+use PDepend\Source\AST\ASTPostfixExpression;
+use PDepend\Source\AST\ASTPostIncrementExpression;
+use PDepend\Source\AST\ASTPreDecrementExpression;
+use PDepend\Source\AST\ASTPreIncrementExpression;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTRequireExpression;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTScope;
+use PDepend\Source\AST\ASTScopeStatement;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTShiftLeftExpression;
+use PDepend\Source\AST\ASTShiftRightExpression;
 use PDepend\Source\AST\ASTStatement;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTStaticVariableDeclaration;
+use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTSwitchLabel;
 use PDepend\Source\AST\ASTSwitchStatement;
+use PDepend\Source\AST\ASTThrowStatement;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTTraitAdaptation;
+use PDepend\Source\AST\ASTTraitAdaptationAlias;
+use PDepend\Source\AST\ASTTraitAdaptationPrecedence;
+use PDepend\Source\AST\ASTTraitReference;
 use PDepend\Source\AST\ASTTraitUseStatement;
+use PDepend\Source\AST\ASTTryStatement;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTUnaryExpression;
+use PDepend\Source\AST\ASTUnsetStatement;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\AST\ASTVariableVariable;
+use PDepend\Source\AST\ASTWhileStatement;
+use PDepend\Source\AST\ASTYieldStatement;
 use PDepend\Source\AST\State;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Parser\InvalidStateException;
 use PDepend\Source\Parser\MissingValueException;
 use PDepend\Source\Parser\NoActiveScopeException;
+use PDepend\Source\Parser\ParserException;
+use PDepend\Source\Parser\SymbolTable;
+use PDepend\Source\Parser\TokenStack;
 use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Source\Tokenizer\Tokens;
 use PDepend\Util\Cache\CacheDriver;
+use PDepend\Util\IdBuilder;
 use PDepend\Util\Log;
 use PDepend\Util\Type;
 
@@ -199,14 +283,14 @@ abstract class AbstractPHPParser
     /**
      * The currently parsed file instance.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit
+     * @var ASTCompilationUnit
      */
     protected $compilationUnit;
 
     /**
      * The symbol table used to handle PHP 5.3 use statements.
      *
-     * @var \PDepend\Source\Parser\SymbolTable
+     * @var SymbolTable
      */
     protected $useSymbolTable;
 
@@ -227,7 +311,7 @@ abstract class AbstractPHPParser
     /**
      * The actually parsed class or interface instance.
      *
-     * @var null|\PDepend\Source\AST\AbstractASTClassOrInterface
+     * @var null|AbstractASTClassOrInterface
      */
     protected $classOrInterface;
 
@@ -242,14 +326,14 @@ abstract class AbstractPHPParser
     /**
      * Stack with all active token scopes.
      *
-     * @var \PDepend\Source\Parser\TokenStack
+     * @var TokenStack
      */
     protected $tokenStack;
 
     /**
      * Used identifier builder instance.
      *
-     * @var \PDepend\Util\IdBuilder
+     * @var IdBuilder
      *
      * @since 0.9.12
      */
@@ -265,7 +349,7 @@ abstract class AbstractPHPParser
     private $maxNestingLevel = 1024;
 
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      *
      * @since 0.10.0
      */
@@ -274,7 +358,7 @@ abstract class AbstractPHPParser
     /**
      * The used code tokenizer.
      *
-     * @var \PDepend\Source\Tokenizer\Tokenizer
+     * @var Tokenizer
      */
     protected $tokenizer;
 
@@ -289,9 +373,9 @@ abstract class AbstractPHPParser
         $this->builder   = $builder;
         $this->cache     = $cache;
 
-        $this->idBuilder    = new \PDepend\Util\IdBuilder();
-        $this->tokenStack     = new \PDepend\Source\Parser\TokenStack();
-        $this->useSymbolTable = new \PDepend\Source\Parser\SymbolTable();
+        $this->idBuilder    = new IdBuilder();
+        $this->tokenStack     = new TokenStack();
+        $this->useSymbolTable = new SymbolTable();
 
         $this->builder->setCache($this->cache);
     }
@@ -478,8 +562,8 @@ abstract class AbstractPHPParser
      * Parses a valid class or interface name and returns the image of the parsed
      * token.
      *
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws TokenStreamEndException
+     * @throws UnexpectedTokenException
      *
      * @return string
      */
@@ -530,8 +614,8 @@ abstract class AbstractPHPParser
      * literal representing the function name. If no valid token exists in the
      * token stream, this method will throw an exception.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws UnexpectedTokenException
+     * @throws TokenStreamEndException
      *
      * @return string
      *
@@ -600,8 +684,8 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws UnexpectedTokenException
+     * @throws TokenStreamEndException
      *
      * @return string
      */
@@ -631,7 +715,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait declaration.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since 1.0.0
      */
@@ -651,7 +735,7 @@ abstract class AbstractPHPParser
     /**
      * Parses the signature of a trait.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      */
     private function parseTraitSignature()
     {
@@ -672,7 +756,7 @@ abstract class AbstractPHPParser
     /**
      * Parses the dependencies in a interface signature.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     private function parseInterfaceDeclaration()
     {
@@ -691,7 +775,7 @@ abstract class AbstractPHPParser
      * Parses the signature of an interface and finally returns a configured
      * interface instance.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      *
      * @since 0.10.2
      */
@@ -714,7 +798,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional interface list of an interface declaration.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      *
      * @since 0.10.2
      */
@@ -733,7 +817,7 @@ abstract class AbstractPHPParser
     /**
      * Parses the dependencies in a class signature.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     protected function parseClassDeclaration()
     {
@@ -756,7 +840,7 @@ abstract class AbstractPHPParser
      * or abstract, the T_CLASS token, the class name, an optional parent class
      * and an optional list of implemented interfaces.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      *
      * @since 1.0.0
      */
@@ -818,7 +902,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a parent class declaration for the given <b>$class</b>.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      *
      * @since 1.0.0
      */
@@ -871,12 +955,12 @@ abstract class AbstractPHPParser
     /**
      * Parses a class/interface/trait body.
      *
-     * @template T of \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @template T of AbstractASTClassOrInterface
      *
      * @param T $classOrInterface
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws UnexpectedTokenException
+     * @throws TokenStreamEndException
      *
      * @return T
      */
@@ -978,7 +1062,7 @@ abstract class AbstractPHPParser
      *
      * @param int $modifiers
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition|\PDepend\Source\AST\ASTFieldDeclaration|\PDepend\Source\AST\ASTMethod
+     * @return ASTConstantDefinition|ASTFieldDeclaration|ASTMethod
      *
      * @since 0.9.6
      */
@@ -1047,7 +1131,7 @@ abstract class AbstractPHPParser
      *
      * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition|\PDepend\Source\AST\ASTFieldDeclaration
+     * @return ASTConstantDefinition|ASTFieldDeclaration
      */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
     {
@@ -1071,7 +1155,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFieldDeclaration
+     * @return ASTFieldDeclaration
      *
      * @since 0.9.6
      */
@@ -1116,7 +1200,7 @@ abstract class AbstractPHPParser
      * This method parses a simple function or a PHP 5.3 lambda function or
      * closure.
      *
-     * @return \PDepend\Source\AST\ASTCallable
+     * @return ASTCallable
      *
      * @since 0.9.5
      */
@@ -1206,7 +1290,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a function declaration.
      *
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return ASTFunction
      *
      * @since 0.9.5
      */
@@ -1247,7 +1331,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a method declaration.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      *
      * @since 0.9.5
      */
@@ -1280,7 +1364,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a PHP 5.3 closure or lambda function.
      *
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      *
      * @since 0.9.5
      */
@@ -1326,7 +1410,7 @@ abstract class AbstractPHPParser
     /**
      * Extension for version specific additions.
      *
-     * @template T of \PDepend\Source\AST\AbstractASTCallable
+     * @template T of AbstractASTCallable
      *
      * @param T $callable
      *
@@ -1367,7 +1451,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait reference instance.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      *
      * @since 1.0.0
      */
@@ -1451,10 +1535,10 @@ abstract class AbstractPHPParser
      * When the method reference contains the declaring trait the returned
      * <b>array</b> will contain two elements. The first element is the plain
      * method name and the second element is an instance of the
-     * {@link \PDepend\Source\AST\ASTTraitReference} class that represents the
+     * {@link ASTTraitReference} class that represents the
      * declaring trait.
      *
-     * @return array<integer, mixed>
+     * @return array<int, mixed>
      *
      * @since 1.0.0
      */
@@ -1485,9 +1569,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait adaptation alias statement.
      *
-     * @param array<integer, mixed> $reference Parsed method reference array.
+     * @param array<int, mixed> $reference Parsed method reference array.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     * @return ASTTraitAdaptationAlias
      *
      * @since 1.0.0
      */
@@ -1529,11 +1613,11 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait adaptation precedence statement.
      *
-     * @param array<integer, mixed> $reference Parsed method reference array.
+     * @param array<int, mixed> $reference Parsed method reference array.
      *
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @return ASTTraitAdaptationPrecedence
      *
      * @since 1.0.0
      */
@@ -1581,7 +1665,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTAllocationExpression
+     * @return ASTAllocationExpression
      *
      * @since 0.9.6
      */
@@ -1604,7 +1688,7 @@ abstract class AbstractPHPParser
     /**
      * Parse the type reference used in an allocation expression.
      *
-     * @template T of \PDepend\Source\AST\ASTAllocationExpression
+     * @template T of ASTAllocationExpression
      *
      * @param T $allocation
      *
@@ -1620,7 +1704,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a eval-expression node.
      *
-     * @return \PDepend\Source\AST\ASTEvalExpression
+     * @return ASTEvalExpression
      *
      * @since 0.9.12
      */
@@ -1638,7 +1722,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses an exit-expression.
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
      *
      * @since 0.9.12
      */
@@ -1659,7 +1743,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a clone-expression node.
      *
-     * @return \PDepend\Source\AST\ASTCloneExpression
+     * @return ASTCloneExpression
      *
      * @since 0.9.12
      */
@@ -1677,8 +1761,8 @@ abstract class AbstractPHPParser
     /**
      * Throws an exception if the given token is not a valid list unpacking opening token for current PHP level.
      *
-     * @param int                             $tokenType
-     * @param \PDepend\Source\Tokenizer\Token $unexpectedToken
+     * @param int   $tokenType
+     * @param Token $unexpectedToken
      *
      * @return void
      */
@@ -1702,7 +1786,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single list-statement node.
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
      *
      * @since 0.9.12
      */
@@ -1761,7 +1845,7 @@ abstract class AbstractPHPParser
     /**
      * Parse individual slot of a list() expression.
      *
-     * @return ASTNode|\PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression|ASTNode
      */
     private function parseListSlotExpression()
     {
@@ -1788,7 +1872,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a include-expression node.
      *
-     * @return \PDepend\Source\AST\ASTIncludeExpression
+     * @return ASTIncludeExpression
      *
      * @since 0.9.12
      */
@@ -1802,7 +1886,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a include_once-expression node.
      *
-     * @return \PDepend\Source\AST\ASTIncludeExpression
+     * @return ASTIncludeExpression
      *
      * @since 0.9.12
      */
@@ -1817,7 +1901,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a require-expression node.
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
      *
      * @since 0.9.12
      */
@@ -1831,7 +1915,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a require_once-expression node.
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
      *
      * @since 0.9.12
      */
@@ -1847,7 +1931,7 @@ abstract class AbstractPHPParser
      * Parses a <b>require_once</b>-, <b>require</b>-, <b>include_once</b>- or
      * <b>include</b>-expression node.
      *
-     * @template T of \PDepend\Source\AST\ASTExpression
+     * @template T of ASTExpression
      *
      * @param T   $expr
      * @param int $type
@@ -1877,7 +1961,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a cast-expression node.
      *
-     * @return \PDepend\Source\AST\ASTCastExpression
+     * @return ASTCastExpression
      *
      * @since 0.10.0
      */
@@ -1897,13 +1981,12 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method will parse an increment-expression. Depending on the previous
-     * node this can be a {@link \PDepend\Source\AST\ASTPostIncrementExpression} or
-     * {@link \PDepend\Source\AST\ASTPostfixExpression}.
+     * This method will parse an increment-expression. Depending on the previous node
+     * this can be a {@link ASTPostIncrementExpression} or {@link ASTPostfixExpression}.
      *
-     * @param array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
+     * @param array<ASTNode> $expressions List of previous parsed expression nodes.
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.10.0
      */
@@ -1918,9 +2001,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a post increment-expression and adds the given child to that node.
      *
-     * @param \PDepend\Source\AST\ASTNode $child The child expression node.
+     * @param ASTNode $child The child expression node.
      *
-     * @return \PDepend\Source\AST\ASTPostfixExpression
+     * @return ASTPostfixExpression
      *
      * @since 0.10.0
      */
@@ -1943,7 +2026,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a pre increment-expression and adds the given child to that node.
      *
-     * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     * @return ASTPreIncrementExpression
      *
      * @since 0.10.0
      */
@@ -1963,13 +2046,12 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method will parse an decrement-expression. Depending on the previous
-     * node this can be a {@link \PDepend\Source\AST\ASTPostDecrementExpression} or
-     * {@link \PDepend\Source\AST\ASTPostfixExpression}.
+     * This method will parse an decrement-expression. Depending on the previous node
+     * this can be a {@link ASTPostDecrementExpression} or {@link ASTPostfixExpression}.
      *
-     * @param array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
+     * @param array<ASTNode> $expressions List of previous parsed expression nodes.
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.10.0
      */
@@ -1984,9 +2066,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a post decrement-expression and adds the given child to that node.
      *
-     * @param \PDepend\Source\AST\ASTNode $child The child expression node.
+     * @param ASTNode $child The child expression node.
      *
-     * @return \PDepend\Source\AST\ASTPostfixExpression
+     * @return ASTPostfixExpression
      *
      * @since 0.10.0
      */
@@ -2009,7 +2091,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a pre decrement-expression and adds the given child to that node.
      *
-     * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     * @return ASTPreDecrementExpression
      *
      * @since 0.10.0
      */
@@ -2045,11 +2127,11 @@ abstract class AbstractPHPParser
      * ----------------
      * </code>
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T $node The parent/context node instance.
      *
-     * @return \PDepend\Source\AST\ASTIndexExpression|T
+     * @return ASTIndexExpression|T
      *
      * @since 0.9.12
      */
@@ -2071,14 +2153,14 @@ abstract class AbstractPHPParser
      * Parses an index expression as it is valid to access elements in a php
      * string or array.
      *
-     * @template T of \PDepend\Source\AST\ASTExpression
+     * @template T of ASTExpression
      *
-     * @param \PDepend\Source\AST\ASTNode $node  The context source node.
-     * @param T                           $expr  The concrete index expression.
-     * @param int                         $open  The open token type.
-     * @param int                         $close The close token type.
+     * @param ASTNode $node  The context source node.
+     * @param T       $expr  The concrete index expression.
+     * @param int     $open  The open token type.
+     * @param int     $close The close token type.
      *
-     * @return \PDepend\Source\AST\ASTIndexExpression|T
+     * @return ASTIndexExpression|T
      *
      * @since 0.9.12
      */
@@ -2115,9 +2197,9 @@ abstract class AbstractPHPParser
      * //    ---
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The context source node.
+     * @param ASTNode $node The context source node.
      *
-     * @return \PDepend\Source\AST\ASTIndexExpression
+     * @return ASTIndexExpression
      *
      * @since 0.9.12
      */
@@ -2143,9 +2225,9 @@ abstract class AbstractPHPParser
      * //     ---
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The context source node.
+     * @param ASTNode $node The context source node.
      *
-     * @return \PDepend\Source\AST\ASTIndexExpression
+     * @return ASTIndexExpression
      *
      * @since 0.9.12
      */
@@ -2178,10 +2260,10 @@ abstract class AbstractPHPParser
     /**
      * This method configures the given node with its start and end positions.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
-     * @param T                                                    $node
-     * @param null|array<integer, \PDepend\Source\Tokenizer\Token> $tokens
+     * @param T                      $node
+     * @param null|array<int, Token> $tokens
      *
      * @return T
      *
@@ -2249,7 +2331,7 @@ abstract class AbstractPHPParser
      *          -----------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     * @return ASTInstanceOfExpression
      *
      * @since 0.9.6
      */
@@ -2279,7 +2361,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTIssetExpression
+     * @return ASTIssetExpression
      *
      * @since 0.9.12
      */
@@ -2314,7 +2396,7 @@ abstract class AbstractPHPParser
     /**
      * @param bool $classRef
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      */
     private function parseStandAloneExpressionTypeReference($classRef)
     {
@@ -2340,10 +2422,10 @@ abstract class AbstractPHPParser
 
     /**
      * This method parses a type identifier as it is used in expression nodes
-     * like {@link \PDepend\Source\AST\ASTInstanceOfExpression} or an object
-     * allocation node like {@link \PDepend\Source\AST\ASTAllocationExpression}.
+     * like {@link ASTInstanceOfExpression} or an object
+     * allocation node like {@link ASTAllocationExpression}.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T    $expr
      * @param bool $classRef
@@ -2372,7 +2454,7 @@ abstract class AbstractPHPParser
      *         --------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConditionalExpression
+     * @return ASTConditionalExpression
      *
      * @since 0.9.8
      */
@@ -2396,7 +2478,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a shift left expression node.
      *
-     * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     * @return ASTShiftLeftExpression
      *
      * @since 1.0.1
      */
@@ -2417,7 +2499,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a shift right expression node.
      *
-     * @return \PDepend\Source\AST\ASTShiftRightExpression
+     * @return ASTShiftRightExpression
      *
      * @since 1.0.1
      */
@@ -2438,7 +2520,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a boolean and-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     * @return ASTBooleanAndExpression
      *
      * @since 0.9.8
      */
@@ -2459,7 +2541,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a boolean or-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     * @return ASTBooleanOrExpression
      *
      * @since 0.9.8
      */
@@ -2480,7 +2562,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>and</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     * @return ASTLogicalAndExpression
      *
      * @since 0.9.8
      */
@@ -2501,7 +2583,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>or</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     * @return ASTLogicalOrExpression
      *
      * @since 0.9.8
      */
@@ -2522,7 +2604,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>xor</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     * @return ASTLogicalXorExpression
      *
      * @since 0.9.8
      */
@@ -2545,7 +2627,7 @@ abstract class AbstractPHPParser
      *
      * @param bool $classReference Force a class reference.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      *
      * @since 0.9.8
      */
@@ -2563,7 +2645,7 @@ abstract class AbstractPHPParser
 
     /**
      * This method parses a brace expression and adds all parsed node instances
-     * to the given {@link \PDepend\Source\AST\ASTNode} object. Finally it returns
+     * to the given {@link ASTNode} object. Finally it returns
      * the prepared input node.
      *
      * A brace expression can be a compound:
@@ -2584,12 +2666,12 @@ abstract class AbstractPHPParser
      * $foo[$bar];
      * </code>
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T   $node
      * @param int $closeToken
      *
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws TokenStreamEndException
      *
      * @return T
      *
@@ -2632,7 +2714,7 @@ abstract class AbstractPHPParser
      * Parses the body of the given statement instance and adds all parsed nodes
      * to that statement.
      *
-     * @template T of \PDepend\Source\AST\ASTStatement
+     * @template T of ASTStatement
      *
      * @param T $stmt The owning statement.
      *
@@ -2658,7 +2740,7 @@ abstract class AbstractPHPParser
     /**
      * Parse a scope enclosed by curly braces.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      *
      * @since 0.9.12
      */
@@ -2679,7 +2761,7 @@ abstract class AbstractPHPParser
      * Parses the scope of a statement that is surrounded with PHP's alternative
      * syntax for statements.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      *
      * @since 0.10.0
      */
@@ -2698,7 +2780,7 @@ abstract class AbstractPHPParser
      * Parses all statements that exist in a scope an adds them to a scope
      * instance.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      *
      * @since 0.10.0
      */
@@ -2706,7 +2788,7 @@ abstract class AbstractPHPParser
     {
         $scope = $this->builder->buildAstScopeStatement();
         while (($child = $this->parseOptionalStatement()) != null) {
-            if ($child instanceof \PDepend\Source\AST\ASTNode) {
+            if ($child instanceof ASTNode) {
                 $scope->addChild($child);
             }
         }
@@ -2781,7 +2863,7 @@ abstract class AbstractPHPParser
      * This method parses multiple expressions and adds them as children to the
      * given <b>$exprList</b> node.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T $exprList
      *
@@ -2803,7 +2885,7 @@ abstract class AbstractPHPParser
     /**
      * Return true if children remain to be added, false else.
      *
-     * @param \PDepend\Source\AST\AbstractASTNode $exprList
+     * @param AbstractASTNode $exprList
      *
      * @return bool
      */
@@ -2831,9 +2913,9 @@ abstract class AbstractPHPParser
      * This method parses an expression node and returns it. When no expression
      * was found this method will throw an InvalidStateException.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 1.0.1
      */
@@ -2855,9 +2937,9 @@ abstract class AbstractPHPParser
      * This method optionally parses an expression node and returns it. When no
      * expression was found this method will return <b>null</b>.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return null|\PDepend\Source\AST\ASTExpression
+     * @return null|ASTExpression
      *
      * @since 0.9.6
      */
@@ -3144,9 +3226,9 @@ abstract class AbstractPHPParser
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.2
      */
@@ -3158,10 +3240,9 @@ abstract class AbstractPHPParser
     /**
      * Applies all reduce rules against the given expression list.
      *
-     * @param \PDepend\Source\AST\ASTExpression[] $expressions Unprepared input
-     *                                                         array with parsed expression nodes found in the source tree.
+     * @param ASTExpression[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
      *
-     * @return \PDepend\Source\AST\ASTExpression[]
+     * @return ASTExpression[]
      *
      * @since 0.10.0
      */
@@ -3173,10 +3254,9 @@ abstract class AbstractPHPParser
     /**
      * Reduces all unary-expressions in the given expression list.
      *
-     * @param \PDepend\Source\AST\ASTExpression[] $expressions Unprepared input
-     *                                                         array with parsed expression nodes found in the source tree.
+     * @param ASTExpression[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
      *
-     * @return \PDepend\Source\AST\ASTExpression[]
+     * @return ASTExpression[]
      *
      * @since 0.10.0
      */
@@ -3184,7 +3264,7 @@ abstract class AbstractPHPParser
     {
         for ($i = count($expressions) - 2; $i >= 0; --$i) {
             $expr = $expressions[$i];
-            if ($expr instanceof \PDepend\Source\AST\ASTUnaryExpression) {
+            if ($expr instanceof ASTUnaryExpression) {
                 $child = $expressions[$i + 1];
 
                 $expr->addChild($child);
@@ -3205,7 +3285,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a switch statement.
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
      *
      * @since 0.9.8
      */
@@ -3224,9 +3304,9 @@ abstract class AbstractPHPParser
     /**
      * Parses the body of a switch statement.
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $switch The parent switch stmt.
+     * @param ASTSwitchStatement $switch The parent switch stmt.
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
      *
      * @since 0.9.8
      */
@@ -3271,7 +3351,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a case label of a switch statement.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      *
      * @since 0.9.8
      */
@@ -3297,7 +3377,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses the default label of a switch statement.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      *
      * @since 0.9.8
      */
@@ -3324,11 +3404,11 @@ abstract class AbstractPHPParser
     /**
      * Parses the body of an switch label node.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label The context switch label.
+     * @param ASTSwitchLabel $label The context switch label.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      */
-    private function parseSwitchLabelBody(\PDepend\Source\AST\ASTSwitchLabel $label)
+    private function parseSwitchLabelBody(ASTSwitchLabel $label)
     {
         $curlyBraceCount = 0;
 
@@ -3397,7 +3477,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a try-statement + associated catch-statements.
      *
-     * @return \PDepend\Source\AST\ASTTryStatement
+     * @return ASTTryStatement
      *
      * @since 0.9.12
      */
@@ -3433,7 +3513,7 @@ abstract class AbstractPHPParser
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
      *
      * @since 0.9.12
      */
@@ -3453,7 +3533,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a goto-statement.
      *
-     * @return \PDepend\Source\AST\ASTGotoStatement
+     * @return ASTGotoStatement
      *
      * @since 0.9.12
      */
@@ -3475,7 +3555,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a label-statement.
      *
-     * @return \PDepend\Source\AST\ASTLabelStatement
+     * @return ASTLabelStatement
      *
      * @since 0.9.12
      */
@@ -3495,7 +3575,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a global-statement.
      *
-     * @return \PDepend\Source\AST\ASTGlobalStatement
+     * @return ASTGlobalStatement
      *
      * @since 0.9.12
      */
@@ -3515,7 +3595,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a unset-statement.
      *
-     * @return \PDepend\Source\AST\ASTUnsetStatement
+     * @return ASTUnsetStatement
      *
      * @since 0.9.12
      */
@@ -3542,7 +3622,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a catch-statement.
      *
-     * @return \PDepend\Source\AST\ASTCatchStatement
+     * @return ASTCatchStatement
      *
      * @since 0.9.8
      */
@@ -3573,7 +3653,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses assigned variable in catch statement.
      *
-     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @param ASTCatchStatement $stmt The owning catch statement.
      *
      * @return void
      */
@@ -3587,7 +3667,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses class references in catch statement.
      *
-     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @param ASTCatchStatement $stmt The owning catch statement.
      *
      * @return void
      */
@@ -3603,7 +3683,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a finally-statement.
      *
-     * @return \PDepend\Source\AST\ASTFinallyStatement
+     * @return ASTFinallyStatement
      *
      * @since 2.0.0
      */
@@ -3623,7 +3703,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single if-statement node.
      *
-     * @return \PDepend\Source\AST\ASTIfStatement
+     * @return ASTIfStatement
      *
      * @since 0.9.8
      */
@@ -3644,7 +3724,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single elseif-statement node.
      *
-     * @return \PDepend\Source\AST\ASTElseIfStatement
+     * @return ASTElseIfStatement
      *
      * @since 0.9.8
      */
@@ -3665,9 +3745,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses an optional else-, else+if- or elseif-statement.
      *
-     * @param \PDepend\Source\AST\ASTStatement $stmt The owning if/elseif statement.
+     * @param ASTStatement $stmt The owning if/elseif statement.
      *
-     * @return \PDepend\Source\AST\ASTStatement
+     * @return ASTStatement
      *
      * @since 0.9.12
      */
@@ -3695,7 +3775,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single for-statement node.
      *
-     * @return \PDepend\Source\AST\ASTForStatement
+     * @return ASTForStatement
      *
      * @since 0.9.8
      */
@@ -3736,7 +3816,7 @@ abstract class AbstractPHPParser
      *      ------------------------
      * </code>
      *
-     * @return null|\PDepend\Source\AST\ASTForInit
+     * @return null|ASTForInit
      *
      * @since 0.9.8
      */
@@ -3759,7 +3839,7 @@ abstract class AbstractPHPParser
     /**
      * Parses the expression part of a for-statement.
      *
-     * @return null|\PDepend\Source\AST\ASTExpression
+     * @return null|ASTExpression
      *
      * @since 0.9.12
      */
@@ -3777,7 +3857,7 @@ abstract class AbstractPHPParser
      *                                        -------------------------------
      * </code>
      *
-     * @return null|\PDepend\Source\AST\ASTForUpdate
+     * @return null|ASTForUpdate
      *
      * @since 0.9.12
      */
@@ -3843,7 +3923,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single foreach-statement node.
      *
-     * @return \PDepend\Source\AST\ASTForeachStatement
+     * @return ASTForeachStatement
      *
      * @since 0.9.8
      */
@@ -3877,7 +3957,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single while-statement node.
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
      *
      * @since 0.9.8
      */
@@ -3897,7 +3977,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a do/while-statement.
      *
-     * @return \PDepend\Source\AST\ASTDoWhileStatement
+     * @return ASTDoWhileStatement
      *
      * @since 0.9.12
      */
@@ -3940,7 +4020,7 @@ abstract class AbstractPHPParser
      * -----------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTDeclareStatement
+     * @return ASTDeclareStatement
      *
      * @since 0.10.0
      */
@@ -3960,10 +4040,9 @@ abstract class AbstractPHPParser
      * This method parses a list of declare values. A declare list value always
      * consists of a string token and a static scalar.
      *
-     * @param \PDepend\Source\AST\ASTDeclareStatement $stmt The declare statement that
-     *                                                      is the owner of this list.
+     * @param ASTDeclareStatement $stmt The declare statement that is the owner of this list.
      *
-     * @return \PDepend\Source\AST\ASTDeclareStatement
+     * @return ASTDeclareStatement
      *
      * @since 0.10.0
      */
@@ -3999,7 +4078,7 @@ abstract class AbstractPHPParser
     /**
      * This method builds a return statement from a given token.
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
      *
      * @since 2.7.0
      */
@@ -4017,7 +4096,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single return-statement node.
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
      *
      * @since 0.9.12
      */
@@ -4037,7 +4116,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a break-statement node.
      *
-     * @return \PDepend\Source\AST\ASTBreakStatement
+     * @return ASTBreakStatement
      *
      * @since 0.9.12
      */
@@ -4058,7 +4137,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a continue-statement node.
      *
-     * @return \PDepend\Source\AST\ASTContinueStatement
+     * @return ASTContinueStatement
      *
      * @since 0.9.12
      */
@@ -4079,7 +4158,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a echo-statement node.
      *
-     * @return \PDepend\Source\AST\ASTEchoStatement
+     * @return ASTEchoStatement
      *
      * @since 0.9.12
      */
@@ -4105,7 +4184,7 @@ abstract class AbstractPHPParser
      * (new MyClass())->bar();
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 1.0.0
      */
@@ -4117,11 +4196,11 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @template T of \PDepend\Source\AST\ASTExpression
+     * @template T of ASTExpression
      *
      * @param T $expr
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix|T
+     * @return ASTMemberPrimaryPrefix|T
      */
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
     {
@@ -4143,10 +4222,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws TokenStreamEndException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\Tokenizer\Token
+     * @return Token
      */
     protected function consumeObjectOperatorToken()
     {
@@ -4157,7 +4236,7 @@ abstract class AbstractPHPParser
      * Parses any expression that is surrounded by an opening and a closing
      * parenthesis
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.9.8
      */
@@ -4210,9 +4289,9 @@ abstract class AbstractPHPParser
      * func();
      * </code>
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -4253,15 +4332,14 @@ abstract class AbstractPHPParser
      * This method will parse an optional function postfix.
      *
      * If the next available token is an opening parenthesis, this method will
-     * wrap the given <b>$node</b> with a {@link \PDepend\Source\AST\ASTFunctionPostfix}
+     * wrap the given <b>$node</b> with a {@link ASTFunctionPostfix}
      * node.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T $node The previously parsed node.
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix|T The original input node or this node
-     *                                                  wrapped with a function postfix instance.
+     * @return ASTFunctionPostfix|T The original input node or this node wrapped with a function postfix instance.
      *
      * @since 1.0.0
      */
@@ -4276,20 +4354,19 @@ abstract class AbstractPHPParser
 
     /**
      * This method parses a function postfix expression. An object of type
-     * {@link \PDepend\Source\AST\ASTFunctionPostfix} represents any valid php
+     * {@link ASTFunctionPostfix} represents any valid php
      * function call.
      *
      * This method will delegate the call to another method that returns a
      * member primary prefix object when the function postfix expression is
      * followed by an object operator.
      *
-     * @param \PDepend\Source\AST\ASTNode $node This node represents the function
-     *                                          identifier. An identifier can be a static string, a variable, a
-     *                                          compound variable or any other valid php function identifier.
+     * @param ASTNode $node This node represents the function identifier. An identifier can be a static string,
+     *                      a variable, a compound variable or any other valid php function identifier.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @return ASTFunctionPostfix
      *
      * @since 0.9.6
      */
@@ -4310,7 +4387,7 @@ abstract class AbstractPHPParser
      * This method parses a PHP version specific identifier for method and
      * property postfix expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 1.0.0
      */
@@ -4331,15 +4408,15 @@ abstract class AbstractPHPParser
      * This method parses an optional member primary expression. It will parse
      * the primary expression when an object operator can be found at the actual
      * token stream position. Otherwise this method simply returns the input
-     * {@link \PDepend\Source\AST\ASTNode} instance.
+     * {@link ASTNode} instance.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T $node This node represents primary prefix
      *                left expression. It will be the first child of the parsed member
      *                primary expression.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
      * @return ASTMemberPrimaryPrefix|T
      *
@@ -4370,10 +4447,9 @@ abstract class AbstractPHPParser
      * $object->foo;
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The left node in the parsed member
-     *                                          primary expression.
+     * @param ASTNode $node The left node in the parsed member primary expression.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
      * @return ASTMemberPrimaryPrefix
      *
@@ -4427,15 +4503,14 @@ abstract class AbstractPHPParser
      * This method parses an optional member primary expression. It will parse
      * the primary expression when a double colon operator can be found at the
      * actual token stream position. Otherwise this method simply returns the
-     * input {@link \PDepend\Source\AST\ASTNode} instance.
+     * input {@link ASTNode} instance.
      *
-     * @param \PDepend\Source\AST\ASTNode $node This node represents primary prefix
-     *                                          left expression. It will be the first child of the parsed member
-     *                                          primary expression.
+     * @param ASTNode $node This node represents primary prefix left expression. It will
+     *                      be the first child of the parsed member primary expression.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 1.0.1
      */
@@ -4473,10 +4548,9 @@ abstract class AbstractPHPParser
      * Foo::BAR;
      * </code>
      *
-     * @param \PDepend\Source\AST\ASTNode $node The left node in the parsed member
-     *                                          primary expression.
+     * @param ASTNode $node The left node in the parsed member primary expression.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
      * @return ASTMemberPrimaryPrefix
      *
@@ -4516,9 +4590,9 @@ abstract class AbstractPHPParser
      * This method parses a method- or constant-postfix expression. This expression
      * will contain an identifier node as nested child.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -4543,13 +4617,12 @@ abstract class AbstractPHPParser
      * This method parses a method- or property-postfix expression. This expression
      * will contain the given node as method or property identifier.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The identifier for the parsed postfix
-     *                                          expression node. This node will be the first child of the returned
-     *                                          postfix node instance.
+     * @param ASTNode $node The identifier for the parsed postfix expression node. This node
+     *                      will be the first child of the returned postfix node instance.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -4572,10 +4645,9 @@ abstract class AbstractPHPParser
     /**
      * Parses/Creates a property postfix node instance.
      *
-     * @param \PDepend\Source\AST\ASTNode $node Node that represents the image of
-     *                                          the property postfix node.
+     * @param ASTNode $node Node that represents the image of the property postfix node.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      *
      * @since 0.10.2
      */
@@ -4599,7 +4671,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a full qualified class name postfix.
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      *
      * @since 2.0.0
      */
@@ -4610,12 +4682,11 @@ abstract class AbstractPHPParser
 
     /**
      * This method will extract the image/name of the real property/variable
-     * that is wrapped by {@link \PDepend\Source\AST\ASTIndexExpression} nodes. If
+     * that is wrapped by {@link ASTIndexExpression} nodes. If
      * the given node is now wrapped by index expressions, this method will
      * return the image of the entire <b>$node</b>.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The context node that may be wrapped
-     *                                          by multiple array or string index expressions.
+     * @param ASTNode $node The context node that may be wrapped by multiple array or string index expressions.
      *
      * @return string
      *
@@ -4632,10 +4703,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a method postfix node instance.
      *
-     * @param \PDepend\Source\AST\ASTNode $node Node that represents the image of
-     *                                          the method postfix node.
+     * @param ASTNode $node Node that represents the image of the method postfix node.
      *
-     * @return \PDepend\Source\AST\ASTMethodPostfix
+     * @return ASTMethodPostfix
      *
      * @since 1.0.0
      */
@@ -4661,9 +4731,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses the arguments passed to a function- or method-call.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      *
      * @since 0.9.6
      */
@@ -4681,9 +4751,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses the tokens after arguments passed to a function- or method-call.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      *
      * @since 0.9.6
      */
@@ -4702,7 +4772,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @template T of \PDepend\Source\AST\ASTArguments
+     * @template T of ASTArguments
      *
      * @param T $arguments
      *
@@ -4718,7 +4788,7 @@ abstract class AbstractPHPParser
      * variables, object/static method. All these expressions are valid in
      * several php language constructs like, isset, empty, unset etc.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.12
      */
@@ -4755,9 +4825,9 @@ abstract class AbstractPHPParser
      * variable is followed by an object operator, double colon or opening
      * parenthesis.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference|\PDepend\Source\AST\ASTExpression
+     * @return ASTClassOrInterfaceReference|ASTExpression
      *
      * @since 0.9.6
      */
@@ -4790,10 +4860,9 @@ abstract class AbstractPHPParser
     /**
      * Parses an assingment expression node.
      *
-     * @param \PDepend\Source\AST\ASTNode $left The left part of the assignment
-     *                                          expression that will be parsed by this method.
+     * @param ASTNode $left The left part of the assignment expression that will be parsed by this method.
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
      *
      * @since 0.9.12
      */
@@ -4822,14 +4891,14 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTStaticReference} node.
+     * This method parses a {@link ASTStaticReference} node.
      *
-     * @param \PDepend\Source\Tokenizer\Token $token The "static" keyword token.
+     * @param Token $token The "static" keyword token.
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws ParserException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      *
      * @since 0.9.6
      */
@@ -4858,14 +4927,14 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTSelfReference} node.
+     * This method parses a {@link ASTSelfReference} node.
      *
-     * @param \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
+     * @param Token $token The "self" keyword token.
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws ParserException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      *
      * @since 0.9.6
      */
@@ -4893,7 +4962,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a simple PHP constant use and returns a corresponding node.
      *
-     * @return null|\PDepend\Source\AST\ASTNode
+     * @return null|ASTNode
      *
      * @since 1.0.0
      */
@@ -4922,16 +4991,15 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTConstant} node or
-     * an instance of {@link \PDepend\Source\AST\ASTSelfReference} as part of
-     * a {@link \PDepend\Source\AST\ASTMemberPrimaryPrefix} that contains the
-     * self reference as its first child when the self token is followed by a
-     * double colon token.
+     * This method parses a {@link ASTConstant} node or an instance of
+     * {@link ASTSelfReference} as part of a {@link ASTMemberPrimaryPrefix} that
+     * contains the self reference as its first child when the self token is
+     * followed by a double colon token.
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws ParserException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -4951,14 +5019,14 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTParentReference} node.
+     * This method parses a {@link ASTParentReference} node.
      *
-     * @param \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
+     * @param Token $token The "self" keyword token.
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws ParserException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @return ASTParentReference
      *
      * @since 0.9.6
      */
@@ -5001,16 +5069,15 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTConstant} node or
-     * an instance of {@link \PDepend\Source\AST\ASTParentReference} as part
-     * of a {@link \PDepend\Source\AST\ASTMemberPrimaryPrefix} that contains
-     * the parent reference as its first child when the self token is followed
-     * by a double colon token.
+     * This method parses a {@link ASTConstant} node or an instance of
+     * {@link ASTParentReference} as part of a {@link ASTMemberPrimaryPrefix}
+     * that contains the parent reference as its first child when the self token
+     * is followed by a double colon token.
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws ParserException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -5043,7 +5110,7 @@ abstract class AbstractPHPParser
      * //     ----------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.18
      */
@@ -5072,7 +5139,7 @@ abstract class AbstractPHPParser
      * //     ----------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      *
      * @since 0.9.18
      */
@@ -5117,7 +5184,7 @@ abstract class AbstractPHPParser
      * This method parses a comma separated list of valid php variables and/or
      * properties and adds them to the given node instance.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param T $node The context parent node.
      *
@@ -5171,10 +5238,10 @@ abstract class AbstractPHPParser
      * ------
      * </code>
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.9.6
      */
@@ -5189,7 +5256,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a PHP compound variable or a simple literal node.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.19
      */
@@ -5225,10 +5292,10 @@ abstract class AbstractPHPParser
      * this is compound variable, otherwise it can be a variable-variable or a
      * compound-variable.
      *
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.9.6
      */
@@ -5270,7 +5337,7 @@ abstract class AbstractPHPParser
      * //     ----------------
      * </code>
      *
-     * @param \PDepend\Source\Tokenizer\Token $token The dollar token.
+     * @param Token $token The dollar token.
      *
      * @return ASTCompoundVariable
      *
@@ -5302,7 +5369,7 @@ abstract class AbstractPHPParser
      * //      -
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.10
      */
@@ -5341,10 +5408,10 @@ abstract class AbstractPHPParser
      * ------------------
      * </code>
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\ParserException
+     * @throws ParserException
+     * @throws ParserException
      *
-     * @return \PDepend\Source\AST\ASTCompoundExpression
+     * @return ASTCompoundExpression
      *
      * @since 0.9.6
      */
@@ -5365,7 +5432,7 @@ abstract class AbstractPHPParser
      *
      * @param int $tokenType
      *
-     * @return \PDepend\Source\AST\ASTIdentifier
+     * @return ASTIdentifier
      *
      * @since 0.9.12
      */
@@ -5385,13 +5452,13 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * This method parses a {@link \PDepend\Source\AST\ASTLiteral} node or an
-     * instance of {@link \PDepend\Source\AST\ASTString} that represents a string
+     * This method parses a {@link ASTLiteral} node or an
+     * instance of {@link ASTString} that represents a string
      * in double quotes or surrounded by backticks.
      *
      * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function parseLiteralOrString()
     {
@@ -5423,7 +5490,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an integer value.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      *
      * @since 1.0.0
      */
@@ -5447,7 +5514,7 @@ abstract class AbstractPHPParser
      *
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since 1.0.0
      */
@@ -5478,7 +5545,7 @@ abstract class AbstractPHPParser
      *
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since 1.0.0
      */
@@ -5500,7 +5567,7 @@ abstract class AbstractPHPParser
      * @param int  $endDelimiter
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since 1.0.0
      */
@@ -5571,7 +5638,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match key.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.9.0
      */
@@ -5597,7 +5664,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match value expression.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.9.0
      */
@@ -5615,7 +5682,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match entry key-expression pair.
      *
-     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @return ASTMatchEntry
      *
      * @since 2.9.0
      */
@@ -5656,7 +5723,7 @@ abstract class AbstractPHPParser
      *
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArrayElement
+     * @return ASTArrayElement
      *
      * @since 1.0.0
      */
@@ -5701,7 +5768,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a here- or nowdoc string instance.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      *
      * @since 0.9.12
      */
@@ -5747,7 +5814,7 @@ abstract class AbstractPHPParser
      * <code>
      * $string = "Manuel $Pichler <{$email}>";
      *
-     * // \PDepend\Source\AST\ASTSTring
+     * // ASTSTring
      * // |-- ASTLiteral             -  "Manuel ")
      * // |-- ASTVariable            -  $Pichler
      * // |-- ASTLiteral             -  " <"
@@ -5758,9 +5825,9 @@ abstract class AbstractPHPParser
      *
      * @param int $delimiterType The start/stop token type.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTString
+     * @return ASTString
      *
      * @since 0.9.10
      */
@@ -5795,8 +5862,8 @@ abstract class AbstractPHPParser
      * input string node.
      * 
      * @param int $stopToken
-     * 
-     * @return \PDepend\Source\AST\ASTNode
+     *
+     * @return ASTNode
      *
      * @since 0.9.12
      */
@@ -5829,7 +5896,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses an escaped sequence of literal tokens.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      *
      * @since 0.9.10
      */
@@ -5864,7 +5931,7 @@ abstract class AbstractPHPParser
      * This method parses a simple literal and configures the position
      * properties.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      *
      * @since 0.9.10
      */
@@ -5903,7 +5970,7 @@ abstract class AbstractPHPParser
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameters
+     * @return ASTFormalParameters
      *
      * @since 0.9.5
      */
@@ -5982,7 +6049,7 @@ abstract class AbstractPHPParser
      * //                ---
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6001,7 +6068,7 @@ abstract class AbstractPHPParser
     /**
      * @param int $tokenType
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      */
     private function parseFormalParameterFromType($tokenType)
     {
@@ -6037,7 +6104,7 @@ abstract class AbstractPHPParser
      * //                ---------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6052,7 +6119,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTTypeArray
+     * @return ASTTypeArray
      */
     protected function parseArrayType()
     {
@@ -6072,7 +6139,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version after the next token.
      *
-     * @return null|\PDepend\Source\AST\ASTType
+     * @return null|ASTType
      *
      * @since 2.9.2
      */
@@ -6092,7 +6159,7 @@ abstract class AbstractPHPParser
      * //                ------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6118,9 +6185,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @throws \PDepend\Source\Parser\InvalidStateException
+     * @throws InvalidStateException
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6134,7 +6201,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @return ASTParentReference
      */
     protected function parseParentType()
     {
@@ -6154,7 +6221,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6181,7 +6248,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 2.9.2
      */
@@ -6196,7 +6263,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      */
     protected function parseSelfType()
     {
@@ -6204,7 +6271,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      */
     protected function parseStaticType()
     {
@@ -6221,7 +6288,7 @@ abstract class AbstractPHPParser
      * //                 ---  -------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6243,7 +6310,7 @@ abstract class AbstractPHPParser
      * //                 ---  --------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6268,7 +6335,7 @@ abstract class AbstractPHPParser
      * //               --  -------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 0.9.6
      */
@@ -6306,7 +6373,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version.
      *
-     * @return null|\PDepend\Source\AST\ASTType
+     * @return null|ASTType
      *
      * @since 1.0.0
      */
@@ -6328,7 +6395,7 @@ abstract class AbstractPHPParser
     /**
      * Extracts all dependencies from a callable body.
      *
-     * @return \PDepend\Source\AST\ASTScope
+     * @return ASTScope
      *
      * @since 0.9.12
      */
@@ -6344,7 +6411,7 @@ abstract class AbstractPHPParser
         while (($stmt = $this->parseOptionalStatement()) !== null) {
             // TODO: Remove if-statement once, we have translated functions and
             //       closures into ast-nodes
-            if ($stmt instanceof \PDepend\Source\AST\ASTNode) {
+            if ($stmt instanceof ASTNode) {
                 $scope->addChild($stmt);
             }
         }
@@ -6358,10 +6425,10 @@ abstract class AbstractPHPParser
     /**
      * Parse a statement.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
+     * @throws UnexpectedTokenException
+     * @throws TokenStreamEndException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 1.0.0
      */
@@ -6379,7 +6446,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional statement or returns <b>null</b>.
      *
-     * @return null|AbstractASTClassOrInterface|\PDepend\Source\AST\ASTCallable|\PDepend\Source\AST\ASTNode
+     * @return null|AbstractASTClassOrInterface|ASTCallable|ASTNode
      *
      * @since 0.9.8
      */
@@ -6531,7 +6598,7 @@ abstract class AbstractPHPParser
      * Parses a comment and optionally an embedded class or interface type
      * annotation.
      *
-     * @return \PDepend\Source\AST\ASTComment
+     * @return ASTComment
      *
      * @since 0.9.8
      */
@@ -6560,7 +6627,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional set of bound closure variables.
      *
-     * @template T of \PDepend\Source\AST\ASTClosure
+     * @template T of ASTClosure
      *
      * @param T $closure The context closure instance.
      *
@@ -6569,7 +6636,7 @@ abstract class AbstractPHPParser
      * @since 1.0.0
      */
     protected function parseOptionalBoundVariables(
-        \PDepend\Source\AST\ASTClosure $closure
+        ASTClosure $closure
     ) {
         $this->consumeComments();
 
@@ -6583,7 +6650,7 @@ abstract class AbstractPHPParser
     /**
      * Parses a list of bound closure variables.
      *
-     * @template T of \PDepend\Source\AST\ASTClosure
+     * @template T of ASTClosure
      *
      * @param T $closure The parent closure instance.
      *
@@ -6591,7 +6658,7 @@ abstract class AbstractPHPParser
      *
      * @since 0.9.5
      */
-    private function parseBoundVariables(\PDepend\Source\AST\ASTClosure $closure)
+    private function parseBoundVariables(ASTClosure $closure)
     {
         $this->consumeToken(Tokens::T_USE);
 
@@ -6931,7 +6998,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
      *
      * @since 0.9.6
      */
@@ -6996,7 +7063,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConstantDeclarator
+     * @return ASTConstantDeclarator
      *
      * @since 0.9.6
      */
@@ -7027,7 +7094,7 @@ abstract class AbstractPHPParser
      * Parses the value of a php constant. By default this can be only static
      * values that were allowed in the oldest supported PHP version.
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      *
      * @since 2.2.x
      */
@@ -7073,10 +7140,10 @@ abstract class AbstractPHPParser
      * };
      * </code>
      *
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws ParserException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 0.9.6
      */
@@ -7133,9 +7200,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @param \PDepend\Source\Tokenizer\Token $token Token with the "static" keyword.
+     * @param Token $token Token with the "static" keyword.
      *
-     * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     * @return ASTStaticVariableDeclaration
      *
      * @since 0.9.6
      */
@@ -7187,7 +7254,7 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTVariableDeclarator
+     * @return ASTVariableDeclarator
      *
      * @since 0.9.6
      */
@@ -7212,7 +7279,7 @@ abstract class AbstractPHPParser
      * This method will parse a static value or a static array as it is
      * used as default value for a parameter or property declaration.
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      *
      * @since 0.9.6
      */
@@ -7237,7 +7304,7 @@ abstract class AbstractPHPParser
      * This method will parse a static default value as it is used for a
      * parameter, property or constant declaration.
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      *
      * @since 0.9.5
      */
@@ -7363,9 +7430,9 @@ abstract class AbstractPHPParser
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
@@ -7375,9 +7442,9 @@ abstract class AbstractPHPParser
     /**
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      */
     protected function parseLambdaFunctionDeclaration()
     {
@@ -7388,7 +7455,7 @@ abstract class AbstractPHPParser
      * Checks if the given expression is a read/write variable as defined in
      * the PHP zend_language_parser.y definition.
      *
-     * @param \PDepend\Source\AST\ASTNode $expr The context node instance.
+     * @param ASTNode $expr The context node instance.
      *
      * @return bool
      *
@@ -7437,7 +7504,7 @@ abstract class AbstractPHPParser
     /**
      * Returns the currently active package or namespace.
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      *
      * @since 1.0.0
      */
@@ -7517,7 +7584,7 @@ abstract class AbstractPHPParser
      *
      * @param string $comment The context doc comment block.
      *
-     * @return array<integer, string>
+     * @return array<int, string>
      */
     private function parseThrowsAnnotations($comment)
     {
@@ -7588,7 +7655,7 @@ abstract class AbstractPHPParser
      * doc comment information. The returned value will be <b>null</b> when no
      * type information exists.
      *
-     * @return null|\PDepend\Source\AST\ASTType
+     * @return null|ASTType
      *
      * @since 0.9.6
      */
@@ -7626,7 +7693,7 @@ abstract class AbstractPHPParser
      * Extracts non scalar types from a field doc comment and creates a
      * matching type instance.
      *
-     * @return null|\PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return null|ASTClassOrInterfaceReference
      *
      * @since 0.9.6
      */
@@ -7648,7 +7715,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a yield-statement node.
      *
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     * @return ASTYieldStatement
      */
     private function parseYield()
     {
@@ -7726,10 +7793,10 @@ abstract class AbstractPHPParser
      *
      * @param int $tokenType The next expected token type.
      *
-     * @throws \PDepend\Source\Parser\TokenStreamEndException
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws TokenStreamEndException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\Tokenizer\Token
+     * @return Token
      */
     protected function consumeToken($tokenType)
     {
@@ -7780,7 +7847,7 @@ abstract class AbstractPHPParser
     /**
      * Throws an UnexpectedTokenException
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
      * @return never
      *
@@ -7806,9 +7873,9 @@ abstract class AbstractPHPParser
      *  $value = $nullableValue ?? throw new InvalidArgumentException();
      *  $value = $falsableValue ?: throw new InvalidArgumentException();
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
      */
     protected function parseThrowExpression()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -164,28 +164,28 @@ abstract class AbstractPHPParser
      * Internal state flag, that will be set to <b>true</b> when the parser has
      * prefixed a qualified name with the actual namespace.
      *
-     * @var boolean
+     * @var bool
      */
     protected $namespacePrefixReplaced = false;
 
     /**
      * The name of the last detected namespace.
      *
-     * @var string|null
+     * @var null|string
      */
     private $namespaceName;
 
     /**
      * Last parsed package tag.
      *
-     * @var string|null
+     * @var null|string
      */
     private $packageName = Builder::DEFAULT_NAMESPACE;
 
     /**
      * The package defined in the file level comment.
      *
-     * @var string|null
+     * @var null|string
      */
     private $globalPackageName = Builder::DEFAULT_NAMESPACE;
 
@@ -213,21 +213,21 @@ abstract class AbstractPHPParser
     /**
      * The last parsed doc comment or <b>null</b>.
      *
-     * @var string|null
+     * @var null|string
      */
     private $docComment;
 
     /**
      * Bitfield of last parsed modifiers.
      *
-     * @var integer
+     * @var int
      */
     private $modifiers = 0;
 
     /**
      * The actually parsed class or interface instance.
      *
-     * @var \PDepend\Source\AST\AbstractASTClassOrInterface|null
+     * @var null|\PDepend\Source\AST\AbstractASTClassOrInterface
      */
     protected $classOrInterface;
 
@@ -235,7 +235,7 @@ abstract class AbstractPHPParser
      * If this property is set to <b>true</b> the parser will ignore all doc
      * comment annotations.
      *
-     * @var boolean
+     * @var bool
      */
     private $ignoreAnnotations = false;
 
@@ -250,6 +250,7 @@ abstract class AbstractPHPParser
      * Used identifier builder instance.
      *
      * @var \PDepend\Util\IdBuilder
+     *
      * @since 0.9.12
      */
     private $idBuilder = null;
@@ -257,14 +258,15 @@ abstract class AbstractPHPParser
     /**
      * The maximum valid nesting level allowed.
      *
-     * @var   integer
+     * @var int
+     *
      * @since 0.9.12
      */
     private $maxNestingLevel = 1024;
 
     /**
-     *
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 0.10.0
      */
     protected $cache;
@@ -279,9 +281,7 @@ abstract class AbstractPHPParser
     /**
      * Constructs a new source parser.
      *
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param PHPBuilder<mixed> $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
      */
     public function __construct(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
@@ -310,9 +310,10 @@ abstract class AbstractPHPParser
     /**
      * Configures the maximum allowed nesting level.
      *
-     * @param integer $maxNestingLevel The maximum allowed nesting level.
+     * @param int $maxNestingLevel The maximum allowed nesting level.
      *
      * @return void
+     *
      * @since 0.9.12
      */
     public function setMaxNestingLevel($maxNestingLevel)
@@ -323,7 +324,8 @@ abstract class AbstractPHPParser
     /**
      * Returns the maximum allowed nesting/recursion level.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.9.12
      */
     protected function getMaxNestingLevel()
@@ -418,6 +420,7 @@ abstract class AbstractPHPParser
      * Initializes the parser environment.
      *
      * @return void
+     *
      * @since 0.9.12
      */
     protected function setUpEnvironment()
@@ -435,6 +438,7 @@ abstract class AbstractPHPParser
      * @throws NoActiveScopeException
      *
      * @return void
+     *
      * @since 0.9.12
      */
     protected function tearDownEnvironment()
@@ -447,7 +451,7 @@ abstract class AbstractPHPParser
     /**
      * Resets some object properties.
      *
-     * @param integer $modifiers Optional default modifiers.
+     * @param int $modifiers Optional default modifiers.
      *
      * @return void
      */
@@ -462,8 +466,10 @@ abstract class AbstractPHPParser
      * Tests if the given token type is a reserved keyword in the supported PHP
      * version.
      *
-     * @param  integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 1.1.1
      */
     abstract protected function isKeyword($tokenType);
@@ -472,9 +478,10 @@ abstract class AbstractPHPParser
      * Parses a valid class or interface name and returns the image of the parsed
      * token.
      *
-     * @return string
      * @throws \PDepend\Source\Parser\TokenStreamEndException
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return string
      */
     protected function parseClassName()
     {
@@ -493,8 +500,10 @@ abstract class AbstractPHPParser
      * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
      * name part.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 0.10.6
      */
     protected function isClassName($tokenType)
@@ -521,9 +530,11 @@ abstract class AbstractPHPParser
      * literal representing the function name. If no valid token exists in the
      * token stream, this method will throw an exception.
      *
-     * @return string
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      * @throws \PDepend\Source\Parser\TokenStreamEndException
+     *
+     * @return string
+     *
      * @since 0.10.0
      */
     protected function parseFunctionName()
@@ -540,8 +551,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
      */
     private function isAllowedName($tokenType)
     {
@@ -563,8 +575,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
      */
     protected function isConstantName($tokenType)
     {
@@ -575,8 +588,10 @@ abstract class AbstractPHPParser
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -585,9 +600,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return string
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      * @throws \PDepend\Source\Parser\TokenStreamEndException
+     *
+     * @return string
      */
     protected function parseMethodName()
     {
@@ -603,7 +619,8 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param integer $tokenType
+     * @param int $tokenType
+     *
      * @return bool
      */
     protected function isMethodName($tokenType)
@@ -615,6 +632,7 @@ abstract class AbstractPHPParser
      * Parses a trait declaration.
      *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since 1.0.0
      */
     private function parseTraitDeclaration()
@@ -674,6 +692,7 @@ abstract class AbstractPHPParser
      * interface instance.
      *
      * @return \PDepend\Source\AST\ASTInterface
+     *
      * @since 0.10.2
      */
     private function parseInterfaceSignature()
@@ -695,8 +714,8 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional interface list of an interface declaration.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return \PDepend\Source\AST\ASTInterface
+     *
      * @since 0.10.2
      */
     private function parseOptionalExtendsList(ASTInterface $interface)
@@ -738,6 +757,7 @@ abstract class AbstractPHPParser
      * and an optional list of implemented interfaces.
      *
      * @return \PDepend\Source\AST\ASTClass
+     *
      * @since 1.0.0
      */
     protected function parseClassSignature()
@@ -798,8 +818,8 @@ abstract class AbstractPHPParser
     /**
      * Parses a parent class declaration for the given <b>$class</b>.
      *
-     * @param \PDepend\Source\AST\ASTClass $class
      * @return \PDepend\Source\AST\ASTClass
+     *
      * @since 1.0.0
      */
     protected function parseClassExtends(ASTClass $class)
@@ -823,7 +843,6 @@ abstract class AbstractPHPParser
      * part of a interface declaration or in the <b>implements</b> part of a
      * class declaration.
      *
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $abstractType
      * @return void
      */
     protected function parseInterfaceList(AbstractASTClassOrInterface $abstractType)
@@ -853,10 +872,13 @@ abstract class AbstractPHPParser
      * Parses a class/interface/trait body.
      *
      * @template T of \PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @param T $classOrInterface
-     * @return T
+     *
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      * @throws \PDepend\Source\Parser\TokenStreamEndException
+     *
+     * @return T
      */
     protected function parseTypeBody(AbstractASTClassOrInterface $classOrInterface)
     {
@@ -954,8 +976,10 @@ abstract class AbstractPHPParser
      * This method will parse a list of modifiers and a following property or
      * method.
      *
-     * @param  integer $modifiers
-     * @return \PDepend\Source\AST\ASTMethod|\PDepend\Source\AST\ASTFieldDeclaration|\PDepend\Source\AST\ASTConstantDefinition
+     * @param int $modifiers
+     *
+     * @return \PDepend\Source\AST\ASTConstantDefinition|\PDepend\Source\AST\ASTFieldDeclaration|\PDepend\Source\AST\ASTMethod
+     *
      * @since 0.9.6
      */
     protected function parseMethodOrFieldDeclaration($modifiers = 0)
@@ -1017,10 +1041,13 @@ abstract class AbstractPHPParser
 
     /**
      * Override this in later PHPParserVersions as necessary
-     * @param integer $tokenType
-     * @param integer $modifiers
-     * @return \PDepend\Source\AST\ASTConstantDefinition|\PDepend\Source\AST\ASTFieldDeclaration
+     *
+     * @param int $tokenType
+     * @param int $modifiers
+     *
      * @throws UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTConstantDefinition|\PDepend\Source\AST\ASTFieldDeclaration
      */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
     {
@@ -1045,6 +1072,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFieldDeclaration
+     *
      * @since 0.9.6
      */
     protected function parseFieldDeclaration()
@@ -1089,6 +1117,7 @@ abstract class AbstractPHPParser
      * closure.
      *
      * @return \PDepend\Source\AST\ASTCallable
+     *
      * @since 0.9.5
      */
     private function parseFunctionOrClosureDeclaration()
@@ -1127,7 +1156,8 @@ abstract class AbstractPHPParser
      * <b>true</b> when a reference token was found, otherwise this method will
      * return <b>false</b>.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.8
      */
     protected function parseOptionalByReference()
@@ -1138,7 +1168,8 @@ abstract class AbstractPHPParser
     /**
      * Tests that the next available token is the returns by reference token.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.8
      */
     private function isNextTokenByReference()
@@ -1149,7 +1180,7 @@ abstract class AbstractPHPParser
     /**
      * This method parses a returns by reference token and returns <b>true</b>.
      *
-     * @return boolean
+     * @return bool
      */
     private function parseByReference()
     {
@@ -1162,7 +1193,8 @@ abstract class AbstractPHPParser
     /**
      * Tests that the next available token is an opening parenthesis.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.10
      */
     private function isNextTokenFormalParameterList()
@@ -1175,6 +1207,7 @@ abstract class AbstractPHPParser
      * This method parses a function declaration.
      *
      * @return \PDepend\Source\AST\ASTFunction
+     *
      * @since 0.9.5
      */
     private function parseFunctionDeclaration()
@@ -1215,6 +1248,7 @@ abstract class AbstractPHPParser
      * This method parses a method declaration.
      *
      * @return \PDepend\Source\AST\ASTMethod
+     *
      * @since 0.9.5
      */
     private function parseMethodDeclaration()
@@ -1247,6 +1281,7 @@ abstract class AbstractPHPParser
      * This method parses a PHP 5.3 closure or lambda function.
      *
      * @return \PDepend\Source\AST\ASTClosure
+     *
      * @since 0.9.5
      */
     private function parseClosureDeclaration()
@@ -1270,7 +1305,6 @@ abstract class AbstractPHPParser
     /**
      * Parses a function or a method and adds it to the parent context node.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     private function parseCallableDeclaration(AbstractASTCallable $callable)
@@ -1293,7 +1327,9 @@ abstract class AbstractPHPParser
      * Extension for version specific additions.
      *
      * @template T of \PDepend\Source\AST\AbstractASTCallable
+     *
      * @param T $callable
+     *
      * @return T
      */
     protected function parseCallableDeclarationAddition($callable)
@@ -1305,6 +1341,7 @@ abstract class AbstractPHPParser
      * Parses a trait use statement.
      *
      * @return ASTTraitUseStatement
+     *
      * @since 1.0.0
      */
     private function parseTraitUseStatement()
@@ -1331,6 +1368,7 @@ abstract class AbstractPHPParser
      * Parses a trait reference instance.
      *
      * @return \PDepend\Source\AST\ASTTraitReference
+     *
      * @since 1.0.0
      */
     private function parseTraitReference()
@@ -1349,8 +1387,8 @@ abstract class AbstractPHPParser
      * Parses the adaptation list of the given use statement or simply reads
      * the terminating semicolon, when no adaptation list exists.
      *
-     * @param ASTTraitUseStatement $useStatement
      * @return ASTTraitUseStatement
+     *
      * @since 1.0.0
      */
     private function parseOptionalTraitAdaptation(ASTTraitUseStatement $useStatement)
@@ -1370,6 +1408,7 @@ abstract class AbstractPHPParser
      * Parses the adaptation expression of a trait use statement.
      *
      * @return ASTTraitAdaptation
+     *
      * @since 1.0.0
      */
     private function parseTraitAdaptation()
@@ -1416,6 +1455,7 @@ abstract class AbstractPHPParser
      * declaring trait.
      *
      * @return array<integer, mixed>
+     *
      * @since 1.0.0
      */
     private function parseTraitMethodReference()
@@ -1448,6 +1488,7 @@ abstract class AbstractPHPParser
      * @param array<integer, mixed> $reference Parsed method reference array.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     *
      * @since 1.0.0
      */
     private function parseTraitAdaptationAliasStatement(array $reference)
@@ -1488,9 +1529,12 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait adaptation precedence statement.
      *
-     * @param  array<integer, mixed> $reference Parsed method reference array.
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @param array<integer, mixed> $reference Parsed method reference array.
+     *
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     *
      * @since 1.0.0
      */
     private function parseTraitAdaptationPrecedenceStatement(array $reference)
@@ -1538,6 +1582,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTAllocationExpression
+     *
      * @since 0.9.6
      */
     private function parseAllocationExpression()
@@ -1560,8 +1605,11 @@ abstract class AbstractPHPParser
      * Parse the type reference used in an allocation expression.
      *
      * @template T of \PDepend\Source\AST\ASTAllocationExpression
+     *
      * @param T $allocation
+     *
      * @return T
+     *
      * @since 2.3
      */
     protected function parseAllocationExpressionTypeReference(ASTAllocationExpression $allocation)
@@ -1573,6 +1621,7 @@ abstract class AbstractPHPParser
      * Parses a eval-expression node.
      *
      * @return \PDepend\Source\AST\ASTEvalExpression
+     *
      * @since 0.9.12
      */
     private function parseEvalExpression()
@@ -1590,6 +1639,7 @@ abstract class AbstractPHPParser
      * This method parses an exit-expression.
      *
      * @return \PDepend\Source\AST\ASTExitExpression
+     *
      * @since 0.9.12
      */
     private function parseExitExpression()
@@ -1610,6 +1660,7 @@ abstract class AbstractPHPParser
      * Parses a clone-expression node.
      *
      * @return \PDepend\Source\AST\ASTCloneExpression
+     *
      * @since 0.9.12
      */
     private function parseCloneExpression()
@@ -1628,6 +1679,7 @@ abstract class AbstractPHPParser
      *
      * @param int                             $tokenType
      * @param \PDepend\Source\Tokenizer\Token $unexpectedToken
+     *
      * @return void
      */
     private function ensureTokenIsListUnpackingOpening($tokenType, $unexpectedToken = null)
@@ -1651,6 +1703,7 @@ abstract class AbstractPHPParser
      * This method parses a single list-statement node.
      *
      * @return \PDepend\Source\AST\ASTListExpression
+     *
      * @since 0.9.12
      */
     private function parseListExpression()
@@ -1708,7 +1761,7 @@ abstract class AbstractPHPParser
     /**
      * Parse individual slot of a list() expression.
      *
-     * @return \PDepend\Source\AST\ASTListExpression|ASTNode
+     * @return ASTNode|\PDepend\Source\AST\ASTListExpression
      */
     private function parseListSlotExpression()
     {
@@ -1736,6 +1789,7 @@ abstract class AbstractPHPParser
      * Parses a include-expression node.
      *
      * @return \PDepend\Source\AST\ASTIncludeExpression
+     *
      * @since 0.9.12
      */
     private function parseIncludeExpression()
@@ -1749,6 +1803,7 @@ abstract class AbstractPHPParser
      * Parses a include_once-expression node.
      *
      * @return \PDepend\Source\AST\ASTIncludeExpression
+     *
      * @since 0.9.12
      */
     private function parseIncludeOnceExpression()
@@ -1763,6 +1818,7 @@ abstract class AbstractPHPParser
      * Parses a require-expression node.
      *
      * @return \PDepend\Source\AST\ASTRequireExpression
+     *
      * @since 0.9.12
      */
     private function parseRequireExpression()
@@ -1776,6 +1832,7 @@ abstract class AbstractPHPParser
      * Parses a require_once-expression node.
      *
      * @return \PDepend\Source\AST\ASTRequireExpression
+     *
      * @since 0.9.12
      */
     private function parseRequireOnceExpression()
@@ -1791,9 +1848,12 @@ abstract class AbstractPHPParser
      * <b>include</b>-expression node.
      *
      * @template T of \PDepend\Source\AST\ASTExpression
-     * @param  T       $expr
-     * @param  integer $type
+     *
+     * @param T   $expr
+     * @param int $type
+     *
      * @return T
+     *
      * @since 0.9.12
      */
     private function parseRequireOrIncludeExpression(ASTExpression $expr, $type)
@@ -1818,6 +1878,7 @@ abstract class AbstractPHPParser
      * Parses a cast-expression node.
      *
      * @return \PDepend\Source\AST\ASTCastExpression
+     *
      * @since 0.10.0
      */
     protected function parseCastExpression()
@@ -1840,8 +1901,10 @@ abstract class AbstractPHPParser
      * node this can be a {@link \PDepend\Source\AST\ASTPostIncrementExpression} or
      * {@link \PDepend\Source\AST\ASTPostfixExpression}.
      *
-     * @param  array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
+     * @param array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
+     *
      * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.10.0
      */
     private function parseIncrementExpression(array &$expressions)
@@ -1858,6 +1921,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTNode $child The child expression node.
      *
      * @return \PDepend\Source\AST\ASTPostfixExpression
+     *
      * @since 0.10.0
      */
     private function parsePostIncrementExpression(ASTNode $child)
@@ -1880,6 +1944,7 @@ abstract class AbstractPHPParser
      * Parses a pre increment-expression and adds the given child to that node.
      *
      * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     *
      * @since 0.10.0
      */
     private function parsePreIncrementExpression()
@@ -1905,6 +1970,7 @@ abstract class AbstractPHPParser
      * @param array<\PDepend\Source\AST\ASTNode> $expressions List of previous parsed expression nodes.
      *
      * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.10.0
      */
     private function parseDecrementExpression(array &$expressions)
@@ -1921,6 +1987,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTNode $child The child expression node.
      *
      * @return \PDepend\Source\AST\ASTPostfixExpression
+     *
      * @since 0.10.0
      */
     private function parsePostDecrementExpression(ASTNode $child)
@@ -1943,6 +2010,7 @@ abstract class AbstractPHPParser
      * Parses a pre decrement-expression and adds the given child to that node.
      *
      * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     *
      * @since 0.10.0
      */
     private function parsePreDecrementExpression()
@@ -1978,9 +2046,11 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param T $node The parent/context node instance.
      *
-     * @return T|\PDepend\Source\AST\ASTIndexExpression
+     * @return \PDepend\Source\AST\ASTIndexExpression|T
+     *
      * @since 0.9.12
      */
     protected function parseOptionalIndexExpression(ASTNode $node)
@@ -2002,17 +2072,19 @@ abstract class AbstractPHPParser
      * string or array.
      *
      * @template T of \PDepend\Source\AST\ASTExpression
+     *
      * @param \PDepend\Source\AST\ASTNode $node  The context source node.
      * @param T                           $expr  The concrete index expression.
-     * @param integer                     $open  The open token type.
-     * @param integer                     $close The close token type.
+     * @param int                         $open  The open token type.
+     * @param int                         $close The close token type.
      *
-     * @return T|\PDepend\Source\AST\ASTIndexExpression
+     * @return \PDepend\Source\AST\ASTIndexExpression|T
+     *
      * @since 0.9.12
      */
     private function parseIndexExpression(
-        \PDepend\Source\AST\ASTNode $node,
-        \PDepend\Source\AST\ASTExpression $expr,
+        ASTNode $node,
+        ASTExpression $expr,
         $open,
         $close
     ) {
@@ -2046,6 +2118,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTNode $node The context source node.
      *
      * @return \PDepend\Source\AST\ASTIndexExpression
+     *
      * @since 0.9.12
      */
     private function parseArrayIndexExpression(ASTNode $node)
@@ -2073,6 +2146,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTNode $node The context source node.
      *
      * @return \PDepend\Source\AST\ASTIndexExpression
+     *
      * @since 0.9.12
      */
     private function parseStringIndexExpression(ASTNode $node)
@@ -2091,7 +2165,8 @@ abstract class AbstractPHPParser
     /**
      * This method checks if the next available token starts an arguments node.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.8
      */
     protected function isNextTokenArguments()
@@ -2104,9 +2179,12 @@ abstract class AbstractPHPParser
      * This method configures the given node with its start and end positions.
      *
      * @template T of \PDepend\Source\AST\ASTNode
-     * @param T $node
-     * @param array<integer, \PDepend\Source\Tokenizer\Token>|null $tokens
+     *
+     * @param T                                                    $node
+     * @param null|array<integer, \PDepend\Source\Tokenizer\Token> $tokens
+     *
      * @return T
+     *
      * @since 0.9.8
      */
     protected function setNodePositionsAndReturn(ASTNode $node, array &$tokens = null)
@@ -2129,8 +2207,10 @@ abstract class AbstractPHPParser
     /**
      * Strips all trailing comments from the given token stream.
      *
-     * @param  Token[] $tokens Original token stream.
+     * @param Token[] $tokens Original token stream.
+     *
      * @return Token[]
+     *
      * @since 1.0.0
      */
     private function stripTrailingComments(array $tokens)
@@ -2170,6 +2250,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     *
      * @since 0.9.6
      */
     private function parseInstanceOfExpression()
@@ -2199,6 +2280,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTIssetExpression
+     *
      * @since 0.9.12
      */
     private function parseIssetExpression()
@@ -2230,7 +2312,8 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param boolean $classRef
+     * @param bool $classRef
+     *
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
      */
     private function parseStandAloneExpressionTypeReference($classRef)
@@ -2261,8 +2344,10 @@ abstract class AbstractPHPParser
      * allocation node like {@link \PDepend\Source\AST\ASTAllocationExpression}.
      *
      * @template T of \PDepend\Source\AST\ASTNode
-     * @param T $expr
-     * @param boolean $classRef
+     *
+     * @param T    $expr
+     * @param bool $classRef
+     *
      * @return T
      */
     protected function parseExpressionTypeReference(ASTNode $expr, $classRef)
@@ -2288,6 +2373,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTConditionalExpression
+     *
      * @since 0.9.8
      */
     protected function parseConditionalExpression()
@@ -2311,6 +2397,7 @@ abstract class AbstractPHPParser
      * This method parses a shift left expression node.
      *
      * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     *
      * @since 1.0.1
      */
     protected function parseShiftLeftExpression()
@@ -2331,6 +2418,7 @@ abstract class AbstractPHPParser
      * This method parses a shift right expression node.
      *
      * @return \PDepend\Source\AST\ASTShiftRightExpression
+     *
      * @since 1.0.1
      */
     protected function parseShiftRightExpression()
@@ -2351,6 +2439,7 @@ abstract class AbstractPHPParser
      * This method parses a boolean and-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     *
      * @since 0.9.8
      */
     protected function parseBooleanAndExpression()
@@ -2371,6 +2460,7 @@ abstract class AbstractPHPParser
      * This method parses a boolean or-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     *
      * @since 0.9.8
      */
     protected function parseBooleanOrExpression()
@@ -2391,6 +2481,7 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>and</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     *
      * @since 0.9.8
      */
     protected function parseLogicalAndExpression()
@@ -2411,6 +2502,7 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>or</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     *
      * @since 0.9.8
      */
     protected function parseLogicalOrExpression()
@@ -2431,6 +2523,7 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>xor</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     *
      * @since 0.9.8
      */
     protected function parseLogicalXorExpression()
@@ -2450,9 +2543,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a class or interface reference node.
      *
-     * @param boolean $classReference Force a class reference.
+     * @param bool $classReference Force a class reference.
      *
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     *
      * @since 0.9.8
      */
     private function parseClassOrInterfaceReference($classReference)
@@ -2491,11 +2585,14 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @template T of \PDepend\Source\AST\ASTNode
-     * @param  T                               $node
-     * @param  \PDepend\Source\Tokenizer\Token $start
-     * @param  integer                         $closeToken
-     * @return T
+     *
+     * @param T   $node
+     * @param int $closeToken
+     *
      * @throws \PDepend\Source\Parser\TokenStreamEndException
+     *
+     * @return T
+     *
      * @since 0.9.6
      */
     protected function parseBraceExpression(
@@ -2536,9 +2633,11 @@ abstract class AbstractPHPParser
      * to that statement.
      *
      * @template T of \PDepend\Source\AST\ASTStatement
+     *
      * @param T $stmt The owning statement.
      *
      * @return T
+     *
      * @since 0.9.12
      */
     private function parseStatementBody(ASTStatement $stmt)
@@ -2560,6 +2659,7 @@ abstract class AbstractPHPParser
      * Parse a scope enclosed by curly braces.
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
+     *
      * @since 0.9.12
      */
     private function parseRegularScope()
@@ -2580,6 +2680,7 @@ abstract class AbstractPHPParser
      * syntax for statements.
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
+     *
      * @since 0.10.0
      */
     private function parseAlternativeScope()
@@ -2598,6 +2699,7 @@ abstract class AbstractPHPParser
      * instance.
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
+     *
      * @since 0.10.0
      */
     private function parseScopeStatements()
@@ -2616,6 +2718,7 @@ abstract class AbstractPHPParser
      * syntax format.
      *
      * @return void
+     *
      * @since 0.10.0
      */
     private function parseOptionalAlternativeScopeTermination()
@@ -2632,9 +2735,10 @@ abstract class AbstractPHPParser
      * the end token of a alternative scope termination symbol. Otherwise this
      * method will return <b>false</b>.
      *
-     * @param integer $tokenType The token type identifier.
+     * @param int $tokenType The token type identifier.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.10.0
      */
     private function isAlternativeScopeTermination($tokenType)
@@ -2655,9 +2759,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a series of tokens that represent an alternative scope termination.
      *
-     * @param integer $tokenType The token type identifier.
+     * @param int $tokenType The token type identifier.
      *
      * @return void
+     *
      * @since 0.10.0
      */
     private function parseAlternativeScopeTermination($tokenType)
@@ -2677,8 +2782,11 @@ abstract class AbstractPHPParser
      * given <b>$exprList</b> node.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param T $exprList
+     *
      * @return T
+     *
      * @since 1.0.0
      */
     private function parseExpressionList(ASTNode $exprList)
@@ -2695,8 +2803,8 @@ abstract class AbstractPHPParser
     /**
      * Return true if children remain to be added, false else.
      *
-     * @param ASTNode $exprList
-     * @param ASTNode $expr
+     * @param \PDepend\Source\AST\AbstractASTNode $exprList
+     *
      * @return bool
      */
     protected function addChildToList(ASTNode $exprList, ASTNode $expr)
@@ -2723,8 +2831,10 @@ abstract class AbstractPHPParser
      * This method parses an expression node and returns it. When no expression
      * was found this method will throw an InvalidStateException.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.1
      */
     private function parseExpression()
@@ -2745,8 +2855,10 @@ abstract class AbstractPHPParser
      * This method optionally parses an expression node and returns it. When no
      * expression was found this method will return <b>null</b>.
      *
-     * @return \PDepend\Source\AST\ASTExpression|null
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return null|\PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.6
      */
     protected function parseOptionalExpression()
@@ -3032,8 +3144,10 @@ abstract class AbstractPHPParser
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.2
      */
     protected function parseOptionalExpressionForVersion()
@@ -3045,9 +3159,10 @@ abstract class AbstractPHPParser
      * Applies all reduce rules against the given expression list.
      *
      * @param \PDepend\Source\AST\ASTExpression[] $expressions Unprepared input
-     *        array with parsed expression nodes found in the source tree.
+     *                                                         array with parsed expression nodes found in the source tree.
      *
      * @return \PDepend\Source\AST\ASTExpression[]
+     *
      * @since 0.10.0
      */
     protected function reduce(array $expressions)
@@ -3059,9 +3174,10 @@ abstract class AbstractPHPParser
      * Reduces all unary-expressions in the given expression list.
      *
      * @param \PDepend\Source\AST\ASTExpression[] $expressions Unprepared input
-     *        array with parsed expression nodes found in the source tree.
+     *                                                         array with parsed expression nodes found in the source tree.
      *
      * @return \PDepend\Source\AST\ASTExpression[]
+     *
      * @since 0.10.0
      */
     private function reduceUnaryExpression(array $expressions)
@@ -3090,6 +3206,7 @@ abstract class AbstractPHPParser
      * This method parses a switch statement.
      *
      * @return \PDepend\Source\AST\ASTSwitchStatement
+     *
      * @since 0.9.8
      */
     private function parseSwitchStatement()
@@ -3110,6 +3227,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTSwitchStatement $switch The parent switch stmt.
      *
      * @return \PDepend\Source\AST\ASTSwitchStatement
+     *
      * @since 0.9.8
      */
     private function parseSwitchStatementBody(ASTSwitchStatement $switch)
@@ -3154,6 +3272,7 @@ abstract class AbstractPHPParser
      * This method parses a case label of a switch statement.
      *
      * @return \PDepend\Source\AST\ASTSwitchLabel
+     *
      * @since 0.9.8
      */
     private function parseSwitchLabel()
@@ -3179,6 +3298,7 @@ abstract class AbstractPHPParser
      * This method parses the default label of a switch statement.
      *
      * @return \PDepend\Source\AST\ASTSwitchLabel
+     *
      * @since 0.9.8
      */
     private function parseSwitchLabelDefault()
@@ -3204,7 +3324,8 @@ abstract class AbstractPHPParser
     /**
      * Parses the body of an switch label node.
      *
-     * @param  \PDepend\Source\AST\ASTSwitchLabel $label The context switch label.
+     * @param \PDepend\Source\AST\ASTSwitchLabel $label The context switch label.
+     *
      * @return \PDepend\Source\AST\ASTSwitchLabel
      */
     private function parseSwitchLabelBody(\PDepend\Source\AST\ASTSwitchLabel $label)
@@ -3253,7 +3374,9 @@ abstract class AbstractPHPParser
      * be a semicolon or a closing php tag.
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
+     *
      * @return void
+     *
      * @since 0.9.12
      */
     private function parseStatementTermination(array $allowedTerminationTokens = array())
@@ -3275,6 +3398,7 @@ abstract class AbstractPHPParser
      * This method parses a try-statement + associated catch-statements.
      *
      * @return \PDepend\Source\AST\ASTTryStatement
+     *
      * @since 0.9.12
      */
     private function parseTryStatement()
@@ -3308,7 +3432,9 @@ abstract class AbstractPHPParser
      * This method parses a throw-statement.
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
+     *
      * @return \PDepend\Source\AST\ASTThrowStatement
+     *
      * @since 0.9.12
      */
     protected function parseThrowStatement(array $allowedTerminationTokens = array())
@@ -3328,6 +3454,7 @@ abstract class AbstractPHPParser
      * This method parses a goto-statement.
      *
      * @return \PDepend\Source\AST\ASTGotoStatement
+     *
      * @since 0.9.12
      */
     private function parseGotoStatement()
@@ -3349,6 +3476,7 @@ abstract class AbstractPHPParser
      * This method parses a label-statement.
      *
      * @return \PDepend\Source\AST\ASTLabelStatement
+     *
      * @since 0.9.12
      */
     private function parseLabelStatement()
@@ -3368,6 +3496,7 @@ abstract class AbstractPHPParser
      * This method parses a global-statement.
      *
      * @return \PDepend\Source\AST\ASTGlobalStatement
+     *
      * @since 0.9.12
      */
     private function parseGlobalStatement()
@@ -3387,6 +3516,7 @@ abstract class AbstractPHPParser
      * This method parses a unset-statement.
      *
      * @return \PDepend\Source\AST\ASTUnsetStatement
+     *
      * @since 0.9.12
      */
     private function parseUnsetStatement()
@@ -3413,6 +3543,7 @@ abstract class AbstractPHPParser
      * This method parses a catch-statement.
      *
      * @return \PDepend\Source\AST\ASTCatchStatement
+     *
      * @since 0.9.8
      */
     private function parseCatchStatement()
@@ -3443,6 +3574,7 @@ abstract class AbstractPHPParser
      * This method parses assigned variable in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     *
      * @return void
      */
     protected function parseCatchVariable(ASTCatchStatement $stmt)
@@ -3456,6 +3588,7 @@ abstract class AbstractPHPParser
      * This method parses class references in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     *
      * @return void
      */
     protected function parseCatchExceptionClass(ASTCatchStatement $stmt)
@@ -3471,6 +3604,7 @@ abstract class AbstractPHPParser
      * This method parses a finally-statement.
      *
      * @return \PDepend\Source\AST\ASTFinallyStatement
+     *
      * @since 2.0.0
      */
     private function parseFinallyStatement()
@@ -3490,6 +3624,7 @@ abstract class AbstractPHPParser
      * This method parses a single if-statement node.
      *
      * @return \PDepend\Source\AST\ASTIfStatement
+     *
      * @since 0.9.8
      */
     private function parseIfStatement()
@@ -3510,6 +3645,7 @@ abstract class AbstractPHPParser
      * This method parses a single elseif-statement node.
      *
      * @return \PDepend\Source\AST\ASTElseIfStatement
+     *
      * @since 0.9.8
      */
     private function parseElseIfStatement()
@@ -3532,6 +3668,7 @@ abstract class AbstractPHPParser
      * @param \PDepend\Source\AST\ASTStatement $stmt The owning if/elseif statement.
      *
      * @return \PDepend\Source\AST\ASTStatement
+     *
      * @since 0.9.12
      */
     private function parseOptionalElseOrElseIfStatement(ASTStatement $stmt)
@@ -3559,6 +3696,7 @@ abstract class AbstractPHPParser
      * This method parses a single for-statement node.
      *
      * @return \PDepend\Source\AST\ASTForStatement
+     *
      * @since 0.9.8
      */
     private function parseForStatement()
@@ -3598,7 +3736,8 @@ abstract class AbstractPHPParser
      *      ------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForInit|null
+     * @return null|\PDepend\Source\AST\ASTForInit
+     *
      * @since 0.9.8
      */
     private function parseForInit()
@@ -3620,7 +3759,8 @@ abstract class AbstractPHPParser
     /**
      * Parses the expression part of a for-statement.
      *
-     * @return \PDepend\Source\AST\ASTExpression|null
+     * @return null|\PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.12
      */
     private function parseForExpression()
@@ -3637,7 +3777,8 @@ abstract class AbstractPHPParser
      *                                        -------------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForUpdate|null
+     * @return null|\PDepend\Source\AST\ASTForUpdate
+     *
      * @since 0.9.12
      */
     private function parseForUpdate()
@@ -3659,7 +3800,9 @@ abstract class AbstractPHPParser
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
      * @param int $tokenType
+     *
      * @return bool
+     *
      * @since 2.6.0
      */
     protected function isListUnpacking($tokenType = null)
@@ -3701,6 +3844,7 @@ abstract class AbstractPHPParser
      * This method parses a single foreach-statement node.
      *
      * @return \PDepend\Source\AST\ASTForeachStatement
+     *
      * @since 0.9.8
      */
     private function parseForeachStatement()
@@ -3734,6 +3878,7 @@ abstract class AbstractPHPParser
      * This method parses a single while-statement node.
      *
      * @return \PDepend\Source\AST\ASTWhileStatement
+     *
      * @since 0.9.8
      */
     private function parseWhileStatement()
@@ -3753,6 +3898,7 @@ abstract class AbstractPHPParser
      * This method parses a do/while-statement.
      *
      * @return \PDepend\Source\AST\ASTDoWhileStatement
+     *
      * @since 0.9.12
      */
     private function parseDoWhileStatement()
@@ -3795,6 +3941,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTDeclareStatement
+     *
      * @since 0.10.0
      */
     private function parseDeclareStatement()
@@ -3814,8 +3961,10 @@ abstract class AbstractPHPParser
      * consists of a string token and a static scalar.
      *
      * @param \PDepend\Source\AST\ASTDeclareStatement $stmt The declare statement that
-     *        is the owner of this list.
+     *                                                      is the owner of this list.
+     *
      * @return \PDepend\Source\AST\ASTDeclareStatement
+     *
      * @since 0.10.0
      */
     private function parseDeclareList(ASTDeclareStatement $stmt)
@@ -3851,6 +4000,7 @@ abstract class AbstractPHPParser
      * This method builds a return statement from a given token.
      *
      * @return \PDepend\Source\AST\ASTReturnStatement
+     *
      * @since 2.7.0
      */
     protected function buildReturnStatement(Token $token)
@@ -3868,6 +4018,7 @@ abstract class AbstractPHPParser
      * This method parses a single return-statement node.
      *
      * @return \PDepend\Source\AST\ASTReturnStatement
+     *
      * @since 0.9.12
      */
     private function parseReturnStatement()
@@ -3887,6 +4038,7 @@ abstract class AbstractPHPParser
      * This method parses a break-statement node.
      *
      * @return \PDepend\Source\AST\ASTBreakStatement
+     *
      * @since 0.9.12
      */
     private function parseBreakStatement()
@@ -3907,6 +4059,7 @@ abstract class AbstractPHPParser
      * This method parses a continue-statement node.
      *
      * @return \PDepend\Source\AST\ASTContinueStatement
+     *
      * @since 0.9.12
      */
     private function parseContinueStatement()
@@ -3927,6 +4080,7 @@ abstract class AbstractPHPParser
      * This method parses a echo-statement node.
      *
      * @return \PDepend\Source\AST\ASTEchoStatement
+     *
      * @since 0.9.12
      */
     private function parseEchoStatement()
@@ -3952,6 +4106,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.0
      */
     protected function parseParenthesisExpressionOrPrimaryPrefix()
@@ -3963,8 +4118,10 @@ abstract class AbstractPHPParser
 
     /**
      * @template T of \PDepend\Source\AST\ASTExpression
+     *
      * @param T $expr
-     * @return T|\PDepend\Source\AST\ASTMemberPrimaryPrefix
+     *
+     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix|T
      */
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
     {
@@ -3986,9 +4143,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return \PDepend\Source\Tokenizer\Token
      * @throws \PDepend\Source\Parser\TokenStreamEndException
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\Tokenizer\Token
      */
     protected function consumeObjectOperatorToken()
     {
@@ -4000,6 +4158,7 @@ abstract class AbstractPHPParser
      * parenthesis
      *
      * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.8
      */
     protected function parseParenthesisExpression()
@@ -4051,8 +4210,10 @@ abstract class AbstractPHPParser
      * func();
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.6
      */
     private function parseMemberPrefixOrFunctionPostfix()
@@ -4096,10 +4257,12 @@ abstract class AbstractPHPParser
      * node.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param T $node The previously parsed node.
      *
-     * @return T|\PDepend\Source\AST\ASTFunctionPostfix The original input node or this node
-     *         wrapped with a function postfix instance.
+     * @return \PDepend\Source\AST\ASTFunctionPostfix|T The original input node or this node
+     *                                                  wrapped with a function postfix instance.
+     *
      * @since 1.0.0
      */
     private function parseOptionalFunctionPostfix(ASTNode $node)
@@ -4120,11 +4283,14 @@ abstract class AbstractPHPParser
      * member primary prefix object when the function postfix expression is
      * followed by an object operator.
      *
-     * @param  \PDepend\Source\AST\ASTNode $node This node represents the function
-     *        identifier. An identifier can be a static string, a variable, a
-     *        compound variable or any other valid php function identifier.
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @param \PDepend\Source\AST\ASTNode $node This node represents the function
+     *                                          identifier. An identifier can be a static string, a variable, a
+     *                                          compound variable or any other valid php function identifier.
+     *
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     *
      * @since 0.9.6
      */
     protected function parseFunctionPostfix(ASTNode $node)
@@ -4145,6 +4311,7 @@ abstract class AbstractPHPParser
      * property postfix expressions.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.0
      */
     protected function parsePostfixIdentifier()
@@ -4167,11 +4334,15 @@ abstract class AbstractPHPParser
      * {@link \PDepend\Source\AST\ASTNode} instance.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param T $node This node represents primary prefix
-     *        left expression. It will be the first child of the parsed member
-     *        primary expression.
-     * @return T|ASTMemberPrimaryPrefix
+     *                left expression. It will be the first child of the parsed member
+     *                primary expression.
+     *
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return ASTMemberPrimaryPrefix|T
+     *
      * @since 0.9.6
      */
     protected function parseOptionalMemberPrimaryPrefix(ASTNode $node)
@@ -4199,10 +4370,13 @@ abstract class AbstractPHPParser
      * $object->foo;
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTNode $node The left node in the parsed member
-     *        primary expression.
-     * @return ASTMemberPrimaryPrefix
+     * @param \PDepend\Source\AST\ASTNode $node The left node in the parsed member
+     *                                          primary expression.
+     *
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return ASTMemberPrimaryPrefix
+     *
      * @since 0.9.6
      */
     protected function parseMemberPrimaryPrefix(ASTNode $node)
@@ -4255,11 +4429,14 @@ abstract class AbstractPHPParser
      * actual token stream position. Otherwise this method simply returns the
      * input {@link \PDepend\Source\AST\ASTNode} instance.
      *
-     * @param  \PDepend\Source\AST\ASTNode $node This node represents primary prefix
-     *        left expression. It will be the first child of the parsed member
-     *        primary expression.
-     * @return \PDepend\Source\AST\ASTNode
+     * @param \PDepend\Source\AST\ASTNode $node This node represents primary prefix
+     *                                          left expression. It will be the first child of the parsed member
+     *                                          primary expression.
+     *
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.1
      */
     private function parseOptionalStaticMemberPrimaryPrefix(ASTNode $node)
@@ -4296,10 +4473,13 @@ abstract class AbstractPHPParser
      * Foo::BAR;
      * </code>
      *
-     * @param  \PDepend\Source\AST\ASTNode $node The left node in the parsed member
-     *        primary expression.
-     * @return ASTMemberPrimaryPrefix
+     * @param \PDepend\Source\AST\ASTNode $node The left node in the parsed member
+     *                                          primary expression.
+     *
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return ASTMemberPrimaryPrefix
+     *
      * @since 0.9.6
      */
     protected function parseStaticMemberPrimaryPrefix(ASTNode $node)
@@ -4336,8 +4516,10 @@ abstract class AbstractPHPParser
      * This method parses a method- or constant-postfix expression. This expression
      * will contain an identifier node as nested child.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.6
      */
     private function parseMethodOrConstantPostfix()
@@ -4362,11 +4544,13 @@ abstract class AbstractPHPParser
      * will contain the given node as method or property identifier.
      *
      * @param \PDepend\Source\AST\ASTNode $node The identifier for the parsed postfix
-     *        expression node. This node will be the first child of the returned
-     *        postfix node instance.
+     *                                          expression node. This node will be the first child of the returned
+     *                                          postfix node instance.
+     *
+     * @throws \PDepend\Source\Parser\ParserException
      *
      * @return \PDepend\Source\AST\ASTNode
-     * @throws \PDepend\Source\Parser\ParserException
+     *
      * @since 0.9.6
      */
     private function parseMethodOrPropertyPostfix(ASTNode $node)
@@ -4389,9 +4573,10 @@ abstract class AbstractPHPParser
      * Parses/Creates a property postfix node instance.
      *
      * @param \PDepend\Source\AST\ASTNode $node Node that represents the image of
-     *        the property postfix node.
+     *                                          the property postfix node.
      *
      * @return \PDepend\Source\AST\ASTPropertyPostfix
+     *
      * @since 0.10.2
      */
     private function parsePropertyPostfix(ASTNode $node)
@@ -4415,6 +4600,7 @@ abstract class AbstractPHPParser
      * Parses a full qualified class name postfix.
      *
      * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     *
      * @since 2.0.0
      */
     protected function parseFullQualifiedClassNamePostfix()
@@ -4429,9 +4615,10 @@ abstract class AbstractPHPParser
      * return the image of the entire <b>$node</b>.
      *
      * @param \PDepend\Source\AST\ASTNode $node The context node that may be wrapped
-     *        by multiple array or string index expressions.
+     *                                          by multiple array or string index expressions.
      *
      * @return string
+     *
      * @since 1.0.0
      */
     protected function extractPostfixImage(ASTNode $node)
@@ -4446,9 +4633,10 @@ abstract class AbstractPHPParser
      * Parses a method postfix node instance.
      *
      * @param \PDepend\Source\AST\ASTNode $node Node that represents the image of
-     *        the method postfix node.
+     *                                          the method postfix node.
      *
      * @return \PDepend\Source\AST\ASTMethodPostfix
+     *
      * @since 1.0.0
      */
     private function parseMethodPostfix(ASTNode $node)
@@ -4473,8 +4661,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses the arguments passed to a function- or method-call.
      *
-     * @return \PDepend\Source\AST\ASTArguments
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTArguments
+     *
      * @since 0.9.6
      */
     protected function parseArguments()
@@ -4491,8 +4681,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses the tokens after arguments passed to a function- or method-call.
      *
-     * @return \PDepend\Source\AST\ASTArguments
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTArguments
+     *
      * @since 0.9.6
      */
     protected function parseArgumentsParenthesesContent(ASTArguments $arguments)
@@ -4511,7 +4703,9 @@ abstract class AbstractPHPParser
 
     /**
      * @template T of \PDepend\Source\AST\ASTArguments
+     *
      * @param T $arguments
+     *
      * @return T
      */
     protected function parseArgumentList(ASTArguments $arguments)
@@ -4525,6 +4719,7 @@ abstract class AbstractPHPParser
      * several php language constructs like, isset, empty, unset etc.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.12
      */
     protected function parseVariableOrConstantOrPrimaryPrefix()
@@ -4560,8 +4755,10 @@ abstract class AbstractPHPParser
      * variable is followed by an object operator, double colon or opening
      * parenthesis.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference|\PDepend\Source\AST\ASTExpression
      * @throws \PDepend\Source\Parser\ParserException
+     *
+     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference|\PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.6
      */
     private function parseVariableOrFunctionPostfixOrMemberPrimaryPrefix()
@@ -4594,9 +4791,10 @@ abstract class AbstractPHPParser
      * Parses an assingment expression node.
      *
      * @param \PDepend\Source\AST\ASTNode $left The left part of the assignment
-     *        expression that will be parsed by this method.
+     *                                          expression that will be parsed by this method.
      *
      * @return \PDepend\Source\AST\ASTAssignmentExpression
+     *
      * @since 0.9.12
      */
     protected function parseAssignmentExpression(ASTNode $left)
@@ -4626,10 +4824,13 @@ abstract class AbstractPHPParser
     /**
      * This method parses a {@link \PDepend\Source\AST\ASTStaticReference} node.
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token The "static" keyword token.
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @param \PDepend\Source\Tokenizer\Token $token The "static" keyword token.
+     *
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTStaticReference
+     *
      * @since 0.9.6
      */
     private function parseStaticReference(Token $token)
@@ -4659,10 +4860,13 @@ abstract class AbstractPHPParser
     /**
      * This method parses a {@link \PDepend\Source\AST\ASTSelfReference} node.
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @param \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
+     *
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTSelfReference
+     *
      * @since 0.9.6
      */
     protected function parseSelfReference(Token $token)
@@ -4689,7 +4893,8 @@ abstract class AbstractPHPParser
     /**
      * Parses a simple PHP constant use and returns a corresponding node.
      *
-     * @return \PDepend\Source\AST\ASTNode|null
+     * @return null|\PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.0
      */
     protected function parseConstant()
@@ -4723,9 +4928,11 @@ abstract class AbstractPHPParser
      * self reference as its first child when the self token is followed by a
      * double colon token.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.6
      */
     private function parseConstantOrSelfMemberPrimaryPrefix()
@@ -4746,10 +4953,13 @@ abstract class AbstractPHPParser
     /**
      * This method parses a {@link \PDepend\Source\AST\ASTParentReference} node.
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @param \PDepend\Source\Tokenizer\Token $token The "self" keyword token.
+     *
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTParentReference
+     *
      * @since 0.9.6
      */
     private function parseParentReference(Token $token)
@@ -4797,9 +5007,11 @@ abstract class AbstractPHPParser
      * the parent reference as its first child when the self token is followed
      * by a double colon token.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.6
      */
     private function parseConstantOrParentMemberPrimaryPrefix()
@@ -4832,6 +5044,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.18
      */
     private function parseVariableOrMemberOptionalByReference()
@@ -4860,6 +5073,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTUnaryExpression
+     *
      * @since 0.9.18
      */
     private function parseVariableOrMemberByReference()
@@ -4878,8 +5092,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a simple PHP variable.
      *
-     * @return ASTVariable
      * @throws UnexpectedTokenException
+     *
+     * @return ASTVariable
+     *
      * @since 0.9.6
      */
     private function parseVariable()
@@ -4902,9 +5118,11 @@ abstract class AbstractPHPParser
      * properties and adds them to the given node instance.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param T $node The context parent node.
      *
      * @return T The prepared entire node.
+     *
      * @since 0.9.12
      */
     private function parseVariableList(ASTNode $node, $inCall = false)
@@ -4953,9 +5171,11 @@ abstract class AbstractPHPParser
      * ------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTExpression
      * @throws \PDepend\Source\Parser\ParserException
      * @throws UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.6
      */
     protected function parseCompoundVariableOrVariableVariableOrVariable()
@@ -4970,6 +5190,7 @@ abstract class AbstractPHPParser
      * Parses a PHP compound variable or a simple literal node.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.19
      */
     private function parseCompoundVariableOrLiteral()
@@ -5004,9 +5225,11 @@ abstract class AbstractPHPParser
      * this is compound variable, otherwise it can be a variable-variable or a
      * compound-variable.
      *
-     * @return \PDepend\Source\AST\ASTExpression
      * @throws \PDepend\Source\Parser\ParserException
      * @throws UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.6
      */
     private function parseCompoundVariableOrVariableVariable()
@@ -5047,8 +5270,10 @@ abstract class AbstractPHPParser
      * //     ----------------
      * </code>
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token The dollar token.
+     * @param \PDepend\Source\Tokenizer\Token $token The dollar token.
+     *
      * @return ASTCompoundVariable
+     *
      * @since 0.10.0
      */
     private function parseCompoundVariable(Token $token)
@@ -5078,6 +5303,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.10
      */
     private function parseCompoundExpressionOrLiteral()
@@ -5115,9 +5341,11 @@ abstract class AbstractPHPParser
      * ------------------
      * </code>
      *
+     * @throws \PDepend\Source\Parser\ParserException
+     * @throws \PDepend\Source\Parser\ParserException
+     *
      * @return \PDepend\Source\AST\ASTCompoundExpression
-     * @throws \PDepend\Source\Parser\ParserException
-     * @throws \PDepend\Source\Parser\ParserException
+     *
      * @since 0.9.6
      */
     protected function parseCompoundExpression()
@@ -5135,8 +5363,10 @@ abstract class AbstractPHPParser
      * Parses a static identifier expression, as it is used for method and
      * function names.
      *
-     * @param integer $tokenType
+     * @param int $tokenType
+     *
      * @return \PDepend\Source\AST\ASTIdentifier
+     *
      * @since 0.9.12
      */
     protected function parseIdentifier($tokenType = Tokens::T_STRING)
@@ -5159,8 +5389,9 @@ abstract class AbstractPHPParser
      * instance of {@link \PDepend\Source\AST\ASTString} that represents a string
      * in double quotes or surrounded by backticks.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTNode
      */
     protected function parseLiteralOrString()
     {
@@ -5193,6 +5424,7 @@ abstract class AbstractPHPParser
      * Parses an integer value.
      *
      * @return \PDepend\Source\AST\ASTLiteral
+     *
      * @since 1.0.0
      */
     protected function parseIntegerNumber()
@@ -5213,8 +5445,10 @@ abstract class AbstractPHPParser
     /**
      * Parses an array structure.
      *
-     * @param boolean $static
+     * @param bool $static
+     *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since 1.0.0
      */
     protected function doParseArray($static = false)
@@ -5233,7 +5467,8 @@ abstract class AbstractPHPParser
      * Tests if the next token is a valid array start delimiter in the supported
      * PHP version.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 1.0.0
      */
     abstract protected function isArrayStartDelimiter();
@@ -5241,10 +5476,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a php array declaration.
      *
-     * @param \PDepend\Source\AST\ASTArray $array
-     * @param boolean                      $static
+     * @param bool $static
      *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since 1.0.0
      */
     abstract protected function parseArray(ASTArray $array, $static = false);
@@ -5262,10 +5497,11 @@ abstract class AbstractPHPParser
     /**
      * Parses all elements in an array.
      *
-     * @param  \PDepend\Source\AST\ASTArray $array
-     * @param  integer                      $endDelimiter
-     * @param  boolean                      $static
+     * @param int  $endDelimiter
+     * @param bool $static
+     *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since 1.0.0
      */
     protected function parseArrayElements(ASTArray $array, $endDelimiter, $static = false)
@@ -5311,8 +5547,8 @@ abstract class AbstractPHPParser
      * or if it's a destructuring list and so check the syntax is valid in the current PHP level.
      *
      * @param bool       $useSquaredBrackets
-     * @param Token|null $openingToken
-     * @param Token|null $consecutiveComma
+     * @param null|Token $openingToken
+     * @param null|Token $consecutiveComma
      *
      * @throws UnexpectedTokenException
      *
@@ -5336,6 +5572,7 @@ abstract class AbstractPHPParser
      * Parses a single match key.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.9.0
      */
     protected function parseMatchEntryKey()
@@ -5361,6 +5598,7 @@ abstract class AbstractPHPParser
      * Parses a single match value expression.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.9.0
      */
     protected function parseMatchEntryValue()
@@ -5378,6 +5616,7 @@ abstract class AbstractPHPParser
      * Parses a single match entry key-expression pair.
      *
      * @return \PDepend\Source\AST\ASTMatchEntry
+     *
      * @since 2.9.0
      */
     protected function parseMatchEntry()
@@ -5415,8 +5654,10 @@ abstract class AbstractPHPParser
      * An array element can have a simple value, a key/value pair, a value by
      * reference or a key/value pair with a referenced value.
      *
-     * @param  boolean $static
+     * @param bool $static
+     *
      * @return \PDepend\Source\AST\ASTArrayElement
+     *
      * @since 1.0.0
      */
     protected function parseArrayElement($static = false)
@@ -5461,6 +5702,7 @@ abstract class AbstractPHPParser
      * Parses a here- or nowdoc string instance.
      *
      * @return \PDepend\Source\AST\ASTHeredoc
+     *
      * @since 0.9.12
      */
     protected function parseHeredoc()
@@ -5480,9 +5722,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a simple string sequence between two tokens of the same type.
      *
-     * @param integer $tokenType The start/stop token type.
+     * @param int $tokenType The start/stop token type.
      *
      * @return string
+     *
      * @since 0.9.10
      */
     private function parseStringSequence($tokenType)
@@ -5513,10 +5756,12 @@ abstract class AbstractPHPParser
      * // |-- ASTLiteral             -  ">"
      * </code>
      *
-     * @param integer $delimiterType The start/stop token type.
+     * @param int $delimiterType The start/stop token type.
+     *
+     * @throws \PDepend\Source\Parser\UnexpectedTokenException
      *
      * @return \PDepend\Source\AST\ASTString
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
      * @since 0.9.10
      */
     private function parseString($delimiterType)
@@ -5548,10 +5793,11 @@ abstract class AbstractPHPParser
      * will not consume the given stop token, so it is up to the calling method
      * to consume the stop token. The return value of this method is the prepared
      * input string node.
-     *
-     * @param  \PDepend\Source\AST\ASTNode $node
-     * @param  integer                     $stopToken
+     * 
+     * @param int $stopToken
+     * 
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.12
      */
     private function parseStringExpressions(ASTNode $node, $stopToken)
@@ -5584,6 +5830,7 @@ abstract class AbstractPHPParser
      * This method parses an escaped sequence of literal tokens.
      *
      * @return \PDepend\Source\AST\ASTLiteral
+     *
      * @since 0.9.10
      */
     private function parseEscapedAstLiteralString()
@@ -5618,6 +5865,7 @@ abstract class AbstractPHPParser
      * properties.
      *
      * @return \PDepend\Source\AST\ASTLiteral
+     *
      * @since 0.9.10
      */
     protected function parseLiteral()
@@ -5641,6 +5889,7 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
+     *
      * @return ASTFormalParameter|ASTNode
      */
     protected function parseFormalParameterOrPrefix(ASTCallable $callable)
@@ -5653,7 +5902,9 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
+     *
      * @return \PDepend\Source\AST\ASTFormalParameters
+     *
      * @since 0.9.5
      */
     protected function parseFormalParameters(ASTCallable $callable)
@@ -5732,6 +5983,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     protected function parseFormalParameterOrTypeHintOrByReference()
@@ -5748,6 +6000,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
+     *
      * @return \PDepend\Source\AST\ASTFormalParameter
      */
     private function parseFormalParameterFromType($tokenType)
@@ -5785,6 +6038,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndArrayTypeHint()
@@ -5818,7 +6072,8 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version after the next token.
      *
-     * @return \PDepend\Source\AST\ASTType|null
+     * @return null|\PDepend\Source\AST\ASTType
+     *
      * @since 2.9.2
      */
     private function parseOptionalTypeHint()
@@ -5838,6 +6093,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndTypeHint(ASTNode $typeHint)
@@ -5862,8 +6118,10 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
      * @throws \PDepend\Source\Parser\InvalidStateException
+     *
+     * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndParentTypeHint()
@@ -5897,6 +6155,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndSelfTypeHint()
@@ -5923,6 +6182,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 2.9.2
      */
     private function parseFormalParameterAndStaticTypeHint()
@@ -5962,6 +6222,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     protected function parseFormalParameterOrByReference()
@@ -5983,6 +6244,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndByReference()
@@ -6007,6 +6269,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 0.9.6
      */
     protected function parseFormalParameter()
@@ -6021,8 +6284,10 @@ abstract class AbstractPHPParser
      * Tests if the given token type is a valid formal parameter in the supported
      * PHP version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 1.0.0
      */
     protected function isTypeHint($tokenType)
@@ -6041,7 +6306,8 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version.
      *
-     * @return \PDepend\Source\AST\ASTType|null
+     * @return null|\PDepend\Source\AST\ASTType
+     *
      * @since 1.0.0
      */
     protected function parseTypeHint()
@@ -6063,6 +6329,7 @@ abstract class AbstractPHPParser
      * Extracts all dependencies from a callable body.
      *
      * @return \PDepend\Source\AST\ASTScope
+     *
      * @since 0.9.12
      */
     private function parseScope()
@@ -6091,9 +6358,11 @@ abstract class AbstractPHPParser
     /**
      * Parse a statement.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
      * @throws \PDepend\Source\Parser\TokenStreamEndException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 1.0.0
      */
     private function parseStatement()
@@ -6110,7 +6379,8 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional statement or returns <b>null</b>.
      *
-     * @return \PDepend\Source\AST\ASTNode|AbstractASTClassOrInterface|\PDepend\Source\AST\ASTCallable|null
+     * @return null|AbstractASTClassOrInterface|\PDepend\Source\AST\ASTCallable|\PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.8
      */
     private function parseOptionalStatement()
@@ -6231,7 +6501,8 @@ abstract class AbstractPHPParser
      * Parses a sequence of none php code tokens and returns the token type of
      * the next token.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.9.12
      */
     private function parseNonePhpCode()
@@ -6261,6 +6532,7 @@ abstract class AbstractPHPParser
      * annotation.
      *
      * @return \PDepend\Source\AST\ASTComment
+     *
      * @since 0.9.8
      */
     private function parseCommentWithOptionalInlineClassOrInterfaceReference()
@@ -6289,9 +6561,11 @@ abstract class AbstractPHPParser
      * Parses an optional set of bound closure variables.
      *
      * @template T of \PDepend\Source\AST\ASTClosure
+     *
      * @param T $closure The context closure instance.
      *
      * @return T
+     *
      * @since 1.0.0
      */
     protected function parseOptionalBoundVariables(
@@ -6310,9 +6584,11 @@ abstract class AbstractPHPParser
      * Parses a list of bound closure variables.
      *
      * @template T of \PDepend\Source\AST\ASTClosure
+     *
      * @param T $closure The parent closure instance.
      *
      * @return T
+     *
      * @since 0.9.5
      */
     private function parseBoundVariables(\PDepend\Source\AST\ASTClosure $closure)
@@ -6355,6 +6631,7 @@ abstract class AbstractPHPParser
 
     /**
      * Trailing commas is allowed in closure use list from PHP 8.0
+     *
      * @return bool
      */
     protected function allowTrailingCommaInClosureUseList()
@@ -6372,6 +6649,7 @@ abstract class AbstractPHPParser
      * @throws NoActiveScopeException
      *
      * @return string
+     *
      * @link   http://php.net/manual/en/language.namespaces.importing.php
      */
     protected function parseQualifiedName()
@@ -6409,6 +6687,7 @@ abstract class AbstractPHPParser
      * identifier and returns the collected tokens as a string array.
      *
      * @return array<string>
+     *
      * @since 0.9.5
      */
     protected function parseQualifiedNameRaw()
@@ -6469,7 +6748,8 @@ abstract class AbstractPHPParser
      * Determines if the given image is a PHP 7 type hint.
      *
      * @param string $image
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
     {
@@ -6479,6 +6759,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $previousElements
+     *
      * @return string
      */
     protected function parseQualifiedNameElement(array $previousElements)
@@ -6492,6 +6773,7 @@ abstract class AbstractPHPParser
      * @throws NoActiveScopeException
      *
      * @return void
+     *
      * @since 0.9.5
      */
     private function parseNamespaceDeclaration()
@@ -6551,6 +6833,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return void
+     *
      * @since 0.9.5
      */
     protected function parseUseDeclarations()
@@ -6577,6 +6860,7 @@ abstract class AbstractPHPParser
      * @throws NoActiveScopeException
      *
      * @return void
+     *
      * @since 0.9.5
      */
     protected function parseUseDeclaration()
@@ -6604,6 +6888,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $fragments
+     *
      * @return void
      */
     protected function parseUseDeclarationForVersion(array $fragments)
@@ -6616,6 +6901,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $fragments
+     *
      * @return string
      */
     protected function parseNamespaceImage(array $fragments)
@@ -6646,6 +6932,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTConstantDefinition
+     *
      * @since 0.9.6
      */
     protected function parseConstantDefinition()
@@ -6710,6 +6997,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTConstantDeclarator
+     *
      * @since 0.9.6
      */
     protected function parseConstantDeclarator()
@@ -6740,6 +7028,7 @@ abstract class AbstractPHPParser
      * values that were allowed in the oldest supported PHP version.
      *
      * @return \PDepend\Source\AST\ASTValue
+     *
      * @since 2.2.x
      */
     protected function parseConstantDeclaratorValue()
@@ -6784,9 +7073,11 @@ abstract class AbstractPHPParser
      * };
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\ParserException
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 0.9.6
      */
     private function parseStaticVariableDeclarationOrMemberPrimaryPrefix()
@@ -6842,8 +7133,10 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token Token with the "static" keyword.
+     * @param \PDepend\Source\Tokenizer\Token $token Token with the "static" keyword.
+     *
      * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     *
      * @since 0.9.6
      */
     private function parseStaticVariableDeclaration(Token $token)
@@ -6895,6 +7188,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return \PDepend\Source\AST\ASTVariableDeclarator
+     *
      * @since 0.9.6
      */
     protected function parseVariableDeclarator()
@@ -6919,6 +7213,7 @@ abstract class AbstractPHPParser
      * used as default value for a parameter or property declaration.
      *
      * @return \PDepend\Source\AST\ASTValue
+     *
      * @since 0.9.6
      */
     protected function parseStaticValueOrStaticArray()
@@ -6943,6 +7238,7 @@ abstract class AbstractPHPParser
      * parameter, property or constant declaration.
      *
      * @return \PDepend\Source\AST\ASTValue
+     *
      * @since 0.9.5
      */
     protected function parseStaticValue()
@@ -7067,9 +7363,9 @@ abstract class AbstractPHPParser
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @param  \PDepend\Source\AST\ASTValue $value
-     * @return \PDepend\Source\AST\ASTValue
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTValue
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
@@ -7079,8 +7375,9 @@ abstract class AbstractPHPParser
     /**
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
-     * @return \PDepend\Source\AST\ASTClosure
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTClosure
      */
     protected function parseLambdaFunctionDeclaration()
     {
@@ -7093,7 +7390,8 @@ abstract class AbstractPHPParser
      *
      * @param \PDepend\Source\AST\ASTNode $expr The context node instance.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.10.0
      */
     private function isReadWriteVariable($expr)
@@ -7125,6 +7423,7 @@ abstract class AbstractPHPParser
      * this method will return the name from the @package annotation.
      *
      * @return string
+     *
      * @since 0.9.8
      */
     private function getNamespaceOrPackageName()
@@ -7139,6 +7438,7 @@ abstract class AbstractPHPParser
      * Returns the currently active package or namespace.
      *
      * @return \PDepend\Source\AST\ASTNamespace
+     *
      * @since 1.0.0
      */
     private function getNamespaceOrPackage()
@@ -7153,7 +7453,8 @@ abstract class AbstractPHPParser
      * Extracts the @package information from the given comment.
      *
      * @param string $comment
-     * @return string|null
+     *
+     * @return null|string
      */
     private function parsePackageAnnotation($comment)
     {
@@ -7190,7 +7491,7 @@ abstract class AbstractPHPParser
      * This method checks that the previous token is an open tag and the following
      * token is not a class, a interface, final, abstract or a function.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isFileComment()
     {
@@ -7237,7 +7538,7 @@ abstract class AbstractPHPParser
      *
      * @param string $comment A doc comment text.
      *
-     * @return string|null
+     * @return null|string
      */
     private function parseReturnAnnotation($comment)
     {
@@ -7262,7 +7563,8 @@ abstract class AbstractPHPParser
      * This method parses the given doc comment text for a var annotation and
      * it returns the found property types.
      *
-     * @param  string $comment A doc comment text.
+     * @param string $comment A doc comment text.
+     *
      * @return array<string>
      */
     private function parseVarAnnotation($comment)
@@ -7286,7 +7588,8 @@ abstract class AbstractPHPParser
      * doc comment information. The returned value will be <b>null</b> when no
      * type information exists.
      *
-     * @return \PDepend\Source\AST\ASTType|null
+     * @return null|\PDepend\Source\AST\ASTType
+     *
      * @since 0.9.6
      */
     private function parseFieldDeclarationType()
@@ -7323,7 +7626,8 @@ abstract class AbstractPHPParser
      * Extracts non scalar types from a field doc comment and creates a
      * matching type instance.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference|null
+     * @return null|\PDepend\Source\AST\ASTClassOrInterfaceReference
+     *
      * @since 0.9.6
      */
     private function parseFieldDeclarationClassOrInterfaceReference()
@@ -7381,7 +7685,6 @@ abstract class AbstractPHPParser
      * Extracts documented <b>throws</b> and <b>return</b> types and sets them
      * to the given <b>$callable</b> instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTCallable $callable
      * @return void
      */
     private function prepareCallable(AbstractASTCallable $callable)
@@ -7421,10 +7724,12 @@ abstract class AbstractPHPParser
      * throw an exception if the type of this token is not identical with
      * <b>$tokenType</b>.
      *
-     * @param  integer $tokenType The next expected token type.
-     * @return \PDepend\Source\Tokenizer\Token
+     * @param int $tokenType The next expected token type.
+     *
      * @throws \PDepend\Source\Parser\TokenStreamEndException
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\Tokenizer\Token
      */
     protected function consumeToken($tokenType)
     {
@@ -7462,7 +7767,6 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param Token|null $token
      * @return UnexpectedTokenException
      */
     protected function getUnexpectedTokenException(Token $token = null)
@@ -7476,9 +7780,10 @@ abstract class AbstractPHPParser
     /**
      * Throws an UnexpectedTokenException
      *
-     * @param \PDepend\Source\Tokenizer\Token|null $token
-     * @return never
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return never
+     *
      * @since 2.2.5
      * @deprecated 3.0.0 Use throw $this->getUnexpectedTokenException($token) instead
      */
@@ -7501,8 +7806,9 @@ abstract class AbstractPHPParser
      *  $value = $nullableValue ?? throw new InvalidArgumentException();
      *  $value = $falsableValue ?: throw new InvalidArgumentException();
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTThrowStatement
      */
     protected function parseThrowExpression()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -44,20 +44,119 @@ namespace PDepend\Source\Language\PHP;
 
 use BadMethodCallException;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\AbstractASTType;
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTAnonymousClass;
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTArrayIndexExpression;
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTBooleanAndExpression;
+use PDepend\Source\AST\ASTBooleanOrExpression;
+use PDepend\Source\AST\ASTBreakStatement;
+use PDepend\Source\AST\ASTCastExpression;
+use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassFqnPostfix;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTClassReference;
+use PDepend\Source\AST\ASTCloneExpression;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTComment;
 use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTCompoundExpression;
+use PDepend\Source\AST\ASTCompoundVariable;
+use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTConstantPostfix;
+use PDepend\Source\AST\ASTContinueStatement;
+use PDepend\Source\AST\ASTDeclareStatement;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTEchoStatement;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTEvalExpression;
+use PDepend\Source\AST\ASTExitExpression;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTFinallyStatement;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForInit;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTForStatement;
+use PDepend\Source\AST\ASTForUpdate;
 use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTGlobalStatement;
+use PDepend\Source\AST\ASTGotoStatement;
+use PDepend\Source\AST\ASTHeredoc;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTIfStatement;
+use PDepend\Source\AST\ASTIncludeExpression;
+use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTIssetExpression;
+use PDepend\Source\AST\ASTLabelStatement;
+use PDepend\Source\AST\ASTListExpression;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTLogicalAndExpression;
+use PDepend\Source\AST\ASTLogicalOrExpression;
+use PDepend\Source\AST\ASTLogicalXorExpression;
+use PDepend\Source\AST\ASTMatchArgument;
+use PDepend\Source\AST\ASTMatchBlock;
+use PDepend\Source\AST\ASTMatchEntry;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTPostfixExpression;
+use PDepend\Source\AST\ASTPreDecrementExpression;
+use PDepend\Source\AST\ASTPreIncrementExpression;
+use PDepend\Source\AST\ASTPrintExpression;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTRequireExpression;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTScope;
+use PDepend\Source\AST\ASTScopeStatement;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTShiftLeftExpression;
+use PDepend\Source\AST\ASTShiftRightExpression;
+use PDepend\Source\AST\ASTStatement;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTStaticVariableDeclaration;
+use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTStringIndexExpression;
+use PDepend\Source\AST\ASTSwitchLabel;
+use PDepend\Source\AST\ASTSwitchStatement;
+use PDepend\Source\AST\ASTThrowStatement;
 use PDepend\Source\AST\ASTTrait;
+use PDepend\Source\AST\ASTTraitAdaptation;
+use PDepend\Source\AST\ASTTraitAdaptationAlias;
+use PDepend\Source\AST\ASTTraitAdaptationPrecedence;
+use PDepend\Source\AST\ASTTraitReference;
+use PDepend\Source\AST\ASTTraitUseStatement;
+use PDepend\Source\AST\ASTTryStatement;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\AST\ASTTypeIterable;
+use PDepend\Source\AST\ASTUnaryExpression;
+use PDepend\Source\AST\ASTUnionType;
+use PDepend\Source\AST\ASTUnsetStatement;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\AST\ASTVariableVariable;
+use PDepend\Source\AST\ASTWhileStatement;
+use PDepend\Source\AST\ASTYieldStatement;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Log;
@@ -70,14 +169,14 @@ use ReturnTypeWillChange;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @implements Builder<\PDepend\Source\AST\ASTNamespace>
+ * @implements Builder<ASTNamespace>
  */
 class PHPBuilder implements Builder
 {
     /**
      * The internal used cache instance.
      *
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      *
      * @since 0.10.0
      */
@@ -86,7 +185,7 @@ class PHPBuilder implements Builder
     /**
      * The ast builder context.
      *
-     * @var \PDepend\Source\Builder\BuilderContext
+     * @var BuilderContext
      *
      * @since 0.10.0
      */
@@ -95,7 +194,7 @@ class PHPBuilder implements Builder
     /**
      * This property holds all packages found during the parsing phase.
      *
-     * @var \PDepend\Source\AST\ASTNamespace[]
+     * @var ASTNamespace[]
      *
      * @since 0.9.12
      */
@@ -105,7 +204,7 @@ class PHPBuilder implements Builder
      * Default package which contains all functions and classes with an unknown
      * scope.
      *
-     * @var \PDepend\Source\AST\ASTNamespace
+     * @var ASTNamespace
      */
     protected $defaultPackage = null;
 
@@ -117,30 +216,30 @@ class PHPBuilder implements Builder
     protected $defaultCompilationUnit = null;
 
     /**
-     * All generated {@link \PDepend\Source\AST\ASTTrait} objects
+     * All generated {@link ASTTrait} objects
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTTrait>>>
+     * @var array<string, array<string, array<int, ASTTrait>>>
      */
     private $traits = array();
 
     /**
-     * All generated {@link \PDepend\Source\AST\ASTClass} objects
+     * All generated {@link ASTClass} objects
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTClass>>>
+     * @var array<string, array<string, array<int, ASTClass>>>
      */
     private $classes = array();
 
     /**
-     * All generated {@link \PDepend\Source\AST\ASTInterface} instances.
+     * All generated {@link ASTInterface} instances.
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTInterface>>>
+     * @var array<string, array<string, array<int, ASTInterface>>>
      */
     private $interfaces = array();
 
     /**
-     * All generated {@link \PDepend\Source\AST\ASTNamespace} objects
+     * All generated {@link ASTNamespace} objects
      *
-     * @var \PDepend\Source\AST\ASTNamespace[]
+     * @var ASTNamespace[]
      */
     private $namespaces = array();
 
@@ -161,21 +260,21 @@ class PHPBuilder implements Builder
     /**
      * Cache of all traits created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTTrait>>>
+     * @var array<string, array<string, array<int, ASTTrait>>>
      */
     private $frozenTraits = array();
 
     /**
      * Cache of all classes created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTClass>>>
+     * @var array<string, array<string, array<int, ASTClass>>>
      */
     private $frozenClasses = array();
 
     /**
      * Cache of all interfaces created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, \PDepend\Source\AST\ASTInterface>>>
+     * @var array<string, array<string, array<int, ASTInterface>>>
      */
     private $frozenInterfaces = array();
 
@@ -220,7 +319,7 @@ class PHPBuilder implements Builder
 
         // Debug method creation
         Log::debug(
-            'Creating: \PDepend\Source\AST\ASTClassOrInterfaceReference(' .
+            'Creating: \\PDepend\\Source\\AST\\ASTClassOrInterfaceReference(' .
             $qualifiedName .
             ')'
         );
@@ -234,7 +333,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName  The qualified name of the referenced type.
      * @param bool   $classReference true if class reference only.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      *
      * @since  0.9.5
      */
@@ -249,12 +348,12 @@ class PHPBuilder implements Builder
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
+     * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      *
      * @since  0.9.5
      */
@@ -277,7 +376,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The full qualified trait name.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since 1.0.0
      */
@@ -295,12 +394,12 @@ class PHPBuilder implements Builder
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTTrait}
+     * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  1.0.0
      */
@@ -318,7 +417,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The full qualified trait name.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      *
      * @since  1.0.0
      */
@@ -327,10 +426,10 @@ class PHPBuilder implements Builder
         $this->checkBuilderState();
 
         Log::debug(
-            'Creating: \PDepend\Source\AST\ASTTraitReference(' . $qualifiedName . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTTraitReference(' . $qualifiedName . ')'
         );
 
-        return new \PDepend\Source\AST\ASTTraitReference($this->context, $qualifiedName);
+        return new ASTTraitReference($this->context, $qualifiedName);
     }
 
     /**
@@ -359,7 +458,7 @@ class PHPBuilder implements Builder
      *
      * @param string $name The class name.
      *
-     * @return \PDepend\Source\AST\ASTClass The created class object.
+     * @return ASTClass The created class object.
      */
     public function buildClass($name)
     {
@@ -375,12 +474,12 @@ class PHPBuilder implements Builder
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
+     * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      *
      * @since  0.9.5
      */
@@ -393,7 +492,7 @@ class PHPBuilder implements Builder
     /**
      * Builds an anonymous class instance.
      *
-     * @return \PDepend\Source\AST\ASTAnonymousClass
+     * @return ASTAnonymousClass
      */
     public function buildAnonymousClass()
     {
@@ -407,7 +506,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The qualified name of the referenced type.
      *
-     * @return \PDepend\Source\AST\ASTClassReference
+     * @return ASTClassReference
      *
      * @since  0.9.5
      */
@@ -417,7 +516,7 @@ class PHPBuilder implements Builder
 
         // Debug method creation
         Log::debug(
-            'Creating: \PDepend\Source\AST\ASTClassReference(' . $qualifiedName . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTClassReference(' . $qualifiedName . ')'
         );
 
         return new ASTClassReference($this->context, $qualifiedName);
@@ -455,7 +554,7 @@ class PHPBuilder implements Builder
      *
      * @param string $name The interface name.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     public function buildInterface($name)
     {
@@ -471,12 +570,12 @@ class PHPBuilder implements Builder
 
     /**
      * This method will try to find an already existing instance for the given
-     * qualified name. It will create a new {@link \PDepend\Source\AST\ASTInterface}
+     * qualified name. It will create a new {@link ASTInterface}
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      *
      * @since  0.9.5
      */
@@ -494,7 +593,7 @@ class PHPBuilder implements Builder
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     public function buildMethod($name)
     {
@@ -515,7 +614,7 @@ class PHPBuilder implements Builder
      *
      * @param string $name The package name.
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function buildNamespace($name)
     {
@@ -556,17 +655,17 @@ class PHPBuilder implements Builder
     /**
      * Builds a new self reference instance.
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      *
      * @since  0.9.6
      */
     public function buildAstSelfReference(AbstractASTClassOrInterface $type)
     {
         Log::debug(
-            'Creating: \PDepend\Source\AST\ASTSelfReference(' . $type->getName() . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getName() . ')'
         );
 
-        return new \PDepend\Source\AST\ASTSelfReference($this->context, $type);
+        return new ASTSelfReference($this->context, $type);
     }
 
     /**
@@ -581,7 +680,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstParentReference(ASTClassOrInterfaceReference $reference)
     {
-        Log::debug('Creating: \PDepend\Source\AST\ASTParentReference()');
+        Log::debug('Creating: \\PDepend\\Source\\AST\\ASTParentReference()');
 
         return new ASTParentReference($reference);
     }
@@ -589,21 +688,21 @@ class PHPBuilder implements Builder
     /**
      * Builds a new static reference instance.
      *
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      *
      * @since  0.9.6
      */
     public function buildAstStaticReference(AbstractASTClassOrInterface $owner)
     {
-        Log::debug('Creating: \PDepend\Source\AST\ASTStaticReference()');
+        Log::debug('Creating: \\PDepend\\Source\\AST\\ASTStaticReference()');
 
-        return new \PDepend\Source\AST\ASTStaticReference($this->context, $owner);
+        return new ASTStaticReference($this->context, $owner);
     }
 
     /**
      * Builds a new field declaration node.
      *
-     * @return \PDepend\Source\AST\ASTFieldDeclaration
+     * @return ASTFieldDeclaration
      *
      * @since  0.9.6
      */
@@ -617,7 +716,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the variable declarator.
      *
-     * @return \PDepend\Source\AST\ASTVariableDeclarator
+     * @return ASTVariableDeclarator
      *
      * @since  0.9.6
      */
@@ -631,7 +730,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the statuc declaration.
      *
-     * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     * @return ASTStaticVariableDeclaration
      *
      * @since  0.9.6
      */
@@ -645,7 +744,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the constant.
      *
-     * @return \PDepend\Source\AST\ASTConstant
+     * @return ASTConstant
      *
      * @since  0.9.6
      */
@@ -659,7 +758,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the variable.
      *
-     * @return \PDepend\Source\AST\ASTVariable
+     * @return ASTVariable
      *
      * @since  0.9.6
      */
@@ -673,7 +772,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the variable variable.
      *
-     * @return \PDepend\Source\AST\ASTVariableVariable
+     * @return ASTVariableVariable
      *
      * @since  0.9.6
      */
@@ -687,7 +786,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the compound variable.
      *
-     * @return \PDepend\Source\AST\ASTCompoundVariable
+     * @return ASTCompoundVariable
      *
      * @since  0.9.6
      */
@@ -699,7 +798,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new compound expression node.
      *
-     * @return \PDepend\Source\AST\ASTCompoundExpression
+     * @return ASTCompoundExpression
      *
      * @since  0.9.6
      */
@@ -711,7 +810,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new closure node.
      *
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      *
      * @since  0.9.12
      */
@@ -723,7 +822,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new formal parameters node.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameters
+     * @return ASTFormalParameters
      *
      * @since  0.9.6
      */
@@ -735,7 +834,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new formal parameter node.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since  0.9.6
      */
@@ -749,7 +848,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      *
      * @since 0.9.8
      */
@@ -763,7 +862,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The assignment operator.
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
      *
      * @since  0.9.8
      */
@@ -777,7 +876,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTAllocationExpression
+     * @return ASTAllocationExpression
      *
      * @since  0.9.6
      */
@@ -791,7 +890,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTEvalExpression
+     * @return ASTEvalExpression
      *
      * @since  0.9.12
      */
@@ -805,7 +904,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
      *
      * @since  0.9.12
      */
@@ -819,7 +918,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTCloneExpression
+     * @return ASTCloneExpression
      *
      * @since  0.9.12
      */
@@ -833,7 +932,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
      *
      * @since  0.9.12
      */
@@ -845,7 +944,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new include- or include_once-expression.
      *
-     * @return \PDepend\Source\AST\ASTIncludeExpression
+     * @return ASTIncludeExpression
      *
      * @since  0.9.12
      */
@@ -857,7 +956,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new require- or require_once-expression.
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
      *
      * @since  0.9.12
      */
@@ -869,7 +968,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array-expression node.
      *
-     * @return \PDepend\Source\AST\ASTArrayIndexExpression
+     * @return ASTArrayIndexExpression
      *
      * @since  0.9.12
      */
@@ -887,7 +986,7 @@ class PHPBuilder implements Builder
      * //     --------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
      *
      * @since  0.9.12
      */
@@ -899,7 +998,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new php array node.
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since  1.0.0
      */
@@ -911,7 +1010,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array element node.
      *
-     * @return \PDepend\Source\AST\ASTArrayElement
+     * @return ASTArrayElement
      *
      * @since  1.0.0
      */
@@ -926,7 +1025,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     * @return ASTInstanceOfExpression
      *
      * @since  0.9.6
      */
@@ -950,7 +1049,7 @@ class PHPBuilder implements Builder
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTIssetExpression
+     * @return ASTIssetExpression
      *
      * @since  0.9.12
      */
@@ -968,7 +1067,7 @@ class PHPBuilder implements Builder
      *         --------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTConditionalExpression
+     * @return ASTConditionalExpression
      *
      * @since  0.9.8
      */
@@ -986,7 +1085,7 @@ class PHPBuilder implements Builder
      * -------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTPrintExpression
+     * @return ASTPrintExpression
      *
      * @since 2.3
      */
@@ -998,7 +1097,7 @@ class PHPBuilder implements Builder
     /**
      * Build a new shift left expression.
      *
-     * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     * @return ASTShiftLeftExpression
      *
      * @since  1.0.1
      */
@@ -1010,7 +1109,7 @@ class PHPBuilder implements Builder
     /**
      * Build a new shift right expression.
      *
-     * @return \PDepend\Source\AST\ASTShiftRightExpression
+     * @return ASTShiftRightExpression
      *
      * @since  1.0.1
      */
@@ -1022,7 +1121,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new boolean and-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     * @return ASTBooleanAndExpression
      *
      * @since  0.9.8
      */
@@ -1034,7 +1133,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new boolean or-expression.
      *
-     * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     * @return ASTBooleanOrExpression
      *
      * @since  0.9.8
      */
@@ -1046,7 +1145,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>and</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     * @return ASTLogicalAndExpression
      *
      * @since  0.9.8
      */
@@ -1058,7 +1157,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>or</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     * @return ASTLogicalOrExpression
      *
      * @since  0.9.8
      */
@@ -1070,7 +1169,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>xor</b>-expression.
      *
-     * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     * @return ASTLogicalXorExpression
      *
      * @since  0.9.8
      */
@@ -1082,7 +1181,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new trait use-statement node.
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
      *
      * @since  1.0.0
      */
@@ -1094,7 +1193,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new trait adaptation scope
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptation
+     * @return ASTTraitAdaptation
      *
      * @since  1.0.0
      */
@@ -1108,7 +1207,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The trait method name.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     * @return ASTTraitAdaptationAlias
      *
      * @since  1.0.0
      */
@@ -1122,7 +1221,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The trait method name.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @return ASTTraitAdaptationPrecedence
      *
      * @since  1.0.0
      */
@@ -1134,7 +1233,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new switch-statement-node.
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
      *
      * @since  0.9.8
      */
@@ -1148,7 +1247,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this label.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      *
      * @since  0.9.8
      */
@@ -1160,7 +1259,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new global-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTGlobalStatement
+     * @return ASTGlobalStatement
      *
      * @since  0.9.12
      */
@@ -1172,7 +1271,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new unset-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTUnsetStatement
+     * @return ASTUnsetStatement
      *
      * @since  0.9.12
      */
@@ -1186,7 +1285,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTCatchStatement
+     * @return ASTCatchStatement
      *
      * @since  0.9.8
      */
@@ -1198,7 +1297,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new finally-statement node.
      *
-     * @return \PDepend\Source\AST\ASTFinallyStatement
+     * @return ASTFinallyStatement
      *
      * @since  2.0.0
      */
@@ -1212,7 +1311,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTIfStatement
+     * @return ASTIfStatement
      *
      * @since  0.9.8
      */
@@ -1226,7 +1325,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTElseIfStatement
+     * @return ASTElseIfStatement
      *
      * @since  0.9.8
      */
@@ -1240,7 +1339,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTForStatement
+     * @return ASTForStatement
      *
      * @since  0.9.8
      */
@@ -1258,7 +1357,7 @@ class PHPBuilder implements Builder
      *      ------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForInit
+     * @return ASTForInit
      *
      * @since  0.9.8
      */
@@ -1276,7 +1375,7 @@ class PHPBuilder implements Builder
      *                                        -------------------------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTForUpdate
+     * @return ASTForUpdate
      *
      * @since  0.9.12
      */
@@ -1290,7 +1389,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTForeachStatement
+     * @return ASTForeachStatement
      *
      * @since  0.9.8
      */
@@ -1304,7 +1403,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
      *
      * @since  0.9.8
      */
@@ -1318,7 +1417,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this statement.
      *
-     * @return \PDepend\Source\AST\ASTDoWhileStatement
+     * @return ASTDoWhileStatement
      *
      * @since  0.9.12
      */
@@ -1348,7 +1447,7 @@ class PHPBuilder implements Builder
      * -----------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTDeclareStatement
+     * @return ASTDeclareStatement
      *
      * @since  0.10.0
      */
@@ -1380,7 +1479,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image of this expression.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      *
      * @since  0.9.6
      */
@@ -1394,7 +1493,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The image of this identifier.
      *
-     * @return \PDepend\Source\AST\ASTIdentifier
+     * @return ASTIdentifier
      *
      * @since  0.9.6
      */
@@ -1418,7 +1517,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @return ASTFunctionPostfix
      *
      * @since  0.9.6
      */
@@ -1442,7 +1541,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTMethodPostfix
+     * @return ASTMethodPostfix
      *
      * @since  0.9.6
      */
@@ -1462,7 +1561,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantPostfix
+     * @return ASTConstantPostfix
      *
      * @since  0.9.6
      */
@@ -1486,7 +1585,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The image of this node.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      *
      * @since  0.9.6
      */
@@ -1508,7 +1607,7 @@ class PHPBuilder implements Builder
      * //       -----
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      *
      * @since  2.0.0
      */
@@ -1530,7 +1629,7 @@ class PHPBuilder implements Builder
      * //       ------------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      *
      * @since  0.9.6
      */
@@ -1546,7 +1645,7 @@ class PHPBuilder implements Builder
      * match($x)
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchArgument
+     * @return ASTMatchArgument
      *
      * @since  0.9.6
      */
@@ -1564,7 +1663,7 @@ class PHPBuilder implements Builder
      * }
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchBlock
+     * @return ASTMatchBlock
      *
      * @since  2.9.0
      */
@@ -1580,7 +1679,7 @@ class PHPBuilder implements Builder
      * "foo" => "bar",
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTMatchEntry
+     * @return ASTMatchEntry
      *
      * @since  2.9.0
      */
@@ -1598,7 +1697,7 @@ class PHPBuilder implements Builder
      *
      * @param string $name
      *
-     * @return \PDepend\Source\AST\ASTNamedArgument
+     * @return ASTNamedArgument
      *
      * @since  2.9.0
      */
@@ -1612,7 +1711,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array type node.
      *
-     * @return \PDepend\Source\AST\ASTTypeArray
+     * @return ASTTypeArray
      *
      * @since  0.9.6
      */
@@ -1624,7 +1723,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the callable type.
      *
-     * @return \PDepend\Source\AST\ASTTypeCallable
+     * @return ASTTypeCallable
      *
      * @since  1.0.0
      */
@@ -1636,7 +1735,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the iterable type.
      *
-     * @return \PDepend\Source\AST\ASTTypeIterable
+     * @return ASTTypeIterable
      *
      * @since  2.5.1
      */
@@ -1650,7 +1749,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the primitive type.
      *
-     * @return \PDepend\Source\AST\ASTScalarType
+     * @return ASTScalarType
      *
      * @since  0.9.6
      */
@@ -1662,7 +1761,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the union type.
      *
-     * @return \PDepend\Source\AST\ASTUnionType
+     * @return ASTUnionType
      *
      * @since  1.0.0
      */
@@ -1676,7 +1775,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source image for the literal node.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      *
      * @since  0.9.6
      */
@@ -1691,7 +1790,7 @@ class PHPBuilder implements Builder
      * <code>
      * $string = "Manuel $Pichler <{$email}>";
      *
-     * // \PDepend\Source\AST\ASTString
+     * // ASTString
      * // |-- ASTLiteral             -  "Manuel ")
      * // |-- ASTVariable            -  $Pichler
      * // |-- ASTLiteral             -  " <"
@@ -1700,7 +1799,7 @@ class PHPBuilder implements Builder
      * // |-- ASTLiteral             -  ">"
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTString
+     * @return ASTString
      *
      * @since  0.9.10
      */
@@ -1712,7 +1811,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new heredoc node.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      *
      * @since  0.9.12
      */
@@ -1735,7 +1834,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
      *
      * @since  0.9.6
      */
@@ -1777,7 +1876,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTConstantDeclarator
+     * @return ASTConstantDeclarator
      *
      * @since  0.9.6
      */
@@ -1791,7 +1890,7 @@ class PHPBuilder implements Builder
      *
      * @param string $cdata The comment text.
      *
-     * @return \PDepend\Source\AST\ASTComment
+     * @return ASTComment
      *
      * @since  0.9.8
      */
@@ -1805,7 +1904,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The unary expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      *
      * @since  0.9.11
      */
@@ -1819,7 +1918,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The cast-expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTCastExpression
+     * @return ASTCastExpression
      *
      * @since  0.10.0
      */
@@ -1833,7 +1932,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The postfix-expression image/character.
      *
-     * @return \PDepend\Source\AST\ASTPostfixExpression
+     * @return ASTPostfixExpression
      *
      * @since  0.10.0
      */
@@ -1845,7 +1944,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new pre-increment-expression node instance.
      *
-     * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     * @return ASTPreIncrementExpression
      *
      * @since  0.10.0
      */
@@ -1857,7 +1956,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new pre-decrement-expression node instance.
      *
-     * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     * @return ASTPreDecrementExpression
      *
      * @since  0.10.0
      */
@@ -1869,7 +1968,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new function/method scope instance.
      *
-     * @return \PDepend\Source\AST\ASTScope
+     * @return ASTScope
      *
      * @since  0.9.12
      */
@@ -1881,7 +1980,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new statement instance.
      *
-     * @return \PDepend\Source\AST\ASTStatement
+     * @return ASTStatement
      *
      * @since  0.9.12
      */
@@ -1895,7 +1994,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
      *
      * @since  0.9.12
      */
@@ -1909,7 +2008,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTBreakStatement
+     * @return ASTBreakStatement
      *
      * @since  0.9.12
      */
@@ -1923,7 +2022,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTContinueStatement
+     * @return ASTContinueStatement
      *
      * @since  0.9.12
      */
@@ -1935,7 +2034,7 @@ class PHPBuilder implements Builder
     /**
      * Builds a new scope-statement instance.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      *
      * @since  0.9.12
      */
@@ -1949,7 +2048,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTTryStatement
+     * @return ASTTryStatement
      *
      * @since  0.9.12
      */
@@ -1963,7 +2062,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
      *
      * @since  0.9.12
      */
@@ -1977,7 +2076,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTGotoStatement
+     * @return ASTGotoStatement
      *
      * @since  0.9.12
      */
@@ -1991,7 +2090,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTLabelStatement
+     * @return ASTLabelStatement
      *
      * @since  0.9.12
      */
@@ -2005,7 +2104,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTEchoStatement
+     * @return ASTEchoStatement
      *
      * @since  0.9.12
      */
@@ -2019,7 +2118,7 @@ class PHPBuilder implements Builder
      *
      * @param string $image The source code image for this node.
      *
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     * @return ASTYieldStatement
      *
      * @since  $version$
      */
@@ -2029,10 +2128,10 @@ class PHPBuilder implements Builder
     }
 
     /**
-     * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
+     * Returns an iterator with all generated {@link ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
+     * @return ASTArtifactList<ASTNamespace>
      */
     #[ReturnTypeWillChange]
     public function getIterator()
@@ -2041,10 +2140,10 @@ class PHPBuilder implements Builder
     }
 
     /**
-     * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
+     * Returns an iterator with all generated {@link ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function getNamespaces()
     {
@@ -2055,10 +2154,10 @@ class PHPBuilder implements Builder
     }
 
     /**
-     * Returns an iterator with all generated {@link \PDepend\Source\AST\ASTNamespace}
+     * Returns an iterator with all generated {@link ASTNamespace}
      * objects.
      *
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      *
      * @since  0.9.12
      */
@@ -2102,7 +2201,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      *
      * @since  0.9.5
      */
@@ -2127,7 +2226,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return null|\PDepend\Source\AST\ASTTrait
+     * @return null|ASTTrait
      *
      * @since  0.9.5
      */
@@ -2178,7 +2277,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      *
      * @since  0.9.5
      */
@@ -2203,7 +2302,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return null|\PDepend\Source\AST\ASTInterface
+     * @return null|ASTInterface
      *
      * @since  0.9.5
      */
@@ -2251,7 +2350,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      *
      * @since  0.9.5
      */
@@ -2276,7 +2375,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return null|\PDepend\Source\AST\ASTClass
+     * @return null|ASTClass
      *
      * @since  0.9.5
      */
@@ -2300,7 +2399,7 @@ class PHPBuilder implements Builder
      * given qualified name in all scopes already processed. It will return the
      * best matching instance or <b>null</b> if no match exists.
      *
-     * @template T of \PDepend\Source\AST\AbstractASTType
+     * @template T of AbstractASTType
      *
      * @param array<string, array<string, array<string, T>>> $instances
      * @param string                                         $qualifiedName
@@ -2368,7 +2467,7 @@ class PHPBuilder implements Builder
      * Creates a copy of the given input array, but skips all types that do not
      * contain a parent package.
      *
-     * @template T of \PDepend\Source\AST\AbstractASTType
+     * @template T of AbstractASTType
      *
      * @param array<string, array<string, array<int, T>>> $originalTypes The original types created during the parsing
      *                                                                   process.
@@ -2607,9 +2706,9 @@ class PHPBuilder implements Builder
     }
 
     /**
-     * Creates a {@link \PDepend\Source\AST\ASTNode} instance.
+     * Creates a {@link ASTNode} instance.
      *
-     * @template T of \PDepend\Source\AST\ASTNode
+     * @template T of ASTNode
      *
      * @param class-string<T> $className
      * @param string          $image

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use BadMethodCallException;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
@@ -61,6 +62,7 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Log;
 use PDepend\Util\Type;
+use ReturnTypeWillChange;
 
 /**
  * Default code tree builder implementation.
@@ -75,7 +77,8 @@ class PHPBuilder implements Builder
     /**
      * The internal used cache instance.
      *
-     * @var   \PDepend\Util\Cache\CacheDriver
+     * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -83,7 +86,8 @@ class PHPBuilder implements Builder
     /**
      * The ast builder context.
      *
-     * @var   \PDepend\Source\Builder\BuilderContext
+     * @var \PDepend\Source\Builder\BuilderContext
+     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -91,7 +95,8 @@ class PHPBuilder implements Builder
     /**
      * This property holds all packages found during the parsing phase.
      *
-     * @var   \PDepend\Source\AST\ASTNamespace[]
+     * @var \PDepend\Source\AST\ASTNamespace[]
+     *
      * @since 0.9.12
      */
     private $preparedNamespaces = null;
@@ -142,14 +147,14 @@ class PHPBuilder implements Builder
     /**
      * Internal status flag used to check that a build request is internal.
      *
-     * @var boolean
+     * @var bool
      */
     private $internal = false;
 
     /**
      * Internal used flag that marks the parsing process as frozen.
      *
-     * @var boolean
+     * @var bool
      */
     private $frozen = false;
 
@@ -190,8 +195,8 @@ class PHPBuilder implements Builder
     /**
      * Setter method for the currently used token cache.
      *
-     * @param  \PDepend\Util\Cache\CacheDriver $cache
      * @return $this
+     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -206,6 +211,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The qualified name of the referenced type.
      *
      * @return ASTClassOrInterfaceReference
+     *
      * @since  0.9.5
      */
     public function buildAstClassOrInterfaceReference($qualifiedName)
@@ -229,6 +235,7 @@ class PHPBuilder implements Builder
      * @param bool   $classReference true if class reference only.
      *
      * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     *
      * @since  0.9.5
      */
     public function buildAstNeededReference($qualifiedName, $classReference)
@@ -245,8 +252,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTClass}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     *
      * @since  0.9.5
      */
     public function getClassOrInterface($qualifiedName)
@@ -269,6 +278,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The full qualified trait name.
      *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since 1.0.0
      */
     public function buildTrait($qualifiedName)
@@ -288,8 +298,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTTrait}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName)
@@ -307,6 +319,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The full qualified trait name.
      *
      * @return \PDepend\Source\AST\ASTTraitReference
+     *
      * @since  1.0.0
      */
     public function buildAstTraitReference($qualifiedName)
@@ -368,6 +381,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The full qualified type identifier.
      *
      * @return \PDepend\Source\AST\ASTClass
+     *
      * @since  0.9.5
      */
     public function getClass($qualifiedName)
@@ -394,6 +408,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The qualified name of the referenced type.
      *
      * @return \PDepend\Source\AST\ASTClassReference
+     *
      * @since  0.9.5
      */
     public function buildAstClassReference($qualifiedName)
@@ -438,7 +453,8 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param  string $name The interface name.
+     * @param string $name The interface name.
+     *
      * @return \PDepend\Source\AST\ASTInterface
      */
     public function buildInterface($name)
@@ -458,8 +474,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link \PDepend\Source\AST\ASTInterface}
      * instance when no matching type exists.
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTInterface
+     *
      * @since  0.9.5
      */
     public function getInterface($qualifiedName)
@@ -474,7 +492,8 @@ class PHPBuilder implements Builder
     /**
      * Builds a new method instance.
      *
-     * @param  string $name
+     * @param string $name
+     *
      * @return \PDepend\Source\AST\ASTMethod
      */
     public function buildMethod($name)
@@ -494,7 +513,8 @@ class PHPBuilder implements Builder
     /**
      * Builds a new package instance.
      *
-     * @param  string $name The package name.
+     * @param string $name The package name.
+     *
      * @return \PDepend\Source\AST\ASTNamespace
      */
     public function buildNamespace($name)
@@ -513,7 +533,8 @@ class PHPBuilder implements Builder
     /**
      * Builds a new function instance.
      *
-     * @param  string $name The function name.
+     * @param string $name The function name.
+     *
      * @return ASTFunction
      */
     public function buildFunction($name)
@@ -535,8 +556,8 @@ class PHPBuilder implements Builder
     /**
      * Builds a new self reference instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $type
      * @return \PDepend\Source\AST\ASTSelfReference
+     *
      * @since  0.9.6
      */
     public function buildAstSelfReference(AbstractASTClassOrInterface $type)
@@ -552,9 +573,10 @@ class PHPBuilder implements Builder
      * Builds a new parent reference instance.
      *
      * @param ASTClassOrInterfaceReference $reference The type
-     *        instance that reference the concrete target of parent.
+     *                                                instance that reference the concrete target of parent.
      *
      * @return ASTParentReference
+     *
      * @since  0.9.6
      */
     public function buildAstParentReference(ASTClassOrInterfaceReference $reference)
@@ -567,8 +589,8 @@ class PHPBuilder implements Builder
     /**
      * Builds a new static reference instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTClassOrInterface $owner
      * @return \PDepend\Source\AST\ASTStaticReference
+     *
      * @since  0.9.6
      */
     public function buildAstStaticReference(AbstractASTClassOrInterface $owner)
@@ -582,6 +604,7 @@ class PHPBuilder implements Builder
      * Builds a new field declaration node.
      *
      * @return \PDepend\Source\AST\ASTFieldDeclaration
+     *
      * @since  0.9.6
      */
     public function buildAstFieldDeclaration()
@@ -595,6 +618,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the variable declarator.
      *
      * @return \PDepend\Source\AST\ASTVariableDeclarator
+     *
      * @since  0.9.6
      */
     public function buildAstVariableDeclarator($image)
@@ -608,6 +632,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the statuc declaration.
      *
      * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     *
      * @since  0.9.6
      */
     public function buildAstStaticVariableDeclaration($image)
@@ -621,6 +646,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the constant.
      *
      * @return \PDepend\Source\AST\ASTConstant
+     *
      * @since  0.9.6
      */
     public function buildAstConstant($image)
@@ -634,6 +660,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the variable.
      *
      * @return \PDepend\Source\AST\ASTVariable
+     *
      * @since  0.9.6
      */
     public function buildAstVariable($image)
@@ -647,6 +674,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the variable variable.
      *
      * @return \PDepend\Source\AST\ASTVariableVariable
+     *
      * @since  0.9.6
      */
     public function buildAstVariableVariable($image)
@@ -660,6 +688,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the compound variable.
      *
      * @return \PDepend\Source\AST\ASTCompoundVariable
+     *
      * @since  0.9.6
      */
     public function buildAstCompoundVariable($image)
@@ -671,6 +700,7 @@ class PHPBuilder implements Builder
      * Builds a new compound expression node.
      *
      * @return \PDepend\Source\AST\ASTCompoundExpression
+     *
      * @since  0.9.6
      */
     public function buildAstCompoundExpression()
@@ -682,6 +712,7 @@ class PHPBuilder implements Builder
      * Builds a new closure node.
      *
      * @return \PDepend\Source\AST\ASTClosure
+     *
      * @since  0.9.12
      */
     public function buildAstClosure()
@@ -693,6 +724,7 @@ class PHPBuilder implements Builder
      * Builds a new formal parameters node.
      *
      * @return \PDepend\Source\AST\ASTFormalParameters
+     *
      * @since  0.9.6
      */
     public function buildAstFormalParameters()
@@ -704,6 +736,7 @@ class PHPBuilder implements Builder
      * Builds a new formal parameter node.
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since  0.9.6
      */
     public function buildAstFormalParameter()
@@ -715,7 +748,9 @@ class PHPBuilder implements Builder
      * Builds a new expression node.
      *
      * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTExpression
+     *
      * @since 0.9.8
      */
     public function buildAstExpression($image = null)
@@ -729,6 +764,7 @@ class PHPBuilder implements Builder
      * @param string $image The assignment operator.
      *
      * @return \PDepend\Source\AST\ASTAssignmentExpression
+     *
      * @since  0.9.8
      */
     public function buildAstAssignmentExpression($image)
@@ -742,6 +778,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTAllocationExpression
+     *
      * @since  0.9.6
      */
     public function buildAstAllocationExpression($image)
@@ -755,6 +792,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTEvalExpression
+     *
      * @since  0.9.12
      */
     public function buildAstEvalExpression($image)
@@ -768,6 +806,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTExitExpression
+     *
      * @since  0.9.12
      */
     public function buildAstExitExpression($image)
@@ -781,6 +820,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTCloneExpression
+     *
      * @since  0.9.12
      */
     public function buildAstCloneExpression($image)
@@ -794,6 +834,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTListExpression
+     *
      * @since  0.9.12
      */
     public function buildAstListExpression($image)
@@ -805,6 +846,7 @@ class PHPBuilder implements Builder
      * Builds a new include- or include_once-expression.
      *
      * @return \PDepend\Source\AST\ASTIncludeExpression
+     *
      * @since  0.9.12
      */
     public function buildAstIncludeExpression()
@@ -816,6 +858,7 @@ class PHPBuilder implements Builder
      * Builds a new require- or require_once-expression.
      *
      * @return \PDepend\Source\AST\ASTRequireExpression
+     *
      * @since  0.9.12
      */
     public function buildAstRequireExpression()
@@ -827,6 +870,7 @@ class PHPBuilder implements Builder
      * Builds a new array-expression node.
      *
      * @return \PDepend\Source\AST\ASTArrayIndexExpression
+     *
      * @since  0.9.12
      */
     public function buildAstArrayIndexExpression()
@@ -844,6 +888,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTStringIndexExpression
+     *
      * @since  0.9.12
      */
     public function buildAstStringIndexExpression()
@@ -855,6 +900,7 @@ class PHPBuilder implements Builder
      * Builds a new php array node.
      *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since  1.0.0
      */
     public function buildAstArray()
@@ -866,6 +912,7 @@ class PHPBuilder implements Builder
      * Builds a new array element node.
      *
      * @return \PDepend\Source\AST\ASTArrayElement
+     *
      * @since  1.0.0
      */
     public function buildAstArrayElement()
@@ -880,6 +927,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     *
      * @since  0.9.6
      */
     public function buildAstInstanceOfExpression($image)
@@ -903,6 +951,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTIssetExpression
+     *
      * @since  0.9.12
      */
     public function buildAstIssetExpression()
@@ -920,6 +969,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTConditionalExpression
+     *
      * @since  0.9.8
      */
     public function buildAstConditionalExpression()
@@ -937,6 +987,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTPrintExpression
+     *
      * @since 2.3
      */
     public function buildAstPrintExpression()
@@ -948,6 +999,7 @@ class PHPBuilder implements Builder
      * Build a new shift left expression.
      *
      * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     *
      * @since  1.0.1
      */
     public function buildAstShiftLeftExpression()
@@ -959,6 +1011,7 @@ class PHPBuilder implements Builder
      * Build a new shift right expression.
      *
      * @return \PDepend\Source\AST\ASTShiftRightExpression
+     *
      * @since  1.0.1
      */
     public function buildAstShiftRightExpression()
@@ -970,6 +1023,7 @@ class PHPBuilder implements Builder
      * Builds a new boolean and-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     *
      * @since  0.9.8
      */
     public function buildAstBooleanAndExpression()
@@ -981,6 +1035,7 @@ class PHPBuilder implements Builder
      * Builds a new boolean or-expression.
      *
      * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     *
      * @since  0.9.8
      */
     public function buildAstBooleanOrExpression()
@@ -992,6 +1047,7 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>and</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalAndExpression()
@@ -1003,6 +1059,7 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>or</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalOrExpression()
@@ -1014,6 +1071,7 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>xor</b>-expression.
      *
      * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     *
      * @since  0.9.8
      */
     public function buildAstLogicalXorExpression()
@@ -1025,6 +1083,7 @@ class PHPBuilder implements Builder
      * Builds a new trait use-statement node.
      *
      * @return \PDepend\Source\AST\ASTTraitUseStatement
+     *
      * @since  1.0.0
      */
     public function buildAstTraitUseStatement()
@@ -1036,6 +1095,7 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation scope
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptation
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptation()
@@ -1049,6 +1109,7 @@ class PHPBuilder implements Builder
      * @param string $image The trait method name.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationAlias($image)
@@ -1062,6 +1123,7 @@ class PHPBuilder implements Builder
      * @param string $image The trait method name.
      *
      * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationPrecedence($image)
@@ -1073,6 +1135,7 @@ class PHPBuilder implements Builder
      * Builds a new switch-statement-node.
      *
      * @return \PDepend\Source\AST\ASTSwitchStatement
+     *
      * @since  0.9.8
      */
     public function buildAstSwitchStatement()
@@ -1086,6 +1149,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this label.
      *
      * @return \PDepend\Source\AST\ASTSwitchLabel
+     *
      * @since  0.9.8
      */
     public function buildAstSwitchLabel($image)
@@ -1097,6 +1161,7 @@ class PHPBuilder implements Builder
      * Builds a new global-statement instance.
      *
      * @return \PDepend\Source\AST\ASTGlobalStatement
+     *
      * @since  0.9.12
      */
     public function buildAstGlobalStatement()
@@ -1108,6 +1173,7 @@ class PHPBuilder implements Builder
      * Builds a new unset-statement instance.
      *
      * @return \PDepend\Source\AST\ASTUnsetStatement
+     *
      * @since  0.9.12
      */
     public function buildAstUnsetStatement()
@@ -1118,8 +1184,10 @@ class PHPBuilder implements Builder
     /**
      * Builds a new catch-statement node.
      *
-     * @param  string $image
+     * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTCatchStatement
+     *
      * @since  0.9.8
      */
     public function buildAstCatchStatement($image)
@@ -1131,6 +1199,7 @@ class PHPBuilder implements Builder
      * Builds a new finally-statement node.
      *
      * @return \PDepend\Source\AST\ASTFinallyStatement
+     *
      * @since  2.0.0
      */
     public function buildAstFinallyStatement()
@@ -1144,6 +1213,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTIfStatement
+     *
      * @since  0.9.8
      */
     public function buildAstIfStatement($image)
@@ -1157,6 +1227,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTElseIfStatement
+     *
      * @since  0.9.8
      */
     public function buildAstElseIfStatement($image)
@@ -1170,6 +1241,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTForStatement
+     *
      * @since  0.9.8
      */
     public function buildAstForStatement($image)
@@ -1187,6 +1259,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTForInit
+     *
      * @since  0.9.8
      */
     public function buildAstForInit()
@@ -1204,6 +1277,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTForUpdate
+     *
      * @since  0.9.12
      */
     public function buildAstForUpdate()
@@ -1217,6 +1291,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTForeachStatement
+     *
      * @since  0.9.8
      */
     public function buildAstForeachStatement($image)
@@ -1230,6 +1305,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTWhileStatement
+     *
      * @since  0.9.8
      */
     public function buildAstWhileStatement($image)
@@ -1243,6 +1319,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this statement.
      *
      * @return \PDepend\Source\AST\ASTDoWhileStatement
+     *
      * @since  0.9.12
      */
     public function buildAstDoWhileStatement($image)
@@ -1272,6 +1349,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTDeclareStatement
+     *
      * @since  0.10.0
      */
     public function buildAstDeclareStatement()
@@ -1303,6 +1381,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image of this expression.
      *
      * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     *
      * @since  0.9.6
      */
     public function buildAstMemberPrimaryPrefix($image)
@@ -1316,6 +1395,7 @@ class PHPBuilder implements Builder
      * @param string $image The image of this identifier.
      *
      * @return \PDepend\Source\AST\ASTIdentifier
+     *
      * @since  0.9.6
      */
     public function buildAstIdentifier($image)
@@ -1339,6 +1419,7 @@ class PHPBuilder implements Builder
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTFunctionPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstFunctionPostfix($image)
@@ -1362,6 +1443,7 @@ class PHPBuilder implements Builder
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTMethodPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstMethodPostfix($image)
@@ -1381,6 +1463,7 @@ class PHPBuilder implements Builder
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTConstantPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstConstantPostfix($image)
@@ -1404,6 +1487,7 @@ class PHPBuilder implements Builder
      * @param string $image The image of this node.
      *
      * @return \PDepend\Source\AST\ASTPropertyPostfix
+     *
      * @since  0.9.6
      */
     public function buildAstPropertyPostfix($image)
@@ -1425,6 +1509,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     *
      * @since  2.0.0
      */
     public function buildAstClassFqnPostfix()
@@ -1446,6 +1531,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTArguments
+     *
      * @since  0.9.6
      */
     public function buildAstArguments()
@@ -1461,6 +1547,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchArgument
+     *
      * @since  0.9.6
      */
     public function buildAstMatchArgument()
@@ -1478,6 +1565,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchBlock
+     *
      * @since  2.9.0
      */
     public function buildAstMatchBlock()
@@ -1493,6 +1581,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTMatchEntry
+     *
      * @since  2.9.0
      */
     public function buildAstMatchEntry()
@@ -1508,8 +1597,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $name
-     * @param ASTNode $value
+     *
      * @return \PDepend\Source\AST\ASTNamedArgument
+     *
      * @since  2.9.0
      */
     public function buildAstNamedArgument($name, ASTNode $value)
@@ -1523,6 +1613,7 @@ class PHPBuilder implements Builder
      * Builds a new array type node.
      *
      * @return \PDepend\Source\AST\ASTTypeArray
+     *
      * @since  0.9.6
      */
     public function buildAstTypeArray()
@@ -1534,6 +1625,7 @@ class PHPBuilder implements Builder
      * Builds a new node for the callable type.
      *
      * @return \PDepend\Source\AST\ASTTypeCallable
+     *
      * @since  1.0.0
      */
     public function buildAstTypeCallable()
@@ -1545,6 +1637,7 @@ class PHPBuilder implements Builder
      * Builds a new node for the iterable type.
      *
      * @return \PDepend\Source\AST\ASTTypeIterable
+     *
      * @since  2.5.1
      */
     public function buildAstTypeIterable()
@@ -1558,6 +1651,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the primitive type.
      *
      * @return \PDepend\Source\AST\ASTScalarType
+     *
      * @since  0.9.6
      */
     public function buildAstScalarType($image)
@@ -1569,6 +1663,7 @@ class PHPBuilder implements Builder
      * Builds a new node for the union type.
      *
      * @return \PDepend\Source\AST\ASTUnionType
+     *
      * @since  1.0.0
      */
     public function buildAstUnionType()
@@ -1582,6 +1677,7 @@ class PHPBuilder implements Builder
      * @param string $image The source image for the literal node.
      *
      * @return \PDepend\Source\AST\ASTLiteral
+     *
      * @since  0.9.6
      */
     public function buildAstLiteral($image)
@@ -1605,6 +1701,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return \PDepend\Source\AST\ASTString
+     *
      * @since  0.9.10
      */
     public function buildAstString()
@@ -1616,6 +1713,7 @@ class PHPBuilder implements Builder
      * Builds a new heredoc node.
      *
      * @return \PDepend\Source\AST\ASTHeredoc
+     *
      * @since  0.9.12
      */
     public function buildAstHeredoc()
@@ -1638,6 +1736,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTConstantDefinition
+     *
      * @since  0.9.6
      */
     public function buildAstConstantDefinition($image)
@@ -1679,6 +1778,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTConstantDeclarator
+     *
      * @since  0.9.6
      */
     public function buildAstConstantDeclarator($image)
@@ -1692,6 +1792,7 @@ class PHPBuilder implements Builder
      * @param string $cdata The comment text.
      *
      * @return \PDepend\Source\AST\ASTComment
+     *
      * @since  0.9.8
      */
     public function buildAstComment($cdata)
@@ -1705,6 +1806,7 @@ class PHPBuilder implements Builder
      * @param string $image The unary expression image/character.
      *
      * @return \PDepend\Source\AST\ASTUnaryExpression
+     *
      * @since  0.9.11
      */
     public function buildAstUnaryExpression($image)
@@ -1718,6 +1820,7 @@ class PHPBuilder implements Builder
      * @param string $image The cast-expression image/character.
      *
      * @return \PDepend\Source\AST\ASTCastExpression
+     *
      * @since  0.10.0
      */
     public function buildAstCastExpression($image)
@@ -1731,6 +1834,7 @@ class PHPBuilder implements Builder
      * @param string $image The postfix-expression image/character.
      *
      * @return \PDepend\Source\AST\ASTPostfixExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPostfixExpression($image)
@@ -1742,6 +1846,7 @@ class PHPBuilder implements Builder
      * Builds a new pre-increment-expression node instance.
      *
      * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPreIncrementExpression()
@@ -1753,6 +1858,7 @@ class PHPBuilder implements Builder
      * Builds a new pre-decrement-expression node instance.
      *
      * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     *
      * @since  0.10.0
      */
     public function buildAstPreDecrementExpression()
@@ -1764,6 +1870,7 @@ class PHPBuilder implements Builder
      * Builds a new function/method scope instance.
      *
      * @return \PDepend\Source\AST\ASTScope
+     *
      * @since  0.9.12
      */
     public function buildAstScope()
@@ -1775,6 +1882,7 @@ class PHPBuilder implements Builder
      * Builds a new statement instance.
      *
      * @return \PDepend\Source\AST\ASTStatement
+     *
      * @since  0.9.12
      */
     public function buildAstStatement()
@@ -1788,6 +1896,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTReturnStatement
+     *
      * @since  0.9.12
      */
     public function buildAstReturnStatement($image)
@@ -1801,6 +1910,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTBreakStatement
+     *
      * @since  0.9.12
      */
     public function buildAstBreakStatement($image)
@@ -1814,6 +1924,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTContinueStatement
+     *
      * @since  0.9.12
      */
     public function buildAstContinueStatement($image)
@@ -1825,6 +1936,7 @@ class PHPBuilder implements Builder
      * Builds a new scope-statement instance.
      *
      * @return \PDepend\Source\AST\ASTScopeStatement
+     *
      * @since  0.9.12
      */
     public function buildAstScopeStatement()
@@ -1838,6 +1950,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTTryStatement
+     *
      * @since  0.9.12
      */
     public function buildAstTryStatement($image)
@@ -1851,6 +1964,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTThrowStatement
+     *
      * @since  0.9.12
      */
     public function buildAstThrowStatement($image)
@@ -1864,6 +1978,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTGotoStatement
+     *
      * @since  0.9.12
      */
     public function buildAstGotoStatement($image)
@@ -1877,6 +1992,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTLabelStatement
+     *
      * @since  0.9.12
      */
     public function buildAstLabelStatement($image)
@@ -1890,6 +2006,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTEchoStatement
+     *
      * @since  0.9.12
      */
     public function buildAstEchoStatement($image)
@@ -1903,6 +2020,7 @@ class PHPBuilder implements Builder
      * @param string $image The source code image for this node.
      *
      * @return \PDepend\Source\AST\ASTYieldStatement
+     *
      * @since  $version$
      */
     public function buildAstYieldStatement($image)
@@ -1916,7 +2034,7 @@ class PHPBuilder implements Builder
      *
      * @return \PDepend\Source\AST\ASTArtifactList<\PDepend\Source\AST\ASTNamespace>
      */
-    #[\ReturnTypeWillChange]
+    #[ReturnTypeWillChange]
     public function getIterator()
     {
         return $this->getNamespaces();
@@ -1941,6 +2059,7 @@ class PHPBuilder implements Builder
      * objects.
      *
      * @return \PDepend\Source\AST\ASTNamespace[]
+     *
      * @since  0.9.12
      */
     private function getPreparedNamespaces()
@@ -1981,8 +2100,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTTrait
+     *
      * @since  0.9.5
      */
     protected function buildTraitInternal($qualifiedName)
@@ -2004,8 +2125,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param  string $qualifiedName
-     * @return \PDepend\Source\AST\ASTTrait|null
+     * @param string $qualifiedName
+     *
+     * @return null|\PDepend\Source\AST\ASTTrait
+     *
      * @since  0.9.5
      */
     protected function findTrait($qualifiedName)
@@ -2053,8 +2176,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTInterface
+     *
      * @since  0.9.5
      */
     protected function buildInterfaceInternal($qualifiedName)
@@ -2076,8 +2201,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param  string $qualifiedName
-     * @return \PDepend\Source\AST\ASTInterface|null
+     * @param string $qualifiedName
+     *
+     * @return null|\PDepend\Source\AST\ASTInterface
+     *
      * @since  0.9.5
      */
     protected function findInterface($qualifiedName)
@@ -2122,8 +2249,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param  string $qualifiedName
+     * @param string $qualifiedName
+     *
      * @return \PDepend\Source\AST\ASTClass
+     *
      * @since  0.9.5
      */
     protected function buildClassInternal($qualifiedName)
@@ -2145,8 +2274,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param  string $qualifiedName
-     * @return \PDepend\Source\AST\ASTClass|null
+     * @param string $qualifiedName
+     *
+     * @return null|\PDepend\Source\AST\ASTClass
+     *
      * @since  0.9.5
      */
     protected function findClass($qualifiedName)
@@ -2170,9 +2301,12 @@ class PHPBuilder implements Builder
      * best matching instance or <b>null</b> if no match exists.
      *
      * @template T of \PDepend\Source\AST\AbstractASTType
-     * @param  array<string, array<string, array<string, T>>>  $instances
-     * @param  string $qualifiedName
-     * @return T|null
+     *
+     * @param array<string, array<string, array<string, T>>> $instances
+     * @param string                                         $qualifiedName
+     *
+     * @return null|T
+     *
      * @since  0.9.5
      */
     protected function findType(array $instances, $qualifiedName)
@@ -2210,6 +2344,7 @@ class PHPBuilder implements Builder
      * runtime scope.
      *
      * @return void
+     *
      * @since  0.9.5
      */
     protected function freeze()
@@ -2236,7 +2371,7 @@ class PHPBuilder implements Builder
      * @template T of \PDepend\Source\AST\AbstractASTType
      *
      * @param array<string, array<string, array<int, T>>> $originalTypes The original types created during the parsing
-     *        process.
+     *                                                                   process.
      *
      * @return array<string, array<string, array<int, T>>>
      */
@@ -2258,8 +2393,8 @@ class PHPBuilder implements Builder
     /**
      * Restores a function within the internal type scope.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreFunction(ASTFunction $function)
@@ -2271,8 +2406,8 @@ class PHPBuilder implements Builder
     /**
      * Restores a trait within the internal type scope.
      *
-     * @param  \PDepend\Source\AST\ASTTrait $trait
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreTrait(ASTTrait $trait)
@@ -2287,8 +2422,8 @@ class PHPBuilder implements Builder
     /**
      * Restores a class within the internal type scope.
      *
-     * @param  \PDepend\Source\AST\ASTClass $class
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreClass(ASTClass $class)
@@ -2303,8 +2438,8 @@ class PHPBuilder implements Builder
     /**
      * Restores an interface within the internal type scope.
      *
-     * @param  \PDepend\Source\AST\ASTInterface $interface
      * @return void
+     *
      * @since  0.10.0
      */
     public function restoreInterface(ASTInterface $interface)
@@ -2319,10 +2454,11 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a trait instance for later reuse.
      *
-     * @param  string                       $traitName
-     * @param  string                       $namespaceName
-     * @param  \PDepend\Source\AST\ASTTrait $trait
+     * @param string $traitName
+     * @param string $namespaceName
+     *
      * @return void
+     *
      * @since 1.0.0
      */
     protected function storeTrait($traitName, $namespaceName, ASTTrait $trait)
@@ -2340,10 +2476,11 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a class instance for later reuse.
      *
-     * @param  string                       $className
-     * @param  string                       $namespaceName
-     * @param  \PDepend\Source\AST\ASTClass $class
+     * @param string $className
+     * @param string $namespaceName
+     *
      * @return void
+     *
      * @since 0.9.5
      */
     protected function storeClass($className, $namespaceName, ASTClass $class)
@@ -2361,10 +2498,11 @@ class PHPBuilder implements Builder
     /**
      * This method will persist an interface instance for later reuse.
      *
-     * @param  string                           $interfaceName
-     * @param  string                           $namespaceName
-     * @param  \PDepend\Source\AST\ASTInterface $interface
+     * @param string $interfaceName
+     * @param string $namespaceName
+     *
      * @return void
+     *
      * @since 0.9.5
      */
     protected function storeInterface($interfaceName, $namespaceName, ASTInterface $interface)
@@ -2383,15 +2521,18 @@ class PHPBuilder implements Builder
     /**
      * Checks that the parser is not frozen or a request is flagged as internal.
      *
-     * @param  boolean $internal The new internal flag value.
+     * @param bool $internal The new internal flag value.
+     *
+     * @throws BadMethodCallException
+     *
      * @return void
-     * @throws \BadMethodCallException
+     *
      * @since  0.9.5
      */
     protected function checkBuilderState($internal = false)
     {
         if ($this->frozen === true && $this->internal === false) {
-            throw new \BadMethodCallException(
+            throw new BadMethodCallException(
                 'Cannot create new nodes, when internal state is frozen.'
             );
         }
@@ -2402,8 +2543,9 @@ class PHPBuilder implements Builder
     /**
      * Returns <b>true</b> if the given package is the default package.
      *
-     * @param  string $namespaceName The package name.
-     * @return boolean
+     * @param string $namespaceName The package name.
+     *
+     * @return bool
      */
     protected function isDefault($namespaceName)
     {
@@ -2452,7 +2594,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The qualified PHP 5.3 class identifier.
      *
-     * @return string|null
+     * @return null|string
      */
     protected function extractNamespaceName($qualifiedName)
     {
@@ -2468,9 +2610,12 @@ class PHPBuilder implements Builder
      * Creates a {@link \PDepend\Source\AST\ASTNode} instance.
      *
      * @template T of \PDepend\Source\AST\ASTNode
+     *
      * @param class-string<T> $className
-     * @param string $image
+     * @param string          $image
+     *
      * @return T
+     *
      * @since 0.9.12
      */
     private function buildAstNodeInstance($className, $image = null)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -115,14 +116,15 @@ class PHPParserGeneric extends PHPParserVersion81
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @param \PDepend\Source\AST\ASTValue $value
+     * @param ASTValue $value
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      *
      * @todo Handle shift left/right expressions in ASTValue
-     */ /*
+     */
+    /*
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
         switch ($this->tokenizer->peek()) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 
@@ -52,6 +53,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 class PHPParserGeneric extends PHPParserVersion81
@@ -60,8 +62,10 @@ class PHPParserGeneric extends PHPParserVersion81
      * Tests if the given token type is a reserved keyword in the supported PHP
      * version.
      *
-     * @param  integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since  1.1.1
      */
     protected function isKeyword($tokenType)
@@ -78,8 +82,10 @@ class PHPParserGeneric extends PHPParserVersion81
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -110,8 +116,11 @@ class PHPParserGeneric extends PHPParserVersion81
      * Parses additional static values that are valid in the supported php version.
      *
      * @param \PDepend\Source\AST\ASTValue $value
-     * @return \PDepend\Source\AST\ASTValue
+     *
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTValue
+     *
      * @todo Handle shift left/right expressions in ASTValue
      */ /*
     protected function parseStaticValueVersionSpecific(ASTValue $value)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
@@ -81,7 +81,7 @@ abstract class PHPParserVersion53 extends AbstractPHPParser
      *
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since 1.0.0
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -52,6 +53,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 abstract class PHPParserVersion53 extends AbstractPHPParser
@@ -61,7 +63,8 @@ abstract class PHPParserVersion53 extends AbstractPHPParser
      * Tests if the next token is a valid array start delimiter in the supported
      * PHP version.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 1.0.0
      */
     protected function isArrayStartDelimiter()
@@ -76,9 +79,10 @@ abstract class PHPParserVersion53 extends AbstractPHPParser
     /**
      * Parses a php array declaration.
      *
-     * @param \PDepend\Source\AST\ASTArray $array
-     * @param boolean $static
+     * @param bool $static
+     *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since 1.0.0
      */
     protected function parseArray(ASTArray $array, $static = false)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -45,6 +45,8 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -210,7 +212,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      *
      * @param bool $static
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      *
      * @since 1.0.0
      */
@@ -233,9 +235,9 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     /**
      * Parses an integer value.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      */
     protected function parseIntegerNumber()
     {
@@ -277,7 +279,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     /**
      * Parses the class expr syntax supported since PHP 5.4.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.3
      */
@@ -295,7 +297,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function parseOptionalExpressionForVersion()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -57,6 +58,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 abstract class PHPParserVersion54 extends PHPParserVersion53
@@ -65,8 +67,10 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
      * name part.
      *
-     * @param  integer $tokenType The type of a parsed token.
-     * @return boolean
+     * @param int $tokenType The type of a parsed token.
+     *
+     * @return bool
+     *
      * @since  0.10.6
      */
     protected function isClassName($tokenType)
@@ -84,8 +88,9 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     }
 
     /**
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
      */
     protected function isConstantName($tokenType)
     {
@@ -93,7 +98,8 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     }
 
     /**
-     * @param integer $tokenType
+     * @param int $tokenType
+     *
      * @return bool
      */
     protected function isMethodName($tokenType)
@@ -105,8 +111,10 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -127,8 +135,9 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Tests if the given token type is a reserved keyword in the supported PHP
      * version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
      */
     protected function isKeyword($tokenType)
     {
@@ -147,8 +156,10 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Tests if the given token type is a valid type hint in the supported
      * PHP version.
      *
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
+     *
      * @since 1.0.0
      */
     protected function isTypeHint($tokenType)
@@ -179,7 +190,8 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Tests if the next token is a valid array start delimiter in the supported
      * PHP version.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 1.0.0
      */
     protected function isArrayStartDelimiter()
@@ -196,9 +208,10 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     /**
      * Parses a php array declaration.
      *
-     * @param \PDepend\Source\AST\ASTArray $array
-     * @param boolean $static
+     * @param bool $static
+     *
      * @return \PDepend\Source\AST\ASTArray
+     *
      * @since 1.0.0
      */
     protected function parseArray(ASTArray $array, $static = false)
@@ -220,8 +233,9 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
     /**
      * Parses an integer value.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTLiteral
      */
     protected function parseIntegerNumber()
     {
@@ -264,6 +278,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
      * Parses the class expr syntax supported since PHP 5.4.
      *
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.3
      */
     protected function parsePostfixIdentifier()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\ASTClassFqnPostfix;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -61,7 +62,7 @@ abstract class PHPParserVersion55 extends PHPParserVersion54
      *
      * parseFullQualifiedClassNamePostfix() exists since 2.0.0 and have been customized for PHP 5.5 since 2.6.0.
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      *
      * @since 2.0.0
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion55.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -50,6 +51,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 abstract class PHPParserVersion55 extends PHPParserVersion54
@@ -60,6 +62,7 @@ abstract class PHPParserVersion55 extends PHPParserVersion54
      * parseFullQualifiedClassNamePostfix() exists since 2.0.0 and have been customized for PHP 5.5 since 2.6.0.
      *
      * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     *
      * @since 2.0.0
      */
     protected function parseFullQualifiedClassNamePostfix()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -56,6 +57,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 abstract class PHPParserVersion56 extends PHPParserVersion55
@@ -63,9 +65,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @param  \PDepend\Source\AST\ASTValue $value
-     * @return \PDepend\Source\AST\ASTValue|null
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return null|\PDepend\Source\AST\ASTValue
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
@@ -288,8 +290,10 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.2
      */
     protected function parseOptionalExpressionForVersion()
@@ -303,7 +307,8 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     /**
      * In this method we implement parsing of PHP 5.6 specific expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode|null
+     * @return null|\PDepend\Source\AST\ASTNode
+     *
      * @since 2.3
      */
     protected function parseExpressionVersion56()
@@ -338,7 +343,6 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTArguments $arguments
      * @return \PDepend\Source\AST\ASTArguments
      */
     protected function parseArgumentList(ASTArguments $arguments)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -46,6 +46,8 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTNamedArgument;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\FullTokenizer;
@@ -65,9 +67,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return null|\PDepend\Source\AST\ASTValue
+     * @return null|ASTValue
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
@@ -290,9 +292,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.2
      */
@@ -307,7 +309,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     /**
      * In this method we implement parsing of PHP 5.6 specific expressions.
      *
-     * @return null|\PDepend\Source\AST\ASTNode
+     * @return null|ASTNode
      *
      * @since 2.3
      */
@@ -335,7 +337,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     }
 
     /**
-     * @return ASTConstant|\PDepend\Source\AST\ASTNamedArgument
+     * @return ASTConstant|ASTNamedArgument
      */
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {
@@ -343,7 +345,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      */
     protected function parseArgumentList(ASTArguments $arguments)
     {
@@ -377,7 +379,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
      * Parses the value of a php constant. By default this can be only static
      * values that were allowed in the oldest supported PHP version.
      *
-     * @return \PDepend\Source\AST\ASTValue
+     * @return ASTValue
      */
     protected function parseConstantDeclaratorValue()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -53,13 +54,15 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 abstract class PHPParserVersion70 extends PHPParserVersion56
 {
     /**
-     * @param integer $tokenType
-     * @return boolean
+     * @param int $tokenType
+     *
+     * @return bool
      */
     protected function isConstantName($tokenType)
     {
@@ -138,7 +141,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @param integer $tokenType
+     * @param int $tokenType
+     *
      * @return bool
      */
     protected function isMethodName($tokenType)
@@ -152,7 +156,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @param integer $tokenType
+     * @param int $tokenType
+     *
      * @return bool
      */
     protected function isTypeHint($tokenType)
@@ -281,7 +286,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * Tests if the given image is a PHP 7 type hint.
      *
      * @param string $image
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
     {
@@ -303,7 +309,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * Parses a scalar type hint or a callable type hint.
      *
      * @param string $image
-     * @return \PDepend\Source\AST\ASTType|false
+     *
+     * @return false|\PDepend\Source\AST\ASTType
      */
     protected function parseScalarOrCallableTypeHint($image)
     {
@@ -326,8 +333,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * Parse the type reference used in an allocation expression.
      *
-     * @param \PDepend\Source\AST\ASTAllocationExpression $allocation
      * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.3
      */
     protected function parseAllocationExpressionTypeReference(ASTAllocationExpression $allocation)
@@ -340,6 +347,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * Attempts to the next sequence of tokens as an anonymous class and adds it to the allocation expression
      *
      * @template T of \PDepend\Source\AST\ASTAllocationExpression
+     *
      * @param T $allocation
      *
      * @return null|T
@@ -438,8 +446,10 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode
      * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     *
+     * @return \PDepend\Source\AST\ASTNode
+     *
      * @since 2.3
      */
     protected function parseOptionalExpressionForVersion()
@@ -451,7 +461,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * In this method we implement parsing of PHP 7.0 specific expressions.
      *
-     * @return \PDepend\Source\AST\ASTNode|null
+     * @return null|\PDepend\Source\AST\ASTNode
+     *
      * @since 2.3
      */
     protected function parseExpressionVersion70()
@@ -489,6 +500,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * </code>
      *
      * @return \PDepend\Source\AST\ASTFormalParameter
+     *
      * @since 2.0.7
      */
     protected function parseFormalParameter()
@@ -509,6 +521,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
 
     /**
      * @param array<string> $fragments
+     *
      * @return void
      */
     protected function parseUseDeclarationForVersion(array $fragments)
@@ -524,6 +537,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
 
     /**
      * @param array<string> $fragments
+     *
      * @return void
      */
     protected function parseUseDeclarationVersion70(array $fragments)
@@ -575,7 +589,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
 
     /**
      * @param array<string> $previousElements
-     * @return string|null
+     *
+     * @return null|string
      */
     protected function parseQualifiedNameElement(array $previousElements)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -46,7 +46,10 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -172,7 +175,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function parsePostfixIdentifier()
     {
@@ -204,7 +207,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     protected function parseEndReturnTypeHint()
     {
@@ -221,7 +224,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     protected function parseReturnTypeHint()
     {
@@ -257,7 +260,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * Parses any expression that is surrounded by an opening and a closing
      * parenthesis
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      */
     protected function parseParenthesisExpression()
     {
@@ -310,7 +313,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      *
      * @param string $image
      *
-     * @return false|\PDepend\Source\AST\ASTType
+     * @return ASTType|false
      */
     protected function parseScalarOrCallableTypeHint($image)
     {
@@ -333,7 +336,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * Parse the type reference used in an allocation expression.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.3
      */
@@ -346,7 +349,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * Attempts to the next sequence of tokens as an anonymous class and adds it to the allocation expression
      *
-     * @template T of \PDepend\Source\AST\ASTAllocationExpression
+     * @template T of ASTAllocationExpression
      *
      * @param T $allocation
      *
@@ -446,9 +449,9 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @throws \PDepend\Source\Parser\UnexpectedTokenException
+     * @throws UnexpectedTokenException
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      *
      * @since 2.3
      */
@@ -461,7 +464,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * In this method we implement parsing of PHP 7.0 specific expressions.
      *
-     * @return null|\PDepend\Source\AST\ASTNode
+     * @return null|ASTNode
      *
      * @since 2.3
      */
@@ -499,7 +502,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
      * //               --  -------
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      *
      * @since 2.0.7
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -45,7 +45,9 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\InvalidStateException;
 use PDepend\Source\Tokenizer\Tokens;
@@ -85,7 +87,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     protected function parseReturnTypeHint()
     {
@@ -112,7 +114,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * //                ---
      * </code>
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      */
     protected function parseFormalParameterOrTypeHintOrByReference()
     {
@@ -165,7 +167,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     protected function parseScalarOrCallableTypeHint($image)
     {
@@ -182,7 +184,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
     /**
      * This method parses class references in catch statement.
      *
-     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @param ASTCatchStatement $stmt The owning catch statement.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -47,7 +48,6 @@ use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\InvalidStateException;
-use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -55,6 +55,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.4
  */
 abstract class PHPParserVersion71 extends PHPParserVersion70
@@ -73,7 +74,9 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
      * @param int $tokenType
+     *
      * @return bool
+     *
      * @since 2.6.0
      */
     protected function isListUnpacking($tokenType = null)
@@ -143,7 +146,8 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * Tests if the given image is a PHP 7 type hint.
      *
      * @param string $image
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
     {
@@ -160,6 +164,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * Parses a scalar type hint or a callable type hint.
      *
      * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTType
      */
     protected function parseScalarOrCallableTypeHint($image)
@@ -178,6 +183,7 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
      * This method parses class references in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     *
      * @return void
      */
     protected function parseCatchExceptionClass(ASTCatchStatement $stmt)
@@ -214,9 +220,10 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
     }
 
     /**
-     * @param integer $tokenType
-     * @param integer $modifiers
-     * @return integer
+     * @param int $tokenType
+     * @param int $modifiers
+     *
+     * @return int
      */
     private function getModifiersForConstantDefinition($tokenType, $modifiers)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\Language\PHP;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.4
  */
 abstract class PHPParserVersion72 extends PHPParserVersion71

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\Language\PHP;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.4
  */
 abstract class PHPParserVersion73 extends PHPParserVersion72

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\ASTClosure;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\Parser\UnexpectedTokenException;
@@ -106,7 +107,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      */
     protected function parseLambdaFunctionDeclaration()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -53,6 +54,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.4
  */
 abstract class PHPParserVersion74 extends PHPParserVersion73
@@ -131,6 +133,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
     /**
      * Override PHP 7.3 checkEllipsisInExpressionSupport to stop throwing the
      * parsing exception.
+     *
      * @return void
      */
     protected function checkEllipsisInExpressionSupport()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.3
  */
 
@@ -47,12 +48,11 @@ use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTCallable;
 use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTConstant;
-use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTIdentifier;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTScalarType;
-use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\ParserException;
 use PDepend\Source\Parser\UnexpectedTokenException;
@@ -63,6 +63,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.9
  */
 abstract class PHPParserVersion80 extends PHPParserVersion74
@@ -82,9 +83,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * Will return <b>true</b> if the given <b>$tokenType</b> is a valid class
      * name part.
      *
-     * @param integer $tokenType The type of a parsed token.
+     * @param int $tokenType The type of a parsed token.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isClassName($tokenType)
     {
@@ -127,8 +128,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return ASTNode
      * @throws UnexpectedTokenException
+     *
+     * @return ASTNode
      */
     protected function parseOptionalExpressionForVersion()
     {
@@ -370,6 +372,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * This method parses assigned variable in catch statement.
      *
      * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     *
      * @return void
      */
     protected function parseCatchVariable(ASTCatchStatement $stmt)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -371,7 +371,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     /**
      * This method parses assigned variable in catch statement.
      *
-     * @param \PDepend\Source\AST\ASTCatchStatement $stmt The owning catch statement.
+     * @param ASTCatchStatement $stmt The owning catch statement.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -78,7 +79,7 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      *
      * @param string $image
      *
-     * @return \PDepend\Source\AST\ASTType
+     * @return ASTType
      */
     protected function parseScalarOrCallableTypeHint($image)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -38,24 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.11
  */
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\Source\AST\ASTArguments;
-use PDepend\Source\AST\ASTCallable;
-use PDepend\Source\AST\ASTCatchStatement;
-use PDepend\Source\AST\ASTConstant;
-use PDepend\Source\AST\ASTIdentifier;
-use PDepend\Source\AST\ASTFormalParameter;
-use PDepend\Source\AST\ASTMethod;
-use PDepend\Source\AST\ASTNode;
-use PDepend\Source\AST\ASTScalarType;
-use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
-use PDepend\Source\Parser\ParserException;
-use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -63,6 +52,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.11
  */
 abstract class PHPParserVersion81 extends PHPParserVersion80
@@ -71,7 +61,8 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      * Tests if the given image is a PHP 8.1 type hint.
      *
      * @param string $image
-     * @return boolean
+     *
+     * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
     {
@@ -86,6 +77,7 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      * Parses a scalar type hint or a callable type hint.
      *
      * @param string $image
+     *
      * @return \PDepend\Source\AST\ASTType
      */
     protected function parseScalarOrCallableTypeHint($image)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -227,7 +227,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Mapping between php internal tokens and php depend tokens.
      *
-     * @var array<integer, integer>
+     * @var array<int, integer>
      */
     protected static $tokenMap = array(
         T_AS                        => Tokens::T_AS,
@@ -443,7 +443,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * Re-map based on the previous token
      *
-     * @var array<integer, array>
+     * @var array<int, array>
      */
     protected static $alternativeMap = array(
         Tokens::T_USE => array(
@@ -557,7 +557,7 @@ class PHPTokenizerInternal implements FullTokenizer
     );
 
     /**
-     * @var array<integer, array<integer, array<string, integer|string>>>
+     * @var array<int, array<int, array<string, integer|string>>>
      */
     protected static $reductionMap = array(
         Tokens::T_CONCAT => array(
@@ -596,7 +596,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * The source file instance.
      *
-     * @var null|\PDepend\Source\AST\ASTCompilationUnit
+     * @var null|ASTCompilationUnit
      */
     protected $sourceFile = null;
 
@@ -631,7 +631,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return null|\PDepend\Source\AST\ASTCompilationUnit
+     * @return null|ASTCompilationUnit
      */
     public function getSourceFile()
     {
@@ -684,7 +684,7 @@ class PHPTokenizerInternal implements FullTokenizer
     }
 
     /**
-     * Returns the next token or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
+     * Returns the next token or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
      * @return int|Token
@@ -701,7 +701,7 @@ class PHPTokenizerInternal implements FullTokenizer
     }
 
     /**
-     * Returns the next token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
+     * Returns the next token type or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
      * @return int
@@ -769,7 +769,7 @@ class PHPTokenizerInternal implements FullTokenizer
     }
 
     /**
-     * Returns the previous token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_BOF}
+     * Returns the previous token type or {@link Tokenizer::T_BOF}
      * if there is no previous token.
      *
      * @return int
@@ -858,9 +858,9 @@ class PHPTokenizerInternal implements FullTokenizer
      * and substitutes some of the tokens with those required by PDepend's
      * parser implementation.
      *
-     * @param array<array<integer, integer|string>|string> $tokens Unprepared array of php tokens.
+     * @param array<array<int, integer|string>|string> $tokens Unprepared array of php tokens.
      *
-     * @return array<array<integer, integer|string>|string>
+     * @return array<array<int, integer|string>|string>
      */
     private function substituteTokens(array $tokens)
     {
@@ -1076,7 +1076,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * returns the collected content. The returned value will be null if there
      * was no none php token.
      *
-     * @param array<array<integer, integer|string>|string> $tokens Reference to the current token stream.
+     * @param array<array<int, integer|string>|string> $tokens Reference to the current token stream.
      *
      * @return null|string
      */
@@ -1110,7 +1110,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * @param string $token The unknown string token.
      *
-     * @return array<integer, mixed>
+     * @return array<int, mixed>
      */
     private function generateUnknownToken($token)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -432,7 +432,6 @@ class PHPTokenizerInternal implements FullTokenizer
     );
 
     /**
-     *
      * @var array<mixed, array>
      */
     protected static $substituteTokens = array(
@@ -558,7 +557,7 @@ class PHPTokenizerInternal implements FullTokenizer
     );
 
     /**
-     * @var array<integer, array<integer, array<string, string|integer>>>
+     * @var array<integer, array<integer, array<string, integer|string>>>
      */
     protected static $reductionMap = array(
         Tokens::T_CONCAT => array(
@@ -597,42 +596,42 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * The source file instance.
      *
-     * @var \PDepend\Source\AST\ASTCompilationUnit|null
+     * @var null|\PDepend\Source\AST\ASTCompilationUnit
      */
     protected $sourceFile = null;
 
     /**
      * Count of all tokens.
      *
-     * @var integer
+     * @var int
      */
     protected $count = 0;
 
     /**
      * Internal stream pointer index.
      *
-     * @var integer
+     * @var int
      */
     protected $index = 0;
 
     /**
      * Prepared token list.
      *
-     * @var Token[]|null
+     * @var null|Token[]
      */
     protected $tokens = null;
 
     /**
      * The next free identifier for unknown string tokens.
      *
-     * @var integer
+     * @var int
      */
     private $unknownTokenID = 1000;
 
     /**
      * Returns the name of the source file.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit|null
+     * @return null|\PDepend\Source\AST\ASTCompilationUnit
      */
     public function getSourceFile()
     {
@@ -655,7 +654,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the previous token or null if there is no one yet.
      *
-     * @return Token|null
+     * @return null|Token
      */
     public function prevToken()
     {
@@ -671,7 +670,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the current token or null if there is no more.
      *
-     * @return Token|null
+     * @return null|Token
      */
     public function currentToken()
     {
@@ -688,7 +687,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the next token or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return Token|integer
+     * @return int|Token
      */
     public function next()
     {
@@ -705,7 +704,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the next token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return integer
+     * @return int
      */
     public function peek()
     {
@@ -721,8 +720,9 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the token type at the given position relatively to the current position.
      *
-     * @param integer $shift positive or negative to apply to the current index.
-     * @return integer
+     * @param int $shift positive or negative to apply to the current index.
+     *
+     * @return int
      */
     public function peekAt($shift)
     {
@@ -745,7 +745,8 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return integer|null
+     * @return null|int
+     *
      * @since  0.9.12
      */
     public function peekNext()
@@ -771,7 +772,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the previous token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_BOF}
      * if there is no previous token.
      *
-     * @return integer
+     * @return int
      */
     public function prev()
     {
@@ -819,7 +820,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Split PHP 8 T_NAME_RELATIVE token into PHP 7 compatible tokens.
      *
      * @param array<int|string> $token
-     * @param string $namespace
+     * @param string            $namespace
      *
      * @return array<array>
      */
@@ -1077,7 +1078,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * @param array<array<integer, integer|string>|string> $tokens Reference to the current token stream.
      *
-     * @return string|null
+     * @return null|string
      */
     private function consumeNonePhpTokens(array &$tokens)
     {

--- a/src/main/php/PDepend/Source/Parser/InvalidStateException.php
+++ b/src/main/php/PDepend/Source/Parser/InvalidStateException.php
@@ -54,9 +54,9 @@ class InvalidStateException extends ParserException
     /**
      * Constructs a new invalid state exception.
      *
-     * @param integer $lineNumber Line number where the parser has stopped.
-     * @param string  $fileName   The source file where this exception occurred.
-     * @param string  $reason     Short description what has happened.
+     * @param int    $lineNumber Line number where the parser has stopped.
+     * @param string $fileName   The source file where this exception occurred.
+     * @param string $reason     Short description what has happened.
      */
     public function __construct($lineNumber, $fileName, $reason)
     {

--- a/src/main/php/PDepend/Source/Parser/MissingValueException.php
+++ b/src/main/php/PDepend/Source/Parser/MissingValueException.php
@@ -56,8 +56,6 @@ class MissingValueException extends ParserException
 {
     /**
      * Constructs a new missing value exception.
-     *
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      */
     public function __construct(Tokenizer $tokenizer)
     {

--- a/src/main/php/PDepend/Source/Parser/ParserException.php
+++ b/src/main/php/PDepend/Source/Parser/ParserException.php
@@ -42,12 +42,14 @@
 
 namespace PDepend\Source\Parser;
 
+use RuntimeException;
+
 /**
  * Base class for exceptions that can occurred during the parsing process.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ParserException extends \RuntimeException
+class ParserException extends RuntimeException
 {
 }

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -60,7 +60,7 @@ class SymbolTable
     /**
      * The currently active scope.
      *
-     * @var array<string, string>|null
+     * @var null|array<string, string>
      */
     private $scope = array();
 
@@ -98,8 +98,8 @@ class SymbolTable
     /**
      * Adds a new value to the top most scope.
      *
-     * @param  string $key   The key of this scope value.
-     * @param  mixed  $value A new scope value.
+     * @param string $key   The key of this scope value.
+     * @param mixed  $value A new scope value.
      *
      * @throws NoActiveScopeException
      *
@@ -133,7 +133,7 @@ class SymbolTable
      *
      * @throws NoActiveScopeException
      *
-     * @return string|null
+     * @return null|string
      */
     public function lookup($key)
     {

--- a/src/main/php/PDepend/Source/Parser/TokenException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenException.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Source\Parser;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.10
  */
 class TokenException extends ParserException

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 
@@ -51,6 +52,7 @@ use PDepend\Source\Tokenizer\Token;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.6
  */
 class TokenStack
@@ -72,7 +74,7 @@ class TokenStack
     /**
      * The current stack offset.
      *
-     * @var integer
+     * @var int
      */
     private $offset = 0;
 
@@ -110,7 +112,8 @@ class TokenStack
     /**
      * This method will add a new token to the currently active token scope.
      *
-     * @param  \PDepend\Source\Tokenizer\Token $token The token to add.
+     * @param \PDepend\Source\Tokenizer\Token $token The token to add.
+     *
      * @return \PDepend\Source\Tokenizer\Token
      */
     public function add(Token $token)

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Parser;
 use PDepend\Source\Tokenizer\Token;
 
 /**
- * This class provides a scoped collection for {@link \PDepend\Source\Tokenizer\Token}
+ * This class provides a scoped collection for {@link Token}
  * objects.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -60,14 +60,14 @@ class TokenStack
     /**
      * The actual token scope.
      *
-     * @var \PDepend\Source\Tokenizer\Token[]
+     * @var Token[]
      */
     private $tokens = array();
 
     /**
      * Stack with token scopes.
      *
-     * @var \PDepend\Source\Tokenizer\Token[][]
+     * @var Token[][]
      */
     private $stack = array();
 
@@ -94,7 +94,7 @@ class TokenStack
      * array with all collected tokens. Additionally this method will add all
      * tokens of the removed scope onto the next token scope.
      *
-     * @return \PDepend\Source\Tokenizer\Token[]
+     * @return Token[]
      */
     public function pop()
     {
@@ -112,9 +112,9 @@ class TokenStack
     /**
      * This method will add a new token to the currently active token scope.
      *
-     * @param \PDepend\Source\Tokenizer\Token $token The token to add.
+     * @param Token $token The token to add.
      *
-     * @return \PDepend\Source\Tokenizer\Token
+     * @return Token
      */
     public function add(Token $token)
     {

--- a/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
@@ -55,8 +55,6 @@ class TokenStreamEndException extends TokenException
 {
     /**
      * Constructs a new end of token stream exception.
-     *
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      */
     public function __construct(Tokenizer $tokenizer)
     {

--- a/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
@@ -54,8 +54,9 @@ interface FullTokenizer extends Tokenizer
     /**
      * Returns the token type at the given position relatively to the current position.
      *
-     * @param integer $shift positive or negative to apply to the current index.
-     * @return integer
+     * @param int $shift positive or negative to apply to the current index.
+     *
+     * @return int
      */
     public function peekAt($shift);
 }

--- a/src/main/php/PDepend/Source/Tokenizer/Token.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Token.php
@@ -53,7 +53,7 @@ class Token
     /**
      * The token type identifier.
      *
-     * @var integer
+     * @var int
      */
     public $type = null;
 
@@ -67,40 +67,40 @@ class Token
     /**
      * The start line number for this token.
      *
-     * @var integer
+     * @var int
      */
     public $startLine = null;
 
     /**
      * The end line number for this token.
      *
-     * @var integer
+     * @var int
      */
     public $endLine = null;
 
     /**
      * The start column number for this token.
      *
-     * @var integer
+     * @var int
      */
     public $startColumn = null;
 
     /**
      * The end column number for this token.
      *
-     * @var integer
+     * @var int
      */
     public $endColumn = null;
 
     /**
      * Constructs a new source token.
      *
-     * @param integer $type        The token type identifier.
-     * @param string  $image       The token image/textual representation.
-     * @param integer $startLine   The start line number for this token.
-     * @param integer $endLine     The end line number for this token.
-     * @param integer $startColumn The start column number for this token.
-     * @param integer $endColumn   The end column number for this token.
+     * @param int    $type        The token type identifier.
+     * @param string $image       The token image/textual representation.
+     * @param int    $startLine   The start line number for this token.
+     * @param int    $endLine     The end line number for this token.
+     * @param int    $startColumn The start column number for this token.
+     * @param int    $endColumn   The end column number for this token.
      */
     public function __construct($type, $image, $startLine, $endLine, $startColumn, $endColumn)
     {

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -63,7 +63,7 @@ interface Tokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return \PDepend\Source\AST\ASTCompilationUnit|null
+     * @return null|\PDepend\Source\AST\ASTCompilationUnit
      */
     public function getSourceFile();
 
@@ -80,14 +80,15 @@ interface Tokenizer
      * Returns the next token or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return \PDepend\Source\Tokenizer\Token|integer
+     * @return int|\PDepend\Source\Tokenizer\Token
      */
     public function next();
 
     /**
      * Returns the previous token or null if there is no one yet.
      *
-     * @return \PDepend\Source\Tokenizer\Token|null
+     * @return null|\PDepend\Source\Tokenizer\Token
+     *
      * @since  2.6.0
      */
     public function prevToken();
@@ -95,7 +96,8 @@ interface Tokenizer
     /**
      * Returns the current token or null if there is no more.
      *
-     * @return \PDepend\Source\Tokenizer\Token|null
+     * @return null|\PDepend\Source\Tokenizer\Token
+     *
      * @since  2.6.0
      */
     public function currentToken();
@@ -104,7 +106,7 @@ interface Tokenizer
      * Returns the next token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return integer
+     * @return int
      */
     public function peek();
     
@@ -112,7 +114,8 @@ interface Tokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return integer
+     * @return int
+     *
      * @since  0.9.12
      */
     public function peekNext();
@@ -121,7 +124,7 @@ interface Tokenizer
      * Returns the previous token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_BOF}
      * if there is no previous token.
      *
-     * @return integer
+     * @return int
      */
     public function prev();
 }

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\Tokenizer;
 
+use PDepend\Source\AST\ASTCompilationUnit;
+
 /**
  * Base interface for all php code tokenizers.
  *
@@ -63,7 +65,7 @@ interface Tokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return null|\PDepend\Source\AST\ASTCompilationUnit
+     * @return null|ASTCompilationUnit
      */
     public function getSourceFile();
 
@@ -77,17 +79,17 @@ interface Tokenizer
     public function setSourceFile($sourceFile);
 
     /**
-     * Returns the next token or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
+     * Returns the next token or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return int|\PDepend\Source\Tokenizer\Token
+     * @return int|Token
      */
     public function next();
 
     /**
      * Returns the previous token or null if there is no one yet.
      *
-     * @return null|\PDepend\Source\Tokenizer\Token
+     * @return null|Token
      *
      * @since  2.6.0
      */
@@ -96,14 +98,14 @@ interface Tokenizer
     /**
      * Returns the current token or null if there is no more.
      *
-     * @return null|\PDepend\Source\Tokenizer\Token
+     * @return null|Token
      *
      * @since  2.6.0
      */
     public function currentToken();
 
     /**
-     * Returns the next token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_EOF} if
+     * Returns the next token type or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
      * @return int
@@ -121,7 +123,7 @@ interface Tokenizer
     public function peekNext();
 
     /**
-     * Returns the previous token type or {@link \PDepend\Source\Tokenizer\Tokenizer::T_BOF}
+     * Returns the previous token type or {@link Tokenizer::T_BOF}
      * if there is no previous token.
      *
      * @return int

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -44,6 +44,7 @@ namespace PDepend\TextUI;
 
 use Exception;
 use PDepend\Application;
+use PDepend\DbusUI\ResultPrinter as DbusResultPrinter;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
 use PDepend\Util\Workarounds;
@@ -77,19 +78,19 @@ class Command
     /**
      * The directories/files to be analyzed
      *
-     * @var array<integer, string>
+     * @var array<int, string>
      */
     private $source = array();
 
     /**
      * The used text ui runner.
      *
-     * @var \PDepend\TextUI\Runner
+     * @var Runner
      */
     private $runner = null;
 
     /**
-     * @var \PDepend\Application
+     * @var Application
      */
     private $application;
 
@@ -217,12 +218,12 @@ class Command
             unset($options['--quiet']);
         } else {
             $runSilent = false;
-            $this->runner->addProcessListener(new \PDepend\TextUI\ResultPrinter());
+            $this->runner->addProcessListener(new ResultPrinter());
         }
 
         if (isset($options['--notify-me'])) {
             $this->runner->addProcessListener(
-                new \PDepend\DbusUI\ResultPrinter()
+                new DbusResultPrinter()
             );
             unset($options['--notify-me']);
         }

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -42,10 +42,12 @@
 
 namespace PDepend\TextUI;
 
+use Exception;
 use PDepend\Application;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
 use PDepend\Util\Workarounds;
+use RuntimeException;
 
 /**
  * Handles the command line stuff and starts the text ui runner.
@@ -94,7 +96,7 @@ class Command
     /**
      * Performs the main cli process and returns the exit code.
      *
-     * @return integer
+     * @return int
      */
     public function run()
     {
@@ -105,7 +107,7 @@ class Command
                 $this->printHelp();
                 return self::CLI_ERROR;
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             echo $e->getMessage(), PHP_EOL, PHP_EOL;
 
             $this->printHelp();
@@ -147,7 +149,7 @@ class Command
         if ($configurationFile) {
             try {
                 $this->application->setConfigurationFile($configurationFile);
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 echo $e->getMessage(), PHP_EOL, PHP_EOL;
 
                 $this->printHelp();
@@ -262,7 +264,7 @@ class Command
             }
 
             return $result;
-        } catch (\RuntimeException $e) {
+        } catch (RuntimeException $e) {
             echo PHP_EOL, PHP_EOL,
                  'Critical error: ', PHP_EOL,
                  '=============== ', PHP_EOL,
@@ -277,7 +279,7 @@ class Command
     /**
      * Parses the cli arguments.
      *
-     * @return boolean
+     * @return bool
      */
     protected function parseArguments()
     {
@@ -498,7 +500,7 @@ class Command
      * Prints all available log options and returns the length of the longest
      * option.
      *
-     * @return integer
+     * @return int
      */
     protected function printLogOptions()
     {
@@ -537,9 +539,9 @@ class Command
     /**
      * Prints the analyzer options.
      *
-     * @param integer $length Length of the longest option.
+     * @param int $length Length of the longest option.
      *
-     * @return integer
+     * @return int
      */
     protected function printAnalyzerOptions($length)
     {
@@ -568,9 +570,9 @@ class Command
     /**
      * Prints a single option.
      *
-     * @param string  $option  The option identifier.
-     * @param string  $message The option help message.
-     * @param integer $length  The length of the longest option.
+     * @param string $option  The option identifier.
+     * @param string $message The option help message.
+     * @param int    $length  The length of the longest option.
      *
      * @return void
      */
@@ -600,7 +602,7 @@ class Command
      * Optionally outputs the dbus option when the required extension
      * is loaded.
      *
-     * @param integer $length Padding length for the option.
+     * @param int $length Padding length for the option.
      *
      * @return void
      */
@@ -619,7 +621,7 @@ class Command
     /**
      * Main method that starts the command line runner.
      *
-     * @return integer The exit code.
+     * @return int The exit code.
      */
     public static function main()
     {
@@ -628,7 +630,8 @@ class Command
     }
 
     /**
-     * @param integer $startTime
+     * @param int $startTime
+     *
      * @return void
      */
     private function printStatistics($startTime)

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -65,14 +65,15 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Number of processed items.
      *
-     * @var integer
+     * @var int
      */
     private $count = 0;
 
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     *
      * @return void
      */
     public function startParseProcess(Builder $builder)
@@ -85,7 +86,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param  \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     *
      * @return void
      */
     public function endParseProcess(Builder $builder)
@@ -96,7 +98,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts parsing of a new file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function startFileParsing(Tokenizer $tokenizer)
@@ -107,7 +108,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished a file.
      *
-     * @param  \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @return void
      */
     public function endFileParsing(Tokenizer $tokenizer)
@@ -154,7 +154,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts a new analyzer.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer
      * @return void
      */
     public function startAnalyzer(Analyzer $analyzer)
@@ -172,7 +171,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished one analyzing process.
      *
-     * @param  \PDepend\Metrics\Analyzer $analyzer
      * @return void
      */
     public function endAnalyzer(Analyzer $analyzer)
@@ -183,7 +181,6 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Generic notification method that is called for every node start.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $node
      * @return void
      */
     public function startVisitNode(AbstractASTArtifact $node)
@@ -194,7 +191,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Prints a single dot for the current step.
      *
-     * @param  integer $size
+     * @param int $size
+     *
      * @return void
      */
     protected function step($size = 1)
@@ -211,7 +209,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Closes the current dot line.
      *
-     * @param  integer $size
+     * @param int $size
+     *
      * @return void
      */
     protected function finish($size = 1)

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -72,7 +72,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param Builder<mixed> $builder
      *
      * @return void
      */
@@ -86,7 +86,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the file parsing process.
      *
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param Builder<mixed> $builder
      *
      * @return void
      */

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -42,12 +42,14 @@
 
 namespace PDepend\TextUI;
 
+use Exception;
 use PDepend\Engine;
 use PDepend\Input\ExcludePathFilter;
 use PDepend\Input\ExtensionFilter;
 use PDepend\ProcessListener;
 use PDepend\Report\ReportGeneratorFactory;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
+use RuntimeException;
 
 /**
  * The command line runner starts a PDepend process.
@@ -100,7 +102,7 @@ class Runner
     /**
      * Should the parse ignore doc comment annotations?
      *
-     * @var boolean
+     * @var bool
      */
     private $withoutAnnotations = false;
 
@@ -155,6 +157,7 @@ class Runner
      * NOTE: If you call this method, it will replace the default file extensions.
      *
      * @param array<string> $extensions
+     *
      * @return void
      */
     public function setFileExtensions(array $extensions)
@@ -168,6 +171,7 @@ class Runner
      * NOTE: If this method is called, it will overwrite the default settings.
      *
      * @param array<string> $excludeDirectories
+     *
      * @return void
      */
     public function setExcludeDirectories(array $excludeDirectories)
@@ -179,6 +183,7 @@ class Runner
      * Sets a list of exclude packages.
      *
      * @param array<string> $excludePackages
+     *
      * @return void
      */
     public function setExcludeNamespaces(array $excludePackages)
@@ -190,6 +195,7 @@ class Runner
      * Sets a list of source directories and files.
      *
      * @param array<string> $sourceArguments
+     *
      * @return void
      */
     public function setSourceArguments(array $sourceArguments)
@@ -212,6 +218,7 @@ class Runner
      *
      * @param string $generatorId
      * @param string $reportFile
+     *
      * @return void
      */
     public function addReportGenerator($generatorId, $reportFile)
@@ -222,8 +229,9 @@ class Runner
     /**
      * Adds a logger or analyzer option.
      *
-     * @param string $identifier
-     * @param string|array<string> $value
+     * @param string               $identifier
+     * @param array<string>|string $value
+     *
      * @return void
      */
     public function addOption($identifier, $value)
@@ -235,7 +243,6 @@ class Runner
      * Adds a process listener instance that will be hooked into PDepend's
      * analyzing process.
      *
-     * @param \PDepend\ProcessListener $processListener
      * @return void
      */
     public function addProcessListener(ProcessListener $processListener)
@@ -247,9 +254,10 @@ class Runner
      * Starts the main PDepend process and returns <b>true</b> after a successful
      * execution.
      *
-     * @return integer
-     * @throws \RuntimeException An exception with a readable error message and
-     * an exit code.
+     * @throws RuntimeException An exception with a readable error message and
+     *                          an exit code.
+     *
+     * @return int
      */
     public function run()
     {
@@ -286,12 +294,12 @@ class Runner
                     $engine->addFile($sourceArgument);
                 }
             }
-        } catch (\Exception $e) {
-            throw new \RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
         }
 
         if (count($this->loggerMap) === 0) {
-            throw new \RuntimeException('No output specified.', self::EXCEPTION_EXIT);
+            throw new RuntimeException('No output specified.', self::EXCEPTION_EXIT);
         }
 
         // To append all registered loggers.
@@ -302,8 +310,8 @@ class Runner
 
                 $engine->addReportGenerator($generator);
             }
-        } catch (\Exception $e) {
-            throw new \RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
         }
 
         foreach ($this->processListeners as $processListener) {
@@ -316,8 +324,8 @@ class Runner
             foreach ($engine->getExceptions() as $exception) {
                 $this->parseErrors[] = $exception->getMessage();
             }
-        } catch (\Exception $e) {
-            throw new \RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
+        } catch (Exception $e) {
+            throw new RuntimeException($e->getMessage(), self::EXCEPTION_EXIT);
         }
 
         return self::SUCCESS_EXIT;
@@ -327,7 +335,7 @@ class Runner
      * This method will return <b>true</b> when there were errors during the
      * parse process.
      *
-     * @return boolean
+     * @return bool
      */
     public function hasParseErrors()
     {

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -124,7 +124,7 @@ class Runner
      * This of process listeners that will be hooked into PDepend's analyzing
      * process.
      *
-     * @var \PDepend\ProcessListener[]
+     * @var ProcessListener[]
      */
     private $processListeners = array();
 
@@ -136,12 +136,12 @@ class Runner
     private $parseErrors = array();
 
     /**
-     * @var \PDepend\Report\ReportGeneratorFactory
+     * @var ReportGeneratorFactory
      */
     private $reportGeneratorFactory;
 
     /**
-     * @var \PDepend\Engine
+     * @var Engine
      */
     private $engine;
 

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -69,7 +69,7 @@ interface CacheDriver
      *
      * @param string $type
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     public function type($type);
 

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Util\Cache;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 interface CacheDriver
@@ -65,7 +67,8 @@ interface CacheDriver
      * you must invoke right before every call to <em>restore()</em> or
      * <em>store()</em>.
      *
-     * @param  string $type
+     * @param string $type
+     *
      * @return \PDepend\Util\Cache\CacheDriver
      */
     public function type($type);
@@ -77,9 +80,10 @@ interface CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  mixed  $data Any data that should be cached.
-     * @param  string $hash Optional hash that will be used for verification.
+     * @param string $key  The cache key for the given data.
+     * @param mixed  $data Any data that should be cached.
+     * @param string $hash Optional hash that will be used for verification.
+     *
      * @return void
      */
     public function store($key, $data, $hash = null);
@@ -91,9 +95,8 @@ interface CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  string $hash Optional hash that will be used for verification.
-     * @return mixed
+     * @param string $key  The cache key for the given data.
+     * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null);
 
@@ -103,7 +106,8 @@ interface CacheDriver
      * <b>$pattern</b>. If no matching entry exists, this method simply does
      * nothing.
      *
-     * @param  string $pattern The cache key pattern.
+     * @param string $pattern The cache key pattern.
+     *
      * @return void
      */
     public function remove($pattern);

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -38,11 +38,13 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
 namespace PDepend\Util\Cache;
 
+use InvalidArgumentException;
 use PDepend\Util\Cache\Driver\FileCacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 use PDepend\Util\Configuration;
@@ -52,6 +54,7 @@ use PDepend\Util\Configuration;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class CacheFactory
@@ -101,9 +104,11 @@ class CacheFactory
     /**
      * Creates a cache instance based on the supplied configuration.
      *
-     * @param  string|null $cacheKey The name/identifier for the cache instance.
+     * @param null|string $cacheKey The name/identifier for the cache instance.
+     *
+     * @throws InvalidArgumentException If the configured cache driver is unknown.
+     *
      * @return \PDepend\Util\Cache\CacheDriver
-     * @throws \InvalidArgumentException If the configured cache driver is unknown.
      */
     protected function createCache($cacheKey = null)
     {
@@ -117,7 +122,7 @@ class CacheFactory
             case 'memory':
                 return $this->createMemoryCache();
         }
-        throw new \InvalidArgumentException(
+        throw new InvalidArgumentException(
             "Unknown cache driver '{$this->configuration->cache->driver}' given."
         );
     }
@@ -125,9 +130,10 @@ class CacheFactory
     /**
      * Creates a new file system based cache instance.
      *
-     * @param  string $location Cache root directory.
-     * @param  int $ttl Cache ttl
-     * @param  string|null $cacheKey The name/identifier for the cache instance.
+     * @param string      $location Cache root directory.
+     * @param int         $ttl      Cache ttl
+     * @param null|string $cacheKey The name/identifier for the cache instance.
+     *
      * @return \PDepend\Util\Cache\Driver\FileCacheDriver
      */
     protected function createFileCache($location, $ttl = self::DEFAULT_TTL, $cacheKey = null)

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -64,21 +64,21 @@ class CacheFactory
     /**
      * The system configuration.
      *
-     * @var \PDepend\Util\Configuration
+     * @var Configuration
      */
     protected $configuration = null;
 
     /**
      * Singleton property that holds existing cache instances.
      *
-     * @var \PDepend\Util\Cache\CacheDriver[]
+     * @var CacheDriver[]
      */
     protected $caches = array();
 
     /**
      * Constructs a new cache factory instance for the given configuration.
      *
-     * @param \PDepend\Util\Configuration $configuration The system configuration.
+     * @param Configuration $configuration The system configuration.
      */
     public function __construct(Configuration $configuration)
     {
@@ -91,7 +91,7 @@ class CacheFactory
      *
      * @param string $cacheKey The name/identifier for the cache instance.
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     public function create($cacheKey = null)
     {
@@ -108,7 +108,7 @@ class CacheFactory
      *
      * @throws InvalidArgumentException If the configured cache driver is unknown.
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     protected function createCache($cacheKey = null)
     {
@@ -134,7 +134,7 @@ class CacheFactory
      * @param int         $ttl      Cache ttl
      * @param null|string $cacheKey The name/identifier for the cache instance.
      *
-     * @return \PDepend\Util\Cache\Driver\FileCacheDriver
+     * @return FileCacheDriver
      */
     protected function createFileCache($location, $ttl = self::DEFAULT_TTL, $cacheKey = null)
     {
@@ -144,7 +144,7 @@ class CacheFactory
     /**
      * Creates an in memory cache instance.
      *
-     * @return \PDepend\Util\Cache\Driver\MemoryCacheDriver
+     * @return MemoryCacheDriver
      */
     protected function createMemoryCache()
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -38,18 +38,22 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
 namespace PDepend\Util\Cache\Driver\File;
 
+use DirectoryIterator;
 use PDepend\Util\Cache\CacheDriver;
+use SplFileInfo;
 
 /**
  * Directory helper for the file system based cache implementation.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class FileCacheDirectory
@@ -84,7 +88,8 @@ class FileCacheDirectory
      * Creates a cache directory for the given cache entry key and returns the
      * full qualified path for that cache directory.
      *
-     * @param  string $key The cache for an entry.
+     * @param string $key The cache for an entry.
+     *
      * @return string
      */
     public function createCacheDirectory($key)
@@ -97,7 +102,8 @@ class FileCacheDirectory
      * creates a new cache directory for the given cache entry key and returns
      * the full qualified path for that cache directory.
      *
-     * @param  string $key The cache for an entry.
+     * @param string $key The cache for an entry.
+     *
      * @return string
      */
     protected function createOrReturnCacheDirectory($key)
@@ -112,7 +118,8 @@ class FileCacheDirectory
     /**
      * Ensures that the given <b>$cacheDir</b> really exists.
      *
-     * @param  string $cacheDir The cache root directory.
+     * @param string $cacheDir The cache root directory.
+     *
      * @return string
      */
     protected function ensureExists($cacheDir)
@@ -127,7 +134,7 @@ class FileCacheDirectory
      * Tests if the current software cache version is similar to the stored
      * file system cache version.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isValidVersion()
     {
@@ -137,7 +144,7 @@ class FileCacheDirectory
     /**
      * Reads the stored cache version number from the cache root directory.
      *
-     * @return string|null
+     * @return null|string
      */
     protected function readVersion()
     {
@@ -199,7 +206,7 @@ class FileCacheDirectory
      */
     protected function flushDirectory($cacheDir)
     {
-        foreach (new \DirectoryIterator($cacheDir) as $child) {
+        foreach (new DirectoryIterator($cacheDir) as $child) {
             $this->flushEntry($child);
         }
     }
@@ -208,10 +215,11 @@ class FileCacheDirectory
      * Flushes the cache record for the given file info instance, independent if
      * it is a file, directory or symlink.
      *
-     * @param  \DirectoryIterator $file
+     * @param DirectoryIterator $file
+     *
      * @return void
      */
-    protected function flushEntry(\SplFileInfo $file)
+    protected function flushEntry(SplFileInfo $file)
     {
         $path = $file->getRealPath();
         if ($file->isDot()) {

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
@@ -43,6 +43,10 @@
 namespace PDepend\Util\Cache\Driver\File;
 
 use PDepend\Util\Log;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use UnexpectedValueException;
 
 /**
  * Simple garbage collector for PDepend's file cache.
@@ -60,13 +64,13 @@ class FileCacheGarbageCollector
     private $cacheDir;
 
     /**
-     * @var integer
+     * @var int
      */
     private $expirationTimestamp;
 
     /**
      * @param string $cacheDir
-     * @param integer $ttl
+     * @param int    $ttl
      */
     public function __construct($cacheDir, $ttl = self::DEFAULT_TTL)
     {
@@ -78,7 +82,7 @@ class FileCacheGarbageCollector
      * Removes all outdated cache files and returns the number of garbage
      * collected files.
      *
-     * @return integer
+     * @return int
      */
     public function garbageCollect()
     {
@@ -89,8 +93,8 @@ class FileCacheGarbageCollector
         $count = 0;
 
         try {
-            $files = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($this->cacheDir)
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($this->cacheDir)
             );
             foreach ($files as $file) {
                 if ($this->isCollectibleFile($file)) {
@@ -100,7 +104,7 @@ class FileCacheGarbageCollector
             }
 
             return $count;
-        } catch (\UnexpectedValueException $e) {
+        } catch (UnexpectedValueException $e) {
             /* This may happen if PHPMD and PDepend run in parallel */
             return $count;
         }
@@ -109,10 +113,9 @@ class FileCacheGarbageCollector
     /**
      * Checks if the given file can be removed.
      *
-     * @param \SplFileInfo $file
-     * @return boolean
+     * @return bool
      */
-    private function isCollectibleFile(\SplFileInfo $file)
+    private function isCollectibleFile(SplFileInfo $file)
     {
         if (false === $file->isFile()) {
             return false;
@@ -134,10 +137,9 @@ class FileCacheGarbageCollector
     /**
      * Removes the given cache file.
      *
-     * @param \SplFileInfo $file
      * @return void
      */
-    private function garbageCollectFile(\SplFileInfo $file)
+    private function garbageCollectFile(SplFileInfo $file)
     {
         Log::debug("Removing file '{$file->getPathname()}' from cache.");
 

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -51,7 +51,7 @@ use PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector;
 /**
  * A file system based cache implementation.
  *
- * This class implements the {@link \PDepend\Util\Cache\CacheDriver} interface
+ * This class implements the {@link CacheDriver} interface
  * based on the local file system. It creates a special directory structure and
  * stores all cache entries in files under this directory structure.
  *

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -56,6 +57,7 @@ use PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class FileCacheDriver implements CacheDriver
@@ -91,7 +93,8 @@ class FileCacheDriver implements CacheDriver
     /**
      * Unique key for this cache instance.
      *
-     * @var   string
+     * @var string
+     *
      * @since 1.0.0
      */
     private $cacheKey;
@@ -100,9 +103,9 @@ class FileCacheDriver implements CacheDriver
      * This method constructs a new file cache instance for the given root
      * directory.
      *
-     * @param string $root          The cache root directory.
-     * @param int $ttl              The cache TTL.
-     * @param string|null $cacheKey Unique key for this cache instance.
+     * @param string      $root     The cache root directory.
+     * @param int         $ttl      The cache TTL.
+     * @param null|string $cacheKey Unique key for this cache instance.
      */
     public function __construct($root, $ttl = self::DEFAULT_TTL, $cacheKey = null)
     {
@@ -122,7 +125,8 @@ class FileCacheDriver implements CacheDriver
      * you must invoke right before every call to <em>restore()</em> or
      * <em>store()</em>.
      *
-     * @param  string $type The name or object type for the next storage method call.
+     * @param string $type The name or object type for the next storage method call.
+     *
      * @return $this
      */
     public function type($type)
@@ -138,9 +142,10 @@ class FileCacheDriver implements CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  mixed  $data Any data that should be cached.
-     * @param  string $hash Optional hash that will be used for verification.
+     * @param string $key  The cache key for the given data.
+     * @param mixed  $data Any data that should be cached.
+     * @param string $hash Optional hash that will be used for verification.
+     *
      * @return void
      */
     public function store($key, $data, $hash = null)
@@ -152,8 +157,9 @@ class FileCacheDriver implements CacheDriver
     /**
      * This method writes the given <em>$data</em> into <em>$file</em>.
      *
-     * @param  string $file The cache file name.
-     * @param  string $data Serialized cache data.
+     * @param string $file The cache file name.
+     * @param string $data Serialized cache data.
+     *
      * @return void
      */
     protected function write($file, $data)
@@ -172,9 +178,8 @@ class FileCacheDriver implements CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  string $hash Optional hash that will be used for verification.
-     * @return mixed
+     * @param string $key  The cache key for the given data.
+     * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null)
     {
@@ -190,9 +195,8 @@ class FileCacheDriver implements CacheDriver
      * to stored hash value. If both hashes are equal this method returns the
      * cached entry. Otherwise this method returns <b>NULL</b>.
      *
-     * @param  string $file The cache file name.
-     * @param  string $hash The verification hash.
-     * @return mixed
+     * @param string $file The cache file name.
+     * @param string $hash The verification hash.
      */
     protected function restoreFile($file, $hash)
     {
@@ -207,7 +211,8 @@ class FileCacheDriver implements CacheDriver
     /**
      * This method reads the raw data from the given <em>$file</em>.
      *
-     * @param  string $file The cache file name.
+     * @param string $file The cache file name.
+     *
      * @return string
      */
     protected function read($file)
@@ -229,7 +234,8 @@ class FileCacheDriver implements CacheDriver
      * <b>$pattern</b>. If no matching entry exists, this method simply does
      * nothing.
      *
-     * @param  string $pattern The cache key pattern.
+     * @param string $pattern The cache key pattern.
+     *
      * @return void
      */
     public function remove($pattern)
@@ -249,7 +255,8 @@ class FileCacheDriver implements CacheDriver
      * file name is a combination of the given <em>$key</em>, the cache root
      * directory and the current entry type.
      *
-     * @param  string $key The cache key for the given data.
+     * @param string $key The cache key for the given data.
+     *
      * @return string
      */
     protected function getCacheFile($key)
@@ -269,7 +276,8 @@ class FileCacheDriver implements CacheDriver
      * directory and the current entry type, but without the used cache file
      * extension.
      *
-     * @param  string $key The cache key for the given data.
+     * @param string $key The cache key for the given data.
+     *
      * @return string
      */
     protected function getCacheFileWithoutExtension($key)
@@ -286,7 +294,8 @@ class FileCacheDriver implements CacheDriver
      * Cleans old cache files.
      *
      * @param string $root
-     * @param int $ttl
+     * @param int    $ttl
+     *
      * @return void
      */
     protected function garbageCollect($root, $ttl)

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -49,7 +49,7 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * A memory based cache implementation.
  *
- * This class implements the {@link \PDepend\Util\Cache\CacheDriver} interface based
+ * This class implements the {@link CacheDriver} interface based
  * on an in memory data structure. This means that all cached entries will get
  * lost when the php process exits.
  *
@@ -68,7 +68,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * The in memory cache.
      *
-     * @var array<string, array<integer, mixed>>
+     * @var array<string, array<int, mixed>>
      */
     protected $cache = array();
 
@@ -89,7 +89,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * Global stack, mainly used during testing.
      *
-     * @var array<string, array<integer, mixed>>
+     * @var array<string, array<int, mixed>>
      */
     protected static $staticCache = array();
 

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -54,6 +55,7 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 class MemoryCacheDriver implements CacheDriver
@@ -107,7 +109,8 @@ class MemoryCacheDriver implements CacheDriver
      * you must invoke right before every call to <em>restore()</em> or
      * <em>store()</em>.
      *
-     * @param  string $type The name or object type for the next storage method call.
+     * @param string $type The name or object type for the next storage method call.
+     *
      * @return $this
      */
     public function type($type)
@@ -123,9 +126,10 @@ class MemoryCacheDriver implements CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  mixed  $data Any data that should be cached.
-     * @param  string $hash Optional hash that will be used for verification.
+     * @param string $key  The cache key for the given data.
+     * @param mixed  $data Any data that should be cached.
+     * @param string $hash Optional hash that will be used for verification.
+     *
      * @return void
      */
     public function store($key, $data, $hash = null)
@@ -140,9 +144,8 @@ class MemoryCacheDriver implements CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param  string $key  The cache key for the given data.
-     * @param  string $hash Optional hash that will be used for verification.
-     * @return mixed
+     * @param string $key  The cache key for the given data.
+     * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null)
     {
@@ -159,7 +162,8 @@ class MemoryCacheDriver implements CacheDriver
      * <b>$pattern</b>. If no matching entry exists, this method simply does
      * nothing.
      *
-     * @param  string $pattern The cache key pattern.
+     * @param string $pattern The cache key pattern.
+     *
      * @return void
      */
     public function remove($pattern)
@@ -176,7 +180,8 @@ class MemoryCacheDriver implements CacheDriver
      * and the <em>$type</em> property. Note that this method resets the cache
      * type, so that it is only valid for a single call.
      *
-     * @param  string $key The concrete object key.
+     * @param string $key The concrete object key.
+     *
      * @return string
      */
     protected function getCacheKey($key)
@@ -191,6 +196,7 @@ class MemoryCacheDriver implements CacheDriver
      * PHP's magic serialize sleep method.
      *
      * @return array
+     *
      * @since  1.0.2
      */
     public function __sleep()
@@ -204,6 +210,7 @@ class MemoryCacheDriver implements CacheDriver
      * PHP's magic serialize wakeup method.
      *
      * @return void
+     *
      * @since  1.0.2
      */
     public function __wakeup()

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Util;
 
+use OutOfRangeException;
+use stdClass;
+
 /**
  * Simple container class that holds settings for PDepend and all its sub
  * systems.
@@ -54,7 +57,8 @@ class Configuration
     /**
      * Simple object tree holding the concrete configuration values.
      *
-     * @var   \stdClass
+     * @var stdClass
+     *
      * @since 0.10.0
      */
     protected $settings = null;
@@ -62,10 +66,11 @@ class Configuration
     /**
      * Constructs a new configuration instance with the given settings tree.
      *
-     * @param \stdClass $settings The concrete configuration values.
+     * @param stdClass $settings The concrete configuration values.
+     *
      * @since 0.10.0
      */
-    public function __construct(\stdClass $settings)
+    public function __construct(stdClass $settings)
     {
         $this->settings = $settings;
     }
@@ -77,9 +82,10 @@ class Configuration
      * for the given <b>$name</b> exists and returns the configuration value if
      * a matching entry exists. Otherwise this method will throw an exception.
      *
-     * @param  string $name Name of the requested configuration value.
-     * @return mixed
-     * @throws \OutOfRangeException If no matching configuration value exists.
+     * @param string $name Name of the requested configuration value.
+     *
+     * @throws OutOfRangeException If no matching configuration value exists.
+     *
      * @since  0.10.0
      */
     public function __get($name)
@@ -87,7 +93,7 @@ class Configuration
         if (isset($this->settings->{$name})) {
             return $this->settings->{$name};
         }
-        throw new \OutOfRangeException(
+        throw new OutOfRangeException(
             sprintf("A configuration option '%s' not exists.", $name)
         );
     }
@@ -98,15 +104,18 @@ class Configuration
      * implementation of the magic set method always throws an exception, because
      * configuration settings are immutable.
      *
-     * @param  string $name  Name of the write property.
-     * @param  mixed  $value The new property value.
+     * @param string $name  Name of the write property.
+     * @param mixed  $value The new property value.
+     *
+     * @throws OutOfRangeException Whenever this method is called.
+     *
      * @return void
-     * @throws \OutOfRangeException Whenever this method is called.
+     *
      * @since  0.10.0
      */
     public function __set($name, $value)
     {
-        throw new \OutOfRangeException(
+        throw new OutOfRangeException(
             sprintf("A configuration option '%s' not exists.", $name)
         );
     }
@@ -117,8 +126,10 @@ class Configuration
      * implementation of the magic isset method tests if a configuration value
      * for the given <b>$name</b> exists.
      *
-     * @param  string $name Name of the requested property.
-     * @return boolean
+     * @param string $name Name of the requested property.
+     *
+     * @return bool
+     *
      * @since  0.10.0
      */
     public function __isset($name)

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -53,14 +53,14 @@ class ConfigurationInstance
     /**
      * The unique configuration instance.
      *
-     * @var null|\PDepend\Util\Configuration
+     * @var null|Configuration
      */
     private static $configuration = null;
 
     /**
      * Returns a configured config instance or <b>null</b>.
      *
-     * @return null|\PDepend\Util\Configuration
+     * @return null|Configuration
      */
     public static function get()
     {
@@ -70,7 +70,7 @@ class ConfigurationInstance
     /**
      * Sets the configuration instance.
      *
-     * @param \PDepend\Util\Configuration $configuration The config instance.
+     * @param Configuration $configuration The config instance.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -53,14 +53,14 @@ class ConfigurationInstance
     /**
      * The unique configuration instance.
      *
-     * @var \PDepend\Util\Configuration|null
+     * @var null|\PDepend\Util\Configuration
      */
     private static $configuration = null;
 
     /**
      * Returns a configured config instance or <b>null</b>.
      *
-     * @return \PDepend\Util\Configuration|null
+     * @return null|\PDepend\Util\Configuration
      */
     public static function get()
     {
@@ -70,7 +70,8 @@ class ConfigurationInstance
     /**
      * Sets the configuration instance.
      *
-     * @param  \PDepend\Util\Configuration $configuration The config instance.
+     * @param \PDepend\Util\Configuration $configuration The config instance.
+     *
      * @return void
      */
     public static function set(Configuration $configuration = null)

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -43,6 +43,7 @@
 namespace PDepend\Util\Coverage;
 
 use PDepend\Source\AST\AbstractASTArtifact;
+use SimpleXMLElement;
 
 /**
  * Coverage report implementation for clover formatted xml files.
@@ -62,9 +63,9 @@ class CloverReport implements Report
     /**
      * Constructs a new clover report instance.
      *
-     * @param \SimpleXMLElement $sxml The context simple xml element.
+     * @param SimpleXMLElement $sxml The context simple xml element.
      */
-    public function __construct(\SimpleXMLElement $sxml)
+    public function __construct(SimpleXMLElement $sxml)
     {
         $this->readProjectCoverage($sxml->project);
     }
@@ -72,10 +73,11 @@ class CloverReport implements Report
     /**
      * Reads the coverage information for a project.
      *
-     * @param  \SimpleXMLElement $sxml Element representing the clover project tag.
+     * @param SimpleXMLElement $sxml Element representing the clover project tag.
+     *
      * @return void
      */
-    private function readProjectCoverage(\SimpleXMLElement $sxml)
+    private function readProjectCoverage(SimpleXMLElement $sxml)
     {
         $this->readFileCoverage($sxml);
         foreach ($sxml->package as $package) {
@@ -87,10 +89,11 @@ class CloverReport implements Report
      * Reads the coverage information for all file elements under the given
      * parent.
      *
-     * @param  \SimpleXMLElement $sxml Element representing a file parent element.
+     * @param SimpleXMLElement $sxml Element representing a file parent element.
+     *
      * @return void
      */
-    private function readFileCoverage(\SimpleXMLElement $sxml)
+    private function readFileCoverage(SimpleXMLElement $sxml)
     {
         foreach ($sxml->file as $file) {
             $lines = array();
@@ -104,7 +107,6 @@ class CloverReport implements Report
     /**
      * Returns the percentage code coverage for the given item instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $artifact
      * @return float
      */
     public function getCoverage(AbstractASTArtifact $artifact)
@@ -138,7 +140,8 @@ class CloverReport implements Report
     /**
      * Returns the lines of the covered file.
      *
-     * @param  string $fileName The source file name.
+     * @param string $fileName The source file name.
+     *
      * @return array<boolean>
      */
     private function getLines($fileName)

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Util\Coverage;
 
+use RuntimeException;
+use SimpleXMLElement;
+
 /**
  * Factory used to abstract concrete coverage report formats from the pdepend
  * application.
@@ -55,10 +58,12 @@ class Factory
      * Factory method that tries to create coverage report instance for a given
      * path name.
      *
-     * @param  string $pathName Qualified path name of a coverage report file.
+     * @param string $pathName Qualified path name of a coverage report file.
+     *
+     * @throws RuntimeException When the given path name does not point to a
+     *                          valid coverage file or onto an unsupported coverage format.
+     *
      * @return \PDepend\Util\Coverage\CloverReport
-     * @throws \RuntimeException When the given path name does not point to a
-     *         valid coverage file or onto an unsupported coverage format.
      */
     public function create($pathName)
     {
@@ -66,17 +71,19 @@ class Factory
         if (isset($sxml->project)) {
             return new CloverReport($sxml);
         }
-        throw new \RuntimeException('Unsupported coverage report format.');
+        throw new RuntimeException('Unsupported coverage report format.');
     }
 
     /**
      * Creates a simple xml instance for the xml contents that are located under
      * the given path name.
      *
-     * @param  string $pathName Qualified path name of a coverage report file.
-     * @return \SimpleXMLElement
-     * @throws \RuntimeException When the given path name does not point to a
-     *         valid xml file.
+     * @param string $pathName Qualified path name of a coverage report file.
+     *
+     * @throws RuntimeException When the given path name does not point to a
+     *                          valid xml file.
+     *
+     * @return SimpleXMLElement
      */
     private function loadXml($pathName)
     {
@@ -86,7 +93,7 @@ class Factory
 
         if ($sxml === false) {
             $xmlError = libxml_get_last_error();
-            throw new \RuntimeException($xmlError ? trim($xmlError->message) : 'Unknown error');
+            throw new RuntimeException($xmlError ? trim($xmlError->message) : 'Unknown error');
         }
         return $sxml;
     }

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -63,7 +63,7 @@ class Factory
      * @throws RuntimeException When the given path name does not point to a
      *                          valid coverage file or onto an unsupported coverage format.
      *
-     * @return \PDepend\Util\Coverage\CloverReport
+     * @return CloverReport
      */
     public function create($pathName)
     {

--- a/src/main/php/PDepend/Util/Coverage/Report.php
+++ b/src/main/php/PDepend/Util/Coverage/Report.php
@@ -55,7 +55,6 @@ interface Report
     /**
      * Returns the percentage code coverage for the given item instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $artifact
      * @return float
      */
     public function getCoverage(AbstractASTArtifact $artifact);

--- a/src/main/php/PDepend/Util/FileUtil.php
+++ b/src/main/php/PDepend/Util/FileUtil.php
@@ -55,6 +55,7 @@ final class FileUtil
      * this method will return the system temp directory.
      *
      * @return string
+     *
      * @since  0.10.0
      */
     public static function getUserHomeDirOrSysTempDir()
@@ -82,6 +83,7 @@ final class FileUtil
      * Returns the home directory of the current user.
      *
      * @return string
+     *
      * @since  0.10.0
      */
     public static function getUserHomeDir()

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -55,6 +56,7 @@ use PDepend\Source\AST\ASTMethod;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 class IdBuilder
@@ -69,7 +71,6 @@ class IdBuilder
     /**
      * Generates an identifier for the given file instance.
      *
-     * @param  \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
      * @return string
      */
     public function forFile(ASTCompilationUnit $compilationUnit)
@@ -80,7 +81,6 @@ class IdBuilder
     /**
      * Generates an identifier for the given function instance.
      *
-     * @param  \PDepend\Source\AST\ASTFunction $function
      * @return string
      */
     public function forFunction(ASTFunction $function)
@@ -91,7 +91,6 @@ class IdBuilder
     /**
      * Generates an identifier for the given class, interface or trait instance.
      *
-     * @param  \PDepend\Source\AST\AbstractASTType $type
      * @return string
      */
     public function forClassOrInterface(AbstractASTType $type)
@@ -105,8 +104,8 @@ class IdBuilder
     /**
      * Generates an identifier for the given source item.
      *
-     * @param  \PDepend\Source\AST\AbstractASTArtifact $artifact
-     * @param  string                                  $prefix   The item type identifier.
+     * @param string $prefix The item type identifier.
+     *
      * @return string
      */
     protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
@@ -122,7 +121,6 @@ class IdBuilder
     /**
      * Generates an identifier for the given method instance.
      *
-     * @param  \PDepend\Source\AST\ASTMethod $method
      * @return string
      */
     public function forMethod(ASTMethod $method)
@@ -137,7 +135,8 @@ class IdBuilder
     /**
      * Creates a base 36 hash for the given string.
      *
-     * @param  string $string The raw input identifier/string.
+     * @param string $string The raw input identifier/string.
+     *
      * @return string
      */
     protected function hash($string)
@@ -149,8 +148,9 @@ class IdBuilder
      * Returns the node offset/occurence of the given <b>$string</b> within a
      * file.
      *
-     * @param  string $file   The file identifier.
-     * @param  string $string The node identifier.
+     * @param string $file   The file identifier.
+     * @param string $string The node identifier.
+     *
      * @return string
      */
     protected function getOffsetInFile($file, $string)

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Util;
 
+use Imagick;
+
 /**
  * Simple utility class that is used to create different image formats. This
  * class can use the ImageMagick cli tool <b>convert</b> and the pecl extension
@@ -55,8 +57,9 @@ class ImageConvert
     /**
      * Tries to converts the <b>$input</b> image into the <b>$output</b> format.
      *
-     * @param  string $input  The input file.
-     * @param  string $output The output file.
+     * @param string $input  The input file.
+     * @param string $output The output file.
+     *
      * @return void
      */
     public static function convert($input, $output)
@@ -77,7 +80,7 @@ class ImageConvert
         if ($inputType === $outputType) {
             file_put_contents($output, file_get_contents($input));
         } elseif (extension_loaded('imagick') === true) {
-            $imagick = new \Imagick($input);
+            $imagick = new Imagick($input);
             $imagick->setImageFormat($outputType);
             $imagick->writeImage($output);
 
@@ -104,7 +107,7 @@ class ImageConvert
     /**
      * Tests that the ImageMagick CLI tool <b>convert</b> exists.
      *
-     * @return boolean
+     * @return bool
      */
     protected static function hasImagickConvert()
     {
@@ -133,7 +136,8 @@ class ImageConvert
      * imageConvert options exists, this method will prepare the input image
      * file.
      *
-     * @param  string $input The input svg file.
+     * @param string $input The input svg file.
+     *
      * @return void
      */
     protected static function prepareSvg($input)

--- a/src/main/php/PDepend/Util/Log.php
+++ b/src/main/php/PDepend/Util/Log.php
@@ -65,7 +65,7 @@ final class Log
     /**
      * Are debugging messages activated?
      *
-     * @var boolean
+     * @var bool
      */
     private static $debug = false;
 
@@ -73,7 +73,7 @@ final class Log
      * Sets the log severity levels, this can be an OR combined list of valid
      * severities.
      *
-     * @param integer $severity The log severity levels.
+     * @param int $severity The log severity levels.
      *
      * @return void
      */

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Util;
 
+use ReflectionExtension;
+
 /**
  * Utility class that can be used to detect simpl scalars or internal types.
  *
@@ -134,7 +136,8 @@ final class Type
      * Hash with all internal namespaces/extensions. Key and value are identical
      * and contain the name of the extension.
      *
-     * @var   array<string, string>
+     * @var array<string, string>
+     *
      * @since 0.9.10
      */
     private static $internalNamespaces = null;
@@ -235,7 +238,7 @@ final class Type
      *
      * @param string $typeName The type name.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isInternalType($typeName)
     {
@@ -253,7 +256,7 @@ final class Type
      *
      * @param string $typeName The type name.
      *
-     * @return string|null
+     * @return null|string
      */
     public static function getTypePackage($typeName)
     {
@@ -289,7 +292,7 @@ final class Type
      *
      * @param string $packageName Name of a package.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isInternalPackage($packageName)
     {
@@ -303,7 +306,7 @@ final class Type
      *
      * @param string $image The type identifier.
      *
-     * @return boolean
+     * @return bool
      */
     public static function isScalarType($image)
     {
@@ -324,7 +327,8 @@ final class Type
      *
      * @param string $image The type image.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public static function isPrimitiveType($image)
@@ -338,7 +342,8 @@ final class Type
      *
      * @param string $image The found primitive type image.
      *
-     * @return string|null
+     * @return null|string
+     *
      * @since  0.9.6
      */
     public static function getPrimitiveType($image)
@@ -364,7 +369,8 @@ final class Type
      *
      * @param string $image The found type image.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since  0.9.6
      */
     public static function isArrayType($image)
@@ -392,7 +398,7 @@ final class Type
         $extensionNames = array_map('strtolower', $extensionNames);
 
         foreach ($extensionNames as $extensionName) {
-            $extension = new \ReflectionExtension($extensionName);
+            $extension = new ReflectionExtension($extensionName);
 
             $classNames = $extension->getClassNames();
             $classNames = array_map('strtolower', $classNames);

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -48,12 +48,14 @@ namespace PDepend\Util;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 2.2.x
  */
 final class Utf8Util
 {
     /**
      * @param string $raw
+     *
      * @return string
      */
     public static function ensureEncoding($raw)

--- a/src/main/php/PDepend/Util/Workarounds.php
+++ b/src/main/php/PDepend/Util/Workarounds.php
@@ -54,7 +54,8 @@ class Workarounds
      * Tests if the used PHP version has the known unserialize issue with object
      * references.
      *
-     * @return boolean
+     * @return bool
+     *
      * @see    https://bugs.php.net/bug.php?id=62373
      */
     public function hasSerializeReferenceIssue()
@@ -66,7 +67,7 @@ class Workarounds
      * Tests if the current environment has no known issues and does not
      * require any workaround.
      *
-     * @return boolean
+     * @return bool
      */
     public function isNotRequired()
     {

--- a/src/main/php/PDepend/Util/Workarounds.php
+++ b/src/main/php/PDepend/Util/Workarounds.php
@@ -77,7 +77,7 @@ class Workarounds
     /**
      * Returns an array with error messages related to the required workarounds.
      *
-     * @return array<integer, string>
+     * @return array<int, string>
      */
     public function getRequiredWorkarounds()
     {


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Apply the same rules for code style in PHPDoc as for native code

- Import classes instead of referencing them via FQN
- Short names for scalar types
- Consistent ordering of types
- Consistent ordering of attributes
- Grouping of attributes
- Remove redundant attributes
- Align values attributes

A large par of the changes where done using php-cs-fixer (see commit description for the settings that where used)

I have verified the changes with PHPStan at level 2