### PR TITLE
PHP 8.1 support pure intersection types

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -69,7 +69,7 @@ class ASTIntersectionType extends ASTType
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @since  2.9.0
+     * @since  2.11.0
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -39,7 +39,7 @@
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @since 0.9.6
+ * @since 2.11.0
  */
 
 namespace PDepend\Source\AST;

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -47,64 +47,44 @@ namespace PDepend\Source\AST;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
- * Abstract base class for a type node.
+ * This class represents an intersection type
  *
+ * @see https://php.watch/versions/8.1/intersection-types
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @since 0.9.6
  */
-class ASTType extends AbstractASTNode
+class ASTIntersectionType extends ASTType
 {
     /**
-     * This method will return <b>true</b> when the underlying type is an array.
-     *
-     * @return bool
-     */
-    public function isArray()
-    {
-        return false;
-    }
-
-    /**
-     * This method will return <b>true</b> when the underlying data type is a
-     * php primitive.
-     *
-     * @return bool
-     */
-    public function isScalar()
-    {
-        return false;
-    }
-
-    /**
-     * This method will return <b>true</b> when this type use union pipe to specify multiple types.
-     *
-     * @return bool
-     */
-    public function isUnion()
-    {
-        return false;
-    }
-
-    /**
-     * This method will return <b>true</b> when this type uses intersection ampersand to specify multiple types.
+     * For this specific type it is always an intersection type.
      *
      * @return bool
      */
     public function isIntersection()
     {
-        return false;
+        return true;
     }
 
     /**
      * Accept method of the visitor design pattern. This method will be called
      * by a visitor during tree traversal.
      *
-     * @since 0.9.12
+     * @since  2.9.0
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {
-        return $visitor->visitType($this, $data);
+        return $visitor->visitUnionType($this, $data);
+    }
+
+    /**
+     * Return concatenated allowed types string representation.
+     *
+     * @return string
+     */
+    public function getImage()
+    {
+        return implode('&', array_map(function ($type) {
+            return $type->getImage();
+        }, $this->getChildren()));
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -58,7 +58,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
 class ASTUnionType extends ASTType
 {
     /**
-     * This method will return <b>true</b> when this type use union pipe tos specify multiple types.
+     * This method will return <b>true</b> when this type use union pipe to specify multiple types.
      * For this concrete implementation the return value will be always true.
      *
      * @return bool

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -96,6 +96,7 @@ use PDepend\Source\AST\ASTIfStatement;
 use PDepend\Source\AST\ASTIncludeExpression;
 use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTIssetExpression;
 use PDepend\Source\AST\ASTLabelStatement;
 use PDepend\Source\AST\ASTListExpression;
@@ -1210,6 +1211,14 @@ interface Builder extends IteratorAggregate
      * @since  2.9.0
      */
     public function buildAstUnionType();
+
+    /**
+     * Builds a new node for the intersection type.
+     *
+     * @return ASTIntersectionType
+     */
+    public function buildAstIntersectionType();
+
 
     /**
      * Builds a new literal node.

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -1219,7 +1219,6 @@ interface Builder extends IteratorAggregate
      */
     public function buildAstIntersectionType();
 
-
     /**
      * Builds a new literal node.
      *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -102,6 +102,7 @@ use PDepend\Source\AST\ASTIfStatement;
 use PDepend\Source\AST\ASTIncludeExpression;
 use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTIssetExpression;
 use PDepend\Source\AST\ASTLabelStatement;
 use PDepend\Source\AST\ASTListExpression;
@@ -1771,6 +1772,16 @@ class PHPBuilder implements Builder
     public function buildAstUnionType()
     {
         return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTUnionType');
+    }
+
+    /**
+     * Builds a new node for the union type.
+     *
+     * @return ASTIntersectionType
+     */
+    public function buildAstIntersectionType()
+    {
+        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIntersectionType');
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -41,7 +41,11 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -59,5 +63,36 @@ class IntersectionTypesTest extends AbstractTest
     {
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
+        /** @var ASTFormalParameter $parameter */
+        $parameter = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTFormalParameter'
+        );
+        $children = $parameter->getChildren();
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        /** @var ASTIntersectionType $intersectionType */
+        $intersectionType = $children[0];
+        $this->assertSame('Iterator&\Countable&\ArrayAccess', $intersectionType->getImage());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $children[1]);
+        /** @var ASTVariableDeclarator $variable */
+        $variable = $children[1];
+        $this->assertSame('$iterator', $variable->getImage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionTypesAsReturn()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTType $return */
+        $return = $method->getFirstChildOfType(
+            'PDepend\\Source\\AST\\ASTType'
+        );
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $return);
+        $this->assertSame('Iterator&\Countable&\ArrayAccess', $return->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP81;
+
+use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTMethod;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @group unittest
+ * @group php8.1
+ */
+class IntersectionTypesTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testIntersectionTypes()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -98,6 +98,15 @@ class IntersectionTypesTest extends AbstractTest
 
     /**
      * @expectedException \PDepend\Source\Parser\ParserException
+     * @expectedExceptionMessage Unexpected token
+     */
+    public function testIntersectionTypesCantBeMixedWithUnionTypes()
+    {
+        $this->getFirstMethodForTestCase();
+    }
+
+    /**
+     * @expectedException \PDepend\Source\Parser\ParserException
      * @expectedExceptionMessage int can not be used in an intersection type
      */
     public function testIntersectionTypesCantBeScalar()

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -95,4 +95,13 @@ class IntersectionTypesTest extends AbstractTest
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $return);
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $return->getImage());
     }
+
+    /**
+     * @expectedException \PDepend\Source\Parser\ParserException
+     * @expectedExceptionMessage int can not be used in an intersection type
+     */
+    public function testIntersectionTypesCantBeScalar()
+    {
+        $this->getFirstMethodForTestCase();
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -64,10 +64,8 @@ class IntersectionTypesTest extends AbstractTest
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTFormalParameter $parameter */
-        $parameter = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
-        );
-        $children = $parameter->getChildren();
+        $parameter = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+        $children  = $parameter->getChildren();
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
         /** @var ASTIntersectionType $intersectionType */
@@ -78,6 +76,23 @@ class IntersectionTypesTest extends AbstractTest
         /** @var ASTVariableDeclarator $variable */
         $variable = $children[1];
         $this->assertSame('$iterator', $variable->getImage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionTypesWithByReference()
+    {
+        /** @var ASTMethod $method */
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTFormalParameter $parameter */
+        $parameter = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+        $children  = $parameter->getChildren();
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        /** @var ASTIntersectionType $intersectionType */
+        $intersectionType = $children[0];
+        $this->assertSame('Iterator&\Countable&\ArrayAccess', $intersectionType->getImage());
     }
 
     /**

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypes.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypes.php
@@ -1,7 +1,7 @@
 <?php
 class Foo
 {
-    public function bar(Iterator&\Countable $iterator)
+    public function bar(Iterator&\Countable&\ArrayAccess $iterator)
     {
         return $iterator;
     }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypes.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypes.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(Iterator&\Countable $iterator)
+    {
+        return $iterator;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesAsReturn.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesAsReturn.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(): Iterator&\Countable&\ArrayAccess
+    {
+        return new ArrayIterator();
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesCantBeMixedWithUnionTypes.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesCantBeMixedWithUnionTypes.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(Iterator|\Countable&\ArrayAccess $iterator)
+    {
+        return $iterator;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesCantBeScalar.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesCantBeScalar.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(Iterator&\Countable&int $iterator)
+    {
+        return null;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesWithByReference.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/IntersectionTypes/testIntersectionTypesWithByReference.php
@@ -1,0 +1,8 @@
+<?php
+class Foo
+{
+    public function bar(Iterator&\Countable&\ArrayAccess &$iterator)
+    {
+        return $iterator;
+    }
+}


### PR DESCRIPTION
Type: feature
Issue: #556
Breaking change: no

Adds support for parsing PHP8.1 intersection types.

As function parameter (or class field)
```php
public function method(Iterator&\Countable&\ArrayAccess $iterator)
```

As return type
```php
public function method(): Iterator&\Countable&\ArrayAccess
```

Added tests for the specific cases.
