### PR TITLE
Correct type signatures

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -61,7 +61,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Parsed child nodes of this node.
      *
-     * @var (ASTArtifact|AbstractASTNode)[]
+     * @var ASTNode[]
      */
     protected $nodes = array();
 
@@ -347,7 +347,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return (ASTArtifact|AbstractASTNode)[]
+     * @return ASTNode[]
      */
     public function getChildren()
     {
@@ -417,7 +417,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method adds a new child node to this node instance.
      *
-     * @param ASTNode&(ASTArtifact|AbstractASTNode) $node
+     * @param ASTNode $node
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\ASTVisitor;
 
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
@@ -51,6 +50,7 @@ use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
@@ -169,7 +169,7 @@ interface ASTVisitor
     /**
      * @template T of array<string, mixed>|numeric-string
      *
-     * @param ASTArtifact|AbstractASTNode $node
+     * @param ASTNode $node
      * @param T $value
      *
      * @return T

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2997,7 +2997,7 @@ abstract class AbstractPHPParser
      * This method parses multiple expressions and adds them as children to the
      * given <b>$exprList</b> node.
      *
-     * @template T of ASTNode
+     * @template T of AbstractASTNode
      *
      * @param T $exprList
      *


### PR DESCRIPTION
Type: documentation  
Breaking change: no

Together with https://github.com/pdepend/pdepend/pull/645 https://github.com/pdepend/pdepend/pull/646 and https://github.com/pdepend/pdepend/pull/647 this will get us to a point where PDepend should pass PHPStan level 5 which covers all basic issues.

Level 6 will make sure that all signatures are hinted which will help any project using it as a library since they can then validate interactions with it. This should be fairly easy to complete once the outstanding PRs are merged.

Level 7/8/9 are mostly about checking assumptions about types which is nice to have and can prevent errors. But I do not consider them high priority to cover before starting work on PHPMD.