### PR TITLE
Upgrade PHPStan to latest stable release (1.8.2)

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -37,14 +37,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-phpstan-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-phpstan-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-phpstan1.8.2-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-phpstan1.8.2-${{ matrix.php }}-${{ matrix.setup }}-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer remove phpunit/phpunit easy-doc/easy-doc squizlabs/php_codesniffer gregwar/rst --no-interaction --dev --no-update;
-          composer require phpstan/phpstan:^0.12.68 --no-interaction --dev --no-update;
+          composer require phpstan/phpstan:^1.8.2 --no-interaction --dev --no-update;
           composer update --prefer-dist --no-progress --no-suggest --prefer-${{ matrix.setup }};
 
       - name: Run PHPStan


### PR DESCRIPTION
Type: update
Breaking change: no

PHPStan now has a stable release!

Also this solves a few false positives for the higher levels where PHPStan was previously unable to deduce the correct state.

Luckily it hasn't detected any new issues, so this turned out to be a very simple upgrade.
