### PR TITLE
Allow readonly before public/protected/private

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1055,6 +1055,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_PROTECTED:
                 case Tokens::T_STATIC:
                 case Tokens::T_FINAL:
+                case Tokens::T_READONLY:
                 case Tokens::T_FUNCTION:
                 case Tokens::T_VARIABLE:
                 case Tokens::T_VAR:

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -120,7 +120,14 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      */
     protected function parseConstructFormalParameterModifiers()
     {
-        $modifier = parent::parseConstructFormalParameterModifiers();
+        $modifier = 0;
+
+        if ($this->tokenizer->peek() === Tokens::T_READONLY) {
+            $modifier |= State::IS_READONLY;
+            $this->tokenStack->add($this->tokenizer->next());
+        }
+
+        $modifier |= parent::parseConstructFormalParameterModifiers();
 
         if ($this->tokenizer->peek() === Tokens::T_READONLY) {
             $modifier |= State::IS_READONLY;

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -81,8 +81,16 @@ class ReadonlyPropertiesTest extends PHPParserVersion81Test
         $this->assertSame('string', $parameter->getFormalParameter()->getChild(0)->getImage());
         $this->assertSame('$bar', $parameter->getFormalParameter()->getChild(1)->getImage());
 
-        $expectedModifiers = ~State::IS_PUBLIC & ~State::IS_READONLY;
-        $this->assertSame(0, ($expectedModifiers & $parameter->getFormalParameter()->getModifiers()));
+        $expectedModifiers = State::IS_PUBLIC | State::IS_READONLY;
+        $this->assertSame($expectedModifiers, $parameter->getFormalParameter()->getModifiers());
+
+        $parameter = $parameters[1];
+
+        $this->assertSame('int|float', $parameter->getFormalParameter()->getChild(0)->getImage());
+        $this->assertSame('$foo', $parameter->getFormalParameter()->getChild(1)->getImage());
+
+        $expectedModifiers = State::IS_PUBLIC | State::IS_READONLY;
+        $this->assertSame($expectedModifiers, $parameter->getFormalParameter()->getModifiers());
     }
 
     /**

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyNameUsedElsewhere.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyNameUsedElsewhere.php
@@ -5,9 +5,12 @@ class Foo
 
     public readonly string $readonly;
 
+    readonly public string $readonly2;
+
     public function __construct()
     {
         $this->readonly = $this->readonly();
+        $this->readonly2 = $this->readonly();
     }
 
     public function readonly()

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyPropertyInConstructor.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP81/ReadonlyProperties/testReadonlyPropertyInConstructor.php
@@ -2,6 +2,7 @@
 class Foo
 {
     public function __construct(
-        public readonly string $bar
+        public readonly string $bar,
+        readonly public int|float $foo
     ) {}
 }


### PR DESCRIPTION
Type: bugfix
Issue: Fix #665
Breaking change: no