### PR TITLE
Add missing type information

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -169,7 +169,7 @@ class Application
     /**
      * Returns available logger options and documentation messages.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, string>>
      */
     public function getAvailableLoggerOptions()
     {
@@ -179,7 +179,7 @@ class Application
     /**
      * Returns available analyzer options and documentation messages.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, string>>
      */
     public function getAvailableAnalyzerOptions()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -68,22 +68,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * Hash with all calculated node metrics.
      *
-     * <code>
-     * array(
-     *     '0375e305-885a-4e91-8b5c-e25bda005438'  =>  array(
-     *         'loc'    =>  42,
-     *         'ncloc'  =>  17,
-     *         'cc'     =>  12
-     *     ),
-     *     'e60c22f0-1a63-4c40-893e-ed3b35b84d0b'  =>  array(
-     *         'loc'    =>  42,
-     *         'ncloc'  =>  17,
-     *         'cc'     =>  12
-     *     )
-     * )
-     * </code>
-     *
-     * @var array<string, array>
+     * @var array<string, array<string, array<string, int>>>
      */
     private $nodeMetrics = null;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -103,7 +103,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * )
      * </code>
      *
-     * @var array<string, array>
+     * @var array<string, array<string, int>>
      */
     private $nodeMetrics = null;
 
@@ -401,6 +401,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
 
     /**
      * @param ASTClass|ASTEnum $class
+     *
+     * @return void
      */
     private function calculateAbstractASTClassOrInterfaceMetrics(AbstractASTClassOrInterface $class)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -81,7 +81,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * All found nodes.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<int, string>>>
      */
     private $nodes = array();
 
@@ -110,7 +110,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * )
      * </code>
      *
-     * @var array<string, array>
+     * @var array<string, array<string, int>>
      */
     private $nodeMetrics = null;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
@@ -55,7 +55,7 @@ interface CodeRankStrategyI extends ASTVisitor
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, array<int, string>>>
      */
     public function getCollectedNodes();
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -59,14 +59,14 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
     /**
      * All found nodes.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<int, string>>>
      */
     private $nodes = array();
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, array<int, string>>>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -58,14 +58,14 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * All found nodes.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<int, string>>>
      */
     private $nodes = array();
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, array<int, string>>>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -57,14 +57,14 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * All found nodes.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<int, string>>>
      */
     private $nodes = array();
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array>
+     * @return array<string, array<string, array<int, string>>>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -117,7 +117,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * Temporary map that is used to hold the id combinations of dependee and
      * depender.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<string, bool>>>
      *
      * @since 0.10.2
      */
@@ -127,7 +127,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * This array holds a mapping between node identifiers and an array with
      * the node's metrics.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, mixed>>
      *
      * @since 0.10.2
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -78,7 +78,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Calculated crap metrics.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, float>>
      */
     private $metrics = null;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -146,7 +146,7 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
      * )
      * </code>
      *
-     * @var array<string, array>
+     * @var array<string, array<string, int>>
      */
     private $nodeMetrics = null;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -133,7 +133,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     /**
      * Metrics calculated for a single source node.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, mixed>>
      */
     private $nodeMetrics = null;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -109,7 +109,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Collected node metrics
      *
-     * @var array<string, array>
+     * @var array<string, array<string, int>>
      */
     private $nodeMetrics = null;
 

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -98,7 +98,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * List of all collected node metrics.
      *
-     * @var array<string, array>
+     * @var array<string, array<string, array<int, string>>>
      */
     protected $nodeMetrics = array();
 

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -112,7 +112,7 @@ class Pyramid implements FileAwareGenerator
      * Holds defined thresholds for the computed proportions. This set is based
      * on java thresholds, we should find better values for php projects.
      *
-     * @var array<string, array>
+     * @var array<string, array<int, float>>
      */
     private $thresholds = array(
         'cyclo-loc'     =>  array(0.16, 0.20, 0.24),

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -281,13 +281,15 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      */
     protected function setMetadataInteger($index, $value)
     {
-        $this->setMetadata($index, $value);
+        $this->setMetadata($index, (string)$value);
     }
 
     /**
      * Returns the value that was stored under the given index.
      *
      * @param int $index
+     *
+     * @return string
      *
      * @since 0.10.4
      */
@@ -302,6 +304,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * container.
      *
      * @param int $index
+     * @param string $value
      *
      * @return void
      *

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -338,6 +338,8 @@ class ASTParameter extends AbstractASTArtifact
      * {@link ASTParameter::isDefaultValueAvailable()} to
      * detect a NULL-value.
      *
+     * @return mixed
+     *
      * @since  0.9.5
      */
     public function getDefaultValue()
@@ -406,6 +408,11 @@ class ASTParameter extends AbstractASTArtifact
         );
     }
 
