### PR TITLE
Numeric-strings

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -248,7 +248,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      */
     public function visitDoWhileStatement($node, $data)
     {
-        $stmt = $node->getChild(0)->accept($this, 1);
+        $stmt = $node->getChild(0)->accept($this, '1');
         $expr = $this->sumComplexity($node->getChild(1));
 
         $npath = MathUtil::add($expr, $stmt);
@@ -290,7 +290,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = $this->sumComplexity($node->getChild(0));
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
-                $expr  = $child->accept($this, 1);
+                $expr  = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $expr);
             }
         }
@@ -326,7 +326,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = '1';
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
-                $stmt  = $child->accept($this, 1);
+                $stmt  = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $stmt);
             } elseif ($child instanceof ASTExpression) {
                 $expr  = $this->sumComplexity($child);
@@ -363,7 +363,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
-                $stmt  = $child->accept($this, 1);
+                $stmt  = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $stmt);
             }
         }
@@ -405,7 +405,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
-                $stmt  = $child->accept($this, 1);
+                $stmt  = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $stmt);
             }
         }
@@ -468,7 +468,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = $this->sumComplexity($node->getChild(0));
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTSwitchLabel) {
-                $label = $child->accept($this, 1);
+                $label = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $label);
             }
         }
@@ -511,7 +511,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = '0';
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
-                $stmt  = $child->accept($this, 1);
+                $stmt  = $child->accept($this, '1');
                 $npath = MathUtil::add($npath, $stmt);
             }
         }
@@ -540,7 +540,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     public function visitWhileStatement($node, $data)
     {
         $expr = $this->sumComplexity($node->getChild(0));
-        $stmt = $node->getChild(1)->accept($this, 1);
+        $stmt = $node->getChild(1)->accept($this, '1');
 
         $npath = MathUtil::add($expr, $stmt);
         $npath = MathUtil::add($npath, '1');
@@ -565,7 +565,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     {
         $sum = '0';
         if ($node instanceof ASTConditionalExpression) {
-            $sum = MathUtil::add($sum, $node->accept($this, 1));
+            $sum = MathUtil::add($sum, $node->accept($this, '1'));
         } elseif ($node instanceof ASTBooleanAndExpression
             || $node instanceof ASTBooleanOrExpression
             || $node instanceof ASTLogicalAndExpression

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -62,7 +62,7 @@ use PDepend\Source\AST\ASTMethod;
 class IdBuilder
 {
     /**
-     * @var array<array>
+     * @var array<string, array<string, int>>
      *
      * @deprecated 3.0.0 This property will no longer be accessible on the public access level in next major version.
      */
@@ -162,7 +162,7 @@ class IdBuilder
         }
         return sprintf(
             '%02s',
-            base_convert($this->offsetInFile[$file][$string], 10, 36)
+            base_convert((string)$this->offsetInFile[$file][$string], 10, 36)
         );
     }
 }

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -55,8 +55,8 @@ final class MathUtil
      * This method will multiply the two given operands with the bcmath extension
      * when available, otherwise it will use the default mathematical operations.
      *
-     * @param string $left  The left arithmetic operand.
-     * @param string $right The right arithmetic operand.
+     * @param numeric-string $left  The left arithmetic operand.
+     * @param numeric-string $right The right arithmetic operand.
      *
      * @return string
      */


### PR DESCRIPTION
Type: refactoring / documentation
Breaking no

bcmath operates on numeric-strings and not integers/floats. This was correct in most places, this PR corrects the rest.