### PR TITLE
Fix parsing of by-reference vararg parameters

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -212,8 +212,9 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
             return $this->parseUnionTypeHint($type);
         }
 
-        // sniff for &, but avoid by_reference &$variable.
-        if ($peek === Tokens::T_BITWISE_AND && $this->tokenizer->peekNext() !== Tokens::T_VARIABLE) {
+        $peekNext = $this->tokenizer->peekNext();
+        // sniff for &, but avoid by_reference &$variable and &...$variables.
+        if ($peek === Tokens::T_BITWISE_AND && $peekNext !== Tokens::T_VARIABLE && $peekNext !== Tokens::T_ELLIPSIS) {
             return $this->parseIntersectionTypeHint($type);
         }
 

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -111,6 +111,23 @@ class PHPParserVersion80Test extends AbstractTest
     }
 
     /**
+     * testFunctionParameterTypeHintByReferenceVariableArguments
+     *
+     * @return void
+     */
+    public function testFunctionParameterTypeHintByReferenceVariableArguments()
+    {
+        $parameters = $this->getFirstFunctionForTestCase()->getParameters();
+        $parameter = $parameters[0];
+        $formalParameter = $parameter->getFormalParameter();
+        $type = $formalParameter->getType();
+
+        $this->assertFalse($type->isIntersection());
+        $this->assertTrue($formalParameter->isPassedByReference());
+        $this->assertTrue($formalParameter->isVariableArgList());
+    }
+
+    /**
      * @return void
      */
     public function testTrailingCommaInClosureUseList()

--- a/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionParameterTypeHintByReferenceVariableArguments.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserVersion80/testFunctionParameterTypeHintByReferenceVariableArguments.php
@@ -1,0 +1,3 @@
+<?php
+
+function foo(mixed &...$vars) {}


### PR DESCRIPTION
Type: bugfix
Issue: #629
Breaking change: no

Fix the mentioned issue and add test code to confirm it.