### PR TITLE
Add keywords to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
     "name": "pdepend/pdepend",
     "description": "Official version of pdepend to be handled with Composer",
+    "keywords": [
+        "dev",
+        "pdepend",
+        "PHP Depend",
+        "PHP_Depend"
+    ],
     "license": "BSD-3-Clause",
     "type": "library",
     "require": {


### PR DESCRIPTION
Keywords to describe pdepend
Dev to let composer know the package is mostly a dev dependency, see: https://github.com/composer/composer/pull/10960

Type: feature
Issue: -
Breaking change: no

With adding dev as keyword composer will suggest it as dev package if someone install it with composer require without --dev.

I found out it didn't had any keywords so I added some, maybe there are other keywords that make sense to add.