### PR TITLE
Implement support for PHP 8.2 null/false stand-alone type

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -266,17 +266,22 @@ class ASTParameter extends AbstractASTArtifact
     {
         $node = $this->formalParameter->getChild(0);
 
-        return (
-            $this->isTypeAllowingNull($node)
-            || (
-                !($node instanceof ASTTypeArray)
-                && !($node instanceof ASTScalarType)
-                && $this->getClass() === null
-            ) || (
-                $this->isDefaultValueAvailable() === true
-                && $this->getDefaultValue() === null
-            )
-        );
+        if ($this->isTypeAllowingNull($node)) {
+            return true;
+        }
+
+        if (!($node instanceof ASTTypeArray)
+            && !($node instanceof ASTScalarType)
+            && $this->getClass() === null
+        ) {
+            return true;
+        }
+
+        if ($this->isDefaultValueAvailable() && $this->getDefaultValue() === null) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -264,9 +264,13 @@ class ASTParameter extends AbstractASTArtifact
      */
     public function allowsNull()
     {
+        $node = $this->formalParameter->getChild(0);
+
         return (
-            (
-                $this->isArray() === false
+            $this->isTypeAllowingNull($node)
+            || (
+                !($node instanceof ASTTypeArray)
+                && !($node instanceof ASTScalarType)
                 && $this->getClass() === null
             ) || (
                 $this->isDefaultValueAvailable() === true
@@ -405,5 +409,18 @@ class ASTParameter extends AbstractASTArtifact
             $this->getName(),
             $default
         );
+    }
+
+    private function isTypeAllowingNull($node)
+    {
+        if ($node instanceof ASTUnionType) {
+            foreach ($node->getChildren() as $child) {
+                if ($this->isTypeAllowingNull($child)) {
+                    return true;
+                }
+            }
+        }
+
+        return $node instanceof ASTScalarType && $node->isNull();
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -6822,7 +6822,7 @@ abstract class AbstractPHPParser
             return $fragments[0];
         }
 
-        // Search for an use alias
+        // Search for a use alias
         $mapsTo = $this->useSymbolTable->lookup($fragments[0]);
 
         if ($mapsTo !== null) {
@@ -7448,7 +7448,9 @@ abstract class AbstractPHPParser
                     $number = $token->image;
 
                     while ($this->tokenizer->peek() === Tokens::T_STRING) {
-                        $number .= $this->tokenizer->next()->image;
+                        $next = $this->tokenizer->next();
+                        $this->tokenStack->add($next);
+                        $number .= $next->image;
                     }
 
                     $defaultValue->setValue($signed * $this->parseIntegerNumberImage($number));
@@ -8011,7 +8013,7 @@ abstract class AbstractPHPParser
      */
     protected function parseEnumSignature()
     {
-        $this->tokenizer->next();
+        $this->tokenStack->add($this->tokenizer->next());
         $this->consumeComments();
 
         if ($this->tokenizer->peek() !== Tokens::T_STRING) {
@@ -8093,7 +8095,7 @@ abstract class AbstractPHPParser
      */
     private function parseEnumCase()
     {
-        $this->tokenizer->next();
+        $this->tokenStack->add($this->tokenizer->next());
         $this->tokenStack->push();
         $this->consumeComments();
 
@@ -8102,7 +8104,7 @@ abstract class AbstractPHPParser
         }
 
         $caseName = $this->tokenizer->currentToken()->image;
-        $this->tokenizer->next();
+        $this->tokenStack->add($this->tokenizer->next());
         $this->consumeComments();
         $case = $this->builder->buildEnumCase($caseName, $this->parseEnumCaseValue());
         $this->consumeComments();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -57,7 +57,7 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @since 0.9.20
  */
-class PHPParserGeneric extends PHPParserVersion81
+class PHPParserGeneric extends PHPParserVersion82
 {
     /**
      * Tests if the given token type is a reserved keyword in the supported PHP

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -245,7 +245,9 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
         $number = $token->image;
 
         while ($this->tokenizer->peek() === Tokens::T_STRING) {
-            $number .= $this->tokenizer->next()->image;
+            $next = $this->tokenizer->next();
+            $this->tokenStack->add($next);
+            $number .= $next->image;
         }
 
         if ('0' !== substr($number, 0, 1)) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -286,7 +286,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     }
 
     /**
-     * Tests if the given image is a PHP 7 type hint.
+     * Tests if the given image is a PHP 7.0 type hint.
      *
      * @param string $image
      *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -144,24 +144,6 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
 
         return parent::parseUnknownDeclaration($tokenType, $modifiers);
     }
-    
-    /**
-     * Tests if the given image is a PHP 7 type hint.
-     *
-     * @param string $image
-     *
-     * @return bool
-     */
-    protected function isScalarOrCallableTypeHint($image)
-    {
-        switch (strtolower($image)) {
-            case 'iterable':
-            case 'void':
-                return true;
-        }
-
-        return parent::isScalarOrCallableTypeHint($image);
-    }
 
     /**
      * Parses a scalar type hint or a callable type hint.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 2.11
+ */
+
+namespace PDepend\Source\Language\PHP;
+
+use PDepend\Source\AST\ASTNode;
+
+/**
+ * Concrete parser implementation that supports features up to PHP version 8.2.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 2.12
+ */
+abstract class PHPParserVersion82 extends PHPParserVersion81
+{
+    /**
+     * Tests if the given image is a PHP 8.2 type hint.
+     *
+     * @param string $image
+     *
+     * @return bool
+     */
+    protected function isScalarOrCallableTypeHint($image)
+    {
+        switch (strtolower($image)) {
+            case 'false':
+            case 'null':
+                return true;
+        }
+
+        return parent::isScalarOrCallableTypeHint($image);
+    }
+
+    /**
+     * @param ASTNode $type
+     *
+     * @return bool
+     */
+    protected function canNotBeStandAloneType($type)
+    {
+        return false;
+    }
+}

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP82;
+
+use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\AST\State;
+
+/**
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @group unittest
+ * @group php8.2
+ */
+class AllowNullAndFalseAsStandAloneTypesTest extends AbstractTest
+{
+    /**
+     * @return void
+     */
+    public function testTypedProperties()
+    {
+        /** @var ASTClass $class */
+        $class = $this->getFirstClassForTestCase();
+        $children = $class->getChildren();
+
+        /** @var array[] $declarations */
+        $declarations = array_map(function (ASTFieldDeclaration $child) {
+            $childChildren = $child->getChildren();
+
+            return array(
+                $child->hasType() ? $child->getType() : null,
+                $childChildren[1],
+            );
+        }, $children);
+
+        foreach (array(
+            array('null', '$nullish'),
+            array('false', '$falsy'),
+        ) as $index => $expected) {
+            list($expectedType, $expectedVariable) = $expected;
+            $expectedTypeClass = isset($expected[2]) ? $expected[2] : 'PDepend\\Source\\AST\\ASTScalarType';
+            list($type, $variable) = $declarations[$index];
+
+            $this->assertInstanceOf(
+                $expectedTypeClass,
+                $type,
+                "Wrong type for $expectedType $expectedVariable"
+            );
+            $this->assertSame(ltrim($expectedType, '?'), $type->getImage());
+            $this->assertInstanceOf(
+                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                $variable,
+                "Wrong variable for $expectedType $expectedVariable"
+            );
+            $this->assertSame($expectedVariable, $variable->getImage());
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function testReturnTypes()
+    {
+        $class = $this->getFirstClassForTestCase();
+        /** @var ASTMethod[] $methods */
+        $methods = $class->getMethods();
+        $nullish = $methods[0]->getReturnType();
+        $falsy = $methods[1]->getReturnType();
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $nullish);
+        $this->assertSame('null', $nullish->getImage());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $falsy);
+        $this->assertSame('false', $falsy->getImage());
+    }
+
+    /**
+     * @return void
+     */
+    public function testParameters()
+    {
+        $method = $this->getFirstMethodForTestCase();
+        /** @var ASTParameter[] $methods */
+        $parameters = $method->getParameters();
+        $nullish = $parameters[0];
+        $falsy = $parameters[1];
+
+        $this->assertTrue($nullish->allowsNull());
+        $this->assertFalse($falsy->allowsNull());
+
+        $nullish = $nullish->getFormalParameter()->getType();
+        $falsy = $falsy->getFormalParameter()->getType();
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $nullish);
+        $this->assertSame('null', $nullish->getImage());
+        $this->assertSame(3, $nullish->getStartLine());
+        $this->assertSame(29, $nullish->getStartColumn());
+        $this->assertSame(3, $nullish->getEndLine());
+        $this->assertSame(32, $nullish->getEndColumn());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $falsy);
+        $this->assertSame('false', $falsy->getImage());
+        $this->assertSame(3, $falsy->getStartLine());
+        $this->assertSame(44, $falsy->getStartColumn());
+        $this->assertSame(3, $falsy->getEndLine());
+        $this->assertSame(48, $falsy->getEndColumn());
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testParameters.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testParameters.php
@@ -1,0 +1,6 @@
+<?php
+class User {
+    public function proceed(null $nullish, false $falsy): void
+    {
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testReturnTypes.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testReturnTypes.php
@@ -1,0 +1,12 @@
+<?php
+class User {
+    public function getNullish(): null
+    {
+        return null;
+    }
+
+    public function getFalsy(): false
+    {
+        return false;
+    }
+}

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testTypedProperties.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypes/testTypedProperties.php
@@ -1,0 +1,5 @@
+<?php
+class User {
+    public null $nullish;
+    public false $falsy;
+}


### PR DESCRIPTION
Type: feature
Issue: #617
Breaking change: no

Specifications: [Allow null and false as stand-alone types](https://wiki.php.net/rfc/null-false-standalone-types)

- Added support for PHP 8.2 null/false stand-alone type
- Fixed allowsNull
- Fixed tokens stack recording