### PR TITLE
Resolve a few PHPstan level 7 issues

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         php: [ '7.4' ]
         setup: [ 'stable' ]
-        phpstan: [1.10.25]
+        phpstan: [1.10.57]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }} - ${{ matrix.phpstan }}
 

--- a/scripts/update-version.php
+++ b/scripts/update-version.php
@@ -87,7 +87,7 @@ class CacheVersionUpdater
      */
     public function __construct()
     {
-        $this->rootDirectory = realpath(dirname(__FILE__) . '/../src/main/php/PDepend');
+        $this->rootDirectory = realpath(__DIR__ . '/../src/main/php/PDepend');
     }
 
     /**

--- a/src/bin/pdepend.php
+++ b/src/bin/pdepend.php
@@ -45,7 +45,7 @@ use PDepend\TextUI\Command;
 
 // PEAR/svn workaround
 if (strpos('@php_bin@', '@php_bin') === 0) {
-    set_include_path('.' . PATH_SEPARATOR . dirname(__FILE__) . '/../main/php');
+    set_include_path('.' . PATH_SEPARATOR . __DIR__ . '/../main/php');
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -43,6 +43,7 @@
 namespace PDepend\DependencyInjection;
 
 use ReflectionClass;
+use RuntimeException;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -134,6 +135,11 @@ abstract class Extension
     {
         $reflection = new ReflectionClass($this);
 
-        return dirname($reflection->getFileName());
+        $fileName = $reflection->getFileName();
+        if (!$fileName) {
+            throw new RuntimeException('Missing file name');
+        }
+
+        return dirname($fileName);
     }
 }

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -43,6 +43,7 @@
 namespace PDepend\DependencyInjection;
 
 use stdClass;
+use RuntimeException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension as SymfonyExtension;
@@ -75,6 +76,11 @@ class PdependExtension extends SymfonyExtension
             foreach ($config['extensions'] as $config) {
                 if (!isset($config['class'])) {
                     continue;
+                }
+                if (!is_a($config['class'], 'PDepend\DependencyInjection\Extension', true)) {
+                    throw new RuntimeException(
+                        sprintf('Class "%s" is not a valid Extension', $config['class'])
+                    );
                 }
 
                 $extensionManager->activateExtension($config['class']);

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -55,6 +55,7 @@ use PDepend\Source\ASTVisitor\AbstractASTVisitor;
 use PDepend\Util\FileUtil;
 use PDepend\Util\ImageConvert;
 use PDepend\Util\Utf8Util;
+use RuntimeException;
 
 /**
  * Generates a chart with the aggregated metrics.
@@ -155,7 +156,12 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
         $bias = 0.1;
 
         $svg = new DOMDocument('1.0', 'UTF-8');
-        $svg->loadXML(file_get_contents(dirname(__FILE__) . '/chart.svg'));
+        $templatePath = __DIR__ . '/chart.svg';
+        $template = file_get_contents($templatePath);
+        if (!$template) {
+            throw new RuntimeException('Missing ' . $templatePath);
+        }
+        $svg->loadXML($template);
 
         $layer = $svg->getElementById('jdepend.layer');
 

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -198,7 +198,12 @@ class Pyramid implements FileAwareGenerator
         $proportions = $this->computeProportions($metrics);
 
         $svg = new DOMDocument('1.0', 'UTF-8');
-        $svg->loadXML(file_get_contents(dirname(__FILE__) . '/pyramid.svg'));
+        $templatePath = __DIR__ . '/pyramid.svg';
+        $template = file_get_contents($templatePath);
+        if (!$template) {
+            throw new RuntimeException('Missing ' . $templatePath);
+        }
+        $svg->loadXML($template);
 
         $items = array_merge($metrics, $proportions);
         foreach ($items as $name => $value) {

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -46,6 +46,7 @@ use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
+use RuntimeException;
 
 /**
  * This class provides an interface to a single source file.
@@ -361,6 +362,9 @@ class ASTCompilationUnit extends AbstractASTArtifact
             (strpos($this->fileName, 'php://') === 0 || file_exists($this->fileName))
         ) {
             $source = file_get_contents($this->fileName);
+            if (!$source) {
+                throw new RuntimeException('File not found ' . $this->fileName);
+            }
 
             $this->source = str_replace(array("\r\n", "\r"), "\n", $source);
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -527,7 +527,7 @@ abstract class AbstractPHPParser
         $this->cache->store(
             $this->compilationUnit->getId(),
             $this->compilationUnit,
-            $hash
+            $hash ?: null
         );
 
         $this->tearDownEnvironment();
@@ -2108,7 +2108,8 @@ abstract class AbstractPHPParser
      */
     private function parseIncrementExpression(array &$expressions)
     {
-        if ($this->isReadWriteVariable(end($expressions))) {
+        $expression = end($expressions);
+        if ($expression && $this->isReadWriteVariable($expression)) {
             return $this->parsePostIncrementExpression(array_pop($expressions));
         }
         return $this->parsePreIncrementExpression();
@@ -2173,7 +2174,8 @@ abstract class AbstractPHPParser
      */
     private function parseDecrementExpression(array &$expressions)
     {
-        if ($this->isReadWriteVariable(end($expressions))) {
+        $expression = end($expressions);
+        if ($expression && $this->isReadWriteVariable($expression)) {
             return $this->parsePostDecrementExpression(array_pop($expressions));
         }
         return $this->parsePreDecrementExpression();
@@ -7123,6 +7125,9 @@ abstract class AbstractPHPParser
     protected function parseUseDeclarationForVersion(array $fragments)
     {
         $image = $this->parseNamespaceImage($fragments);
+        if ($image === false) {
+            return;
+        }
 
         // Add mapping between image and qualified name to symbol table
         $this->useSymbolTable->add($image, join('', $fragments));
@@ -7131,7 +7136,7 @@ abstract class AbstractPHPParser
     /**
      * @param array<string> $fragments
      *
-     * @return string
+     * @return string|false
      */
     protected function parseNamespaceImage(array $fragments)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion70.php
@@ -577,10 +577,12 @@ abstract class PHPParserVersion70 extends PHPParserVersion56
             $this->consumeComments();
 
             // Add mapping between image and qualified name to symbol table
-            $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+            if ($image !== false) {
+                $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
+            }
         } while (true);
 
-        if (isset($image, $subFragments)) {
+        if (isset($image, $subFragments) && $image !== false) {
             $this->useSymbolTable->add($image, join('', array_merge($fragments, $subFragments)));
         }
 

--- a/src/test/php/PDepend/AbstractTest.php
+++ b/src/test/php/PDepend/AbstractTest.php
@@ -809,14 +809,14 @@ abstract class AbstractTest extends TestCase
         spl_autoload_register(array(__CLASS__, 'autoload'));
 
         // Is it not installed?
-        if (is_file(dirname(__FILE__) . '/../../../main/php/PDepend/Engine.php')) {
-            $path  = realpath(dirname(__FILE__) . '/../../../main/php/');
+        if (is_file(__DIR__ . '/../../../main/php/PDepend/Engine.php')) {
+            $path  = realpath(__DIR__ . '/../../../main/php/');
             $path .= PATH_SEPARATOR . get_include_path();
             set_include_path($path);
         }
 
         // Set test path
-        $path  = realpath(dirname(__FILE__) . '/..');
+        $path  = realpath(__DIR__ . '/..');
         $path .= PATH_SEPARATOR . get_include_path();
         set_include_path($path);
 
@@ -832,8 +832,8 @@ abstract class AbstractTest extends TestCase
     public static function autoload($className)
     {
         $file = strtr($className, '\\', DIRECTORY_SEPARATOR) . '.php';
-        if (is_file(dirname(__FILE__) . '/../../../main/php/PDepend/Engine.php')) {
-            $file = dirname(__FILE__) . '/../../../main/php/' . $file;
+        if (is_file(__DIR__ . '/../../../main/php/PDepend/Engine.php')) {
+            $file = __DIR__ . '/../../../main/php/' . $file;
         }
         if (file_exists($file)) {
             include $file;

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -72,7 +72,7 @@ class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegress
         $iterator = new Iterator(
             new \ArrayIterator(array(new \SplFileInfo(__FILE__))),
             $filter,
-            dirname(__FILE__)
+            __DIR__
         );
         $iterator->accept();
     }

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -63,7 +63,7 @@ class EngineTest extends AbstractTest
      */
     public function testAddInvalidDirectoryFail()
     {
-        $dir = dirname(__FILE__) . '/foobar';
+        $dir = __DIR__ . '/foobar';
         $msg = "Invalid directory '{$dir}' added.";
 
         $this->setExpectedException('InvalidArgumentException', $msg);

--- a/src/test/php/PDepend/Input/CompositeFilterTest.php
+++ b/src/test/php/PDepend/Input/CompositeFilterTest.php
@@ -67,7 +67,7 @@ class CompositeFilterTest extends AbstractTest
         $composite = new CompositeFilter();
         $composite->append($filter0);
 
-        $composite->accept(dirname(__FILE__), dirname(__FILE__));
+        $composite->accept(__DIR__, __DIR__);
 
         $this->assertTrue($filter0->invoked);
     }
@@ -86,7 +86,7 @@ class CompositeFilterTest extends AbstractTest
         $composite->append($filter0);
         $composite->append($filter1);
 
-        $composite->accept(dirname(__FILE__), dirname(__FILE__));
+        $composite->accept(__DIR__, __DIR__);
 
         $this->assertTrue($filter1->invoked);
     }
@@ -105,7 +105,7 @@ class CompositeFilterTest extends AbstractTest
         $composite->append($filter0);
         $composite->append($filter1);
 
-        $composite->accept(dirname(__FILE__), dirname(__FILE__));
+        $composite->accept(__DIR__, __DIR__);
 
         $this->assertFalse($filter1->invoked);
     }

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -123,7 +123,7 @@ class IteratorTest extends AbstractTest
         $iterator = new Iterator(
             new \ArrayIterator(array(new \SplFileInfo(__FILE__))),
             $filter,
-            dirname(__FILE__)
+            __DIR__
         );
         $iterator->accept();
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -225,7 +225,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTest
     {
         $pathName = $this->createRunResourceURI('clover.xml');
 
-        $content = file_get_contents(dirname(__FILE__) . '/_files/clover.xml');
+        $content = file_get_contents(__DIR__ . '/_files/clover.xml');
         $directory = dirname($this->createCodeResourceUriForTest()) . DIRECTORY_SEPARATOR;
         $content = str_replace('${pathName}', $directory, $content);
         file_put_contents($pathName, $content);

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -177,7 +177,7 @@ class XmlTest extends AbstractTest
 
         $fileName = 'xml-log-without-metrics.xml';
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$fileName}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }
@@ -223,7 +223,7 @@ class XmlTest extends AbstractTest
 
         $fileName = 'xml-log-with-metrics.xml';
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$fileName}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -189,7 +189,7 @@ class XmlTest extends AbstractTest
 
         $fileName = 'xml-log-without-metrics.xml';
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$fileName}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }
@@ -218,7 +218,7 @@ class XmlTest extends AbstractTest
 
         $fileName = 'project-aware-result-set-without-code.xml';
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$fileName}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }
@@ -246,7 +246,7 @@ class XmlTest extends AbstractTest
 
         $fileName = 'node-and-project-aware-result-set.xml';
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$fileName}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$fileName}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }
@@ -306,7 +306,7 @@ class XmlTest extends AbstractTest
         $log->close();
 
         $this->assertXmlStringEqualsXmlString(
-            $this->getNormalizedPathXml(dirname(__FILE__) . "/_expected/{$expectation}"),
+            $this->getNormalizedPathXml(__DIR__ . "/_expected/{$expectation}"),
             $this->getNormalizedPathXml($this->resultFile)
         );
     }

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -205,7 +205,7 @@ class CommandTest extends AbstractTest
         $logFile  = $this->createRunResourceURI();
         $resource = $this->createCodeResourceUriForTest();
 
