### PR TITLE
Implement generic visit method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,6 +7,4 @@ parameters:
         - src/main/php/PDepend/Util/ImageConvert.php
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
-    ignoreErrors:
-        - '#Call to an undefined method PDepend\\.*::visit.*\(\)\.#'
     level: 4

--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -69,14 +69,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTAllocationExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitAllocationExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -222,14 +222,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     }
 
     /**
-     * @return int
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitAnonymousClass($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -114,15 +114,4 @@ class ASTArguments extends AbstractASTNode
 
         parent::addChild($node);
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitArguments($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -66,16 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTArray extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitArray($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -99,17 +99,4 @@ class ASTArrayElement extends ASTExpression
     {
         return 6;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitArrayElement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -66,16 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTArrayIndexExpression extends ASTIndexExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitArrayIndexExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -71,7 +71,11 @@ interface ASTArtifact /* extends ASTNode */
     /**
      * ASTVisitor method for node tree traversal.
      *
-     * @return void
+     * @template T of array<string, mixed>|string|null
+     *
+     * @param T $data
+     *
+     * @return T
      */
-    public function accept(ASTVisitor $visitor);
+    public function accept(ASTVisitor $visitor, $data = null);
 }

--- a/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
@@ -52,14 +52,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTAssignmentExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitAssignmentExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -56,14 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTBooleanAndExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitBooleanAndExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -56,14 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTBooleanOrExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitBooleanOrExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTBreakStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitBreakStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -168,15 +168,4 @@ class ASTCastExpression extends ASTUnaryExpression
     {
         return ($this->getImage() === '(unset)');
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitCastExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -52,16 +52,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTCatchStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitCatchStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -201,15 +201,6 @@ class ASTClass extends AbstractASTClassOrInterface
         $this->modifiers = $modifiers;
     }
 
