### PR TITLE
Remove unessesery check

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2497,9 +2497,7 @@ class PHPBuilder implements Builder
         foreach ($originalTypes as $typeName => $namespaces) {
             foreach ($namespaces as $namespaceName => $types) {
                 foreach ($types as $index => $type) {
-                    if (is_object($type->getNamespace())) {
-                        $copiedTypes[$typeName][$namespaceName][$index] = $type;
-                    }
+                    $copiedTypes[$typeName][$namespaceName][$index] = $type;
                 }
             }
         }


### PR DESCRIPTION
Return value will always be of ASTNamespace

Type: refactoring 
Breaking change: no