### PR TITLE
Base enum label validity on constant name rule

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8173,17 +8173,12 @@ abstract class AbstractPHPParser
         $this->tokenStack->add($this->tokenizer->next());
         $this->tokenStack->push();
         $this->consumeComments();
+        $caseName = $this->tokenizer->currentToken()->image;
 
-        if (in_array($this->tokenizer->peek(), array(
-                Tokens::T_NEW,
-                Tokens::T_NULL,
-                Tokens::T_STRING,
-                Tokens::T_DEFAULT
-            ), true) === false) {
+        if (!preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $caseName)) {
             throw $this->getUnexpectedTokenException();
         }
 
-        $caseName = $this->tokenizer->currentToken()->image;
         $this->tokenStack->add($this->tokenizer->next());
         $this->consumeComments();
         $case = $this->builder->buildEnumCase($caseName, $this->parseEnumCaseValue());


### PR DESCRIPTION
Drop token type filtering to simply check the token image.

As per
https://wiki.php.net/rfc/enumerations
https://www.php.net/manual/en/language.constants.php

Type: bugfix
Issue:
- Fix phpmd/phpmd#932
- Fix phpmd/phpmd#994
- Fix #635
Breaking change: no