### PR TITLE
Setup the signing of the phar file. Needed for Phive #397

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -55,7 +55,7 @@ jobs:
           ant package -D-phar:filename=./pdepend.phar;
           ./pdepend.phar --version;
 
-      - name: Sign phat
+      - name: Sign phar
         env:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -55,11 +55,18 @@ jobs:
           ant package -D-phar:filename=./pdepend.phar;
           ./pdepend.phar --version;
 
-      - name: Upload pdepend.phar
-        uses: actions/upload-artifact@v2
+      - name: Sign phat
+        env:
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        run: gpg --command-fd 0 --pinentry-mode loopback -u pgp@pdepend.org --batch --detach-sign --output pdepend.phar.asc pdepend.phar
+
+      - name: Upload pdepend.phar and pdepend.phar.asc
+        uses: actions/upload-artifact@v3
         with:
-          name: pdepend.phar
-          path: pdepend.phar
+          path: |
+            pdepend.phar
+            pdepend.phar.asc
 
       - name: Release pdepend.phar
         if: github.event_name == 'release'
@@ -67,4 +74,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: 'pdepend.phar'
+          args: |
+            pdepend.phar
+            pdepend.phar.asc


### PR DESCRIPTION
Type: feature
Issue: #397 
Breaking change: no

To be honest, I have use https://github.com/phpDocumentor/phar-ga as an example for signing the phar file 😃 

@ravage84 If I'm correct you are currently the only one that can manage the secrets. Can you create/verify the secrets? I'm not sure if the key file has  a PASSPHRASE.