### PR TITLE
Analyze ImageConvert.php with PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,6 @@ parameters:
     rememberPossiblyImpureFunctionValues: false
     excludePaths:
         - src/main/php/PDepend/DbusUI/ResultPrinter.php
-        - src/main/php/PDepend/Util/ImageConvert.php
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
     level: 6


### PR DESCRIPTION
Type: testing
Breaking change: no

2 files where skipped when analyzing the code base with PHPStan, the reason being that they made use of PHP extensions. Since the imagick extension is already installed we can actually analyze ImageConvert.php and do not need to exclude it.

I was unable to get the dbus extension installed so ResultPrinter.php is still excluded from the analysis.