### PR TITLE
Correct return type for ASTAnonymousClass::accept()

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -222,7 +222,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     }
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, mixed>|string
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -222,7 +222,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     }
 
     /**
-     * @return int
+     * @return array<string, mixed>
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {


### PR DESCRIPTION
Type: documentation update
Breaking change: no

These are a bit hard to find since we make use of a magic `visitor*()`, which I'm currently looking in to switching to a proper generic instead...