### PR TITLE
Add support for NULL, DEFAULT and NEW as enum case.

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8142,7 +8142,12 @@ abstract class AbstractPHPParser
         $this->tokenStack->push();
         $this->consumeComments();
 
-        if ($this->tokenizer->peek() !== Tokens::T_STRING) {
+        if (in_array($this->tokenizer->peek(), array(
+                Tokens::T_NEW,
+                Tokens::T_NULL,
+                Tokens::T_STRING,
+                Tokens::T_DEFAULT
+            )) === false) {
             throw $this->getUnexpectedTokenException();
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8147,7 +8147,7 @@ abstract class AbstractPHPParser
                 Tokens::T_NULL,
                 Tokens::T_STRING,
                 Tokens::T_DEFAULT
-            )) === false) {
+            ), true) === false) {
             throw $this->getUnexpectedTokenException();
         }
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -64,13 +64,15 @@ class EnumTest extends PHPParserVersion81Test
             ->current()
             ->getTypes();
 
-        $this->assertCount(3, $types);
+        $this->assertCount(4, $types);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTInterface', $types[0]);
         $this->assertSame('HasColor', $types[0]->getName());
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $types[1]);
         $this->assertSame('Suit', $types[1]->getName());
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClass', $types[2]);
         $this->assertSame('UseEnum', $types[2]->getName());
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $types[3]);
+        $this->assertSame('SpecialCases', $types[3]->getName());
 
         $methods = $types[1]->getMethods();
 

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/Enum/testEnum.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/Enum/testEnum.php
@@ -38,3 +38,10 @@ class UseEnum
         return Suit::DIAMONDS->getColor() === 'red';
     }
 }
+
+enum SpecialCases
+{
+    case NULL;
+    case DEFAULT;
+    case NEW;
+}


### PR DESCRIPTION
Type: bugfix
Issue: #635
Breaking change: no

This PR adds support for the NULL, DEFAULT and NEW enum case.