### PR TITLE
Resolve edge cases cought by PHPStan level 7

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -194,10 +194,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(?) = NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 2 --
      * </code>
      *
-     * @param ASTNode $node
-     * @param string  $data
+     * @param ASTNode        $node
+     * @param numeric-string $data
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -237,10 +237,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(do) = NP(<do-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -277,9 +277,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * </code>
      *
      * @param ASTElseIfStatement $node The currently visited node.
-     * @param string             $data The previously calculated npath value.
+     * @param numeric-string     $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -312,10 +312,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(for) = NP(<for-range>) + NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 1 --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -347,10 +347,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(foreach) = NP(<foreach-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -391,9 +391,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * </code>
      *
      * @param ASTIfStatement $node The currently visited node.
-     * @param string         $data The previously calculated npath value.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -425,10 +425,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(return) = NP(<expr>) --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -454,10 +454,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(switch) = NP(<expr>) + NP(<default-range>) +  NP(<case-range1>) ... --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -497,10 +497,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(try) = NP(<try-range>) + NP(<catch-range1>) + NP(<catch-range2>) ... --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -528,10 +528,10 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(while) = NP(<while-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode $node The currently visited node.
-     * @param string  $data The previously calculated npath value.
+     * @param ASTNode        $node The currently visited node.
+     * @param numeric-string $data The previously calculated npath value.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      */
@@ -551,7 +551,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      *
      * @param ASTNode $node The currently visited node.
      *
-     * @return string
+     * @return numeric-string
      *
      * @since  0.9.12
      *

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
@@ -230,6 +231,10 @@ class ASTCompilationUnit extends AbstractASTArtifact
      */
     public function setTokens(array $tokens)
     {
+        if ($tokens === array()) {
+            throw new InvalidArgumentException('A compilation unit should contain at least one token');
+        }
+
         $this->cache
             ->type('tokens')
             ->store($this->getId(), $tokens);

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -42,8 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Source\AST\AbstractASTNode;
-use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -239,6 +239,10 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      */
     public function setTokens(array $tokens)
     {
+        if ($tokens === array()) {
+            throw new InvalidArgumentException('An AST node should contain at least one token');
+        }
+
         $this->startLine = reset($tokens)->startLine;
         $this->endLine   = end($tokens)->endLine;
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -399,6 +399,9 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function setTokens(array $tokens, Token $startToken = null)
     {
+        if (!$tokens) {
+            return;
+        }
         if (!$startToken) {
             $startToken = reset($tokens);
         }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -402,6 +402,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
         if (!$tokens) {
             return;
         }
+
         if (!$startToken) {
             $startToken = reset($tokens);
         }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -44,6 +44,7 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTTraitUseStatement;
 use PDepend\Source\Builder\BuilderContext;
@@ -399,8 +400,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function setTokens(array $tokens, Token $startToken = null)
     {
-        if (!$tokens) {
-            return;
+        if ($tokens === array()) {
+            throw new InvalidArgumentException('An AST node should contain at least one token');
         }
 
         if (!$startToken) {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7530,10 +7530,7 @@ abstract class AbstractPHPParser
                     $token = $this->consumeToken(Tokens::T_LNUMBER);
                     $number = $token->image;
 
-                    while ($this->tokenizer->peek() === Tokens::T_STRING) {
-                        $next = $this->tokenizer->next();
-                        assert($next instanceof Token);
-                        $this->tokenStack->add($next);
+                    while ($next = $this->addTokenToStackIfType(Tokens::T_STRING)) {
                         $number .= $next->image;
                     }
 
@@ -8147,6 +8144,27 @@ abstract class AbstractPHPParser
         }
 
         return $enum;
+    }
+
+    /**
+     * Peek the next token if it's of the given type, add it to current tokenStack, and return it if so.
+     *
+     * @param string $type
+     * @psalm-param Tokens::T_* $type
+     *
+     * @return Token|null
+     */
+    protected function addTokenToStackIfType($type)
+    {
+        if ($this->tokenizer->peek() === $type) {
+            $next = $this->tokenizer->next();
+            assert($next instanceof Token);
+            $this->tokenStack->add($next);
+
+            return $next;
+        }
+
+        return null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -612,7 +612,7 @@ abstract class AbstractPHPParser
             throw new TokenStreamEndException($this->tokenizer);
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -666,7 +666,7 @@ abstract class AbstractPHPParser
             throw new TokenStreamEndException($this->tokenizer);
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -734,7 +734,7 @@ abstract class AbstractPHPParser
             throw new TokenStreamEndException($this->tokenizer);
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -935,21 +935,21 @@ abstract class AbstractPHPParser
         while (in_array($tokenType, $validModifiers, true)) {
             if ($tokenType === Tokens::T_ABSTRACT) {
                 if (!$abstractAllowed) {
-                    throw $this->getUnexpectedTokenException();
+                    throw $this->getUnexpectedNextTokenException();
                 }
                 $finalAllowed = false;
                 $this->consumeToken(Tokens::T_ABSTRACT);
                 $this->modifiers |= State::IS_EXPLICIT_ABSTRACT;
             } elseif ($tokenType === Tokens::T_FINAL) {
                 if (!$finalAllowed) {
-                    throw $this->getUnexpectedTokenException();
+                    throw $this->getUnexpectedNextTokenException();
                 }
                 $abstractAllowed = false;
                 $this->consumeToken(Tokens::T_FINAL);
                 $this->modifiers |= State::IS_FINAL;
             } elseif ($tokenType === Tokens::T_READONLY) {
                 if (!static::READONLY_CLASS_ALLOWED) {
-                    throw $this->getUnexpectedTokenException();
+                    throw $this->getUnexpectedNextTokenException();
                 }
 
                 $this->consumeToken(Tokens::T_READONLY);
@@ -1126,7 +1126,7 @@ abstract class AbstractPHPParser
                     $classOrInterface->addChild($case);
                     break;
                 default:
-                    throw $this->getUnexpectedTokenException();
+                    throw $this->getUnexpectedNextTokenException();
             }
 
             $tokenType = $this->tokenizer->peek();
@@ -1199,7 +1199,7 @@ abstract class AbstractPHPParser
             $tokenType = $this->tokenizer->peek();
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -1214,7 +1214,7 @@ abstract class AbstractPHPParser
      */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -1805,7 +1805,7 @@ abstract class AbstractPHPParser
         $expression = $this->parseOptionalExpression();
 
         if (!$expression) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $allocation->addChild($expression);
@@ -2537,7 +2537,7 @@ abstract class AbstractPHPParser
                 return $this->parseStaticReference($this->consumeToken(Tokens::T_STATIC));
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -3046,7 +3046,7 @@ abstract class AbstractPHPParser
         }
 
         if ($exprList instanceof ASTArguments && !$exprList->acceptsMoreArguments()) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $this->consumeToken(Tokens::T_COMMA);
@@ -3380,7 +3380,7 @@ abstract class AbstractPHPParser
      */
     protected function parseOptionalExpressionForVersion()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -3493,7 +3493,7 @@ abstract class AbstractPHPParser
             }
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -3641,7 +3641,7 @@ abstract class AbstractPHPParser
         $this->consumeComments();
 
         if (false === in_array($this->tokenizer->peek(), array(Tokens::T_CATCH, Tokens::T_FINALLY))) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         while ($this->tokenizer->peek() === Tokens::T_CATCH) {
@@ -4826,7 +4826,7 @@ abstract class AbstractPHPParser
      */
     protected function parseFullQualifiedClassNamePostfix()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -4962,7 +4962,7 @@ abstract class AbstractPHPParser
                 return $this->parseParenthesisExpression();
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -5807,7 +5807,7 @@ abstract class AbstractPHPParser
         }
 
         if ($this->isKeyword($this->tokenizer->peek())) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         return $this->parseExpression();
@@ -5897,7 +5897,7 @@ abstract class AbstractPHPParser
 
         $this->consumeComments();
         if ($this->isKeyword($this->tokenizer->peek())) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $element->addChild($this->parseExpression());
@@ -6591,11 +6591,8 @@ abstract class AbstractPHPParser
         if ($stmt = $this->parseOptionalStatement()) {
             return $stmt;
         }
-        $token = $this->tokenizer->next();
-        if ($token instanceof Token) {
-            throw $this->getUnexpectedTokenException($token);
-        }
-        throw new TokenStreamEndException($this->tokenizer);
+
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -7249,7 +7246,7 @@ abstract class AbstractPHPParser
         $tokenType = $this->tokenizer->peek();
 
         if (false === $this->isConstantName($tokenType)) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $token = $this->consumeToken($tokenType);
@@ -7623,7 +7620,7 @@ abstract class AbstractPHPParser
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -7635,7 +7632,7 @@ abstract class AbstractPHPParser
      */
     protected function parseLambdaFunctionDeclaration()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -7998,7 +7995,7 @@ abstract class AbstractPHPParser
                 throw new TokenStreamEndException($this->tokenizer);
         }
 
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -8025,15 +8022,33 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return UnexpectedTokenException
+     * Return the appropriate exception for either UnexpectedTokenException
+     * configured with the next token, or TokenStreamEndException if there
+     * is no more token.
+     *
+     * @return TokenStreamEndException|UnexpectedTokenException
      */
-    protected function getUnexpectedTokenException(Token $token = null)
+    protected function getUnexpectedNextTokenException()
     {
-        $token = (null === $token) ? $this->tokenizer->next() : $token;
-        if (!$token instanceof Token) {
-            throw new TokenStreamEndException($this->tokenizer);
+        return $this->getUnexpectedTokenException($this->tokenizer->next());
+    }
+
+    /**
+     * Return the appropriate exception for either UnexpectedTokenException
+     * configured with the given token, or TokenStreamEndException if given
+     * null.
+     *
+     * @param Token|Tokenizer::T_*|null $token
+     *
+     * @return TokenStreamEndException|UnexpectedTokenException
+     */
+    protected function getUnexpectedTokenException($token)
+    {
+        if ($token instanceof Token) {
+            return new UnexpectedTokenException($token, $this->tokenizer->getSourceFile());
         }
-        return new UnexpectedTokenException($token, $this->tokenizer->getSourceFile());
+
+        return new TokenStreamEndException($this->tokenizer);
     }
 
     /**
@@ -8056,7 +8071,7 @@ abstract class AbstractPHPParser
      */
     protected function checkEllipsisInExpressionSupport()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -8071,7 +8086,7 @@ abstract class AbstractPHPParser
      */
     protected function parseThrowExpression()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -8084,7 +8099,7 @@ abstract class AbstractPHPParser
      */
     protected function parseEnumDeclaration()
     {
-        throw $this->getUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**
@@ -8103,7 +8118,7 @@ abstract class AbstractPHPParser
         $this->consumeComments();
 
         if ($this->tokenizer->peek() !== Tokens::T_STRING) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $name = $this->tokenizer->currentToken()->image;
@@ -8221,7 +8236,7 @@ abstract class AbstractPHPParser
         $caseName = $this->tokenizer->currentToken()->image;
 
         if (!preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $caseName)) {
-            throw $this->getUnexpectedTokenException();
+            throw $this->getUnexpectedNextTokenException();
         }
 
         $next = $this->tokenizer->next();

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5879,6 +5879,7 @@ abstract class AbstractPHPParser
         if ($this->parseOptionalByReference()) {
             if ($static) {
                 $tokens = $this->tokenStack->pop();
+
                 throw $this->getUnexpectedTokenException(end($tokens) ?: null);
             }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
@@ -45,9 +45,6 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArray;
-use PDepend\Source\Parser\TokenStreamEndException;
-use PDepend\Source\Parser\UnexpectedTokenException;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -98,11 +95,7 @@ abstract class PHPParserVersion53 extends AbstractPHPParser
                 $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
                 break;
             default:
-                $next = $this->tokenizer->next();
-                if (!$next instanceof Token) {
-                    throw new TokenStreamEndException($this->tokenizer);
-                }
-                throw new UnexpectedTokenException($next, $this->tokenizer->getSourceFile());
+                throw $this->getUnexpectedNextTokenException();
         }
 
         return $array;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion53.php
@@ -45,7 +45,9 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTArray;
+use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -96,10 +98,11 @@ abstract class PHPParserVersion53 extends AbstractPHPParser
                 $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
                 break;
             default:
-                throw new UnexpectedTokenException(
-                    $this->tokenizer->next(),
-                    $this->tokenizer->getSourceFile()
-                );
+                $next = $this->tokenizer->next();
+                if (!$next instanceof Token) {
+                    throw new TokenStreamEndException($this->tokenizer);
+                }
+                throw new UnexpectedTokenException($next, $this->tokenizer->getSourceFile());
         }
 
         return $array;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -245,10 +245,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
         $token = $this->consumeToken(Tokens::T_LNUMBER);
         $number = $token->image;
 
-        while ($this->tokenizer->peek() === Tokens::T_STRING) {
-            $next = $this->tokenizer->next();
-            assert($next instanceof Token);
-            $this->tokenStack->add($next);
+        while ($next = $this->addTokenToStackIfType(Tokens::T_STRING)) {
             $number .= $next->image;
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -48,6 +48,7 @@ use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -246,6 +247,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
 
         while ($this->tokenizer->peek() === Tokens::T_STRING) {
             $next = $this->tokenizer->next();
+            assert($next instanceof Token);
             $this->tokenStack->add($next);
             $number .= $next->image;
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\Parser\UnexpectedTokenException;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -52,6 +52,7 @@ use PDepend\Source\AST\ASTValue;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\FullTokenizer;
 use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -221,10 +222,9 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
                     $expressions[] = $expr;
                     break;
                 default:
-                    throw new UnexpectedTokenException(
-                        $this->tokenizer->next(),
-                        $this->tokenizer->getSourceFile()
-                    );
+                    $next = $this->tokenizer->next();
+                    assert($next instanceof Token);
+                    throw new UnexpectedTokenException($next, $this->tokenizer->getSourceFile());
             }
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion56.php
@@ -52,7 +52,6 @@ use PDepend\Source\AST\ASTValue;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\FullTokenizer;
 use PDepend\Source\Tokenizer\Tokenizer;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -222,9 +221,7 @@ abstract class PHPParserVersion56 extends PHPParserVersion55
                     $expressions[] = $expr;
                     break;
                 default:
-                    $next = $this->tokenizer->next();
-                    assert($next instanceof Token);
-                    throw new UnexpectedTokenException($next, $this->tokenizer->getSourceFile());
+                    throw $this->getUnexpectedNextTokenException();
             }
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -49,7 +49,9 @@ use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTType;
+use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -605,7 +607,12 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             return null;
         }
 
-        throw $this->getUnexpectedTokenException($this->tokenizer->next());
+        $next = $this->tokenizer->next();
+        if (!$next instanceof Token) {
+            throw new TokenStreamEndException($this->tokenizer);
+        }
+
+        throw $this->getUnexpectedTokenException($next);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -49,9 +49,7 @@ use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTType;
-use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -607,12 +607,7 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             return null;
         }
 
-        $next = $this->tokenizer->next();
-        if (!$next instanceof Token) {
-            throw new TokenStreamEndException($this->tokenizer);
-        }
-
-        throw $this->getUnexpectedTokenException($next);
+        throw $this->getUnexpectedNextTokenException();
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -218,13 +218,8 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         $modifiers &= $allowed;
 
         if ($this->classOrInterface instanceof ASTInterface && ($modifiers & (State::IS_PROTECTED | State::IS_PRIVATE)) !== 0) {
-            $next = $this->tokenizer->next();
-            if (!$next instanceof Token) {
-                throw new TokenStreamEndException($this->tokenizer);
-            }
-
             throw new InvalidStateException(
-                $next->startLine,
+                $this->requireNextToken()->startLine,
                 (string) $this->compilationUnit,
                 sprintf(
                     'Constant can\'t be declared private or protected in interface "%s".',

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -51,6 +51,8 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\InvalidStateException;
+use PDepend\Source\Parser\TokenStreamEndException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -216,8 +218,13 @@ abstract class PHPParserVersion71 extends PHPParserVersion70
         $modifiers &= $allowed;
 
         if ($this->classOrInterface instanceof ASTInterface && ($modifiers & (State::IS_PROTECTED | State::IS_PRIVATE)) !== 0) {
+            $next = $this->tokenizer->next();
+            if (!$next instanceof Token) {
+                throw new TokenStreamEndException($this->tokenizer);
+            }
+
             throw new InvalidStateException(
-                $this->tokenizer->next()->startLine,
+                $next->startLine,
                 (string) $this->compilationUnit,
                 sprintf(
                     'Constant can\'t be declared private or protected in interface "%s".',

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion71.php
@@ -51,8 +51,6 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\InvalidStateException;
-use PDepend\Source\Parser\TokenStreamEndException;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -476,6 +476,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
             ));
         }
 
-        $this->throwUnexpectedTokenException();
+        throw $this->getUnexpectedNextTokenException();
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -58,6 +58,7 @@ use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\ParserException;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -209,7 +210,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
         if (isset($states[$token])) {
             $modifier |= $states[$token];
-            $this->tokenStack->add($this->tokenizer->next());
+            $next = $this->tokenizer->next();
+            assert($next instanceof Token);
+            $this->tokenStack->add($next);
         }
 
         return $modifier;
@@ -235,7 +238,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
     protected function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
     {
         if ($this->tokenizer->peek() === Tokens::T_COLON) {
-            $this->tokenStack->add($this->tokenizer->next());
+            $token = $this->tokenizer->next();
+            assert($token instanceof Token);
+            $this->tokenStack->add($token);
 
             return $this->builder->buildAstNamedArgument(
                 $constant->getImage(),
@@ -320,11 +325,15 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
                 break;
             case Tokens::T_NULL:
                 $type = new ASTScalarType('null');
-                $this->tokenStack->add($this->tokenizer->next());
+                $token = $this->tokenizer->next();
+                assert($token instanceof Token);
+                $this->tokenStack->add($token);
                 break;
             case Tokens::T_FALSE:
                 $type = new ASTScalarType('false');
-                $this->tokenStack->add($this->tokenizer->next());
+                $token = $this->tokenizer->next();
+                assert($token instanceof Token);
+                $this->tokenStack->add($token);
                 break;
             default:
                 $type = parent::parseTypeHint();
@@ -346,7 +355,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         $types = array($firstType);
 
         while ($this->tokenizer->peek() === Tokens::T_BITWISE_OR) {
-            $this->tokenStack->add($this->tokenizer->next());
+            $token = $this->tokenizer->next();
+            assert($token instanceof Token);
+            $this->tokenStack->add($token);
             $types[] = $this->parseSingleTypeHint();
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -53,6 +53,7 @@ use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\ParserException;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -124,7 +125,9 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
 
         if ($this->tokenizer->peek() === Tokens::T_READONLY) {
             $modifier |= State::IS_READONLY;
-            $this->tokenStack->add($this->tokenizer->next());
+            $next = $this->tokenizer->next();
+            assert($next instanceof Token);
+            $this->tokenStack->add($next);
         }
 
         return $modifier;
@@ -180,7 +183,9 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
         $types = array($firstType);
 
         while ($this->tokenizer->peek() === Tokens::T_BITWISE_AND && $this->tokenizer->peekNext() !== Tokens::T_VARIABLE) {
-            $this->tokenStack->add($this->tokenizer->next());
+            $next = $this->tokenizer->next();
+            assert($next instanceof Token);
+            $this->tokenStack->add($next);
             $types[] = $this->parseSingleTypeHint();
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -121,23 +121,9 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      */
     protected function parseConstructFormalParameterModifiers()
     {
-        $modifier = 0;
-
-        if ($this->tokenizer->peek() === Tokens::T_READONLY) {
-            $modifier |= State::IS_READONLY;
-            $this->tokenStack->add($this->tokenizer->next());
-        }
-
-        $modifier |= parent::parseConstructFormalParameterModifiers();
-
-        if ($this->tokenizer->peek() === Tokens::T_READONLY) {
-            $modifier |= State::IS_READONLY;
-            $next = $this->tokenizer->next();
-            assert($next instanceof Token);
-            $this->tokenStack->add($next);
-        }
-
-        return $modifier;
+        return $this->checkReadonlyToken()
+            | parent::parseConstructFormalParameterModifiers()
+            | $this->checkReadonlyToken();
     }
 
     /**
@@ -251,5 +237,21 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
         }
 
         return $arguments;
+    }
+
+    /**
+     * @return int
+     */
+    private function checkReadonlyToken()
+    {
+        if ($this->tokenizer->peek() === Tokens::T_READONLY) {
+            $next = $this->tokenizer->next();
+            assert($next instanceof Token);
+            $this->tokenStack->add($next);
+
+            return State::IS_READONLY;
+        }
+
+        return 0;
     }
 }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -49,11 +49,9 @@ use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTType;
-use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\State;
 use PDepend\Source\Parser\ParserException;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -175,10 +175,7 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
         $token = $this->tokenizer->currentToken();
         $types = array($firstType);
 
-        while ($this->tokenizer->peek() === Tokens::T_BITWISE_AND && $this->tokenizer->peekNext() !== Tokens::T_VARIABLE) {
-            $next = $this->tokenizer->next();
-            assert($next instanceof Token);
-            $this->tokenStack->add($next);
+        while ($this->tokenizer->peekNext() !== Tokens::T_VARIABLE && $this->addTokenToStackIfType(Tokens::T_BITWISE_AND)) {
             $types[] = $this->parseSingleTypeHint();
         }
 
@@ -244,11 +241,7 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      */
     private function checkReadonlyToken()
     {
-        if ($this->tokenizer->peek() === Tokens::T_READONLY) {
-            $next = $this->tokenizer->next();
-            assert($next instanceof Token);
-            $this->tokenStack->add($next);
-
+        if ($this->addTokenToStackIfType(Tokens::T_READONLY)) {
             return State::IS_READONLY;
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -47,6 +47,7 @@ namespace PDepend\Source\Language\PHP;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTType;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -122,7 +123,9 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
 
             case Tokens::T_TRUE:
                 $type = new ASTScalarType('true');
-                $this->tokenStack->add($this->tokenizer->next());
+                $token = $this->tokenizer->next();
+                assert($token instanceof Token);
+                $this->tokenStack->add($token);
                 $this->consumeComments();
 
                 return $type;

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -86,19 +86,19 @@ class TokenStack
     public function push()
     {
         $this->stack[$this->offset++] = $this->tokens;
-        $this->tokens                  = array();
+        $this->tokens                 = array();
     }
 
     /**
      * This method will pop the top token scope from the stack and return an
-     * array with all collected tokens. Additionally this method will add all
+     * array with all collected tokens. Additionally, this method will add all
      * tokens of the removed scope onto the next token scope.
      *
      * @return Token[]
      */
     public function pop()
     {
-        $tokens        = $this->tokens;
+        $tokens       = $this->tokens;
         $this->tokens = $this->stack[--$this->offset];
 
         unset($this->stack[$this->offset]);

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -312,18 +312,20 @@ class Command
 
         for ($i = 0, $c = count($argv); $i < $c; ++$i) {
             // Is it an ini_set option?
-            if ($argv[$i] === '-d' && isset($argv[$i + 1])) {
-                if (strpos($argv[++$i], '=') === false) {
-                    ini_set($argv[$i], 'on');
+            $arg = (string)$argv[$i];
+            if ($arg === '-d' && isset($argv[$i + 1])) {
+                $arg = (string)$argv[++$i];
+                if (strpos($arg, '=') === false) {
+                    ini_set($arg, 'on');
                 } else {
-                    list($key, $value) = explode('=', $argv[$i]);
+                    list($key, $value) = explode('=', $arg);
 
                     ini_set($key, $value);
                 }
-            } elseif (strpos($argv[$i], '=') === false) {
-                $this->options[$argv[$i]] = true;
+            } elseif (strpos($arg, '=') === false) {
+                $this->options[$arg] = true;
             } else {
-                list($key, $value) = explode('=', $argv[$i]);
+                list($key, $value) = explode('=', $arg);
 
                 $this->options[$key] = $value;
             }
@@ -401,11 +403,12 @@ class Command
     {
         $build = __DIR__ . '/../../../../../build.properties';
 
+        $version = '@package_version@';
         if (file_exists($build)) {
             $data = @parse_ini_file($build);
-            $version = $data['project.version'];
-        } else {
-            $version = '@package_version@';
+            if (is_array($data)) {
+                $version = $data['project.version'];
+            }
         }
 
         echo 'PDepend ', $version, PHP_EOL, PHP_EOL;
@@ -524,7 +527,8 @@ class Command
 
         $last = null;
         foreach ($options as $option => $message) {
-            $current = substr($option, 0, strrpos($option, '-'));
+            $pos = strrpos($option, '-');
+            $current = substr($option, 0, $pos === false ? null : $pos);
             if ($last !== null && $last !== $current) {
                 echo PHP_EOL;
             }

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -45,7 +45,6 @@
 namespace PDepend\Util\Cache\Driver\File;
 
 use DirectoryIterator;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 use SplFileInfo;
 

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -45,6 +45,7 @@
 namespace PDepend\Util\Cache\Driver\File;
 
 use DirectoryIterator;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 use SplFileInfo;
 
@@ -149,7 +150,7 @@ class FileCacheDirectory
     protected function readVersion()
     {
         if (file_exists($this->getVersionFile())) {
-            return trim(file_get_contents($this->getVersionFile()));
+            return trim(file_get_contents($this->getVersionFile()) ?: '');
         }
         return null;
     }

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -165,6 +165,9 @@ class FileCacheDriver implements CacheDriver
     protected function write($file, $data)
     {
         $handle = fopen($file, 'wb');
+        if (!$handle) {
+            return;
+        }
         flock($handle, LOCK_EX);
         fwrite($handle, $data);
         flock($handle, LOCK_UN);
@@ -220,14 +223,21 @@ class FileCacheDriver implements CacheDriver
     protected function read($file)
     {
         $handle = fopen($file, 'rb');
+        if (!$handle) {
+            return '';
+        }
         flock($handle, LOCK_EX);
+        $size = filesize($file);
+        if (!$size) {
+            return '';
+        }
 
-        $data = fread($handle, filesize($file));
+        $data = fread($handle, $size);
 
         flock($handle, LOCK_UN);
         fclose($handle);
 
-        return $data;
+        return $data ?: '';
     }
 
     /**
@@ -246,7 +256,7 @@ class FileCacheDriver implements CacheDriver
         $glob = glob("{$file}*.*");
         // avoid error if we dont find files
         if ($glob !== false) {
-            foreach (glob("{$file}*.*") as $f) {
+            foreach (glob("{$file}*.*") ?: array() as $f) {
                 @unlink($f);
             }
         }

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -97,7 +97,7 @@ class IdBuilder
     {
         return $this->forOffsetItem(
             $type,
-            ltrim(strrchr(strtolower(get_class($type)), '_'), '_')
+            ltrim(strrchr(strtolower(get_class($type)), '_') ?: '', '_')
         );
     }
 

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -58,7 +58,7 @@ final class MathUtil
      * @param numeric-string $left  The left arithmetic operand.
      * @param numeric-string $right The right arithmetic operand.
      *
-     * @return string
+     * @return numeric-string
      */
     public static function mul($left, $right)
     {
@@ -75,7 +75,7 @@ final class MathUtil
      * @param string $left  The left arithmetic operand.
      * @param string $right The right arithmetic operand.
      *
-     * @return string
+     * @return numeric-string
      */
     public static function add($left, $right)
     {

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -110,16 +110,24 @@ class ParserTest extends AbstractTest
             unset($expected[$namespace->getName()]);
             $namespaces[$namespace->getName()] = $namespace;
         }
-        $this->assertEquals(0, count($expected));
+        $this->assertSame(0, count($expected));
 
-        $this->assertEquals(1, $namespaces['pkg1']->getFunctions()->count());
-        $this->assertEquals(1, $namespaces['pkg1']->getTypes()->count());
+        $this->assertSame(1, $namespaces['pkg1']->getFunctions()->count());
+        $this->assertSame(1, $namespaces['pkg1']->getTypes()->count());
         $this->assertFalse($namespaces['pkg1']->getTypes()->current()->isAbstract());
 
-        $this->assertEquals(1, $namespaces['pkg2']->getTypes()->count());
+        $this->assertSame(1, $namespaces['pkg2']->getTypes()->count());
         $this->assertTrue($namespaces['pkg2']->getTypes()->current()->isAbstract());
+        $this->assertSame(
+            123456781234567812345678,
+            $namespaces['pkg2']->getTypes()->current()->getConstant('BIZ')
+        );
+        $this->assertSame(
+            0x12345678123456781,
+            $namespaces['pkg2']->getTypes()->current()->getConstant('FOOBAR')
+        );
 
-        $this->assertEquals(1, $namespaces['pkg3']->getTypes()->count());
+        $this->assertSame(1, $namespaces['pkg3']->getTypes()->count());
         $this->assertTrue($namespaces['pkg3']->getTypes()->current()->isAbstract());
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -330,7 +330,7 @@ class ASTCompilationUnitTest extends AbstractTest
     public function testGetEndLineReturnsOneWhenSourceFileExists()
     {
         $file = new ASTCompilationUnit(__FILE__);
-        $this->assertEquals(362, $file->getEndLine());
+        $this->assertEquals($this->getEndLineOfThisFile(), $file->getEndLine());
     }
 
     /**
@@ -367,5 +367,10 @@ class ASTCompilationUnitTest extends AbstractTest
     {
         $file = new ASTCompilationUnit(null);
         $file->setTokens(array());
+    }
+
+    private function getEndLineOfThisFile()
+    {
+        return __LINE__ + 3;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -358,4 +358,14 @@ class ASTCompilationUnitTest extends AbstractTest
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A compilation unit should contain at least one token
+     */
+    public function testSetTokensWithEmptyArray()
+    {
+        $file = new ASTCompilationUnit(null);
+        $file->setTokens(array());
+    }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -330,7 +330,7 @@ class ASTCompilationUnitTest extends AbstractTest
     public function testGetEndLineReturnsOneWhenSourceFileExists()
     {
         $file = new ASTCompilationUnit(__FILE__);
-        $this->assertEquals($this->getEndLineOfThisFile(), $file->getEndLine());
+        $this->assertSame($this->getEndLineOfThisFile(), $file->getEndLine());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -44,7 +44,6 @@ namespace PDepend\Source\AST;
 
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
-use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -106,6 +105,16 @@ class ASTEnumTest extends AbstractASTArtifactTest
             'PDepend\Source\AST\ASTClass' => array('test'),
             'PDepend\Source\AST\ASTNamespace' => array('+global', '+global'),
         ), $nodes);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage An AST node should contain at least one token
+     */
+    public function testSetTokensWithEmptyArray()
+    {
+        $enum = new ASTEnum('FooBar');
+        $enum->setTokens(array());
     }
 
     protected function createItem()

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -806,4 +806,14 @@ class ASTMethodTest extends AbstractASTArtifactTest
 
         return $method;
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage An AST node should contain at least one token
+     */
+    public function testSetTokensWithEmptyArray()
+    {
+        $method = new ASTMethod('FooBar');
+        $method->setTokens(array());
+    }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
@@ -147,7 +147,8 @@ class PHPParserVersion53Test extends AbstractTest
     }
 
     /**
-     * Tests that the parser throws an exception when trying to parse an array with end of file.
+     * Tests that the parser throws an exception when trying to parse an array
+     * when being at the end of the file.
      *
      * @return void
      */

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
@@ -44,9 +44,14 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTest;
+use PDepend\Source\AST\ASTArray;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Source\Tokenizer\Tokens;
 use PDepend\Util\Cache\CacheDriver;
+use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use ReflectionMethod;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion53} class.
@@ -139,6 +144,64 @@ class PHPParserVersion53Test extends AbstractTest
         );
 
         $this->parseCodeResourceForTest();
+    }
+
+    /**
+     * Tests that the parser throws an exception when trying to parse an array with end of file.
+     *
+     * @return void
+     */
+    public function testParserThrowsUnexpectedTokenExceptionForArrayWithEOF()
+    {
+        $this->setExpectedException(
+            '\\PDepend\\Source\\Parser\\TokenStreamEndException',
+            'Unexpected end of token stream in file:'
+        );
+
+        $cache = new MemoryCacheDriver();
+        $builder = new PHPBuilder();
+        /** @var Tokenizer $tokenizer */
+        $tokenizer = $this->getMockBuilder('PDepend\\Source\\Tokenizer\\Tokenizer')
+            ->getMock();
+        $tokenizer
+            ->method('peek')
+            ->willReturn(Tokenizer::T_EOF);
+        $tokenizer
+            ->method('next')
+            ->willReturn(null);
+        $parser = $this->createPHPParser($tokenizer, $builder, $cache);
+        $parseArray = new ReflectionMethod($parser, 'parseArray');
+        $parseArray->setAccessible(true);
+        $parseArray->invoke($parser, new ASTArray());
+    }
+
+    /**
+     * Tests that the parser throws an exception when trying to parse an array with invalid token.
+     *
+     * @return void
+     */
+    public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenArray()
+    {
+        $this->setExpectedException(
+            '\\PDepend\\Source\\Parser\\UnexpectedTokenException',
+            'Unexpected token: [, line: 55, col: 10, file:'
+        );
+
+        $cache = new MemoryCacheDriver();
+        $builder = new PHPBuilder();
+        /** @var Tokenizer $tokenizer */
+        $tokenizer = $this->getMockBuilder('PDepend\\Source\\Tokenizer\\Tokenizer')
+            ->getMock();
+        $tokenizer
+            ->method('peek')
+            ->willReturn(Tokens::T_SQUARED_BRACKET_OPEN);
+        $tokenizer
+            ->method('next')
+            ->willReturn(new Token(Tokens::T_SQUARED_BRACKET_OPEN, '[', 55, 55, 10, 11));
+        $parser = $this->createPHPParser($tokenizer, $builder, $cache);
+        $parseArray = new ReflectionMethod($parser, 'parseArray');
+        $parseArray->setAccessible(true);
+        $parseArray->invoke($parser, new ASTArray());
     }
 
     /**

--- a/src/test/resources/files/Parser/testParseMixedCode.php
+++ b/src/test/resources/files/Parser/testParseMixedCode.php
@@ -13,7 +13,8 @@ function foo($foo = array()) {
  * @package pkg2
  */
 interface Foo {
-    const FOOBAR = 0x1742;
+    const FOOBAR = 0x12345678123456781;
+    const BIZ = 123456781234567812345678;
     function x();
 }
 


### PR DESCRIPTION
Type: bugfix / refactoring / documentation update
Breaking change: no

Resolve about half of the issues detected by PHPStan at level 7. This mostly involves handles a few edge cases and improve some PHPDoc. And a few `assert()` to validate what is asserted by peek().