### PR TITLE
Prevent the use of a not set id value in the AbstractASTType and AbstractASTCallable

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -227,7 +227,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     {
         return (array) $this->cache
             ->type('tokens')
-            ->restore($this->id);
+            ->restore($this->getId());
     }
 
     /**
@@ -244,7 +244,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
 
         $this->cache
             ->type('tokens')
-            ->store($this->id, $tokens);
+            ->store($this->getId(), $tokens);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -383,7 +383,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     {
         return (array) $this->cache
             ->type('tokens')
-            ->restore($this->id);
+            ->restore($this->getId());
     }
 
     /**
@@ -404,7 +404,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
         $this->cache
             ->type('tokens')
-            ->store($this->id, $tokens);
+            ->store($this->getId(), $tokens);
     }
 
     /**
@@ -502,7 +502,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
         if (is_array($this->methods)) {
             $this->cache
                 ->type('methods')
-                ->store($this->id, $this->methods);
+                ->store($this->getId(), $this->methods);
 
             $this->methods = null;
         }

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -1282,7 +1282,7 @@ class ASTClassTest extends AbstractASTArtifactTest
             ->will($this->returnValue($cache));
         $cache->expects($this->once())
             ->method('store')
-            ->with($this->equalTo(null), $this->equalTo($tokens));
+            ->with($this->isType('string'), $this->equalTo($tokens));
 
         $class = new ASTClass(__CLASS__);
         $class->setCache($cache)

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -316,7 +316,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
             ->will($this->returnValue($cache));
         $cache->expects($this->once())
             ->method('store')
-            ->with($this->equalTo(null), $this->equalTo($tokens));
+            ->with($this->isType('string'), $this->equalTo($tokens));
 
         $function = $this->createItem();
         $function->setCache($cache)
@@ -336,7 +336,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
             ->will($this->returnValue($cache));
         $cache->expects($this->once())
             ->method('restore')
-            ->with($this->equalTo(null))
+            ->with($this->isType('string'))
             ->will($this->returnValue(array()));
 
         $function = $this->createItem();
@@ -357,7 +357,7 @@ class ASTFunctionTest extends AbstractASTArtifactTest
             ->will($this->returnValue($cache));
         $cache->expects($this->once())
             ->method('restore')
-            ->with($this->equalTo(null))
+            ->with($this->isType('string'))
             ->will($this->returnValue(null));
 
         $function = $this->createItem();

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -537,7 +537,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
             ->will($this->returnValue($cache));
         $cache->expects($this->once())
             ->method('store')
-            ->with($this->equalTo(null), $this->equalTo($tokens));
+            ->with($this->isType('string'), $this->equalTo($tokens));
 
         $interface = $this->createItem();
         $interface->setCache($cache)


### PR DESCRIPTION
Prevent the use of a not set id value in the AbstractASTType and AbstractASTCallable

This prevent deprecated warning if null is passed to the storage driver.

Type: bugfix / refactoring  
Issue: #.. the corresponding issue for this PR (if exist)
Breaking change: yes/no (if yes explain why)

I got the error:
`
Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in /[project]/vendor/pdepend/pdepend/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php on line 111
` 

While debugging I found out that it was from a call to the storage with null because the id wasn't set. By using the getId() function the id will be set if not yet done and it prevents errors more downstream the application.
