### PR TITLE
Disable external code coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,6 +8,4 @@ filter:
         - src/test/resources/files/
 
 tools:
-    external_code_coverage:
-        timeout: 600
-        runs: 2
+    external_code_coverage: false


### PR DESCRIPTION
The builds seemt o fail because of missing external code coverage data:

![grafik](https://user-images.githubusercontent.com/625761/155032172-6f90dd4e-5e66-4e2a-ba8f-bafd297ff663.png)


https://scrutinizer-ci.com/docs/tools/external-code-coverage/