### PR TITLE
Fix float parsing for number starting with 0.

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8216,8 +8216,8 @@ abstract class AbstractPHPParser
                 return bindec(substr($numberRepresentation, 2));
 
             default:
-                if (substr($numberRepresentation, 0, 1) === '0') {
-                    return octdec(preg_replace('/^0+(oO)?/', '', $numberRepresentation));
+                if (preg_match('/^0+[oO]?(\d+)$/', $numberRepresentation, $match)) {
+                    return octdec($match[1]);
                 }
 
                 return $numberRepresentation;

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -218,6 +218,23 @@ class ASTLiteralTest extends ASTNodeTest
     }
 
     /**
+     * testLiteralWithZeroFloatValue
+     *
+     * @return void
+     * @since 2.16.0
+     * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+     */
+    public function testLiteralWithZeroFloatValue()
+    {
+        $class = $this->getFirstClassForTestCase();
+        $properties = $class->getProperties();
+        /** @var ASTProperty $property */
+        $property = $properties[0];
+
+        $this->assertSame(0.0, $property->getDefaultValue());
+    }
+
+    /**
      * testLiteralWithCurlyBraceFollowedByCompoundExpression
      *
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -46,6 +46,7 @@ use PDepend\Source\AST\ASTConstantDeclarator;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  * @group php8.1
  */

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -588,7 +588,7 @@ class CommandTest extends AbstractTest
         $output   = ob_get_contents();
         ob_end_clean();
 
-        Log::setSeverity(0);
+        Log::setSeverity(2);
         $error = file_get_contents($file);
         unlink($file);
         $streamProperty->setValue(STDERR);

--- a/src/test/resources/files/Source/AST/ASTLiteral/testLiteralWithZeroFloatValue.php
+++ b/src/test/resources/files/Source/AST/ASTLiteral/testLiteralWithZeroFloatValue.php
@@ -1,0 +1,6 @@
+<?php
+
+class testLiteralWithZeroFloatValue
+{
+    private float $amount = 0.00;
+}


### PR DESCRIPTION
Type: bugfix
Issue: Fix #690
Breaking change: no