### PR TITLE
Correct a few PHPStan level 7 issues

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -93,7 +93,10 @@ class Application
      */
     public function getConfiguration()
     {
-        return $this->getContainer()->get('pdepend.configuration');
+        $obj = $this->getContainer()->get('pdepend.configuration');
+        assert($obj instanceof Configuration);
+
+        return $obj;
     }
 
     /**
@@ -101,7 +104,10 @@ class Application
      */
     public function getEngine()
     {
-        return $this->getContainer()->get('pdepend.engine');
+        $obj = $this->getContainer()->get('pdepend.engine');
+        assert($obj instanceof Engine);
+
+        return $obj;
     }
 
     /**
@@ -109,7 +115,10 @@ class Application
      */
     public function getRunner()
     {
-        return $this->getContainer()->get('pdepend.textui.runner'); // TODO: Use standard name? textui is detail.
+        $obj = $this->getContainer()->get('pdepend.textui.runner'); // TODO: Use standard name? textui is detail.
+        assert($obj instanceof Runner);
+
+        return $obj;
     }
 
     /**
@@ -117,7 +126,10 @@ class Application
      */
     public function getReportGeneratorFactory()
     {
-        return $this->getContainer()->get('pdepend.report_generator_factory');
+        $obj = $this->getContainer()->get('pdepend.report_generator_factory');
+        assert($obj instanceof ReportGeneratorFactory);
+
+        return $obj;
     }
 
     /**
@@ -125,7 +137,10 @@ class Application
      */
     public function getAnalyzerFactory()
     {
-        return $this->getContainer()->get('pdepend.analyzer_factory');
+        $obj = $this->getContainer()->get('pdepend.analyzer_factory');
+        assert($obj instanceof AnalyzerFactory);
+
+        return $obj;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -270,8 +270,10 @@ abstract class AbstractASTArtifact implements ASTArtifact
     public function accept(ASTVisitor $visitor, $data = null)
     {
         $methodName = 'visit' . substr(get_class($this), 22);
+        $callable = array($visitor, $methodName);
+        assert(is_callable($callable));
 
-        return call_user_func(array($visitor, $methodName), $this, $data);
+        return call_user_func($callable, $this, $data);
     }
 
     // END@deprecated

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -101,8 +101,10 @@ abstract class AbstractASTNode implements ASTNode
     public function accept(ASTVisitor $visitor, $data = null)
     {
         $methodName = 'visit' . substr(get_class($this), 22);
+        $callable = array($visitor, $methodName);
+        assert(is_callable($callable));
 
-        return call_user_func(array($visitor, $methodName), $this, $data);
+        return call_user_func($callable, $this, $data);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -222,21 +222,21 @@ class PHPBuilder implements Builder
     /**
      * All generated {@link ASTTrait} objects
      *
-     * @var array<string, array<string, array<int, ASTTrait>>>
+     * @var array<string, array<string, array<string, ASTTrait>>>
      */
     private $traits = array();
 
     /**
      * All generated {@link ASTClass} objects
      *
-     * @var array<string, array<string, array<int, ASTClass>>>
+     * @var array<string, array<string, array<string, ASTClass|ASTEnum>>>
      */
     private $classes = array();
 
     /**
      * All generated {@link ASTInterface} instances.
      *
-     * @var array<string, array<string, array<int, ASTInterface>>>
+     * @var array<string, array<string, array<string, ASTInterface>>>
      */
     private $interfaces = array();
 
@@ -264,21 +264,21 @@ class PHPBuilder implements Builder
     /**
      * Cache of all traits created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, ASTTrait>>>
+     * @var array<string, array<string, array<string, ASTTrait>>>
      */
     private $frozenTraits = array();
 
     /**
      * Cache of all classes created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, ASTClass>>>
+     * @var array<string, array<string, array<string, ASTClass|ASTEnum>>>
      */
     private $frozenClasses = array();
 
     /**
      * Cache of all interfaces created during the regular parsing process.
      *
-     * @var array<string, array<string, array<int, ASTInterface>>>
+     * @var array<string, array<string, array<string, ASTInterface>>>
      */
     private $frozenInterfaces = array();
 
@@ -483,7 +483,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The full qualified type identifier.
      *
-     * @return ASTClass
+     * @return ASTClass|ASTEnum
      *
      * @since  0.9.5
      */
@@ -2391,7 +2391,7 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName
      *
-     * @return ASTClass|null
+     * @return ASTClass|ASTEnum|null
      *
      * @since  0.9.5
      */
@@ -2399,7 +2399,7 @@ class PHPBuilder implements Builder
     {
         $this->freeze();
 
-        /** @var ASTClass|null $class */
+        /** @var ASTClass|ASTEnum|null $class */
         $class = $this->findType(
             $this->frozenClasses,
             $qualifiedName
@@ -2418,7 +2418,7 @@ class PHPBuilder implements Builder
      *
      * @template T of AbstractASTType
      *
-     * @param array<string, array<string, array<int, T>>> $instances
+     * @param array<string, array<string, array<string, T>>> $instances
      * @param string                                         $qualifiedName
      *
      * @return T|null
@@ -2486,10 +2486,10 @@ class PHPBuilder implements Builder
      *
      * @template T of AbstractASTType
      *
-     * @param array<string, array<string, array<int, T>>> $originalTypes The original types created during the parsing
+     * @param array<string, array<string, array<string, T>>> $originalTypes The original types created during the parsing
      *                                                                   process.
      *
-     * @return array<string, array<string, array<int, T>>>
+     * @return array<string, array<string, array<string, T>>>
      */
     private function copyTypesWithPackage(array $originalTypes)
     {


### PR DESCRIPTION
Type: bugfix|documentation  
Breaking change: no

Gets us from 48 to 37 remaining issues at level 7. This is mainly done by asserting object types and adjusting a few signatures that where done slightly wrong earlier or not updated as things expanded.
This feels a bit like progress is made in baby steps, but the last batch is always the more complex to solve, and it's should be easier to review this way :)