### PR TITLE
Make visitor call concreat

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -158,12 +158,28 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
         return $efferents;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -173,14 +189,14 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->fireStartNamespace($namespace);
 
@@ -191,30 +207,32 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
         }
 
         $this->fireEndNamespace($namespace);
+
+        return $value;
     }
 
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->fireStartClass($class);
         $this->visitType($class);
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits an interface node.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->fireStartInterface($interface);
         $this->visitType($interface);
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -188,36 +188,58 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         return $metrics;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTTrait) {
+            return $this->visitTrait($node, $value);
+        }
+        if ($node instanceof ASTEnum) {
+            return $this->visitEnum($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->fireStartClass($class);
         $this->calculateAbstractASTClassOrInterfaceMetrics($class);
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         // Empty visit method, we don't want interface metrics
+
+        return $value;
     }
 
     /**
      * Visits a trait node.
      *
-     * @return void
-     *
      * @since  1.0.0
      */
-    public function visitTrait(ASTTrait $trait)
+    public function visitTrait(ASTTrait $trait, $value)
     {
         $this->fireStartTrait($trait);
 
@@ -244,28 +266,28 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         }
 
         $this->fireEndTrait($trait);
+
+        return $value;
     }
 
     /**
      * Visits a enum node.
      *
-     * @return void
-     *
      * @since  2.12.1
      */
-    public function visitEnum(ASTEnum $enum)
+    public function visitEnum(ASTEnum $enum, $value)
     {
         $this->fireStartEnum($enum);
         $this->calculateAbstractASTClassOrInterfaceMetrics($enum);
         $this->fireEndEnum($enum);
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -288,14 +310,14 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a property node.
-     *
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->fireStartProperty($property);
 
@@ -315,6 +337,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         }
 
         $this->fireEndProperty($property);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -73,28 +73,40 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
         return $this->nodes;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a code class object.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->fireStartClass($class);
         $this->visitType($class);
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->fireStartInterface($interface);
         $this->visitType($interface);
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -72,12 +72,19 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         return $this->nodes;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -95,6 +102,8 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -71,18 +71,25 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         return $this->nodes;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a property node.
-     *
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->fireStartProperty($property);
 
         if (($depClass = $property->getClass()) === null) {
             $this->fireEndProperty($property);
-            return;
+            return $value;
         }
 
         $depNamespace = $depClass->getNamespace();
@@ -107,6 +114,8 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         }
 
         $this->fireEndProperty($property);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -115,15 +115,31 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         $this->fireEndAnalyzer();
     }
 
+    public function visit($node, $value)
+    {
+        /*
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        */
+
+        return parent::visit($node, $value);
+    }
+
     /*
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->fireStartProperty($property);
         echo ltrim($property->getName(), '$'), PHP_EOL;
         $this->fireEndProperty($property);
+
+        return $value;
     }
 
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -155,6 +171,8 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
     */
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -256,12 +256,31 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         $this->dependencyMap = array();
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -292,42 +311,38 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         $this->countCalls($function);
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visit method for classes that will be called by PDepend during the
      * analysis phase with the current context class.
      *
