### PR TITLE
Improve UTF8 encoding process

### DIFF
--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -79,9 +79,9 @@ final class Utf8Util
             $text = mb_convert_encoding($raw, 'UTF-8', mb_list_encodings());
         }
 
-        // Then try with native PHP function, if not deprecated.
-        if ($text === '' && PHP_VERSION_ID < 80200) {
-            $text = utf8_encode($raw);
+        // Then try with native PHP function, if not removed.
+        if ($text === '' && function_exists('utf8_encode')) {
+            $text = @utf8_encode($raw);
         }
 
         // Then finally use a polyfill.

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -43,8 +43,10 @@
 namespace PDepend\Util;
 
 /**
- * This is a simply utility class that will perform mathematical operations with
- * bcmath when the extension exists, otherwise it will use default math operations.
+ * This is a simply utility class that will ensure the encoding of a raw string
+ * into an UTF8 encoded string. It will try using "iconv" extension if
+ * available, or "mbstring" extension if available, or native PHP function if
+ * available, or finally a polyfill if nothing is available.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
@@ -66,14 +68,51 @@ final class Utf8Util
         }
 
         $text = '';
+
+        // Try to convert raw text to UTF8 using "iconv", if exists.
         if (function_exists('iconv')) {
             $text = @iconv($encoding, 'UTF8//IGNORE', $raw) ?: '';
         }
 
-        if ($text === '') {
+        // Then try with "mbstring" extension, if available.
+        if ($text === '' && extension_loaded('mbstring')) {
+            $text = mb_convert_encoding($raw, 'UTF-8', mb_list_encodings());
+        }
+
+        // Then try with native PHP function, if not deprecated.
+        if ($text === '' && PHP_VERSION_ID < 80200) {
             $text = utf8_encode($raw);
         }
 
+        // Then finally use a polyfill.
+        if ($text === '') {
+            $text = self::polyfillUtf8Encode($raw);
+        }
+
         return $text;
+    }
+
+    /**
+     * Polyfill exported from 
+     * @link https://github.com/symfony/polyfill-php72/blob/main/Php72.php
+     *
+     * @param string $s
+     *
+     * @return string
+     */
+    private static function polyfillUtf8Encode($s)
+    {
+        $s .= $s;
+        $len = \strlen($s);
+
+        for ($i = $len >> 1, $j = 0; $i < $len; ++$i, ++$j) {
+            switch (true) {
+                case $s[$i] < "\x80": $s[$j] = $s[$i]; break;
+                case $s[$i] < "\xC0": $s[$j] = "\xC2"; $s[++$j] = $s[$i]; break;
+                default: $s[$j] = "\xC3"; $s[++$j] = \chr(\ord($s[$i]) - 64); break;
+            }
+        }
+
+        return substr($s, 0, $j);
     }
 }


### PR DESCRIPTION
Type: Deprecation warning removal 
Issue: None (yet?)
Breaking change: no

Due to PHP 8.2 deprecating functions `utf8_encode` and `utf8_decode`, the utils method `Utf8Util::ensureEncoding` can create deprecation warnings when ran with PHP 8.2 without the "iconv" extension loaded.

![image](https://user-images.githubusercontent.com/9560327/212715118-1d60a431-cf8d-4a39-a858-b9ca56b82cf1.png)


In this PR, I want to offer 2 new ways to ensure about the encoding in UTF-8 in case "iconv" is not enabled:
1) The usage of "mbstring" extension's functions `mb_convert_encoding` (and `mb_list_encodings` to prevent wrongly forced encodings) in case "iconv" wasn't used
2) The prevention of usage of `utf8_encode` in PHP 8.2 (and more recent versions) that is replaced by a polyfill Symfony is already providing since quite a long time.


I did not added some unit tests to cover my case as I don't know how to simulate the non-existance of `iconv` extension nor the existance of `mbstring` extension, nor how to detect there are no more deprecated message in PHP 8.2. I just ran this modified version of pdepend on one of my project and I got the exact same values but without the deprecation messages.  
If someone can help me to provide unit tests if this is mandatory on this class, I would be really gladful to provide them.