-    /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitClass($this);
-    }
 
     /**
      * The magic wakeup method will be called by PHP's runtime environment when

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -66,16 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTClassFqnPostfix extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitClassFqnPostfix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -100,17 +100,6 @@ class ASTClassOrInterfaceReference extends ASTType
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitClassOrInterfaceReference($this, $data);
-    }
-
-    /**
      * Magic method which returns the names of all those properties that should
      * be cached for this node instance.
      *

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -69,15 +69,4 @@ class ASTClassReference extends ASTClassOrInterfaceReference
 
         return $this->typeInstance;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitClassReference($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTCloneExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitCloneExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -136,19 +136,6 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitClosure($this, $data);
-    }
-
-    /**
      * Returns the total number of the used property bag.
      *
      * @return int

--- a/src/main/php/PDepend/Source/AST/ASTComment.php
+++ b/src/main/php/PDepend/Source/AST/ASTComment.php
@@ -52,14 +52,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTComment extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitComment($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -296,16 +296,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitCompilationUnit($this);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before it serializes an instance of this class. This method returns an
      * array with those property names that should be serialized.

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -70,14 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTCompoundExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitCompoundExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -66,14 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTCompoundVariable extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitCompoundVariable($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -62,14 +62,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTConditionalExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitConditionalExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTConstant.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstant.php
@@ -56,14 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTConstant extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitConstant($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -109,17 +109,6 @@ class ASTConstantDeclarator extends AbstractASTNode
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitConstantDeclarator($this, $data);
-    }
-
-    /**
      * Magic sleep method that returns an array with those property names that
      * should be cached for this node instance.
      *

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -138,18 +138,6 @@ class ASTConstantDefinition extends AbstractASTNode
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitConstantDefinition($this, $data);
-    }
-
-
-    /**
      * Returns the total number of the used property bag.
      *
      * @return int

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -61,14 +61,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTConstantPostfix extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitConstantPostfix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTContinueStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitContinueStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -104,17 +104,6 @@ class ASTDeclareStatement extends ASTStatement
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.10.0
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitDeclareStatement($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTDoWhileStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitDoWhileStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTEchoStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitEchoStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -71,17 +71,4 @@ class ASTElseIfStatement extends ASTStatement
         }
         return false;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitElseIfStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -265,16 +265,6 @@ class ASTEnum extends AbstractASTClassOrInterface
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitEnum($this);
-    }
-
-    /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation
      * of the wakeup method will register this object in the the global class

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -99,17 +99,6 @@ class ASTEnumCase extends AbstractASTNode implements ASTArtifact
         return null;
     }
 
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        $visitor->visitASTEnumCase($this, $data);
-    }
-
     public function getName()
     {
         return $this->getImage();

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTEvalExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitEvalExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTExitExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitExitExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTExpression extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -184,19 +184,6 @@ class ASTFieldDeclaration extends AbstractASTNode
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitFieldDeclaration($this, $data);
-    }
-
-    /**
      * Returns the total number of the used property bag.
      *
      * @return int

--- a/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
@@ -52,12 +52,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTFinallyStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitFinallyStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -58,16 +58,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTForInit extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitForInit($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTForStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitForStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -62,16 +62,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTForUpdate extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitForUpdate($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTForeachStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitForeachStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -141,19 +141,6 @@ class ASTFormalParameter extends AbstractASTNode
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitFormalParameter($this, $data);
-    }
-
-    /**
      * Returns the total number of the used property bag.
      *
      * @return int

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -73,16 +73,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTFormalParameters extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitFormalParameters($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -142,16 +142,6 @@ class ASTFunction extends AbstractASTCallable
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitFunction($this);
-    }
-
-    /**
      * The magic sleep method will be called by the PHP engine when this class
      * gets serialized. It returns an array with those properties that should be
      * cached for all function instances.

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -66,16 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTFunctionPostfix extends ASTInvocation
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitFunctionPostfix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTGlobalStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitGlobalStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTGotoStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitGotoStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -74,15 +74,4 @@ class ASTHeredoc extends ASTExpression
     {
         $this->delimiter = $delimiter;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitHeredoc($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -57,16 +57,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTIdentifier extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitIdentifier($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -68,17 +68,4 @@ class ASTIfStatement extends ASTStatement
     {
         return (count($this->nodes) === 3);
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitIfStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -84,17 +84,6 @@ class ASTIncludeExpression extends ASTExpression
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitIncludeExpression($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTInstanceOfExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitInstanceOfExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -119,16 +119,6 @@ class ASTInterface extends AbstractASTClassOrInterface
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitInterface($this);
-    }
-
-    /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation
      * of the wakeup method will register this object in the the global class

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -65,17 +65,6 @@ class ASTIntersectionType extends AbstractASTCombinationType
         return true;
     }
 
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  2.11.0
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitUnionType($this, $data);
-    }
-
     protected function getSymbol()
     {
         return '&';

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -56,14 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTIssetExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitIssetExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTLabelStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitLabelStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTListExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitListExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTLiteral extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitLiteral($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTLogicalAndExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitLogicalAndExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTLogicalOrExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitLogicalOrExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTLogicalXorExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitLogicalXorExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -69,15 +69,4 @@ class ASTMatchArgument extends ASTArguments
     {
         return count($this->getChildren()) < 1;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitMatchArgument($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -65,16 +65,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTMatchBlock extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitMatchBlock($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -61,16 +61,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTMatchEntry extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitMatchEntry($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -85,17 +85,4 @@ class ASTMemberPrimaryPrefix extends AbstractASTNode
     {
         return ($this->getImage() === '::');
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitMemberPrimaryPrefix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -217,16 +217,6 @@ class ASTMethod extends AbstractASTCallable
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitMethod($this);
-    }
-
-    /**
      * The magic sleep method will be called by the PHP engine when this class
      * gets serialized. It returns an array with those properties that should be
      * cached for method instances.

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -66,16 +66,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTMethodPostfix extends ASTInvocation
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitMethodPostfix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -95,15 +95,4 @@ class ASTNamedArgument extends AbstractASTNode
     {
         return sprintf('%s: %s', $this->name, $this->getChild(0)->getImage());
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitNamedArgument($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -328,14 +328,4 @@ class ASTNamespace extends AbstractASTArtifact
     {
         $this->packageAnnotation = $packageAnnotation;
     }
-
-    /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitNamespace($this);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -98,14 +98,14 @@ interface ASTNode
      *
      * @throws OutOfBoundsException When no node exists at the given index.
      *
-     * @return AbstractASTNode
+     * @return ASTArtifact|AbstractASTNode
      */
     public function getChild($index);
 
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return ASTNode[]
+     * @return (ASTArtifact|AbstractASTNode)[]
      */
     public function getChildren();
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -348,16 +348,6 @@ class ASTParameter extends AbstractASTArtifact
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitParameter($this);
-    }
-
-    /**
      * Returns the wrapped formal parameter instance.
      *
      * @return ASTFormalParameter

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -104,17 +104,6 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitParentReference($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -56,12 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTPostfixExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitPostfixExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -56,12 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTPreDecrementExpression extends ASTUnaryExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitPreDecrementExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -56,12 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTPreIncrementExpression extends ASTUnaryExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitPreIncrementExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
@@ -61,13 +61,4 @@ class ASTPrintExpression extends ASTExpression
     {
         parent::__construct('print');
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitPrintExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -333,16 +333,6 @@ class ASTProperty extends AbstractASTArtifact
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitProperty($this);
-    }
-
-    /**
      * This method returns a string representation of this parameter.
      *
      * @return string

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTPropertyPostfix extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitPropertyPostfix($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -84,17 +84,6 @@ class ASTRequireExpression extends ASTExpression
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitRequireExpression($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTReturnStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitReturnStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -97,15 +97,4 @@ class ASTScalarType extends ASTType
     {
         return $this->getImage() === 'true';
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitScalarType($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTScope extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitScope($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTScopeStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitScopeStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -136,15 +136,4 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
 
         return array_merge(array('qualifiedName'), parent::__sleep());
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitSelfReference($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -70,15 +70,4 @@ class ASTShiftLeftExpression extends ASTExpression
     {
         return self::IMAGE;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitShiftLeftExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -70,15 +70,4 @@ class ASTShiftRightExpression extends ASTExpression
     {
         return self::IMAGE;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitShiftRightExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTStatement extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -73,17 +73,4 @@ class ASTStaticReference extends ASTSelfReference
     {
         return self::IMAGE;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitStaticReference($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTStaticVariableDeclaration extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitStaticVariableDeclaration($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -68,16 +68,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTString extends AbstractASTNode
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitString($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -62,12 +62,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTStringIndexExpression extends ASTIndexExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitStringIndexExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -84,19 +84,6 @@ class ASTSwitchLabel extends AbstractASTNode
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitSwitchLabel($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -52,16 +52,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTSwitchStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitSwitchStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTThrowStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitThrowStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -104,16 +104,6 @@ class ASTTrait extends ASTClass
     }
 
     /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @return void
-     */
-    public function accept(ASTVisitor $visitor)
-    {
-        $visitor->visitTrait($this);
-    }
-
-    /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation
      * of the wakeup method will register this object in the the global class

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -56,12 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTTraitAdaptation extends ASTScope
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTraitAdaptation($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -127,15 +127,4 @@ class ASTTraitAdaptationAlias extends ASTStatement
     {
         return array_merge(array('newName', 'newModifier'), parent::__sleep());
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTraitAdaptationAlias($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -56,12 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTTraitAdaptationPrecedence extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTraitAdaptationPrecedence($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -68,15 +68,4 @@ class ASTTraitReference extends ASTClassOrInterfaceReference
         }
         return $this->typeInstance;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTraitReference($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -204,13 +204,4 @@ class ASTTraitUseStatement extends ASTStatement
     {
         return $this->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationAlias');
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTraitUseStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTTryStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTryStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -96,15 +96,4 @@ class ASTType extends AbstractASTNode
     {
         return false;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since 0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitType($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -80,17 +80,4 @@ class ASTTypeArray extends ASTType
     {
         return true;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTypeArray($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -68,15 +68,4 @@ class ASTTypeCallable extends ASTType
     {
         return self::IMAGE;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTypeCallable($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -80,17 +80,4 @@ class ASTTypeIterable extends ASTType
     {
         return true;
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitTypeIterable($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTUnaryExpression extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitUnaryExpression($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -68,17 +68,6 @@ class ASTUnionType extends AbstractASTCombinationType
         return true;
     }
 
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @since  2.9.0
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitUnionType($this, $data);
-    }
-
     protected function getSymbol()
     {
         return '|';

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTUnsetStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitUnsetStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -74,17 +74,4 @@ class ASTVariable extends ASTExpression
     {
         return ($this->getImage() === '$this');
     }
-
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitVariable($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -87,19 +87,6 @@ class ASTVariableDeclarator extends ASTExpression
     }
 
     /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitVariableDeclarator($this, $data);
-    }
-
-    /**
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTVariableVariable extends ASTExpression
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitVariableVariable($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -56,16 +56,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTWhileStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitWhileStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -70,16 +70,4 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 class ASTYieldStatement extends ASTStatement
 {
-    /**
-     * Accept method of the visitor design pattern. This method will be called
-     * by a visitor during tree traversal.
-     *
-     * @param ASTVisitor $visitor The calling visitor instance.
-     *
-     * @since  0.9.12
-     */
-    public function accept(ASTVisitor $visitor, $data = null)
-    {
-        return $visitor->visitYieldStatement($this, $data);
-    }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+
 /**
  * Abstract base class for code item.
  *
@@ -256,6 +258,20 @@ abstract class AbstractASTArtifact implements ASTArtifact
     public function setDocComment($docComment)
     {
         $this->setComment($docComment);
+    }
+
+    /**
+     * @template T of array<string, mixed>|string|null
+     *
+     * @param T $data
+     *
+     * @return T
+     */
+    public function accept(ASTVisitor $visitor, $data = null)
+    {
+        $methodName = 'visit' . substr(get_class($this), 22);
+
+        return call_user_func(array($visitor, $methodName), $this, $data);
     }
 
     // END@deprecated

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -61,7 +61,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Parsed child nodes of this node.
      *
-     * @var ASTNode[]
+     * @var (ASTArtifact|AbstractASTNode)[]
      */
     protected $nodes = array();
 
@@ -91,9 +91,18 @@ abstract class AbstractASTNode implements ASTNode
      */
     protected $metadata = '::::';
 
+    /**
+     * @template T of array<string, mixed>|string|null
+     *
+     * @param T $data
+     *
+     * @return T
+     */
     public function accept(ASTVisitor $visitor, $data = null)
     {
-        throw new BadMethodCallException('Accept must be overwritten');
+        $methodName = 'visit' . substr(get_class($this), 22);
+
+        return call_user_func(array($visitor, $methodName), $this, $data);
     }
 
     /**
@@ -338,7 +347,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return ASTNode[]
+     * @return (ASTArtifact|AbstractASTNode)[]
      */
     public function getChildren()
     {
@@ -407,6 +416,8 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * This method adds a new child node to this node instance.
+     *
+     * @param ASTNode&(ASTArtifact|AbstractASTNode) $node
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\ASTVisitor;
 
+use PDepend\Source\AST\AbstractASTNode;
+use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTEnum;
@@ -163,4 +165,14 @@ interface ASTVisitor
      * @since  0.9.12
      */
     public function __call($method, $args);
+
+    /**
+     * @template T of array<string, mixed>|numeric-string
+     *
+     * @param ASTArtifact|AbstractASTNode $node
+     * @param T $value
+     *
+     * @return T
+     */
+    public function visit($node, $value);
 }

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -299,8 +299,12 @@ abstract class AbstractASTVisitor implements ASTVisitor
             throw new RuntimeException("No node to visit provided for $method.");
         }
 
-        $value = $args[1];
-        foreach ($args[0]->getChildren() as $child) {
+        return $this->visit($args[0], $args[1]);
+    }
+
+    public function visit($node, $value)
+    {
+        foreach ($node->getChildren() as $child) {
             $value = $child->accept($this, $value);
         }
         return $value;

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -347,7 +347,7 @@ class ChartTest extends AbstractTest
         $packageA = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTNamespace')
             ->setMethods(array('isUserDefined'))
             ->setConstructorArgs(array($packageName))
-            ->setMockClassName('package_' . md5(microtime()))
+            ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTNamespace')
             ->getMock();
         $packageA->expects($this->atLeastOnce())
             ->method('isUserDefined')

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -477,7 +477,11 @@ class ASTPropertyTest extends AbstractTest
         $visitor->expects($this->once())
             ->method('visitProperty');
 
-        $property = $this->getMockWithoutConstructor('PDepend\\Source\\AST\\ASTProperty');
+        $property = $this->getMockBuilder('PDepend\\Source\\AST\\ASTProperty')
+            ->setMethods(array('__construct'))
+            ->disableOriginalConstructor()
+            ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTProperty')
+            ->getMock();
         $property->accept($visitor);
     }
 

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -272,4 +272,8 @@ class StubASTVisitor implements ASTVisitor
     public function __call($method, $args)
     {
     }
+
+    public function visit($node, $value)
+    {
+    }
 }


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Call visitor functions dynamically. This gets rid of the last PHPStan exception, avoids a lot of boiler plate code, and fixes a few issues in the code.

It also corrects two instances where the wrong method was called:
- `ASTEnumCase` called `visitASTEnumCase()` should have been `visitEnumCase()`
- `ASTIntersectionType` called `visitUnionType()` instead of `visitIntersectionType()`

`ASTAnonymousClass::accept(): int` had an incorrect return type

`ASTArtifact::accept($node): void` did not match `AbstractASTNode::accept($node, $data = null): $data` but was being used interchangeably, this affected`ASTClass`, `ASTCompilationUnit`, `ASTEnum`, `ASTFunction`, `ASTMethod`, `ASTParameter`, `ASTProperty`, and `ASTTrait`.

There is still a similar issue where `*::visit*()` does not always match `ASTVisitor::visit()`. These do not directly interferer with the scope of this PR and so will be handled separately.

The following code is being used for generating the correct visitor call, this is taken from our tests. If desired we can look in to more robust solutions:
```php
$methodName = 'visit' . substr(get_class($this), 22);
```
------------

### Side notes

Ideally analyzers would overwrite `visit()` and call its type specific visitors based on `instanceof`, how ever this would break backwards comparability since it requires changes to any external analyzer.
```php
    public function visit($node, $value)
    {
        if ($node instanceof ASTBooleanAndExpression) {
            return $this->visitBooleanAndExpression($node, $value);
        }
        return parent::visit($node, $value);
    }
```
This would have avoid the use of `call_user_func()` and provide for a more robust analysis of the code. I recommend that we make this change for version 3.0.0.

Another alternative I considered was using `method_exists()` and making the call from `AbstractASTVisitor`, again this would have provided better analysis (some of the issues I found where picked up when using this implementation). The down side here is that if a analyzer is using `__call()` to collect it's data then the would break as `method_exists()` would not pick up on them and thus not call the method.