### PR TITLE
Allow Symfony 7

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -2,10 +2,9 @@ name: Generate phar
 
 on:
   push:
-    tags:
-      - "*"
-    branches:
-      - "*"
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
   release:
     types:
       - created
@@ -52,6 +51,7 @@ jobs:
 
       - name: Ant
         run: |
+          php src/conf/prepare-phar.php
           ant package -D-phar:filename=./pdepend.phar;
           ./pdepend.phar --version;
 

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -1,5 +1,10 @@
 name: Symfony
 
+# Ensure tests pass whatever is the major version of Symfony installed
+# along with the library
+# Guarantee to users that it can be installed and ran with no conflict
+# in a composer project that also include Symfony dependencies
+
 on:
   push:
     branches: [ '**' ]

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: Symfony
 
 on:
   push:
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
-        setup: [ 'lowest', 'stable' ]
+        php: [ 8.3 ]
+        symfony: [ 2, 3, 4, 5, 6, 7 ]
 
-    name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
+    name: Symfony ${{ matrix.symfony }}
 
     steps:
       - uses: actions/checkout@v3
@@ -38,24 +38,31 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
 
       - name: Cache test packages
         id: composer-test-cache
         uses: actions/cache@v3
         with:
           path: src/test/vendor
-          key: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-
 
-      - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
+      - name: Set Symfony version
+        run: |
+          composer require  --no-update --no-interaction \
+            symfony/dependency-injection:^${{ matrix.symfony }} \
+            symfony/filesystem:^${{ matrix.symfony }} \
+            symfony/config:^${{ matrix.symfony }}
 
       - name: Upgrade PHPUnit
         if: matrix.php >= 7.2
         run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer update --prefer-dist --no-progress --prefer-stable --ignore-platform-req=php+
 
       - name: Install test dependencies
         if: steps.composer-test-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -1,0 +1,53 @@
