### PR TITLE
Fix PHPStan level 3 issues

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -37,14 +37,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-phpstan-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-phpstan-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-phpstan1.8.2-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-phpstan1.8.2-${{ matrix.php }}-${{ matrix.setup }}-
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: |
           composer remove phpunit/phpunit easy-doc/easy-doc squizlabs/php_codesniffer gregwar/rst --no-interaction --dev --no-update;
-          composer require phpstan/phpstan:^0.12.68 --no-interaction --dev --no-update;
+          composer require phpstan/phpstan:^1.8.2 --no-interaction --dev --no-update;
           composer update --prefer-dist --no-progress --no-suggest --prefer-${{ matrix.setup }};
 
       - name: Run PHPStan

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,4 +8,4 @@ parameters:
         - PDepend\Util\Configuration
     ignoreErrors:
         - '#Call to an undefined method PDepend\\.*::visit.*\(\)\.#'
-    level: 2
+    level: 3

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -95,14 +95,14 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Nodes in which the current analyzed class is used.
      *
-     * @var array<string, array<int, AbstractASTArtifact>>
+     * @var array<string, array<int, AbstractASTType>>
      */
     private $efferentNodes = array();
 
     /**
      * Nodes that is used by the current analyzed class.
      *
-     * @var array<string, array<int, AbstractASTArtifact>>
+     * @var array<string, array<int, AbstractASTType>>
      */
     private $afferentNodes = array();
 

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -63,7 +63,7 @@ class ASTClassReference extends ASTClassOrInterfaceReference
      */
     public function getType()
     {
-        if ($this->typeInstance === null) {
+        if (!$this->typeInstance instanceof ASTClass) {
             $this->typeInstance = $this->context->getClass($this->getImage());
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -89,8 +89,9 @@ class ASTFieldDeclaration extends AbstractASTNode
      */
     public function getType()
     {
-        if ($this->hasType()) {
-            return $this->getChild(0);
+        $child = $this->getChild(0);
+        if ($child instanceof ASTType) {
+            return $child;
         }
 
         throw new OutOfBoundsException('The parameter does not have a type specification.');

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -87,8 +87,9 @@ class ASTFormalParameter extends AbstractASTNode
      */
     public function getType()
     {
-        if ($this->hasType()) {
-            return $this->getChild(0);
+        $child = $this->getChild(0);
+        if ($child instanceof ASTType) {
+            return $child;
         }
 
         throw new OutOfBoundsException('The parameter does not have a type specification.');

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -56,7 +56,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * The parent type object.
      *
-     * @var AbstractASTType
+     * @var AbstractASTClassOrInterface
      */
     protected $parent = null;
 
@@ -179,7 +179,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the parent type object or <b>null</b>
      *
-     * @return AbstractASTType|null
+     * @return AbstractASTClassOrInterface|null
      */
     public function getParent()
     {
@@ -188,6 +188,8 @@ class ASTMethod extends AbstractASTCallable
 
     /**
      * Sets the parent type object.
+     *
+     * @param AbstractASTClassOrInterface|null $parent
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -195,7 +195,7 @@ class ASTNamespace extends AbstractASTArtifact
     {
         $types = array();
         foreach ($this->types as $type) {
-            if (get_class($type) === $className) {
+            if ($type instanceof $className && get_class($type) === $className) {
                 $types[] = $type;
             }
         }


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: no

Resolve PHPStan level 3 issues, and increase the config level to reflect this.

Note, this includes the changes from https://github.com/pdepend/pdepend/pull/605

This makes `hasType()` unused, but I kept them to not cause BC issues.