### PR TITLE
Disable php_cpd checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,7 @@ jobs:
         run: composer update --prefer-dist --no-progress --no-suggest --prefer-${{ matrix.setup }} ${{ matrix.php >= 8 && '--ignore-platform-req=php' || '' }}
 
       - name: Fix PHP compatibility
+        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: php src/test/php/PDepend/fix-php-compatibility.php
 
       - name: Run test suite

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -55,9 +55,7 @@ tools:
     php_code_coverage:
         filter:
             excluded_paths: ['vendor/*', 'app/*', 'web/*', 'src/main/resources/*', 'src/test/resources/*']
-    php_cpd:
-        filter:
-            excluded_paths: ['vendor/*', 'app/*', 'web/*', 'src/main/resources/*', 'src/test/resources/*']
+    php_cpd: false
     php_loc:
         filter:
             excluded_paths: ['vendor/*', 'app/*', 'web/*', 'src/main/resources/*', 'src/test/resources/*']


### PR DESCRIPTION
Scrutinizer is finishing, but failing

| PHP Copy/Paste Detector and PHP Code Similarity Analyzer cannot both be used at |
| the same time. Please remove either one, f.e. by adding 'php_cpd: false'.       |