+name: Composer test script
+
+# Ensure composer test can be run from both fresh build and with test/vendor
+# folder already installed, making sure contributors can rely on it to work locally.
+
+on:
+  push:
+    branches: [ '**' ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.3' ]
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, imagick
+          tools: composer:v2
+          coverage: none
+
+      - name: Imagick SVG support
+        continue-on-error: true
+        run: sudo apt-get install libmagickcore-6.q16-3-extra
+
+      - name: Cache library packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-php-composer-${{ matrix.setup }}-
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer up
+
+      - name: Run `composer test` twice
+        run: |
+          composer test
+          composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: Tests
 
+# Ensure tests pass whatever is the minor PHP version currently supported (see strategy.matrix.php)
+# crossed with "lowest" setup (install the lowest possible dependency versions allowed by the range)
+# and with "stable" setup (install the highest possible dependency stable versions allowed by the range)
+
 on:
   push:
     branches: [ '**' ]

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ PHP_Depend-*.tgz
 .build
 .pear
 vendor
+src/test/vendor
 composer.phar
 composer.lock
 dist

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr-4": {"PDepend\\": "src/main/php/PDepend"}
     },
     "scripts": {
-        "test": "cd src/test && composer update && cd ../.. && php src/test/php/PDepend/fix-php-compatibility.php && php src/test/vendor/bin/phpunit --no-coverage",
+        "test": "php src/test/php/PDepend/install-test-vendor.php && php src/test/vendor/bin/phpunit --no-coverage",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "build-website": [

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,12 @@
     "type": "library",
     "require": {
         "php": ">=5.3.7",
+        "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
         "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
         "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-        "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36|^5.7.27",
         "squizlabs/php_codesniffer": "^2.0.0",
         "gregwar/rst": "^1.0",
         "easy-doc/easy-doc": "0.0.0|^1.2.3"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "psr-4": {"PDepend\\": "src/main/php/PDepend"}
     },
     "scripts": {
-        "test": "phpunit",
+        "test": "cd src/test && composer update && cd ../.. && php src/test/php/PDepend/fix-php-compatibility.php && php src/test/vendor/bin/phpunit --no-coverage",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "build-website": [
@@ -38,5 +38,8 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
+    },
+    "config": {
+        "process-timeout": 900
     }
 }

--- a/src/conf/prepare-phar.php
+++ b/src/conf/prepare-phar.php
@@ -1,0 +1,55 @@
+<?php
+
+$source = __DIR__ . '/../main/php';
+
+$replacements = array(
+    $source . '/PDepend/DependencyInjection/Configuration.php' => array(
+        function ($contents) {
+            global $source;
+
+            $extract = (string)file_get_contents($source . '/Lazy/PDepend/DependencyInjection/Configuration.weak.php');
+            $pattern = '(// <AbstractConfiguration>[\s\S]+</AbstractConfiguration>)';
+
+            if (!preg_match($pattern, $extract, $match)) {
+                return $contents;
+            }
+
+            return preg_replace($pattern, $match[0], $contents);
+        },
+    ),
+    $source . '/Lazy/PDepend/DependencyInjection/Configuration.weak.php' => array(
+        function () {
+            return '';
+        },
+    ),
+    $source . '/Lazy/PDepend/DependencyInjection/Configuration.strong.php' => array(
+        function () {
+            return '';
+        },
+    ),
+);
+
+foreach ($replacements as $file => $callbacks) {
+    echo "$file: ";
+
+    if (!file_exists($file)) {
+        echo "File not found.\n";
+
+        continue;
+    }
+
+    foreach ($callbacks as $callback) {
+        $contents = @file_get_contents($file) ?: '';
+
+        $newContents = call_user_func($callback, $contents);
+
+        if ($newContents !== $contents) {
+            file_put_contents($file, $newContents);
+            echo "Content changed.\n";
+
+            continue;
+        }
+
+        echo "Replace pattern not found.\n";
+    }
+}

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
@@ -39,10 +39,13 @@
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-use PDepend\DependencyInjection\TreeBuilderFactory;
+
+namespace PDepend\DependencyInjection;
+
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+// <AbstractConfiguration>
 /**
  * This is the class that validates and merges configuration
  *
@@ -66,3 +69,4 @@ abstract class AbstractConfiguration implements ConfigurationInterface
         return $this->treeBuilderFactory->getConfigTreeBuilder();
     }
 }
+// </AbstractConfiguration>

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
@@ -39,8 +39,6 @@
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-
-
 use PDepend\DependencyInjection\TreeBuilderFactory;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.strong.php
@@ -40,38 +40,31 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\DependencyInjection;
 
-use AbstractConfiguration;
-use Exception;
-use ReflectionMethod;
+use PDepend\DependencyInjection\TreeBuilderFactory;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-// @codeCoverageIgnoreStart
-$typingMode = 'weak';
-
-try {
-    $method = new ReflectionMethod(
-        'Symfony\\Component\\Config\\Definition\\ConfigurationInterface',
-        'getConfigTreeBuilder'
-    );
-
-    if (method_exists($method, 'hasReturnType') && $method->hasReturnType()) {
-        $typingMode = 'strong';
-    }
-} catch (Exception $exception) {
-    // keep "weak"
-}
-
-require $file = __DIR__ . '/../../Lazy/PDepend/DependencyInjection/Configuration.' . $typingMode . '.php';
-// @codeCoverageIgnoreEnd
-
-class Configuration extends AbstractConfiguration
+/**
+ * This is the class that validates and merges configuration
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @codeCoverageIgnore
+ */
+abstract class AbstractConfiguration implements ConfigurationInterface
 {
     /**
-     * @param array<Extension> $extensions
+     * @var TreeBuilderFactory
      */
-    public function __construct(array $extensions)
+    protected $treeBuilderFactory;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $this->treeBuilderFactory = new TreeBuilderFactory($extensions);
+        return $this->treeBuilderFactory->getConfigTreeBuilder();
     }
 }

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
@@ -39,9 +39,12 @@
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-use PDepend\DependencyInjection\TreeBuilderFactory;
+
+namespace PDepend\DependencyInjection;
+
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+// <AbstractConfiguration>
 /**
  * This is the class that validates and merges configuration
  *
@@ -65,3 +68,4 @@ abstract class AbstractConfiguration implements ConfigurationInterface
         return $this->treeBuilderFactory->getConfigTreeBuilder();
     }
 }
+// </AbstractConfiguration>

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
@@ -39,8 +39,6 @@
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-
-
 use PDepend\DependencyInjection\TreeBuilderFactory;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
+++ b/src/main/php/Lazy/PDepend/DependencyInjection/Configuration.weak.php
@@ -40,38 +40,30 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\DependencyInjection;
 
-use AbstractConfiguration;
-use Exception;
-use ReflectionMethod;
+use PDepend\DependencyInjection\TreeBuilderFactory;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
-// @codeCoverageIgnoreStart
-$typingMode = 'weak';
-
-try {
-    $method = new ReflectionMethod(
-        'Symfony\\Component\\Config\\Definition\\ConfigurationInterface',
-        'getConfigTreeBuilder'
-    );
-
-    if (method_exists($method, 'hasReturnType') && $method->hasReturnType()) {
-        $typingMode = 'strong';
-    }
-} catch (Exception $exception) {
-    // keep "weak"
-}
-
-require $file = __DIR__ . '/../../Lazy/PDepend/DependencyInjection/Configuration.' . $typingMode . '.php';
-// @codeCoverageIgnoreEnd
-
-class Configuration extends AbstractConfiguration
+/**
+ * This is the class that validates and merges configuration
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @codeCoverageIgnore
+ */
+abstract class AbstractConfiguration implements ConfigurationInterface
 {
     /**
-     * @param array<Extension> $extensions
+     * @var TreeBuilderFactory
      */
-    public function __construct(array $extensions)
+    protected $treeBuilderFactory;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
     {
-        $this->treeBuilderFactory = new TreeBuilderFactory($extensions);
+        return $this->treeBuilderFactory->getConfigTreeBuilder();
     }
 }

--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -42,29 +42,38 @@
 
 namespace PDepend\DependencyInjection;
 
-use AbstractConfiguration;
 use Exception;
 use ReflectionMethod;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
+// <AbstractConfiguration>
 // @codeCoverageIgnoreStart
-$typingMode = 'weak';
+if (!class_exists('PDepend\\DependencyInjection\\AbstractConfiguration')) {
+    $typingMode = 'weak';
 
-try {
-    $method = new ReflectionMethod(
-        'Symfony\\Component\\Config\\Definition\\ConfigurationInterface',
-        'getConfigTreeBuilder'
-    );
+    try {
+        $method = new ReflectionMethod(
+            'Symfony\\Component\\Config\\Definition\\ConfigurationInterface',
+            'getConfigTreeBuilder'
+        );
 
-    if (method_exists($method, 'hasReturnType') && $method->hasReturnType()) {
-        $typingMode = 'strong';
+        if (method_exists($method, 'hasReturnType') && $method->hasReturnType()) {
+            $typingMode = 'strong';
+        }
+    } catch (Exception $exception) {
+        // keep "weak"
     }
-} catch (Exception $exception) {
-    // keep "weak"
+
+    require_once __DIR__ . '/../../Lazy/PDepend/DependencyInjection/Configuration.' . $typingMode . '.php';
 }
-
-require $file = __DIR__ . '/../../Lazy/PDepend/DependencyInjection/Configuration.' . $typingMode . '.php';
 // @codeCoverageIgnoreEnd
+// </AbstractConfiguration>
 
+/**
+ * @see ConfigurationInterface
+ * @see TreeBuilder
+ */
 class Configuration extends AbstractConfiguration
 {
     /**

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\DependencyInjection;
+
+use PDepend\Util\FileUtil;
+use PDepend\Util\Workarounds;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+/**
+ * This is the class that validates and merges configuration
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+class TreeBuilderFactory
+{
+    const DEFAULT_TTL = 2592000; //30 days
+
+    /**
+     * @var array<Extension>
+     */
+    private $extensions = array();
+
+    /**
+     * @param array<Extension> $extensions
+     */
+    public function __construct(array $extensions)
+    {
+        $this->extensions = $extensions;
+    }
+
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return TreeBuilder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $home = FileUtil::getUserHomeDirOrSysTempDir();
+        $workarounds = new Workarounds();
+
+        $defaultCacheDriver = ($workarounds->hasSerializeReferenceIssue()) ? 'memory' : 'file';
+
+        $name = 'pdepend';
+        $treeBuilder = new TreeBuilder($name);
+        // @codeCoverageIgnoreStart
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = method_exists($treeBuilder, 'getRootNode')
+            ? $treeBuilder->getRootNode()
+            : $treeBuilder->root($name); // @phpstan-ignore-line
+        // @codeCoverageIgnoreEnd
+
+        $nodes = $rootNode->children();
+
+        $cacheNode = $nodes->arrayNode('cache')->addDefaultsIfNotSet()->children();
+        $cacheNode->enumNode('driver')->defaultValue($defaultCacheDriver)->values(array('file', 'memory'));
+        $cacheNode->scalarNode('location')->info('This value is only used for the file cache.')->defaultValue($home . '/.pdepend');
+        $cacheNode->integerNode('ttl')->info('This value is only used for the file cache. Value in seconds.')->defaultValue(self::DEFAULT_TTL);
+
+        $imageConvertNode = $nodes->arrayNode('image_convert')->addDefaultsIfNotSet()->children();
+        $imageConvertNode->scalarNode('font_size')->defaultValue('11');
+        $imageConvertNode->scalarNode('font_family')->defaultValue('Arial');
+
+        $parserNode = $nodes->arrayNode('parser')->addDefaultsIfNotSet()->children();
+        $parserNode->integerNode('nesting')->defaultValue(65536);
+
+        $extensionsNode = $nodes->arrayNode('extensions')->addDefaultsIfNotSet()->children();
+
+        foreach ($this->extensions as $extension) {
+            $extensionNode = $extensionsNode->arrayNode($extension->getName());
+            $extension->getConfig($extensionNode);
+        }
+
+        return $treeBuilder;
+    }
+}

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -79,7 +79,7 @@ class ExcludePathFilter implements Filter
         $quoted = array_map('preg_quote', $patterns);
 
         $this->relative = '(' . str_replace('\*', '.*', join('|', $quoted)) . ')i';
-        $this->absolute = '(^(' . str_replace('\*', '.*', join('|', $quoted)) .'))i';
+        $this->absolute = '(^(' . str_replace('\*', '.*', join('|', $quoted)) . '))i';
     }
 
     /**

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "pdepend/pdepend-tester",
+    "license": "BSD-3-Clause",
+    "type": "library",
+    "require": {
+        "php": ">=5.3.7",
+        "phpunit/phpunit": "^4.8.36|^5.7.27"
+    }
+}

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "pdepend/pdepend-tester",
+    "description": "Test-related dependencies for pdepend/pdepend",
     "license": "BSD-3-Clause",
     "type": "library",
     "require": {

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\DependencyInjection;
+
+use Exception;
+use PDepend\AbstractTest;
+use PDepend\TestExtension;
+use ReflectionMethod;
+
+/**
+ * Test cases for the {@link \PDepend\Application} class.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @covers \PDepend\DependencyInjection\TreeBuilderFactory
+ * @group unittest
+ */
+class ConfigurationTest extends AbstractTest
+{
+    /**
+     * @return bool
+     */
+    private function isStronglyTyped()
+    {
+        try {
+            $method = new ReflectionMethod(
+                'Symfony\\Component\\Config\\Definition\\ConfigurationInterface',
+                'getConfigTreeBuilder'
+            );
+
+            if (method_exists($method, 'hasReturnType') && $method->hasReturnType()) {
+                return true;
+            }
+        } catch (Exception $exception) {
+            // keep "weak"
+        }
+
+        return false;
+    }
+
+    public function testSymfonyGte7()
+    {
+        if (!self::isStronglyTyped()) {
+            $this->markTestSkipped('This test requires Symfony >= 7');
+        }
+
+        $config = new Configuration(array(new TestExtension()));
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            $config->getConfigTreeBuilder()
+        );
+
+        $method = new ReflectionMethod(
+            'PDepend\\DependencyInjection\\Configuration',
+            'getConfigTreeBuilder'
+        );
+
+        $this->assertSame(
+            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            $method->getReturnType()->getName()
+        );
+    }
+
+    public function testSymfonyLt7()
+    {
+        if (self::isStronglyTyped()) {
+            $this->markTestSkipped('This test requires Symfony < 7');
+        }
+
+        $config = new Configuration(array(new TestExtension()));
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            $config->getConfigTreeBuilder()
+        );
+
+        if (PHP_VERSION < 7) {
+            return;
+        }
+
+        $method = new ReflectionMethod(
+            'PDepend\\DependencyInjection\\Configuration',
+            'getConfigTreeBuilder'
+        );
+
+        $this->assertNull($method->getReturnType());
+    }
+}

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -54,6 +54,7 @@ use ReflectionMethod;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @covers \PDepend\DependencyInjection\TreeBuilderFactory
+ * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
 class ConfigurationTest extends AbstractTest

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -54,6 +54,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @covers \PDepend\DependencyInjection\ExtensionManager
  * @covers \PDepend\DependencyInjection\Extension
+ * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
 class ExtensionManagerTest extends AbstractTest

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\DependencyInjection;
+
+use PDepend\AbstractTest;
+
+/**
+ * Test cases for the {@link \PDepend\Application} class.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @covers \PDepend\DependencyInjection\TreeBuilder
+ * @group unittest
+ */
+class TreeBuilderTest extends AbstractTest
+{
+    public function testTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition',
+            $treeBuilder->getRootNode()
+        );
+
+        $this->assertInstanceOf(
+            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            $treeBuilder->getTreeBuilder()
+        );
+    }
+}

--- a/src/test/php/PDepend/fix-php-compatibility.php
+++ b/src/test/php/PDepend/fix-php-compatibility.php
@@ -39,6 +39,10 @@ $replacements = array(
             'xdebug.default_enable=0',
             'xdebug.mode=coverage',
         ),
+        array(
+            "'track_errors=1',",
+            "// 'track_errors=1',",
+        ),
     ),
     $vendor . '/phpunit/phpunit/src/Framework/TestCase.php' => array(
         array(

--- a/src/test/php/PDepend/fix-php-compatibility.php
+++ b/src/test/php/PDepend/fix-php-compatibility.php
@@ -1,10 +1,11 @@
 <?php
 
+$vendor = __DIR__ . '/../../vendor';
 $replacements = array(
     /**
      * Patch phpunit/phpunit-mock-objects Generator.php file to not create double nullable tokens: `??`
      */
-    __DIR__ . '/../../../../vendor/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php' => array(
+    $vendor . '/phpunit/phpunit-mock-objects/src/Framework/MockObject/Generator.php' => array(
         array(
             "if (version_compare(PHP_VERSION, '7.1', '>=') && \$parameter->allowsNull() && !\$parameter->isVariadic()) {",
             "if (version_compare(PHP_VERSION, '7.1', '>=') && version_compare(PHP_VERSION, '8.0', '<') && \$parameter->allowsNull() && !\$parameter->isVariadic()) {",
@@ -13,7 +14,7 @@ $replacements = array(
     /**
      * Fix phpunit/phpunit to not trigger warning on `final private function`
      */
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Util/Configuration.php' => array(
+    $vendor . '/phpunit/phpunit/src/Util/Configuration.php' => array(
         array(
             'final private function',
             'private function',
@@ -23,13 +24,13 @@ $replacements = array(
             '',
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Framework/Constraint.php' => array(
+    $vendor . '/phpunit/phpunit/src/Framework/Constraint.php' => array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Extensions/PhptTestCase.php' => array(
+    $vendor . '/phpunit/phpunit/src/Extensions/PhptTestCase.php' => array(
         array(
             'public function count()',
             "#[\\ReturnTypeWillChange]\npublic function count()",
@@ -39,23 +40,13 @@ $replacements = array(
             'xdebug.mode=coverage',
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Framework/TestCase.php' => array(
+    $vendor . '/phpunit/phpunit/src/Framework/TestCase.php' => array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Framework/TestSuite.php' => array(
-        array(
-            'public function count(',
-            "#[\\ReturnTypeWillChange]\npublic function count(",
-        ),
-        array(
-            'public function getIterator(',
-            "#[\\ReturnTypeWillChange]\npublic function getIterator(",
-        ),
-    ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Framework/TestResult.php' => array(
+    $vendor . '/phpunit/phpunit/src/Framework/TestSuite.php' => array(
         array(
             'public function count(',
             "#[\\ReturnTypeWillChange]\npublic function count(",
@@ -65,19 +56,29 @@ $replacements = array(
             "#[\\ReturnTypeWillChange]\npublic function getIterator(",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Runner/Filter/Test.php' => array(
+    $vendor . '/phpunit/phpunit/src/Framework/TestResult.php' => array(
+        array(
+            'public function count(',
+            "#[\\ReturnTypeWillChange]\npublic function count(",
+        ),
+        array(
+            'public function getIterator(',
+            "#[\\ReturnTypeWillChange]\npublic function getIterator(",
+        ),
+    ),
+    $vendor . '/phpunit/phpunit/src/Runner/Filter/Test.php' => array(
         array(
             'public function accept(',
             "#[\\ReturnTypeWillChange]\npublic function accept(",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/php-file-iterator/src/Iterator.php' => array(
+    $vendor . '/phpunit/php-file-iterator/src/Iterator.php' => array(
         array(
             'public function accept(',
             "#[\\ReturnTypeWillChange]\npublic function accept(",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Util/TestSuiteIterator.php' => array(
+    $vendor . '/phpunit/phpunit/src/Util/TestSuiteIterator.php' => array(
         array(
             'public function hasChildren(',
             "#[\\ReturnTypeWillChange]\npublic function hasChildren(",
@@ -107,19 +108,19 @@ $replacements = array(
             "#[\\ReturnTypeWillChange]\npublic function rewind(",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/phpunit/src/Util/Getopt.php' => array(
+    $vendor . '/phpunit/phpunit/src/Util/Getopt.php' => array(
         array(
             'strlen($opt_arg)',
             'strlen((string) $opt_arg)',
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
+    $vendor . '/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
         array(
             '$docblock = $token->getDocblock();',
             '$docblock = $token->getDocblock() ?? \'\';',
         ),
     ) : array(),
-    __DIR__ . '/../../../../vendor/phpunit/php-token-stream/src/Token/Stream.php' => array(
+    $vendor . '/phpunit/php-token-stream/src/Token/Stream.php' => array(
         array(
             'public function offsetExists',
             "#[\\ReturnTypeWillChange]\npublic function offsetExists",
@@ -165,7 +166,7 @@ $replacements = array(
             "#[\\ReturnTypeWillChange]\npublic function rewind",
         ),
     ),
-    __DIR__ . '/../../../../vendor/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php' => (PHP_VERSION >= 7) ? array(
+    $vendor . '/phpunit/php-code-coverage/src/Report/Html/Renderer/File.php' => (PHP_VERSION >= 7) ? array(
         array(
             '$numTests = count($coverageData[$i]);',
             '$numTests = count($coverageData[$i] ?? []);',

--- a/src/test/php/PDepend/fix-php-compatibility.php
+++ b/src/test/php/PDepend/fix-php-compatibility.php
@@ -113,6 +113,10 @@ $replacements = array(
             'strlen($opt_arg)',
             'strlen((string) $opt_arg)',
         ),
+        array(
+            'while (list($i, $arg) = each($args)) {',
+            'foreach ($args as $i => $arg) {',
+        ),
     ),
     $vendor . '/phpunit/php-code-coverage/src/CodeCoverage.php' => (PHP_VERSION >= 7) ? array(
         array(
@@ -187,6 +191,13 @@ foreach ($replacements as $file => $patterns) {
         list($from, $to) = $replacement;
 
         $contents = @file_get_contents($file) ?: '';
+
+        if (strpos($contents, $to) !== false) {
+            echo "Already changed.\n";
+
+            continue;
+        }
+
         $newContents = str_replace($from, $to, $contents);
 
         if ($newContents !== $contents) {

--- a/src/test/php/PDepend/fix-php-compatibility.php
+++ b/src/test/php/PDepend/fix-php-compatibility.php
@@ -17,11 +17,11 @@ $replacements = array(
     $vendor . '/phpunit/phpunit/src/Util/Configuration.php' => array(
         array(
             'final private function',
-            'private function',
+            '/** @final */ private function',
         ),
         array(
             '$target = &$GLOBALS;',
-            '',
+            '// Access to $GLOBALS removed',
         ),
     ),
     $vendor . '/phpunit/phpunit/src/Framework/Constraint.php' => array(

--- a/src/test/php/PDepend/install-test-vendor.php
+++ b/src/test/php/PDepend/install-test-vendor.php
@@ -1,0 +1,14 @@
+<?php
+
+$cwd = getcwd();
+chdir(__DIR__ . '/../..');
+$phar = $cwd . '/composer.phar';
+$composer = file_exists($phar) ? 'php ' . escapeshellarg(realpath($phar)) : 'composer';
+$command = $composer . ' update --ignore-platform-req=php+';
+
+echo "> $command\n";
+echo shell_exec($command);
+
+require __DIR__ . '/fix-php-compatibility.php';
+
+chdir($cwd);

--- a/src/test/symfony-version.php
+++ b/src/test/symfony-version.php
@@ -1,0 +1,19 @@
+<?php
+
+$installed = require __DIR__.'/../../vendor/composer/installed.php';
+$versions = $installed['versions'];
+
+$symfonyPackages = array(
+    'config',
+    'dependency-injection',
+    'filesystem',
+    'yaml'
+);
+
+foreach ($symfonyPackages as $package) {
+    echo "$package: ".
+        (isset($versions['symfony/'.$package]['pretty_version'])
+            ? $versions['symfony/'.$package]['pretty_version']
+            : 'not installed').
+        "\n";
+}

--- a/src/test/symfony-version.php
+++ b/src/test/symfony-version.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Check which version of Symfony packages that PDepend depends on
+ * is installed.
+ * It can be used in CI to see with which exact version tests were
+ * run for a given commit.
+ */
+
 $installed = require __DIR__.'/../../vendor/composer/installed.php';
 $versions = $installed['versions'];
 


### PR DESCRIPTION
Type: bugfix
Issue: Fix #695
Breaking change: no

- Add lazy configuration for Symfony (JIT loading of the implementation compatible with installed version of symfony/config)
- Move test dependencies in the test folder (so it can have different Symfony packages version without conflict)
- Test each Symfony version in GitHub Actions
- Make `composer test` automatically installing test dependencies