-     * @return void
-     *
      * @since  0.10.2
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->initDependencyMap($class);
-        parent::visitClass($class);
+        return parent::visitClass($class, $value);
     }
 
     /**
      * Visit method for interfaces that will be called by PDepend during the
      * analysis phase with the current context interface.
      *
-     * @return void
-     *
      * @since  0.10.2
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->initDependencyMap($interface);
-        parent::visitInterface($interface);
+        return parent::visitInterface($interface, $value);
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -348,14 +363,14 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         $this->countCalls($method);
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a property node.
-     *
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->fireStartProperty($property);
 
@@ -365,6 +380,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         );
 
         $this->fireEndProperty($property);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -178,26 +178,38 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
         $this->fireEndAnalyzer();
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits the given method.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         if ($method->isAbstract() === false) {
             $this->visitCallable($method);
         }
+
+        return $value;
     }
 
     /**
      * Visits the given function.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->visitCallable($function);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -47,12 +47,24 @@ use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTArtifact;
+use PDepend\Source\AST\ASTBooleanAndExpression;
+use PDepend\Source\AST\ASTBooleanOrExpression;
+use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForStatement;
 use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTIfStatement;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTLogicalAndExpression;
+use PDepend\Source\AST\ASTLogicalOrExpression;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTSwitchLabel;
+use PDepend\Source\AST\ASTWhileStatement;
 
 /**
  * This class calculates the Cyclomatic Complexity Number(CCN) for the project,
@@ -165,12 +177,61 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
         );
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTBooleanAndExpression) {
+            return $this->visitBooleanAndExpression($node, $value);
+        }
+        if ($node instanceof ASTBooleanOrExpression) {
+            return $this->visitBooleanOrExpression($node, $value);
+        }
+        if ($node instanceof ASTCatchStatement) {
+            return $this->visitCatchStatement($node, $value);
+        }
+        if ($node instanceof ASTConditionalExpression) {
+            return $this->visitConditionalExpression($node, $value);
+        }
+        if ($node instanceof ASTDoWhileStatement) {
+            return $this->visitDoWhileStatement($node, $value);
+        }
+        if ($node instanceof ASTElseIfStatement) {
+            return $this->visitElseIfStatement($node, $value);
+        }
+        if ($node instanceof ASTForeachStatement) {
+            return $this->visitForeachStatement($node, $value);
+        }
+        if ($node instanceof ASTForStatement) {
+            return $this->visitForStatement($node, $value);
+        }
+        if ($node instanceof ASTIfStatement) {
+            return $this->visitIfStatement($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTLogicalAndExpression) {
+            return $this->visitLogicalAndExpression($node, $value);
+        }
+        if ($node instanceof ASTLogicalOrExpression) {
+            return $this->visitLogicalOrExpression($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTSwitchLabel) {
+            return $this->visitSwitchLabel($node, $value);
+        }
+        if ($node instanceof ASTWhileStatement) {
+            return $this->visitWhileStatement($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -180,24 +241,23 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
         $this->updateProjectMetrics($function->getId());
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         // Empty visit method, we don't want interface metrics
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -207,6 +267,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
         $this->updateProjectMetrics($method->getId());
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
@@ -249,33 +311,33 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a boolean AND-expression.
      *
-     * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param ASTBooleanAndExpression $node The currently visited node.
+     * @param array<string, integer>  $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitBooleanAndExpression($node, $data)
+    public function visitBooleanAndExpression(ASTBooleanAndExpression $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a boolean OR-expression.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTBooleanOrExpression $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitBooleanOrExpression($node, $data)
+    public function visitBooleanOrExpression(ASTBooleanOrExpression $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
@@ -288,188 +350,188 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      *
      * @since  0.9.8
      */
