### PR TITLE
Re-allow empty compilation unit

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -231,10 +231,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      */
     public function setTokens(array $tokens)
     {
-        if ($tokens === array()) {
-            throw new InvalidArgumentException('A compilation unit should contain at least one token');
-        }
-
         $this->cache
             ->type('tokens')
             ->store($this->getId(), $tokens);

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -99,7 +99,7 @@ class TokenStack
     public function pop()
     {
         $tokens       = $this->tokens;
-        $this->tokens = $this->stack[--$this->offset];
+        $this->tokens = isset($this->stack[--$this->offset]) ? $this->stack[$this->offset] : array();
 
         unset($this->stack[$this->offset]);
 

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -359,16 +359,6 @@ class ASTCompilationUnitTest extends AbstractTest
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage A compilation unit should contain at least one token
-     */
-    public function testSetTokensWithEmptyArray()
-    {
-        $file = new ASTCompilationUnit(null);
-        $file->setTokens(array());
-    }
-
     private function getEndLineOfThisFile()
     {
         return __LINE__ + 3;


### PR DESCRIPTION
Type: bugfix
Issue: Fix #682
Breaking change: it actually revert an unwanted breaking change from 2.15.0