### PR TITLE
Handle extra parenthis for functions. #639

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4953,6 +4953,8 @@ abstract class AbstractPHPParser
             case Tokens::T_BACKSLASH:
             case Tokens::T_NAMESPACE:
                 return $this->parseMemberPrefixOrFunctionPostfix();
+            case Tokens::T_PARENTHESIS_OPEN:
+                return $this->parseParenthesisExpression();
         }
 
         throw $this->getUnexpectedTokenException();

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -769,6 +769,14 @@ class PHPParserGenericTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testParserHandlesExtraParenthesisForIsset()
+    {
+        $this->assertEmpty($this->parseCodeResourceForTest());
+    }
+
+    /**
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
      *

--- a/src/test/resources/files/Source/Language/PHP/PHPParserGeneric/testParserHandlesExtraParenthesisForIsset.php
+++ b/src/test/resources/files/Source/Language/PHP/PHPParserGeneric/testParserHandlesExtraParenthesisForIsset.php
@@ -1,0 +1,5 @@
+<?php
+$value = 1;
+if (isset(($value))) {
+    print "value = $value\n";
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #639 
Breaking change: no

It adds a check of we have a parenthesis open and if that is the case it will handle it instead of creating a fatal error.