### PR TITLE
Fix Declaration of Configuration::getConfigTreeBuilder()

### DIFF
--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -44,6 +44,7 @@ namespace PDepend\DependencyInjection;
 
 use PDepend\Util\FileUtil;
 use PDepend\Util\Workarounds;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
@@ -74,14 +75,14 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $home = FileUtil::getUserHomeDirOrSysTempDir();
         $workarounds = new Workarounds();
 
         $defaultCacheDriver = ($workarounds->hasSerializeReferenceIssue()) ? 'memory' : 'file';
 
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder('pdepend');
         /** @var ArrayNodeDefinition */
         $rootNode = $treeBuilder->getRootNode();
 
@@ -106,6 +107,6 @@ class Configuration implements ConfigurationInterface
             $extension->getConfig($extensionNode);
         }
 
-        return $treeBuilder->getTreeBuilder();
+        return $treeBuilder;
     }
 }


### PR DESCRIPTION
Type: bugfix
Breaking change: I think so since Symfony 6.4 has been released ?

I upgraded my project to [Symfony 6.4](https://symfony.com/blog/symfony-6-4-0-released).
Now when I use [phpmd](https://github.com/phpmd/phpmd) with `vendor/bin/phpmd`, I have the following error :
```
PHP Fatal error:
Declaration of PDepend\DependencyInjection\Configuration::getConfigTreeBuilder()
must be compatible with
Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()
```