### PR TITLE
Replace UTF8 with UTF-8 (correct name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ pdepend-2.13.0 (2023/02/28)
 - Added [\#636](https://github.com/pdepend/pdepend/pull/636): Add support for NULL, DEFAULT and NEW as enum case.
 - Added [\#651](https://github.com/pdepend/pdepend/pull/651): Add a follow on mastodon link to the footer on the website.
 - Fixed [\#633](https://github.com/pdepend/pdepend/pull/633): Fix parsing for new with parentheses.
-- Fixed [\#641](https://github.com/pdepend/pdepend/pull/641): Improve UTF8 encoding process.
+- Fixed [\#641](https://github.com/pdepend/pdepend/pull/641): Improve UTF-8 encoding process.
 - Fixed [\#637](https://github.com/pdepend/pdepend/pull/637): Prevent the use of a not set id value in the AbstractASTType and AbstractASTCallable.
 - Fixed [\#642](https://github.com/pdepend/pdepend/pull/642): Fix [\#638](https://github.com/pdepend/pdepend/issue/638) Unexpected Token with double class modifiers.
 - Changed [\#644](https://github.com/pdepend/pdepend/pull/644): Correct collection of Enum and Intersection type information during analysis.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=5.3.7",
         "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
         "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-        "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0"
+        "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
+        "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36|^5.7.27",

--- a/src/test/php/PDepend/Util/Utf8UtilTest.php
+++ b/src/test/php/PDepend/Util/Utf8UtilTest.php
@@ -42,29 +42,33 @@
 
 namespace PDepend\Util;
 
+use PDepend\AbstractTest;
+use ReflectionMethod;
+
 /**
- * This is a simply utility class that will ensure the encoding of a raw string
- * into a UTF-8 encoded string. It will try using "mbstring" extension if
- * available, or symfony polyfill if not.
+ * Test case for type utility class.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @since 2.2.x
+ * @covers \PDepend\Util\Utf8Util
+ * @group unittest
  */
-final class Utf8Util
+class Utf8UtilTest extends AbstractTest
 {
-    /**
-     * @param string $raw
-     *
-     * @return string
-     */
-    public static function ensureEncoding($raw)
+    public function testEnsureEncoding()
     {
-        if (mb_check_encoding($raw, 'UTF-8')) {
-            return $raw;
-        }
-
-        return mb_convert_encoding($raw, 'UTF-8', mb_list_encodings());
+        self::assertSame('🚀', Utf8Util::ensureEncoding('🚀'));
+        self::assertSame('', Utf8Util::ensureEncoding(''));
+        self::assertSame(
+            'Été für baño',
+            Utf8Util::ensureEncoding(base64_decode('w4l0w6kgZsO8ciBiYcOxbw==')),
+            'Éüñ UTF-8 should stay Éüñ UTF-8'
+        );
+        self::assertSame(
+            'Été für baño',
+            Utf8Util::ensureEncoding(base64_decode('yXTpIGb8ciBiYfFv')),
+            'Éüñ ISO-8859-1 should become Éüñ UTF-8'
+        );
     }
 }


### PR DESCRIPTION
Type: bugfix
Issue: Fix #688
Breaking change: no

Precedent behavior had inconsistent behavior depending on system, as iconv with IGNORE actually remove non-ASCII character even for a UTF-8 valid string which is not equivalent with utf8_encode and the previous polyfill.

Also many strings in previous implementation would be incorrectly considered as latin1.

Added tests fails when using the previous iconv but pass with the new implementation.

They also pass even when mbstring is disabled thanks to Symfony polyfill (that is already an intermediate dependency of the project anyway).