-        set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__FILE__));
+        set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__);
 
         $argv = array(
             '--suffix=inc',
@@ -232,7 +232,7 @@ class CommandTest extends AbstractTest
         $logFile  = $this->createRunResourceURI();
         $resource = $this->createCodeResourceUriForTest();
 
-        set_include_path(get_include_path() . PATH_SEPARATOR . dirname(__FILE__));
+        set_include_path(get_include_path() . PATH_SEPARATOR . __DIR__);
 
         $argv = array(
             '--suffix=inc',
@@ -516,7 +516,7 @@ class CommandTest extends AbstractTest
     public function testTextUiCommandAcceptsExistingFileForCoverageReportOption()
     {
         $argv = array(
-            '--coverage-report=' . dirname(__FILE__) . '/_files/clover.xml',
+            '--coverage-report=' . __DIR__ . '/_files/clover.xml',
             '--dummy-logger=' . $this->createRunResourceURI(),
             '--configuration=' . __DIR__ . '/../../../resources/pdepend.xml.dist',
             __FILE__,
@@ -551,7 +551,7 @@ class CommandTest extends AbstractTest
     {
         $argv = array(
             '--quiet',
-            '--coverage-report=' . dirname(__FILE__) . '/_files/clover.xml',
+            '--coverage-report=' . __DIR__ . '/_files/clover.xml',
             '--dummy-logger=' . $this->createRunResourceURI(),
             '--configuration=' . __DIR__ . '/../../../resources/pdepend.xml.dist',
             __FILE__,

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -179,7 +179,7 @@ class CloverReportTest extends AbstractTest
      */
     private function createCloverReport()
     {
-        $sxml = simplexml_load_file(dirname(__FILE__) . '/_files/clover.xml');
+        $sxml = simplexml_load_file(__DIR__ . '/_files/clover.xml');
         return new CloverReport($sxml);
     }
 
@@ -190,7 +190,7 @@ class CloverReportTest extends AbstractTest
      */
     private function createNamespacedCloverReport()
     {
-        $sxml = simplexml_load_file(dirname(__FILE__) . '/_files/clover-namespaced.xml');
+        $sxml = simplexml_load_file(__DIR__ . '/_files/clover-namespaced.xml');
         return new CloverReport($sxml);
     }
 

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -101,6 +101,6 @@ class FactoryTest extends AbstractTest
     public function testCreateMethodThrowsExceptionForUnsupportedReportFormat()
     {
         $factory = new Factory();
-        $factory->create(dirname(__FILE__) . '/_files/fail.xml');
+        $factory->create(__DIR__ . '/_files/fail.xml');
     }
 }

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -110,7 +110,7 @@ class ImageConvertTest extends AbstractTest
      */
     public function testSvgFixtureContainsExpectedNumberOfFontFamilyDefinitions()
     {
-        $svg = file_get_contents(dirname(__FILE__) . '/_input/pyramid.svg');
+        $svg = file_get_contents(__DIR__ . '/_input/pyramid.svg');
         $this->assertEquals(25, substr_count($svg, 'font-family:Arial'));
     }
 
@@ -145,7 +145,7 @@ class ImageConvertTest extends AbstractTest
      */
     public function testSvgFixtureContainsExpectedNumberOfFontSizeDefinitions()
     {
-        $svg = file_get_contents(dirname(__FILE__) . '/_input/pyramid.svg');
+        $svg = file_get_contents(__DIR__ . '/_input/pyramid.svg');
         $this->assertEquals(25, substr_count($svg, 'font-size:11px'));
     }
 
@@ -181,7 +181,7 @@ class ImageConvertTest extends AbstractTest
     protected function createInputSvg()
     {
         $input = $this->createRunResourceURI(uniqid('input_')) . '.svg';
-        copy(dirname(__FILE__) . '/_input/pyramid.svg', $input);
+        copy(__DIR__ . '/_input/pyramid.svg', $input);
 
         return $input;
     }

--- a/src/test/resources/files/bugs/030/testCorrectClassTokensAreSet.php
+++ b/src/test/resources/files/bugs/030/testCorrectClassTokensAreSet.php
@@ -10,7 +10,7 @@ abstract class PHP_Depend_ParserTest extends PHP_Depend_AbstractTest
      */
     public function testParserBacktickExpressionBug15()
     {
-        $sourceFile = dirname(__FILE__) . '/my/test/file.php';
+        $sourceFile = __DIR__ . '/my/test/file.php';
         $tokenizer  = new PHP_Depend_Tokenizer_Internal($sourceFile);
         $builder    = new PHP_Depend_Builder_Default();
         $parser     = new PHP_Depend_Parser($tokenizer, $builder);

--- a/src/test/resources/files/bugs/030/testCorrectClassTokensAreSet.php
+++ b/src/test/resources/files/bugs/030/testCorrectClassTokensAreSet.php
@@ -10,7 +10,7 @@ abstract class PHP_Depend_ParserTest extends PHP_Depend_AbstractTest
      */
     public function testParserBacktickExpressionBug15()
     {
-        $sourceFile = __DIR__ . '/my/test/file.php';
+        $sourceFile = dirname(__FILE__) . '/my/test/file.php';
         $tokenizer  = new PHP_Depend_Tokenizer_Internal($sourceFile);
         $builder    = new PHP_Depend_Builder_Default();
         $parser     = new PHP_Depend_Parser($tokenizer, $builder);


### PR DESCRIPTION
Type: bugfix|documentation  
Breaking change: no

Gets us from 58 to 48 remaining issues at level 7. This is mainly done by checking for invalid configurations and adjusting a few signatures.

Note: The two failing tests do not appear to be related to any of my changes here.