### PR TITLE
Test first-class callback are not triggering issues

### DIFF
--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP81;
+
+use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTMethodPostfix;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @group unittest
+ * @group php8.1
+ */
+class FirstClassCallableSyntaxTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testFirstClassCallable()
+    {
+        $method = $this->getFirstMethodForTestCase();
+        $children = $method->getChildren();
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeCallable', $children[1]);
+        $children = $children[2]->getChildren();
+        $this->assertCount(1, $children);
+        $return = $children[0];
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $return);
+        $children = $return->getChildren();
+        $this->assertCount(1, $children);
+        $prefix = $children[0];
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $prefix);
+        $children = $prefix->getChildren();
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+        /** @var ASTMethodPostfix $methodPostFix */
+        $methodPostFix = $children[1];
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMethodPostfix', $methodPostFix);
+        $this->assertSame('getTime', $methodPostFix->getImage());
+        $children = $methodPostFix->getChildren();
+        $this->assertCount(2, $children);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArguments', $children[1]);
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntax/testFirstClassCallable.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntax/testFirstClassCallable.php
@@ -1,0 +1,15 @@
+<?php
+
+class Clock {
+    public function getClockCallable(): callable {
+        return $this->getTime(...);
+    }
+
+    private function getTime(): int {
+        return time();
+    }
+}
+
+$clock = new Clock();
+$clock_callback = $clock->getClockCallable();
+echo $clock_callback();


### PR DESCRIPTION
Type: test
Issue: #556
Breaking change: no

This test ensure PHP 8.1 first-class callable syntax is not causing new issues and that parsing can complete.

This is not really supported as the AST nodes generated does not allow to differentiate `method()` and `method(...)` which is already the case for all syntaxes around ellipsis (unpacking and rest argument).