+    /**
+     * @param ASTNode $node
+     *
+     * @return bool
+     */
     private function isTypeAllowingNull($node)
     {
         if ($node instanceof ASTUnionType) {

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -321,6 +321,8 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return the default value for this property instance or
      * <b>null</b> when this property was only declared and not initialized.
      *
+     * @return mixed
+     *
      * @since  0.9.6
      */
     public function getDefaultValue()

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -65,11 +65,15 @@ class ASTValue
 
     /**
      * The parsed PHP-value,
+     *
+     * @var mixed
      */
     private $value = null;
 
     /**
      * This method will return the parsed PHP value.
+     *
+     * @return mixed
      */
     public function getValue()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -256,6 +256,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @param string $name Name of the searched constant.
      *
+     * @return mixed
+     *
      * @since  0.9.6
      */
     public function getConstant($name)

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -243,7 +243,7 @@ abstract class AbstractASTNode implements ASTNode
      */
     protected function setMetadataInteger($index, $value)
     {
-        $this->setMetadata($index, $value);
+        $this->setMetadata($index, (string)$value);
     }
 
     /**
@@ -273,7 +273,7 @@ abstract class AbstractASTNode implements ASTNode
      */
     protected function setMetadataBoolean($index, $value)
     {
-        $this->setMetadata($index, $value ? 1 : 0);
+        $this->setMetadata($index, $value ? '1' : '0');
     }
 
     /**
@@ -296,6 +296,7 @@ abstract class AbstractASTNode implements ASTNode
      * container.
      *
      * @param int $index
+     * @param string $value
      *
      * @return void
      *

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -162,6 +162,8 @@ interface ASTVisitor
      * @param string            $method Name of the called method.
      * @param array<int, mixed> $args   Array with method argument.
      *
+     * @return array<string, mixed>|numeric-string
+     *
      * @since  0.9.12
      */
     public function __call($method, $args);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2508,6 +2508,9 @@ abstract class AbstractPHPParser
         return $expr;
     }
 
+    /**
+     * @return bool
+     */
     protected function allowTrailingCommaInSpecialFunctions()
     {
         return false;
@@ -2807,6 +2810,7 @@ abstract class AbstractPHPParser
      *
      * @param T   $node
      * @param int $closeToken
+     * @param int|null $separatorToken
      *
      * @throws TokenStreamEndException
      *
@@ -3377,11 +3381,9 @@ abstract class AbstractPHPParser
     /**
      * Applies all reduce rules against the given expression list.
      *
-     * @template T of ASTNode[]
+     * @param ASTNode[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
      *
-     * @param T $expressions Unprepared input array with parsed expression nodes found in the source tree.
-     *
-     * @return T
+     * @return ASTNode[]
      *
      * @since 0.10.0
      */
@@ -4356,7 +4358,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @eturn bool
+     * @return bool
      */
     protected function isNextTokenObjectOperator()
     {
@@ -5329,6 +5331,7 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTNode
      *
      * @param T $node The context parent node.
+     * @param bool $inCall
      *
      * @return T The prepared entire node.
      *
@@ -6169,6 +6172,8 @@ abstract class AbstractPHPParser
     /**
      * use of trailing comma in formal parameters list is allowed since PHP 8.0
      * example function foo(string $bar, int $baz,)
+     *
+     * @return bool
      */
     protected function allowTrailingCommaInFormalParametersList()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -370,6 +370,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
         return $arguments;
     }
 
+    /**
+     * @return ASTNode|null
+     */
     protected function parseArgumentExpression()
     {
         return $this->parseOptionalExpression();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -611,6 +611,8 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
     /**
      * use Foo\Bar\{TestA, TestB} is allowed since PHP 7.0
      * use Foo\Bar\{TestA, TestB,} but trailing comma isn't
+     *
+     * @return bool
      */
     protected function allowUseGroupDeclarationTrailingComma()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
@@ -54,6 +54,9 @@ namespace PDepend\Source\Language\PHP;
  */
 abstract class PHPParserVersion73 extends PHPParserVersion72
 {
+    /**
+     * @return bool
+     */
     protected function allowTrailingCommaInSpecialFunctions()
     {
         return true;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -79,6 +79,7 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
                        0[bB][01]+(?:_[01]+)*
                      )$/x';
 
+    /** @var array<int, int> */
     protected $possiblePropertyTypes = array(
         Tokens::T_STRING,
         Tokens::T_ARRAY,

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -290,11 +290,17 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $function;
     }
 
+    /**
+     * @return ASTType
+     */
     protected function parseEndReturnTypeHint()
     {
         return $this->parseTypeHint();
     }
 
+    /**
+     * @return ASTType
+     */
     protected function parseSingleTypeHint()
     {
         $this->consumeComments();
@@ -352,6 +358,11 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $unionType;
     }
 
+    /**
+     * @param ASTType $type
+     *
+     * @return ASTType
+     */
     protected function parseTypeHintCombination($type)
     {
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_OR) {
@@ -371,6 +382,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $type instanceof ASTScalarType && ($type->isFalse() || $type->isNull());
     }
 
+    /**
+     * @return ASTType
+     */
     protected function parseTypeHint()
     {
         $this->consumeComments();
@@ -412,12 +426,17 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     /**
      * use of trailing comma in formal parameters list is allowed since PHP 8.0
      * example function foo(string $bar, int $baz,)
+     *
+     * @return bool
      */
     protected function allowTrailingCommaInFormalParametersList()
     {
         return true;
     }
 
+    /**
+     * @return bool
+     */
     protected function isNextTokenObjectOperator()
     {
         return in_array($this->tokenizer->peek(), array(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -46,6 +46,7 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTType;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -58,6 +59,7 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion82 extends PHPParserVersion81
 {
+    /** @var array<int, int> */
     protected $possiblePropertyTypes = array(
         Tokens::T_STRING,
         Tokens::T_ARRAY,
@@ -100,6 +102,9 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
         return parent::isTypeHint($tokenType);
     }
 
+    /**
+     * @return ASTType
+     */
     protected function parseSingleTypeHint()
     {
         $this->consumeComments();

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -437,7 +437,7 @@ class PHPTokenizerInternal implements FullTokenizer
     );
 
     /**
-     * @var array<mixed, array>
+     * @var array<int, array<int, string>>
      */
     protected static $substituteTokens = array(
         T_DOLLAR_OPEN_CURLY_BRACES  =>  array('$', '{'),
@@ -448,7 +448,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * Re-map based on the previous token
      *
-     * @var array<int, array>
+     * @var array<int, array<int, int>>
      */
     protected static $alternativeMap = array(
         Tokens::T_USE => array(
@@ -794,7 +794,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * @param array<int|string> $token
      *
-     * @return array<array>
+     * @return array<int, array<int|string>>
      */
     private function splitQualifiedNameToken($token)
     {
@@ -827,7 +827,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array<int|string> $token
      * @param string            $namespace
      *
-     * @return array<array>
+     * @return array<int, array<int, string|int>>
      */
     private function splitRelativeNameToken($token, $namespace)
     {

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -53,7 +53,7 @@ class SymbolTable
     /**
      * Stack with all active scopes.
      *
-     * @var array<array>
+     * @var array<array<string, string>>
      */
     private $scopeStack = array();
 

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -97,6 +97,8 @@ interface CacheDriver
      *
      * @param string $key  The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
+     *
+     * @return mixed
      */
     public function restore($key, $hash = null);
 

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -197,6 +197,8 @@ class FileCacheDriver implements CacheDriver
      *
      * @param string $file The cache file name.
      * @param string $hash The verification hash.
+     *
+     * @return mixed
      */
     protected function restoreFile($file, $hash)
     {

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -84,6 +84,8 @@ class Configuration
      *
      * @param string $name Name of the requested configuration value.
      *
+     * @return mixed
+     *
      * @throws OutOfRangeException If no matching configuration value exists.
      *
      * @since  0.10.0

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -56,7 +56,7 @@ class CloverReport implements Report
     /**
      * Holds the line coverage for all files found in the coverage report.
      *
-     * @var array<string, array>
+     * @var array<string, array<int, bool>>
      */
     private $fileLineCoverage = array();
 


### PR DESCRIPTION
Type: documentation
Breaking change: no

This adds all missing types. Happily it uncovered very little in terms of issues, just a few integers that should be cast to string and a block of wrong documentation (copied from another analyzer).

This resolves all PHPStan level 6 specific issues