### PR TITLE
Bump test to 8.1 as the base

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [5.3]
+        php: [8.1]
         setup: [prefer-stable]
 
     name: Release phar

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '7.4' ]
+        php: [ '8.1' ]
         setup: [ 'stable' ]
         phpstan: [1.10.57]
 

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -61,10 +61,6 @@ jobs:
             symfony/filesystem:^${{ matrix.symfony }} \
             symfony/config:^${{ matrix.symfony }}
 
-      - name: Upgrade PHPUnit
-        if: matrix.php >= 7.2
-        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
-
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --prefer-dist --no-progress --prefer-stable --ignore-platform-req=php+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
         setup: [ 'lowest', 'stable' ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
@@ -56,10 +56,6 @@ jobs:
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
-
-      - name: Upgrade PHPUnit
-        if: matrix.php >= 7.2
-        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
 
       - name: Install test dependencies
         if: steps.composer-test-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.4]
+        php: [8.1]
         setup: [prefer-stable]
 
     name: Build website

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -4,7 +4,9 @@
     "license": "BSD-3-Clause",
     "type": "library",
     "require": {
-        "php": ">=5.3.7",
-        "phpunit/phpunit": "^4.8.36|^5.7.27"
+        "php": ">=8.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^5.7.27"
     }
 }


### PR DESCRIPTION
Type: refactoring  
Breaking change: no

Simply stop running tests on unsupported versions of PHP to avoid them being blockers for other PRs