### PR TITLE
Update the submodule protocol to work after a GitHub update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "setup"]
 	path = setup
-	url = git://github.com/Qafoo/build-commons.git
+	url = https://github.com/Qafoo/build-commons.git


### PR DESCRIPTION
Type: bugfix
Issue: -
Breaking change: no

Update the submodule protocol to work after a GitHub update (see: https://github.blog/2021-09-01-improving-git-protocol-security-github/ )

It is mostly an internal update and not targeted on the users.