### PR TITLE
Correct and check for PHPStan level 4 issues

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
     paths:
         - src/main
+    rememberPossiblyImpureFunctionValues: false
     excludePaths:
         - src/main/php/PDepend/DbusUI/ResultPrinter.php
         - src/main/php/PDepend/Util/ImageConvert.php
@@ -8,4 +9,4 @@ parameters:
         - PDepend\Util\Configuration
     ignoreErrors:
         - '#Call to an undefined method PDepend\\.*::visit.*\(\)\.#'
-    level: 3
+    level: 4

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -186,7 +186,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
             foreach ($top->interfaceReferences as $interfaceReference) {
                 $interface = $interfaceReference->getType();
 
-                if (in_array($interface, $interfaces, true) === true) {
+                if (in_array($interface, $interfaces, true)) {
                     continue;
                 }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -106,25 +106,6 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
         return parent::parseUnknownDeclaration($tokenType, $modifiers);
     }
 
-    protected function parseMethodOrFieldDeclaration($modifiers = 0)
-    {
-        $field = parent::parseMethodOrFieldDeclaration($modifiers);
-
-        if ($field instanceof ASTType) {
-            $type = $field;
-
-            $field = parent::parseMethodOrFieldDeclaration($modifiers);
-
-            if (!($field instanceof ASTFieldDeclaration)) {
-                throw new UnexpectedTokenException($this->tokenizer->prevToken(), $this->tokenizer->getSourceFile());
-            }
-
-            $field->prependChild($type);
-        }
-
-        return $field;
-    }
-
     /**
      * @return ASTClosure
      */


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: no

`rememberPossiblyImpureFunctionValues` is `true` by default, which makes assumptions that a function will always return the same in the object has not been changed. How ever it does not check for classes refererede in properties being changed, which is the case when `$this->tokenizer->next()`, so simply set it to `false` meaning that it never assumes that calling a function will always yield the same result.

`parseMethodOrFieldDeclaration()` was removed as `ASTType` is never returned by the parent meaning the function will never do anything. It was introduced here: https://github.com/pdepend/pdepend/pull/414. @kylekatarnls if you know what this was supposed to do please elaborate :)

`parseVariableOrFunctionPostfixOrMemberPrimaryPrefix()` does not return `ASTClassOrInterfaceReference`, leading to an incorrect return for `parseStandAloneExpressionTypeReference`. There was a safe assumption for this, in that we already peaked at the type before calling it, and could then call `addChild()` on the returned instance with out checking the type. To avoid this assumption I have split the function in two and throw an exception if it gets used in the wrong context.