### PR TITLE
Decouple AST nodes from visitors and make visitor despatching analyzable

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -104,7 +104,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
             $this->nodeMetrics = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->postProcess();
@@ -196,7 +196,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
         }
 
         foreach ($type->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -129,7 +129,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
 
             // Visit all nodes
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();
@@ -216,10 +216,10 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         ];
 
         foreach ($trait->getProperties() as $property) {
-            $property->accept($this);
+            $this->dispatch($property);
         }
         foreach ($trait->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         $this->fireEndTrait($trait);
@@ -400,12 +400,12 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
 
         if ($class instanceof ASTClass) {
             foreach ($class->getProperties() as $property) {
-                $property->accept($this);
+                $this->dispatch($property);
             }
         }
 
         foreach ($class->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -137,7 +137,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
             foreach ($namespaces as $namespace) {
                 // Traverse all strategies
                 foreach ($this->strategies as $strategy) {
-                    $namespace->accept($strategy);
+                    $strategy->dispatch($namespace);
                 }
             }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -98,7 +98,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         $this->fireStartAnalyzer();
 
         foreach ($namespaces as $namespace) {
-            $namespace->accept($this);
+            $this->dispatch($namespace);
         }
 
         $this->fireEndAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -188,7 +188,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         $this->reset();
 
         foreach ($namespaces as $namespace) {
-            $namespace->accept($this);
+            $this->dispatch($namespace);
         }
 
         $this->postProcessTemporaryCouplingMap();

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -153,7 +153,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
         $this->fireStartAnalyzer();
 
         foreach ($namespaces as $namespace) {
-            $namespace->accept($this);
+            $this->dispatch($namespace);
         }
 
         $this->fireEndAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -63,6 +63,7 @@ use PDepend\Source\AST\ASTLogicalAndExpression;
 use PDepend\Source\AST\ASTLogicalOrExpression;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTSwitchLabel;
 use PDepend\Source\AST\ASTWhileStatement;
 
@@ -414,5 +415,25 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
         ++$this->collector[self::M_CYCLOMATIC_COMPLEXITY_2];
 
         $this->visit($node);
+    }
+
+    public function dispatch(ASTNode $node): void
+    {
+        match ($node::class) {
+            ASTBooleanAndExpression::class => $this->visitBooleanAndExpression($node),
+            ASTBooleanOrExpression::class => $this->visitBooleanOrExpression($node),
+            ASTCatchStatement::class => $this->visitCatchStatement($node),
+            ASTConditionalExpression::class => $this->visitConditionalExpression($node),
+            ASTDoWhileStatement::class => $this->visitDoWhileStatement($node),
+            ASTElseIfStatement::class => $this->visitElseIfStatement($node),
+            ASTForeachStatement::class => $this->visitForeachStatement($node),
+            ASTForStatement::class => $this->visitForStatement($node),
+            ASTIfStatement::class => $this->visitIfStatement($node),
+            ASTLogicalAndExpression::class => $this->visitLogicalAndExpression($node),
+            ASTLogicalOrExpression::class => $this->visitLogicalOrExpression($node),
+            ASTSwitchLabel::class => $this->visitSwitchLabel($node),
+            ASTWhileStatement::class => $this->visitWhileStatement($node),
+            default => parent::dispatch($node),
+        };
     }
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -104,7 +104,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
             $this->metrics = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -144,7 +144,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
             $this->nodeCollector = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->postProcess();
@@ -259,7 +259,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
         $this->nodeSet[$namespace->getId()] = $namespace;
 
         foreach ($namespace->getTypes() as $type) {
-            $type->accept($this);
+            $this->dispatch($type);
         }
 
         $this->fireEndNamespace($namespace);
@@ -314,7 +314,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
         }
 
         foreach ($type->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -89,7 +89,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
             $this->metrics = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -143,7 +143,7 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
 
             // Visit all nodes
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();
@@ -209,10 +209,10 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         $this->nodeMetrics[$class->getId()] = [];
 
         foreach ($class->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
         foreach ($class->getProperties() as $property) {
-            $property->accept($this);
+            $this->dispatch($property);
         }
 
         $this->fireEndClass($class);
@@ -238,7 +238,7 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ++$this->interfs;
 
         foreach ($interface->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         $this->fireEndInterface($interface);
@@ -262,11 +262,11 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         $this->fireStartNamespace($namespace);
 
         foreach ($namespace->getTypes() as $type) {
-            $type->accept($this);
+            $this->dispatch($type);
         }
 
         foreach ($namespace->getFunctions() as $function) {
-            $function->accept($this);
+            $this->dispatch($function);
         }
 
         $this->fireEndNamespace($namespace);

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -168,7 +168,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
     private function doAnalyze($namespaces): void
     {
         foreach ($namespaces as $namespace) {
-            $namespace->accept($this);
+            $this->dispatch($namespace);
         }
 
         if ($this->numberOfClasses > 0) {

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -110,7 +110,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
             $this->metrics = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -104,7 +104,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
 
             $this->metrics = [];
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();
@@ -233,7 +233,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     public function visitDoWhileStatement(ASTDoWhileStatement $node): void
     {
         $this->pushCollector();
-        $node->getChild(0)->accept($this);
+        $this->dispatch($node->getChild(0));
         $expr = $this->sumComplexity($node->getChild(1));
 
         $npath = MathUtil::add($expr, $this->collector);
@@ -273,7 +273,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             }
@@ -307,7 +307,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             } elseif ($child instanceof ASTExpression) {
@@ -342,7 +342,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             }
@@ -382,7 +382,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             }
@@ -439,7 +439,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTSwitchLabel) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             }
@@ -481,7 +481,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         foreach ($node->getChildren() as $child) {
             if ($child instanceof ASTStatement) {
                 $this->pushCollector();
-                $child->accept($this);
+                $this->dispatch($child);
                 $npath = MathUtil::add($npath, $this->collector);
                 $this->popCollector();
             }
@@ -509,7 +509,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
     {
         $expr = $this->sumComplexity($node->getChild(0));
         $this->pushCollector();
-        $node->getChild(1)->accept($this);
+        $this->dispatch($node->getChild(1));
 
         $npath = MathUtil::add($expr, $this->collector);
         $npath = MathUtil::add($npath, '1');
@@ -533,7 +533,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $sum = '0';
         $this->pushCollector();
         if ($node instanceof ASTConditionalExpression) {
-            $node->accept($this);
+            $this->dispatch($node);
             $sum = MathUtil::add($sum, $this->collector);
         } elseif (
             $node instanceof ASTBooleanAndExpression

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -518,6 +518,23 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $this->collector = MathUtil::mul($npath, $this->collector);
     }
 
+    public function dispatch(ASTNode $node): void
+    {
+        match ($node::class) {
+            ASTConditionalExpression::class => $this->visitConditionalExpression($node),
+            ASTDoWhileStatement::class => $this->visitDoWhileStatement($node),
+            ASTElseIfStatement::class => $this->visitElseIfStatement($node),
+            ASTForeachStatement::class => $this->visitForeachStatement($node),
+            ASTForStatement::class => $this->visitForStatement($node),
+            ASTIfStatement::class => $this->visitIfStatement($node),
+            ASTReturnStatement::class => $this->visitReturnStatement($node),
+            ASTSwitchStatement::class => $this->visitSwitchStatement($node),
+            ASTTryStatement::class => $this->visitTryStatement($node),
+            ASTWhileStatement::class => $this->visitWhileStatement($node),
+            default => parent::dispatch($node),
+        };
+    }
+
     /**
      * Calculates the expression sum of the given node.
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -151,7 +151,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
             $this->nodeMetrics = [];
 
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();
@@ -180,7 +180,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ];
 
         foreach ($class->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         $this->fireEndClass($class);
@@ -224,7 +224,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ];
 
         foreach ($interface->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         $this->fireEndInterface($interface);
@@ -269,13 +269,13 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ];
 
         foreach ($namespace->getClasses() as $class) {
-            $class->accept($this);
+            $this->dispatch($class);
         }
         foreach ($namespace->getInterfaces() as $interface) {
-            $interface->accept($this);
+            $this->dispatch($interface);
         }
         foreach ($namespace->getFunctions() as $function) {
-            $function->accept($this);
+            $this->dispatch($function);
         }
 
         $this->fireEndNamespace($namespace);

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -173,7 +173,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
 
             $this->metrics = [];
             foreach ($namespaces as $namespace) {
-                $namespace->accept($this);
+                $this->dispatch($namespace);
             }
 
             $this->fireEndAnalyzer();
@@ -188,13 +188,16 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     {
         $this->fireStartClass($class);
 
-        $class->getCompilationUnit()?->accept($this);
+        $unit = $class->getCompilationUnit();
+        if ($unit) {
+            $this->dispatch($unit);
+        }
 
         $this->classExecutableLines = 0;
         $this->classLogicalLines = 0;
 
         foreach ($class->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         if ($this->restoreFromCache($class)) {
@@ -268,7 +271,10 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     {
         $this->fireStartFunction($function);
 
-        $function->getCompilationUnit()?->accept($this);
+        $unit = $function->getCompilationUnit();
+        if ($unit) {
+            $this->dispatch($unit);
+        }
 
         if ($this->restoreFromCache($function)) {
             $this->fireEndFunction($function);
@@ -302,10 +308,13 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     {
         $this->fireStartInterface($interface);
 
-        $interface->getCompilationUnit()?->accept($this);
+        $unit = $interface->getCompilationUnit();
+        if ($unit) {
+            $this->dispatch($unit);
+        }
 
         foreach ($interface->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
 
         if ($this->restoreFromCache($interface)) {

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -169,7 +169,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->xmlStack[] = $dependencies;
 
         foreach ($this->code as $node) {
-            $node->accept($this);
+            $this->dispatch($node);
         }
 
         $dom->appendChild($dependencies);
@@ -264,10 +264,10 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->xmlStack[] = $packageXml;
 
         foreach ($namespace->getTypes() as $type) {
-            $type->accept($this);
+            $this->dispatch($type);
         }
         foreach ($namespace->getFunctions() as $function) {
-            $function->accept($this);
+            $this->dispatch($function);
         }
 
         array_pop($this->xmlStack);

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -186,7 +186,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->cycles = $jdepend->appendChild($dom->createElement('Cycles'));
 
         foreach ($this->code as $node) {
-            $node->accept($this);
+            $this->dispatch($node);
         }
 
         $dom->appendChild($jdepend);
@@ -344,7 +344,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         foreach ($namespace->getTypes() as $type) {
-            $type->accept($this);
+            $this->dispatch($type);
         }
 
         if (

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -208,7 +208,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->xmlStack[] = $metrics;
 
         foreach ($this->code as $node) {
-            $node->accept($this);
+            $this->dispatch($node);
         }
 
         if (count($this->fileSet) > 0) {
@@ -302,10 +302,10 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->xmlStack[] = $typeXml;
 
         foreach ($type->getMethods() as $method) {
-            $method->accept($this);
+            $this->dispatch($method);
         }
         foreach ($type->getProperties() as $property) {
-            $property->accept($this);
+            $this->dispatch($property);
         }
 
         array_pop($this->xmlStack);
@@ -399,10 +399,10 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->xmlStack[] = $packageXml;
 
         foreach ($namespace->getTypes() as $type) {
-            $type->accept($this);
+            $this->dispatch($type);
         }
         foreach ($namespace->getFunctions() as $function) {
-            $function->accept($this);
+            $this->dispatch($function);
         }
 
         array_pop($this->xmlStack);

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -45,7 +45,6 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is an abstract base implementation of the ast node interface.
@@ -56,11 +55,6 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  */
 interface ASTNode
 {
-    /**
-     * ASTVisitor method for node tree traversal.
-     */
-    public function accept(ASTVisitor $visitor): void;
-
     /**
      * Returns the source image of this ast node.
      *

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -44,7 +44,6 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Abstract base class for code item.
@@ -289,18 +288,5 @@ abstract class AbstractASTArtifact implements ASTArtifact
     public function getEndColumn(): int
     {
         return $this->endColumn;
-    }
-
-    public function accept(ASTVisitor $visitor): void
-    {
-        $methodName = 'visit' . substr(static::class, 22);
-        $callable = [$visitor, $methodName];
-        if (is_callable($callable)) {
-            $callable($this);
-
-            return;
-        }
-
-        $visitor->visit($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -45,7 +45,6 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is an abstract base implementation of the ast node interface.
@@ -122,19 +121,6 @@ abstract class AbstractASTNode implements ASTNode
         foreach ($this->nodes as $node) {
             $node->setParent($this);
         }
-    }
-
-    public function accept(ASTVisitor $visitor): void
-    {
-        $methodName = 'visit' . substr(static::class, 22);
-        $callable = [$visitor, $methodName];
-        if (is_callable($callable)) {
-            $callable($this);
-
-            return;
-        }
-
-        $visitor->visit($this);
     }
 
     /**

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -120,6 +120,9 @@ interface ASTVisitor
      */
     public function visitProperty(ASTProperty $property): void;
 
+    /**
+     * Visit child nodes of the given node.
+     */
     public function visit(ASTNode $node): void;
 
     public function dispatch(ASTNode $node): void;

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -120,8 +120,7 @@ interface ASTVisitor
      */
     public function visitProperty(ASTProperty $property): void;
 
-    /**
-     * @param ASTNode $node
-     */
-    public function visit($node): void;
+    public function visit(ASTNode $node): void;
+
+    public function dispatch(ASTNode $node): void;
 }

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -263,21 +263,28 @@ abstract class AbstractASTVisitor implements ASTVisitor
         $this->fireEndProperty($property);
     }
 
-    public function dispatch(ASTNode $node): void
-    {
-        $methodName = 'visit' . substr($node::class, 22);
-        if (method_exists($this, $methodName)) {
-            $this->{$methodName}($node);
-        } else {
-            $this->visit($node);
-        }
-    }
-
     public function visit(ASTNode $node): void
     {
         foreach ($node->getChildren() as $child) {
             $this->dispatch($child);
         }
+    }
+
+    public function dispatch(ASTNode $node): void
+    {
+        match ($node::class) {
+            ASTClass::class => $this->visitClass($node),
+            ASTCompilationUnit::class => $this->visitCompilationUnit($node),
+            ASTEnum::class => $this->visitEnum($node),
+            ASTFunction::class => $this->visitFunction($node),
+            ASTInterface::class => $this->visitInterface($node),
+            ASTMethod::class => $this->visitMethod($node),
+            ASTNamespace::class => $this->visitNamespace($node),
+            ASTParameter::class => $this->visitParameter($node),
+            ASTProperty::class => $this->visitProperty($node),
+            ASTTrait::class => $this->visitTrait($node),
+            default => $this->visit($node),
+        };
     }
 
     /**

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -146,7 +146,7 @@ class MethodStrategyTest extends AbstractTestCase
 
         $strategy = new MethodStrategy();
         foreach ($namespaces as $namespace) {
-            $namespace->accept($strategy);
+            $strategy->dispatch($namespace);
         }
 
         $actual = $strategy->getCollectedNodes();

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -146,7 +146,7 @@ class PropertyStrategyTest extends AbstractTestCase
 
         $strategy = new PropertyStrategy();
         foreach ($namespaces as $namespace) {
-            $namespace->accept($strategy);
+            $strategy->dispatch($namespace);
         }
 
         $actual = $strategy->getCollectedNodes();

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -512,7 +512,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     private function calculateNPathComplexity(AbstractASTCallable $callable)
     {
         $analyzer = $this->createAnalyzer();
-        $callable->accept($analyzer);
+        $analyzer->dispatch($callable);
 
         $metrics = $analyzer->getNodeMetrics($callable);
 

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -51,6 +51,7 @@ use PDepend\Report\DummyAnalyzer;
 use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
 
 /**
@@ -325,14 +326,14 @@ class ChartTest extends AbstractTestCase
      */
     private function createPackage($userDefined, $packageName)
     {
-        $packageA = $this->getMockBuilder(ASTNamespace::class)
+        $packageA = new ASTNamespace($packageName);
+        $type = $this->getMockBuilder(ASTClass::class)
             ->onlyMethods(['isUserDefined'])
-            ->setConstructorArgs([$packageName])
-            ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTNamespace')
             ->getMock();
-        $packageA->expects(static::atLeastOnce())
+        $type->expects(static::atLeastOnce())
             ->method('isUserDefined')
             ->will(static::returnValue($userDefined));
+        $packageA->addType($type);
 
         return $packageA;
     }

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -1118,7 +1118,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $class = new ASTClass(__CLASS__);
         $visitor = new StubASTVisitor();
 
-        $class->accept($visitor);
+        $visitor->dispatch($class);
         static::assertSame($class, $visitor->class);
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -44,7 +44,6 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code file class.
@@ -137,21 +136,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
         $compilationUnit->setId(__FUNCTION__);
 
         $compilationUnit->setTokens([1, 2, 3]);
-    }
-
-    /**
-     * testAcceptInvokesVisitFileOnGivenVisitor
-     */
-    public function testAcceptInvokesVisitFileOnGivenVisitor(): void
-    {
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visitCompilationUnit')
-            ->with(static::isInstanceOf(ASTCompilationUnit::class));
-
-        $file = new ASTCompilationUnit(null);
-        $file->accept($visitor);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -82,11 +82,11 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
     {
         $enum = $this->createItem();
         $strategy = new PropertyStrategy();
-        $enum->accept($strategy);
+        $strategy->dispatch($enum);
         static::assertSame([], $strategy->getCollectedNodes());
 
         $strategy = new MethodStrategy();
-        $enum->accept($strategy);
+        $strategy->dispatch($enum);
 
         $nodes = [];
 

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -566,7 +566,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $function = $this->createItem();
         $visitor = new StubASTVisitor();
 
-        $function->accept($visitor);
+        $visitor->dispatch($function);
         static::assertSame($function, $visitor->function);
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -44,7 +44,6 @@
 namespace PDepend\Source\AST;
 
 use BadMethodCallException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
@@ -805,21 +804,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->with(static::isInstanceOf(ASTInterface::class));
 
         $interface->setContext($context)->__wakeup();
-    }
-
-    /**
-     * testAcceptInvokesVisitInterfaceOnGivenVisitor
-     */
-    public function testAcceptInvokesVisitInterfaceOnGivenVisitor(): void
-    {
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visitInterface')
-            ->with(static::isInstanceOf(ASTInterface::class));
-
-        $interface = $this->createItem();
-        $interface->accept($visitor);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -330,7 +330,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     {
         $method = new ASTMethod('method', 0);
         $visitor = new StubASTVisitor();
-        $method->accept($visitor);
+        $visitor->dispatch($method);
 
         static::assertSame($method, $visitor->method);
     }

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -364,7 +364,7 @@ class ASTNamespaceTest extends AbstractTestCase
         $namespace = new ASTNamespace('package1');
         $visitor = new StubASTVisitor();
 
-        $namespace->accept($visitor);
+        $visitor->dispatch($namespace);
         static::assertSame($namespace, $visitor->namespace);
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -45,7 +45,6 @@ namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
 use PDepend\AbstractTestCase;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use ReflectionClass;
 
 /**
@@ -571,22 +570,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
         $parent->prependChild($child1);
 
         static::assertSame($child2, $parent->getChild(1));
-    }
-
-    /**
-     * testAcceptInvokesVisitOnGivenVisitor
-     */
-    public function testAcceptInvokesVisitOnGivenVisitor(): void
-    {
-        $node = $this->createNodeInstance();
-
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visit')
-            ->with(static::equalTo($node));
-
-        $node->accept($visitor);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -44,7 +44,6 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code parameter class.
@@ -216,25 +215,5 @@ class ASTParameterTest extends AbstractTestCase
             ->current()
             ->getMethods()
             ->current();
-    }
-
-    /**
-     * testAcceptInvokesVisitParameterOnSuppliedVisitor
-     */
-    public function testAcceptInvokesVisitParameterOnSuppliedVisitor(): void
-    {
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visitParameter')
-            ->with(static::isInstanceOf(ASTParameter::class));
-
-        $formalParameter = $this->getMockBuilder(ASTFormalParameter::class)
-            ->getMock();
-        $formalParameter->expects(static::any())
-            ->method('getFirstChildOfType')
-            ->will(static::returnValue(new ASTVariableDeclarator('test')));
-        $parameter = new ASTParameter($formalParameter);
-        $parameter->accept($visitor);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -44,7 +44,6 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code property class.
@@ -395,24 +394,6 @@ class ASTPropertyTest extends AbstractTestCase
     {
         $property = $this->getFirstPropertyInClass();
         static::assertTrue($property->isStatic());
-    }
-
-    /**
-     * testAcceptCallsVisitorMethodVisitProperty
-     */
-    public function testAcceptCallsVisitorMethodVisitProperty(): void
-    {
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visitProperty');
-
-        $property = $this->getMockBuilder(ASTProperty::class)
-            ->onlyMethods(['__construct'])
-            ->disableOriginalConstructor()
-            ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTProperty')
-            ->getMock();
-        $property->accept($visitor);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
 
 /**
@@ -361,22 +360,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
         $Trait->setNamespace($namespace);
 
         static::assertSame('MyTrait', $Trait->getNamespacedName());
-    }
-
-    /**
-     * testAcceptInvokesVisitTraitOnGivenVisitor
-     */
-    public function testAcceptInvokesVisitTraitOnGivenVisitor(): void
-    {
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->disableOriginalClone()
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('visitTrait')
-            ->with(static::isInstanceOf(ASTTrait::class));
-
-        $trait = new ASTTrait('MyTrait');
-        $trait->accept($visitor);
     }
 
     /**

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -115,7 +115,7 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor = new StubAbstractASTVisitor();
         $visitor->addVisitListener($listener);
 
-        $class->accept($visitor);
+        $visitor->dispatch($class);
 
         $actual = $listener->nodes;
         $expected = [
@@ -141,7 +141,7 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor = new StubAbstractASTVisitor();
         $visitor->addVisitListener($listener);
 
-        $interface->accept($visitor);
+        $visitor->dispatch($interface);
 
         $actual = $listener->nodes;
         $expected = [
@@ -167,7 +167,7 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor = new StubAbstractASTVisitor();
         $visitor->addVisitListener($listener);
 
-        $function->accept($visitor);
+        $visitor->dispatch($function);
 
         $actual = $listener->nodes;
         $expected = [
@@ -193,7 +193,7 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor = new StubAbstractASTVisitor();
         $visitor->addVisitListener($listener);
 
-        $method->accept($visitor);
+        $visitor->dispatch($method);
 
         $actual = $listener->nodes;
         $expected = [

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -69,7 +69,7 @@ class DefaultVisitorTest extends AbstractTestCase
 
         $visitor = new StubAbstractASTVisitor();
         foreach ($namespaces as $namespace) {
-            $namespace->accept($visitor);
+            $visitor->dispatch($namespace);
         }
 
         $expected = [
@@ -265,7 +265,7 @@ class DefaultVisitorTest extends AbstractTestCase
         $visitor->expects(static::exactly(2))
             ->method('visitTrait');
 
-        $namespace->accept($visitor);
+        $visitor->dispatch($namespace);
     }
 
     /**
@@ -284,7 +284,7 @@ class DefaultVisitorTest extends AbstractTestCase
         $visitor->method('visitMethod')
             ->willReturnOnConsecutiveCalls(static::equalTo($method0), static::equalTo($method1));
 
-        $trait->accept($visitor);
+        $visitor->dispatch($trait);
     }
 
     /**

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -50,6 +50,7 @@ use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
@@ -183,7 +184,17 @@ class StubASTVisitor implements ASTVisitor
     {
     }
 
-    public function visit($node): void
+    public function visit(ASTNode $node): void
     {
+    }
+
+    public function dispatch(ASTNode $node): void
+    {
+        $methodName = 'visit' . substr($node::class, 22);
+        if (method_exists($this, $methodName)) {
+            $this->{$methodName}($node);
+        } else {
+            $this->visit($node);
+        }
     }
 }

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -190,11 +190,18 @@ class StubASTVisitor implements ASTVisitor
 
     public function dispatch(ASTNode $node): void
     {
-        $methodName = 'visit' . substr($node::class, 22);
-        if (method_exists($this, $methodName)) {
-            $this->{$methodName}($node);
-        } else {
-            $this->visit($node);
-        }
+        match ($node::class) {
+            ASTClass::class => $this->visitClass($node),
+            ASTCompilationUnit::class => $this->visitCompilationUnit($node),
+            ASTEnum::class => $this->visitEnum($node),
+            ASTFunction::class => $this->visitFunction($node),
+            ASTInterface::class => $this->visitInterface($node),
+            ASTMethod::class => $this->visitMethod($node),
+            ASTNamespace::class => $this->visitNamespace($node),
+            ASTParameter::class => $this->visitParameter($node),
+            ASTProperty::class => $this->visitProperty($node),
+            ASTTrait::class => $this->visitTrait($node),
+            default => $this->visit($node),
+        };
     }
 }


### PR DESCRIPTION
Type: Refactoring
Breaking change: Yes

This PR decouples the AST nodes from the visitor by moving the logic for visiting nodes from the node to the visitor itself. This reduces coupling for nodes and makes it easier to understand the call graph. This gives developers implementing a new analyzer the freedom to control how it walks the nodes by overriding the `dispatch()` function, which was previously embedded in the nodes and difficult to change. And it results in more code coverage despite the removed tests as there is now fewer code paths that needs to be tested.

Additionally, instead of relying on string manipulation to find and call `visitor*` functions, this refactor makes analyzers call their specific visitor functions using a `match` case. This enables PHPStan to analyze the mapping and ensure there are no mismatches or incorrectly named functions, a common source of bugs in the past.

During the implementation of this PR, I identified multiple bugs where the code could either fail when encountering an unknown node type or skip nodes altogether if naming was incorrect. By avoiding string manipulation, PHP now enforces that more things are implemented correctly.

See https://github.com/pdepend/pdepend/pull/644 for the bug fixes and original proposal for this change.