-    public function visitSwitchLabel($node, $data)
+    public function visitSwitchLabel(ASTSwitchLabel $node, $data)
     {
         if (!$node->isDefault()) {
             ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
             ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
         }
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a catch statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTCatchStatement      $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitCatchStatement($node, $data)
+    public function visitCatchStatement(ASTCatchStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits an elseif statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTElseIfStatement     $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitElseIfStatement($node, $data)
+    public function visitElseIfStatement(ASTElseIfStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a for statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTForStatement        $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitForStatement($node, $data)
+    public function visitForStatement(ASTForStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a foreach statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTForeachStatement    $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitForeachStatement($node, $data)
+    public function visitForeachStatement(ASTForeachStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits an if statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTIfStatement         $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitIfStatement($node, $data)
+    public function visitIfStatement(ASTIfStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a logical AND expression.
      *
-     * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param ASTLogicalAndExpression $node The currently visited node.
+     * @param array<string, integer>  $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitLogicalAndExpression($node, $data)
+    public function visitLogicalAndExpression(ASTLogicalAndExpression $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a logical OR expression.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTLogicalOrExpression $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitLogicalOrExpression($node, $data)
+    public function visitLogicalOrExpression(ASTLogicalOrExpression $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a ternary operator.
      *
-     * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param ASTConditionalExpression $node The currently visited node.
+     * @param array<string, integer>   $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitConditionalExpression($node, $data)
+    public function visitConditionalExpression(ASTConditionalExpression $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a while-statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTWhileStatement      $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.8
      */
-    public function visitWhileStatement($node, $data)
+    public function visitWhileStatement(ASTWhileStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 
     /**
      * Visits a do/while-statement.
      *
-     * @param ASTNode                $node The currently visited node.
+     * @param ASTDoWhileStatement    $node The currently visited node.
      * @param array<string, integer> $data The previously calculated ccn values.
      *
      * @return array<string, integer>
      *
      * @since  0.9.12
      */
-    public function visitDoWhileStatement($node, $data)
+    public function visitDoWhileStatement(ASTDoWhileStatement $node, $data)
     {
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_1];
         ++$data[self::M_CYCLOMATIC_COMPLEXITY_2];
 
-        return $this->visit($node, $data);
+        return parent::visit($node, $data);
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -228,12 +228,28 @@ class DependencyAnalyzer extends AbstractAnalyzer
         return $this->collectedCycles[$node->getId()];
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTMethod) {
+             return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -243,14 +259,14 @@ class DependencyAnalyzer extends AbstractAnalyzer
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->fireStartNamespace($namespace);
 
@@ -263,30 +279,32 @@ class DependencyAnalyzer extends AbstractAnalyzer
         }
 
         $this->fireEndNamespace($namespace);
+
+        return $value;
     }
 
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->fireStartClass($class);
         $this->visitType($class);
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits an interface node.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->fireStartInterface($interface);
         $this->visitType($interface);
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -133,12 +133,25 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
         return array();
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -147,24 +160,24 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
         }
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         // Empty visit method, we don't want interface metrics
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -173,6 +186,8 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -207,15 +207,34 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         return array();
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Calculates metrics for the given <b>$class</b> instance.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         if (false === $class->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $this->fireStartClass($class);
@@ -245,26 +264,26 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Calculates metrics for the given <b>$function</b> instance.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
         ++$this->fcs;
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Calculates metrics for the given <b>$interface</b> instance.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->fireStartInterface($interface);
 
@@ -275,26 +294,26 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
         ++$this->mts;
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Calculates metrics for the given <b>$namespace</b> instance.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->fireStartNamespace($namespace);
 
@@ -307,5 +326,7 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndNamespace($namespace);
+
+        return $value;
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -215,26 +215,35 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
         }
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         if (!$class->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $this->fireStartClass($class);
 
         $this->initNodeMetricsForClass($class);
-        
+
         $this->calculateNumberOfDerivedClasses($class);
         $this->calculateNumberOfAddedAndOverwrittenMethods($class);
         $this->calculateDepthOfInheritanceTree($class);
 
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
@@ -280,7 +289,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
             ++$dit;
             $root = $parent->getId();
         }
-        
+
         // Collect max dit value
         $this->maxDIT = max($this->maxDIT, $dit);
 
@@ -317,7 +326,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
             if ($method->getParent() !== $class) {
                 continue;
             }
-            
+
             if (isset($parentMethodNames[$method->getName()])) {
                 if (!$parentMethodNames[$method->getName()]) {
                     ++$numberOfOverwrittenMethods;

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -147,12 +147,25 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
         return array();
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -161,24 +174,24 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
         }
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         // Empty visit method, we don't want interface metrics
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -187,6 +200,8 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -186,15 +186,34 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         if (false === $class->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $this->fireStartClass($class);
@@ -214,14 +233,14 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -232,17 +251,17 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ++$this->nodeMetrics[$id][self::M_NUMBER_OF_FUNCTIONS];
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         if (false === $interface->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $this->fireStartInterface($interface);
@@ -262,14 +281,14 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -286,14 +305,14 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ++$this->nodeMetrics[$id][self::M_NUMBER_OF_METHODS];
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->fireStartNamespace($namespace);
 
@@ -318,5 +337,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         }
 
         $this->fireEndNamespace($namespace);
+
+        return $value;
     }
 }

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -188,24 +188,45 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         file_put_contents($this->logFile, $buffer);
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTTrait) {
+            return $this->visitTrait($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->generateTypeXml($class, 'class');
+
+        return $value;
     }
 
     /**
      * Visits a trait node.
-     *
-     * @return void
      */
-    public function visitTrait(ASTTrait $trait)
+    public function visitTrait(ASTTrait $trait, $value)
     {
         $this->generateTypeXml($trait, 'trait');
+
+        return $value;
     }
 
     /**
@@ -240,34 +261,32 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         // Do not care
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->generateTypeXml($interface, 'interface');
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $xml = end($this->xmlStack);
         if (!$xml) {
-            return;
+            return $value;
         }
 
         $doc = $xml->ownerDocument;
@@ -287,10 +306,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         array_pop($this->xmlStack);
 
         if ($packageXml->firstChild === null) {
-            return;
+            return $value;
         }
 
         $xml->appendChild($packageXml);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -222,15 +222,28 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         file_put_contents($this->logFile, $buffer);
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         if (!$class->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $doc = $this->packages->ownerDocument;
@@ -248,17 +261,17 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         } else {
             $this->concreteClasses->appendChild($classXml);
         }
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         if (!$interface->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $doc = $this->abstractClasses->ownerDocument;
@@ -272,22 +285,22 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         );
 
         $this->abstractClasses->appendChild($classXml);
+
+        return $value;
     }
 
     /**
      * Visits a package node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         if (!$namespace->isUserDefined()) {
-            return;
+            return $value;
         }
 
         $stats = $this->analyzer->getStats($namespace);
         if (count($stats) === 0) {
-            return;
+            return $value;
         }
 
         $doc = $this->packages->ownerDocument;
@@ -369,9 +382,11 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         if ($this->concreteClasses->firstChild === null
             && $this->abstractClasses->firstChild === null
         ) {
-            return;
+            return $value;
         }
 
         $this->packages->appendChild($packageXml);
+
+        return $value;
     }
 }

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -259,24 +259,48 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         return $projectMetrics;
     }
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTTrait) {
+            return $this->visitTrait($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->generateTypeXml($class, 'class');
+
+        return $value;
     }
 
     /**
      * Visits a trait node.
-     *
-     * @return void
      */
-    public function visitTrait(ASTTrait $trait)
+    public function visitTrait(ASTTrait $trait, $value)
     {
         $this->generateTypeXml($trait, 'trait');
+
+        return $value;
     }
 
     /**
@@ -324,14 +348,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $xml = end($this->xmlStack);
         if (!$xml) {
-            return;
+            return $value;
         }
 
         $doc = $xml->ownerDocument;
@@ -345,28 +367,28 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->writeFileReference($functionXml, $function->getCompilationUnit());
 
         $xml->appendChild($functionXml);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         // Empty implementation, because we don't want interface methods.
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $xml = end($this->xmlStack);
         if (!$xml) {
-            return;
+            return $value;
         }
 
         $doc = $xml->ownerDocument;
@@ -379,18 +401,18 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->writeNodeMetrics($methodXml, $method);
 
         $xml->appendChild($methodXml);
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $xml = end($this->xmlStack);
         if (!$xml) {
-            return;
+            return $value;
         }
 
         $doc = $xml->ownerDocument;
@@ -412,10 +434,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         array_pop($this->xmlStack);
 
         if ($packageXml->firstChild === null) {
-            return;
+            return $value;
         }
 
         $xml->appendChild($packageXml);
+
+        return $value;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -45,6 +45,7 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is an abstract base implementation of the ast node interface.
@@ -56,6 +57,15 @@ use OutOfBoundsException;
  */
 interface ASTNode
 {
+    /**
+     * @template T of array<string, mixed>|string|null
+     *
+     * @param T $data
+     *
+     * @return T
+     */
+    public function accept(ASTVisitor $visitor, $data = null);
+
     /**
      * Returns the source image of this ast node.
      *

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -269,9 +269,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      */
     public function accept(ASTVisitor $visitor, $data = null)
     {
-        $methodName = 'visit' . substr(get_class($this), 22);
-
-        return call_user_func(array($visitor, $methodName), $this, $data);
+        return $visitor->visit($this, $data);
     }
 
     // END@deprecated

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -91,18 +91,9 @@ abstract class AbstractASTNode implements ASTNode
      */
     protected $metadata = '::::';
 
-    /**
-     * @template T of array<string, mixed>|string|null
-     *
-     * @param T $data
-     *
-     * @return T
-     */
     public function accept(ASTVisitor $visitor, $data = null)
     {
-        $methodName = 'visit' . substr(get_class($this), 22);
-
-        return call_user_func(array($visitor, $methodName), $this, $data);
+        return $visitor->visit($this, $data);
     }
 
     /**

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -72,101 +72,64 @@ interface ASTVisitor
 
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class);
+    public function visitClass(ASTClass $class, $value);
 
     /**
      * Visits an enum node.
-     *
-     * @return void
      */
-    public function visitEnum(ASTEnum $enum);
+    public function visitEnum(ASTEnum $enum, $value);
 
     /**
      * Visits a trait node.
      *
-     * @return void
-     *
      * @since  1.0.0
      */
-    public function visitTrait(ASTTrait $trait);
+    public function visitTrait(ASTTrait $trait, $value);
 
     /**
      * Visits a file node.
-     *
-     * @return void
      */
-    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit);
+    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit, $value);
 
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function);
+    public function visitFunction(ASTFunction $function, $value);
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface);
+    public function visitInterface(ASTInterface $interface, $value);
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method);
+    public function visitMethod(ASTMethod $method, $value);
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace);
+    public function visitNamespace(ASTNamespace $namespace, $value);
 
     /**
      * Visits a parameter node.
-     *
-     * @return void
      */
-    public function visitParameter(ASTParameter $parameter);
+    public function visitParameter(ASTParameter $parameter, $value);
 
     /**
      * Visits a property node.
-     *
-     * @return void
      */
-    public function visitProperty(ASTProperty $property);
+    public function visitProperty(ASTProperty $property, $value);
 
     /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
+     * Takes two argument. The first argument is the current context ast node
+     * and the second argument is a data array or object that is used to
+     * collect data.
      *
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
-     * @since  0.9.12
-     */
-    public function __call($method, $args);
-
-    /**
      * @template T of array<string, mixed>|numeric-string
      *
      * @param ASTNode $node

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -97,10 +97,8 @@ abstract class AbstractASTVisitor implements ASTVisitor
 
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->fireStartClass($class);
 
@@ -114,14 +112,14 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndClass($class);
+
+        return $value;
     }
 
     /**
      * Visits a class node.
-     *
-     * @return void
      */
-    public function visitEnum(ASTEnum $enum)
+    public function visitEnum(ASTEnum $enum, $value)
     {
         $this->fireStartEnum($enum);
 
@@ -135,16 +133,16 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndEnum($enum);
+
+        return $value;
     }
 
     /**
      * Visits a trait node.
      *
-     * @return void
-     *
      * @since  1.0.0
      */
-    public function visitTrait(ASTTrait $trait)
+    public function visitTrait(ASTTrait $trait, $value)
     {
         $this->fireStartTrait($trait);
 
@@ -155,25 +153,25 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndTrait($trait);
+
+        return $value;
     }
 
     /**
      * Visits a file node.
-     *
-     * @return void
      */
-    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
+    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit, $value)
     {
         $this->fireStartFile($compilationUnit);
         $this->fireEndFile($compilationUnit);
+
+        return $value;
     }
 
     /**
      * Visits a function node.
-     *
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->fireStartFunction($function);
 
@@ -184,14 +182,14 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndFunction($function);
+
+        return $value;
     }
 
     /**
      * Visits a code interface object.
-     *
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->fireStartInterface($interface);
 
@@ -202,14 +200,14 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndInterface($interface);
+
+        return $value;
     }
 
     /**
      * Visits a method node.
-     *
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->fireStartMethod($method);
 
@@ -218,14 +216,14 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndMethod($method);
+
+        return $value;
     }
 
     /**
      * Visits a namespace node.
-     *
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->fireStartNamespace($namespace);
 
@@ -246,64 +244,65 @@ abstract class AbstractASTVisitor implements ASTVisitor
         }
 
         $this->fireEndNamespace($namespace);
+
+        return $value;
     }
 
     /**
      * Visits a parameter node.
-     *
-     * @return void
      */
-    public function visitParameter(ASTParameter $parameter)
+    public function visitParameter(ASTParameter $parameter, $value)
     {
         $this->fireStartParameter($parameter);
         $this->fireEndParameter($parameter);
+
+        return $value;
     }
 
     /**
      * Visits a property node.
-     *
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->fireStartProperty($property);
         $this->fireEndProperty($property);
-    }
 
-
-    /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
-     * @since  0.9.12
-     */
-    public function __call($method, $args)
-    {
-        if (!isset($args[1])) {
-            throw new RuntimeException("No node to visit provided for $method.");
-        }
-
-        return $this->visit($args[0], $args[1]);
+        return $value;
     }
 
     public function visit($node, $value)
     {
+        if ($node instanceof ASTCompilationUnit) {
+            return $this->visitCompilationUnit($node, $value);
+        }
+        if ($node instanceof ASTEnum) {
+            return $this->visitEnum($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+        if ($node instanceof ASTParameter) {
+            return $this->visitParameter($node, $value);
+        }
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+        if ($node instanceof ASTTrait) {
+            return $this->visitTrait($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+
         foreach ($node->getChildren() as $child) {
             $value = $child->accept($this, $value);
         }

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -136,7 +136,7 @@ class HierarchyAnalyzerTest extends AbstractMetricsTest
         $class = new ASTClass(null);
 
         $analyzer = $this->createAnalyzer();
-        $analyzer->visitClass($class);
+        $analyzer->visitClass($class, '1');
 
         $metrics = $analyzer->getNodeMetrics($class);
         $this->assertEquals(array(), $metrics);

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -213,7 +213,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
         $actual = array();
         foreach ($namespaces[0]->getClasses() as $class) {
             $metrics = $analyzer->getNodeMetrics($class);
-            
+
             $actual[$class->getName()] = $metrics['dit'];
         }
         ksort($actual);
@@ -313,7 +313,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTest
         $class = new ASTClass(null);
 
         $analyzer = $this->createAnalyzer();
-        $analyzer->visitClass($class);
+        $analyzer->visitClass($class, '1');
 
         $metrics = $analyzer->getNodeMetrics($class);
         $this->assertEquals(array(), $metrics);

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -128,7 +128,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
 
         ksort($expected);
         ksort($actual);
-        
+
         $this->assertEquals($expected, $actual);
     }
 
@@ -688,7 +688,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTest
         $compilationUnit->setId(42);
 
         $analyzer = $this->createAnalyzer();
-        $analyzer->visitCompilationUnit($compilationUnit);
+        $analyzer->visitCompilationUnit($compilationUnit, '1');
 
         $metrics = $analyzer->getNodeMetrics($compilationUnit);
         $this->assertEquals(array(), $metrics);

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -181,7 +181,7 @@ class ASTCompilationUnitTest extends AbstractTest
         $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('visitCompilationUnit')
+            ->method('visit')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTCompilationUnit'));
 
         $file = new ASTCompilationUnit(null);

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -913,7 +913,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
         $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('visitInterface')
+            ->method('visit')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
 
         $interface = $this->createItem();
@@ -930,7 +930,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTest
         $interface = new ASTInterface(__CLASS__);
         $interface->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $interface->setCache(new MemoryCacheDriver());
-        
+
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
         $interface->setContext($context);

--- a/src/test/php/PDepend/Source/AST/ASTNodeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTest.php
@@ -623,13 +623,13 @@ abstract class ASTNodeTest extends AbstractTest
      */
     public function testAcceptInvokesVisitOnGivenVisitor()
     {
-        $methodName = 'visit' . substr(get_class($this), 22, -4);
+        $methodName = 'PDepend\\Source\\AST\\AST' . substr(get_class($this), 22, -4);
 
         $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo($methodName));
+            ->method('visit')
+            ->with($this->isInstanceOf($methodName));
 
         $node = $this->createNodeInstance();
         $node->accept($visitor);
@@ -642,13 +642,13 @@ abstract class ASTNodeTest extends AbstractTest
      */
     public function testAcceptReturnsReturnValueOfVisitMethod()
     {
-        $methodName = 'visit' . substr(get_class($this), 22, -4);
+        $methodName = 'PDepend\\Source\\AST\\AST' . substr(get_class($this), 22, -4);
 
         $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('__call')
-            ->with($this->equalTo($methodName))
+            ->method('visit')
+            ->with($this->isInstanceOf($methodName))
             ->will($this->returnValue(42));
 
         $node = $this->createNodeInstance();

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -251,7 +251,7 @@ class ASTParameterTest extends AbstractTest
         $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('visitParameter')
+            ->method('visit')
             ->with($this->isInstanceOf('\\PDepend\\Source\\AST\\ASTParameter'));
 
         $formalParameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTFormalParameter')

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -475,7 +475,7 @@ class ASTPropertyTest extends AbstractTest
         $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
             ->getMock();
         $visitor->expects($this->once())
-            ->method('visitProperty');
+            ->method('visit');
 
         $property = $this->getMockBuilder('PDepend\\Source\\AST\\ASTProperty')
             ->setMethods(array('__construct'))

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -425,7 +425,7 @@ class ASTTraitTest extends AbstractASTArtifactTest
             ->disableOriginalClone()
             ->getMock();
         $visitor->expects($this->once())
-            ->method('visitTrait')
+            ->method('visit')
             ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTTrait'));
 
         $trait = new ASTTrait('MyTrait');

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -71,7 +71,7 @@ class DefaultListenerTest extends AbstractTest
         $listener = new StubAbstractASTVisitListener();
         $visitor  = new StubAbstractASTVisitor();
         $visitor->addVisitListener($listener);
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
 
         $actual   = $listener->nodes;
         $expected = array(

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -67,12 +67,12 @@ class DefaultVisitorTest extends AbstractTest
     public function testDefaultVisitOrder()
     {
         $namespaces = $this->parseCodeResourceForTest();
-        
+
         $visitor = new StubAbstractASTVisitor();
         foreach ($namespaces as $namespace) {
             $namespace->accept($visitor);
         }
-        
+
         $expected = array(
             'pkgA',
             'classB',
@@ -91,7 +91,7 @@ class DefaultVisitorTest extends AbstractTest
             'funcD',
             'PDepend\\Source\\AST\\ASTCompilationUnit'
         );
-        
+
         $this->assertEquals($expected, $visitor->visits);
     }
 
@@ -110,7 +110,7 @@ class DefaultVisitorTest extends AbstractTest
         $visitor->expects($this->exactly(2))
             ->method('visitParameter');
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -128,7 +128,7 @@ class DefaultVisitorTest extends AbstractTest
         $visitor->expects($this->exactly(3))
             ->method('visitParameter');
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -139,7 +139,7 @@ class DefaultVisitorTest extends AbstractTest
     public function testVisitorInvokesStartVisitParameterOnListener()
     {
         $namespaces = $this->parseCodeResourceForTest();
-        
+
         $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
             ->getMock();
         $listener->expects($this->exactly(2))
@@ -150,7 +150,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -172,7 +172,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -194,7 +194,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -216,7 +216,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -238,7 +238,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -260,7 +260,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespaces[0]);
+        $visitor->visitNamespace($namespaces[0], '1');
     }
 
     /**
@@ -336,7 +336,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespace);
+        $visitor->visitNamespace($namespace, '1');
     }
 
     /**
@@ -363,7 +363,7 @@ class DefaultVisitorTest extends AbstractTest
             ->getMock();
         $visitor->addVisitListener($listener);
 
-        $visitor->visitNamespace($namespace);
+        $visitor->visitNamespace($namespace, '1');
     }
 
     /**

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -139,34 +139,37 @@ class StubASTVisitor implements ASTVisitor
      * Visits a class node.
      *
      * @param \PDepend\Source\AST\ASTClass $class
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->class = $class;
+
+        return $value;
     }
 
     /**
      * Visits an enum node.
      *
      * @param \PDepend\Source\AST\ASTEnum $enum
-     * @return void
      */
-    public function visitEnum(ASTEnum $enum)
+    public function visitEnum(ASTEnum $enum, $value)
     {
         $this->enum = $enum;
+
+        return $value;
     }
 
     /**
      * Visits a trait node.
      *
      * @param \PDepend\Source\AST\ASTTrait $trait
-     * @return void
      * @since 1.0.0
      */
-    public function visitTrait(ASTTrait $trait)
+    public function visitTrait(ASTTrait $trait, $value)
     {
         $this->trait = $trait;
+
+        return $value;
     }
 
 
@@ -174,106 +177,114 @@ class StubASTVisitor implements ASTVisitor
      * Visits a code interface object.
      *
      * @param \PDepend\Source\AST\ASTInterface $interface
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->interface = $interface;
+
+        return $value;
     }
 
     /**
      * Visits a method node.
      *
      * @param \PDepend\Source\AST\ASTMethod $method
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->method = $method;
+
+        return $value;
     }
 
     /**
      * Visits a package node.
      *
      * @param \PDepend\Source\AST\ASTNamespace $namespace The package class node.
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->namespace = $namespace;
+
+        return $value;
     }
 
     /**
      * Visits a parameter node.
      *
      * @param \PDepend\Source\AST\ASTParameter $parameter
-     * @return void
      */
-    public function visitParameter(ASTParameter $parameter)
+    public function visitParameter(ASTParameter $parameter, $value)
     {
         $this->parameter = $parameter;
+
+        return $value;
     }
 
     /**
      * Visits a property node.
      *
      * @param \PDepend\Source\AST\ASTProperty $property
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->property = $property;
+
+        return $value;
     }
 
     /**
      * Visits a function node.
      *
      * @param \PDepend\Source\AST\ASTFunction $function
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->function = $function;
+
+        return $value;
     }
 
     /**
      * Visits a file node.
      *
      * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
-     * @return void
      */
-    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
+    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit, $value)
     {
-    }
-
-    /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string $method Name of the called method.
-     * @param array $args Array with method argument.
-     *
-     * @return mixed
-     * @since 0.9.12
-     */
-    public function __call($method, $args)
-    {
+        return $value;
     }
 
     public function visit($node, $value)
     {
+        if ($node instanceof ASTEnum) {
+            return $this->visitEnum($node, $value);
+        }
+        if ($node instanceof ASTTrait) {
+            return $this->visitTrait($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+        if ($node instanceof ASTParameter) {
+            return $this->visitParameter($node, $value);
+        }
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+
+        return $value;
     }
 }

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
@@ -65,94 +65,114 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public $visits = array();
 
+    public function visit($node, $value)
+    {
+        if ($node instanceof ASTCompilationUnit) {
+            return $this->visitCompilationUnit($node, $value);
+        }
+        if ($node instanceof ASTFunction) {
+            return $this->visitFunction($node, $value);
+        }
+        if ($node instanceof ASTInterface) {
+            return $this->visitInterface($node, $value);
+        }
+        if ($node instanceof ASTMethod) {
+            return $this->visitMethod($node, $value);
+        }
+        if ($node instanceof ASTNamespace) {
+            return $this->visitNamespace($node, $value);
+        }
+        if ($node instanceof ASTProperty) {
+            return $this->visitProperty($node, $value);
+        }
+        if ($node instanceof ASTClass) {
+            return $this->visitClass($node, $value);
+        }
+
+        return parent::visit($node, $value);
+    }
+
     /**
      * Visits a class node.
      *
      * @param \PDepend\Source\AST\ASTClass $class
-     * @return void
      */
-    public function visitClass(ASTClass $class)
+    public function visitClass(ASTClass $class, $value)
     {
         $this->visits[] = $class->getName();
 
-        parent::visitClass($class);
+        return parent::visitClass($class, $value);
     }
 
     /**
      * Visits a file node.
      *
      * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
-     * @return void
      */
-    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit)
+    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit, $value)
     {
         $this->visits[] = get_class($compilationUnit);
 
-        parent::visitCompilationUnit($compilationUnit);
+        return parent::visitCompilationUnit($compilationUnit, $value);
     }
 
     /**
      * Visits a function node.
      *
      * @param \PDepend\Source\AST\ASTFunction $function
-     * @return void
      */
-    public function visitFunction(ASTFunction $function)
+    public function visitFunction(ASTFunction $function, $value)
     {
         $this->visits[] = $function->getName();
 
-        parent::visitFunction($function);
+        return parent::visitFunction($function, $value);
     }
 
     /**
      * Visits a code interface object.
      *
      * @param \PDepend\Source\AST\ASTInterface $interface
-     * @return void
      */
-    public function visitInterface(ASTInterface $interface)
+    public function visitInterface(ASTInterface $interface, $value)
     {
         $this->visits[] = $interface->getName();
 
-        parent::visitInterface($interface);
+        return parent::visitInterface($interface, $value);
     }
 
     /**
      * Visits a method node.
      *
      * @param \PDepend\Source\AST\ASTMethod $method
-     * @return void
      */
-    public function visitMethod(ASTMethod $method)
+    public function visitMethod(ASTMethod $method, $value)
     {
         $this->visits[] = $method->getName();
 
-        parent::visitMethod($method);
+        return parent::visitMethod($method, $value);
     }
 
     /**
      * Visits a package node.
      *
      * @param \PDepend\Source\AST\ASTNamespace $namespace The package class node.
-     * @return void
      */
-    public function visitNamespace(ASTNamespace $namespace)
+    public function visitNamespace(ASTNamespace $namespace, $value)
     {
         $this->visits[] = $namespace->getName();
 
-        parent::visitNamespace($namespace);
+        return parent::visitNamespace($namespace, $value);
     }
 
     /**
      * Visits a property node.
      *
      * @param \PDepend\Source\AST\ASTProperty $property
-     * @return void
      */
-    public function visitProperty(ASTProperty $property)
+    public function visitProperty(ASTProperty $property, $value)
     {
         $this->visits[] = $property->getName();
 
-        parent::visitProperty($property);
+        return parent::visitProperty($property, $value);
     }
 }


### PR DESCRIPTION
Instead of relying on a magic function make the analyzers call there specific visitor functions using instanceof in an overwrite

Type: refactoring
Breaking change: yes

This moves the responsibility of calling type specific visitors to the definer as suggested here: https://github.com/pdepend/pdepend/pull/644

The benefit is that the code can now be evaluated by static analysis since it does not make use of magic methods or run time generated callbacks.
To simplify things further I have also adjusted all `vist*()` methods to follow the same base signature so that they can all be used in the same way.