### PR TITLE
Prepare for version 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+pdepend-2.14.0 (2023/04/26)
+
+- Added [\#663](https://github.com/pdepend/pdepend/pull/663): Added, sign the phar files.
+- Added [\#657](https://github.com/pdepend/pdepend/pull/657): Added keywords to composer.json.
+- Fixed [\#656](https://github.com/pdepend/pdepend/pull/656): Fix [\#635](https://github.com/pdepend/pdepend/issues/635), [\#650](https://github.com/pdepend/pdepend/issues/650) Base enum label validity on constant name rule.
+- Fixed [\#661](https://github.com/pdepend/pdepend/pull/661): Fix [\#639](https://github.com/pdepend/pdepend/issues/639) Handle extra parenthis for functions.
+
+
 pdepend-2.13.0 (2023/02/28)
 ==========================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-pdepend-2.14.0 (2023/04/26)
+pdepend-2.14.0 (2023/05/26)
 
 - Added [\#663](https://github.com/pdepend/pdepend/pull/663): Added, sign the phar files.
 - Added [\#657](https://github.com/pdepend/pdepend/pull/657): Added keywords to composer.json.

--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 project.dir       =
 project.uri       = pdepend.org
 project.name      = pdepend
-project.version   = 2.13.0
+project.version   = 2.14.0
 project.stability = stable
 
 project.pear.uri = pear.example.com


### PR DESCRIPTION
Type:  documentation / release 
Issue: -
Breaking change: no

Before releasing this version we need to check the settings for signing the phar file. This need to be done by @ravage84 