### PR TITLE
Phpstan corrections

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -348,8 +348,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Weight Method Per Class metric, this method only counts
      * protected and public methods of parent classes.
      *
-     * @param ASTClass|ASTEnum|ASTTrait $class The context class instance.
-     *
      * @return int
      */
     private function calculateWmciForClass(AbstractASTClassOrInterface $class)
@@ -401,6 +399,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         return $ccn;
     }
 
+    /**
+     * @param ASTClass|ASTEnum $class
+     */
     private function calculateAbstractASTClassOrInterfaceMetrics(AbstractASTClassOrInterface $class)
     {
         $impl  = count($class->getInterfaces());

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -211,7 +211,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param ASTClass $type
      * @param string   $typeIdentifier
      *
      * @return void

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -192,8 +192,8 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
                 $angle = rand(0, 314) / 100 - 1.57;
                 $legend = $legendTemplate->cloneNode(true);
                 if ($legend instanceof DOMElement) {
-                    $legend->setAttribute('x', $e + $item['ratio'] * (1 + cos($angle)));
-                    $legend->setAttribute('y', $f + $item['ratio'] * (1 + sin($angle)));
+                    $legend->setAttribute('x', (string)($e + $item['ratio'] * (1 + cos($angle))));
+                    $legend->setAttribute('y', (string)($f + $item['ratio'] * (1 + sin($angle))));
                     $legend->nodeValue = $found[1];
                     $legendTemplate->parentNode->appendChild($legend);
                 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -298,9 +298,11 @@ abstract class AbstractASTType extends AbstractASTArtifact
             ->type('methods')
             ->restore($this->getId());
 
-        foreach ($methods as $method) {
-            $method->compilationUnit = $this->compilationUnit;
-            $method->setParent($this);
+        if ($this instanceof AbstractASTClassOrInterface) {
+            foreach ($methods as $method) {
+                $method->compilationUnit = $this->compilationUnit;
+                $method->setParent($this);
+            }
         }
 
         return new ASTArtifactList($methods);
@@ -313,7 +315,9 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function addMethod(ASTMethod $method)
     {
-        $method->setParent($this);
+        if ($this instanceof AbstractASTClassOrInterface) {
+            $method->setParent($this);
+        }
 
         $this->methods[] = $method;
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8194,7 +8194,7 @@ abstract class AbstractPHPParser
 
         $expression = $this->parseOptionalExpression();
 
-        if ($expression === null) {
+        if (!$expression instanceof AbstractASTNode) {
             throw new MissingValueException($this->tokenizer);
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1112,8 +1112,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_CASE:
                     if (!($classOrInterface instanceof ASTEnum)) {
                         throw new TokenException(
-                            'Enum case should be located only inside enum classes',
-                            $this->tokenizer->getSourceFile()
+                            'Enum case should be located only inside enum classes'
                         );
                     }
 
@@ -8097,8 +8096,7 @@ abstract class AbstractPHPParser
                 !in_array($type->getImage(), array('int', 'string'), true)
             ) {
                 throw new TokenException(
-                    "Enum backing type must be 'int' or 'string'",
-                    $this->tokenizer->getSourceFile()
+                    "Enum backing type must be 'int' or 'string'"
                 );
             }
         }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -965,7 +965,11 @@ abstract class AbstractPHPParser
     /**
      * Parses a parent class declaration for the given <b>$class</b>.
      *
-     * @return ASTClass
+     * @template T of ASTClass
+     *
+     * @param T $class
+     *
+     * @return T
      *
      * @since 1.0.0
      */
@@ -1484,7 +1488,7 @@ abstract class AbstractPHPParser
     /**
      * Extension for version specific additions.
      *
-     * @template T of AbstractASTCallable
+     * @template T of AbstractASTCallable|ASTClosure
      *
      * @param T $callable
      *
@@ -1949,7 +1953,7 @@ abstract class AbstractPHPParser
     /**
      * Return true if the current node can be used as a list key.
      *
-     * @param ASTExpression|null $node
+     * @param ASTNode|null $node
      *
      * @return bool
      */
@@ -2996,7 +3000,7 @@ abstract class AbstractPHPParser
      * This method parses multiple expressions and adds them as children to the
      * given <b>$exprList</b> node.
      *
-     * @template T of ASTNode
+     * @template T of AbstractASTNode
      *
      * @param T $exprList
      *
@@ -3072,7 +3076,7 @@ abstract class AbstractPHPParser
      *
      * @throws ParserException
      *
-     * @return AbstractASTNode|null
+     * @return ASTNode|null
      *
      * @since 0.9.6
      */
@@ -3373,9 +3377,11 @@ abstract class AbstractPHPParser
     /**
      * Applies all reduce rules against the given expression list.
      *
-     * @param ASTExpression[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
+     * @template T of ASTNode[]
      *
-     * @return ASTExpression[]
+     * @param T $expressions Unprepared input array with parsed expression nodes found in the source tree.
+     *
+     * @return T
      *
      * @since 0.10.0
      */
@@ -3387,9 +3393,11 @@ abstract class AbstractPHPParser
     /**
      * Reduces all unary-expressions in the given expression list.
      *
-     * @param ASTExpression[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
+     * @template T of ASTNode[]
      *
-     * @return ASTExpression[]
+     * @param T $expressions Unprepared input array with parsed expression nodes found in the source tree.
+     *
+     * @return T
      *
      * @since 0.10.0
      */
@@ -3973,7 +3981,7 @@ abstract class AbstractPHPParser
     /**
      * Parses the expression part of a for-statement.
      *
-     * @return AbstractASTNode|null
+     * @return ASTNode|null
      *
      * @since 0.9.12
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2418,7 +2418,7 @@ class PHPBuilder implements Builder
      *
      * @template T of AbstractASTType
      *
-     * @param array<string, array<string, array<string, T>>> $instances
+     * @param array<string, array<string, array<int, T>>> $instances
      * @param string                                         $qualifiedName
      *
      * @return T|null


### PR DESCRIPTION
Type: documentation
Breaking change: no

A few scattered corrections to issues found by PHPStan at level 5.

`addMethod()` and `getMethods()` should probably be moved to `AbstractASTClassOrInterface`, but to not make breaking changes i have simply guarded against calling methods that would fail if not extended.