### PR TITLE
Make ExcludePathFilter account for directory separators

### DIFF
--- a/scripts/php-keywords.php
+++ b/scripts/php-keywords.php
@@ -28,7 +28,7 @@ $regexp = '(
     \s+\}
 )xi';
 
-if (0 === preg_match_all($regexp, $data, $matches)) {
+if (!preg_match_all($regexp, $data, $matches)) {
     fwrite(STDERR, "No matches found :-(\nUsage:\n~ \$ php-keywords.php <path/to/zend_language_scanner.l>\n");
     exit(42);
 }

--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -82,7 +82,7 @@ class CompositeFilter implements Filter
     public function accept($relative, $absolute)
     {
         foreach ($this->filters as $filter) {
-            if (false === $filter->accept($relative, $absolute)) {
+            if (!$filter->accept($relative, $absolute)) {
                 return false;
             }
         }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -7807,7 +7807,7 @@ abstract class AbstractPHPParser
      */
     private function parseReturnAnnotation($comment)
     {
-        if (0 === preg_match(self::REGEXP_RETURN_TYPE, $comment, $match)) {
+        if (!preg_match(self::REGEXP_RETURN_TYPE, $comment, $match)) {
             return null;
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion54.php
@@ -257,7 +257,7 @@ abstract class PHPParserVersion54 extends PHPParserVersion53
         }
 
         $token1 = $this->consumeToken(Tokens::T_STRING);
-        if (0 === preg_match('(^b[01]+$)i', $token1->image)) {
+        if (!preg_match('(^b[01]+$)i', $token1->image)) {
             throw new UnexpectedTokenException(
                 $token1,
                 $this->tokenizer->getSourceFile()

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -78,6 +78,19 @@ class ExcludePathFilterTest extends AbstractTest
     }
 
     /**
+     * @return void
+     */
+    public function testRelativePathMatchOrNot()
+    {
+        $filter = new ExcludePathFilter(array('link-to/bar'));
+        $this->assertFalse($filter->accept('foo\\link-to\\bar', 'C:\\real-path-to\\bar'));
+        $this->assertTrue($filter->accept('real-path-to\\bar', 'C:\\real-path-to\\bar'));
+        $filter = new ExcludePathFilter(array('*/foo/bar'));
+        $this->assertFalse($filter->accept('foo\\link-to\\bar\\nested', 'C:\\biz\\foo\\bar\\nested'));
+        $this->assertTrue($filter->accept('foo\\link-to\\bar\\nested', 'C:\\biz\\baz\\bar\\nested'));
+    }
+
+    /**
      * testUnixPathAsFilterPatternNotMatchesPartial
      *
      * @return void


### PR DESCRIPTION
Type: bugfix
Issue: Fix https://github.com/phpmd/phpmd/issues/1075
Breaking change: some users might rely on the unwanted wildcard effect, i.e. rely that "word" would exclude any path containing "word" and not just directory or file matching it, they will need to update their config to use "*word*" instead.