### PR TITLE
Correct name space collection types (bump to PHPStan level 5)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,4 +7,4 @@ parameters:
         - src/main/php/PDepend/Util/ImageConvert.php
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
-    level: 4
+    level: 5

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Metrics;
 
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
 /**
@@ -72,7 +73,7 @@ interface Analyzer
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
+     * @param ASTArtifactList<ASTNamespace> $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -109,8 +109,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -117,8 +117,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -117,8 +117,6 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -100,8 +100,6 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -48,6 +48,7 @@ use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\AbstractASTType;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -179,8 +180,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)
@@ -195,7 +194,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This method traverses all namespaces in the given iterator and calculates
      * the coupling metrics for them.
      *
-     * @param ASTNamespace[] $namespaces
+     * @param ASTArtifactList<ASTNamespace> $namespaces
      *
      * @return void
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -48,6 +48,7 @@ use PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
@@ -145,8 +146,6 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)
@@ -159,7 +158,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Performs the crap index analysis.
      *
-     * @param ASTNamespace[] $namespaces
+     * @param ASTArtifactList<ASTNamespace> $namespaces
      *
      * @return void
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -86,8 +86,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -133,8 +133,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -78,8 +78,6 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -153,8 +153,6 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -47,6 +47,7 @@ use PDepend\Metrics\AnalyzerFilterAware;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
 
@@ -176,8 +177,6 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)
@@ -195,7 +194,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * Calculates several inheritance related metrics for the given source
      * namespaces.
      *
-     * @param ASTNamespace[] $namespaces
+     * @param ASTArtifactList<ASTNamespace> $namespaces
      *
      * @return void
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -100,8 +100,6 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -83,8 +83,6 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -166,8 +166,6 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -171,8 +171,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *
-     * @param ASTNamespace[] $namespaces
-     *
      * @return void
      */
     public function analyze($namespaces)

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -127,7 +127,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -104,7 +104,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -94,7 +94,6 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -93,7 +93,6 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
      *
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
      * @return void
      */
     public function analyze($namespaces)


### PR DESCRIPTION
Type: documentation
Breaking change: no

`ASTNamespace` are not passed around in simples arrays but instead `ASTArtifactList`. Correct the base implementations and let everything else inherit the definition.

This is solves the remaining PHPStan level 5 and bumps the checks to that level