### PR TITLE
Fix PHPUnit 10 warnings and stale cache

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
         composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
     - name: Coverage
-      run: vendor/bin/phpunit -v --coverage-clover=coverage.xml --coverage-text --coverage-html=coverage
+      run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --coverage-html=coverage
       env:
         XDEBUG_MODE: coverage
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: vendor
-        key: ${{ runner.os }}-v3-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-v3-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-
+        key: ${{ runner.os }}-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -39,9 +39,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}
+            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress --no-dev -o -a

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,8 +38,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -60,4 +60,4 @@ jobs:
         run: php src/test/symfony-version.php
 
       - name: Run test suite
-        run: vendor/bin/phpunit -v
+        run: composer test

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -43,16 +43,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-v3-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
-
-      - name: Cache test packages
-        id: composer-test-cache
-        uses: actions/cache@v4
-        with:
-          path: src/test/vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-v3-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.json') }}
 
       - name: Set Symfony version
         run: |

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -40,8 +40,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-v3-php-composer-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,4 +52,4 @@ jobs:
         run: php src/test/symfony-version.php
 
       - name: Run test suite
-        run: vendor/bin/phpunit -v
+        run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,16 +42,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}-
-
-      - name: Cache test packages
-        id: composer-test-cache
-        uses: actions/cache@v4
-        with:
-          path: src/test/vendor
-          key: ${{ runner.os }}-v3-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-v3-php-test-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
-            ${{ runner.os }}-v3-php-${{ matrix.php }}-${{ matrix.setup }}
+            ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.0.0",
-        "gregwar/rst": "^1.0",
         "easy-doc/easy-doc": "0.0.0|^1.2.3",
-        "phpunit/phpunit": "^10.5.20"
+        "gregwar/rst": "^1.0",
+        "phpunit/phpunit": "^10.5.20",
+        "squizlabs/php_codesniffer": "^2.0.0"
     },
     "bin": ["src/bin/pdepend"],
     "autoload": {
@@ -41,6 +41,7 @@
         }
     },
     "config": {
-        "process-timeout": 900
+        "process-timeout": 900,
+        "sort-packages": true
     }
 }

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -71,7 +71,7 @@ use ReflectionProperty;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-abstract class AbstractTest extends TestCase
+abstract class AbstractTestCase extends TestCase
 {
     /**
      * The current working directory.
@@ -909,4 +909,4 @@ abstract class AbstractTest extends TestCase
     }
 }
 
-AbstractTest::init();
+AbstractTestCase::init();

--- a/src/test/php/PDepend/ApplicationTest.php
+++ b/src/test/php/PDepend/ApplicationTest.php
@@ -53,7 +53,7 @@ use PDepend\Metrics\Analyzer\CrapIndexAnalyzer;
  * @covers \PDepend\Application
  * @group integration
  */
-class ApplicationTest extends AbstractTest
+class ApplicationTest extends AbstractTestCase
 {
     public function testGetRunner()
     {

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -40,46 +40,47 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Issues;
+namespace PDepend\Bugs;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
+use PDepend\Report\Summary\Xml;
 
 /**
- * Abstract base class for issue tests.
+ * Abstract test case for the "Bugs" package.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-abstract class AbstractFeatureTest extends AbstractTest
+abstract class AbstractRegressionTestCase extends AbstractTestCase
 {
     /**
-     * Returns the parameters of the first function in the test case file.
+     * Creates the PDepend summary report for the source associated with the
+     * calling test case.
      *
-     * @return \PDepend\Source\AST\ASTParameter[]
+     * @return string
+     * @since 0.10.0
      */
-    protected function getParametersOfFirstFunction()
+    protected function createSummaryXmlForCallingTest()
     {
-        return $this->getFirstFunctionForTestCase()
-            ->getParameters();
-    }
-    
-    /**
-     * Parses the source for the calling test case.
-     *
-     * @param string $testCase
-     * @return \PDepend\Source\AST\ASTNamespace[]
-     */
-    protected function parseTestCase($testCase = null)
-    {
-        if ($testCase === null) {
-            $testCase = $this->getTestCaseMethod();
-        }
-        return $this->parseTestCaseSource($testCase);
+        $this->changeWorkingDirectory(
+            self::createCodeResourceURI('config/')
+        );
+
+        $file = $this->createRunResourceURI('summary.xml');
+
+        $log = new Xml();
+        $log->setLogFile($file);
+
+        $pdepend = $this->createEngineFixture();
+        $pdepend->addFile($this->createCodeResourceUriForTest());
+        $pdepend->addReportGenerator($log);
+        $pdepend->analyze();
+
+        return $file;
     }
 
     /**
-     * Parses the given source file or directory with the default tokenizer
-     * and node builder implementations.
+     * Parses the source of a test case file.
      *
      * @param string $testCase
      * @param boolean $ignoreAnnotations
@@ -87,26 +88,26 @@ abstract class AbstractFeatureTest extends AbstractTest
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
-        list($class, $method) = explode('::', $testCase);
-        if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0) {
-            throw new \ErrorException('Unexpected class name format');
-        }
-        return $this->parseSource('issues/' . $match[1] . '/' . $method . '.php');
+        return $this->parseSource(
+            $this->getSourceFileForTestCase($testCase),
+            $ignoreAnnotations
+        );
     }
 
     /**
-     * Returns a php callback for the calling test case method.
+     * Returns the source file for the given test case.
      *
+     * @param string $testCase The qualified test case name.
      * @return string
      */
-    protected function getTestCaseMethod()
+    protected function getSourceFileForTestCase($testCase)
     {
-        $trace = debug_backtrace();
-        foreach ($trace as $frame) {
-            if (strpos($frame['function'], 'test') === 0) {
-                return $frame['class'] . '::' . $frame['function'];
-            }
-        }
-        throw new \ErrorException('Cannot locate test case method.');
+        list($class, $method) = explode('::', $testCase);
+
+        preg_match('(Bug(\d+)Test$)', $class, $match);
+
+        return self::createCodeResourceURI(
+            sprintf('bugs/%s/%s.php', $match[1], $method)
+        );
     }
 }

--- a/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
+++ b/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link      http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
- * @covers \stdClass
  * @group regressiontest
  */
-class AlternativeSyntaxClosingTagBug163Test extends AbstractRegressionTest
+class AlternativeSyntaxClosingTagBug163Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesAlternativeSyntaxTerminatedByClosingTag

--- a/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
+++ b/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTest
+class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 {
     /**
      * testParserAcceptsNullAsClassName

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test extends AbstractRegressionTest
+class ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser does not throw an exception.

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassConstantAsArrayExpressionBug299Test extends AbstractRegressionTest
+class ClassConstantAsArrayExpressionBug299Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser does not throw an exception.

--- a/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
+++ b/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTest
+class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser does not end in an endless loop when it detects an

--- a/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
+++ b/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
@@ -54,10 +54,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegressionTest
+class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegressionTestCase
 {
     /**
      * testAnalyzerCountsNumberOfMethodsForClassInterfaceSize

--- a/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -55,10 +55,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @link https://www.pivotaltracker.com/story/show/9936901
  *
  * @ticket 9936901
- * @covers \stdClass
  * @group regressiontest
  */
-class ClassLevelAnalyzerBug09936901Test extends AbstractRegressionTest
+class ClassLevelAnalyzerBug09936901Test extends AbstractRegressionTestCase
 {
     /**
      * testWmciMetricIsCalculatedForCurrentAndNotParentClass

--- a/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
+++ b/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/182
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTest
+class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTestCase
 {
     /**
      * testParserAcceptsCloneAsFunctionName

--- a/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClosureAsArrayElement126Test extends AbstractRegressionTest
+class ClosureAsArrayElement126Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesClosureAsArrayElement

--- a/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClosureResultsInExceptionBug070Test extends AbstractRegressionTest
+class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser does not throw an exception when it detects a

--- a/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ClosureReturnsByReferenceBug094Test extends AbstractRegressionTest
+class ClosureReturnsByReferenceBug094Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesClosureThatReturnsReference

--- a/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -51,10 +51,9 @@ use PDepend\Source\AST\ASTString;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ComplexStringParsingBug114Test extends AbstractRegressionTest
+class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesStringWithEmbeddedBacktickExpression

--- a/src/test/php/PDepend/Bugs/ConflictingImportTest.php
+++ b/src/test/php/PDepend/Bugs/ConflictingImportTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Bugs;
 
-class ConflictingImportTest extends AbstractRegressionTest
+class ConflictingImportTest extends AbstractRegressionTestCase
 {
     public function testSymfonyExtension()
     {

--- a/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
+++ b/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
@@ -50,10 +50,9 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class CouplingAnalyzerBug014Test extends AbstractRegressionTest
+class CouplingAnalyzerBug014Test extends AbstractRegressionTestCase
 {
     /**
      * Test case for the execution chain bug 14.

--- a/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class DefaultNamespaceBug106Test extends AbstractRegressionTest
+class DefaultNamespaceBug106Test extends AbstractRegressionTestCase
 {
     /**
      * testAllocatedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile

--- a/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
@@ -50,10 +50,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class DefaultPackageContainsBrokenAritfactsBug098Test extends AbstractRegressionTest
+class DefaultPackageContainsBrokenAritfactsBug098Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the result does not contain an interface with a broken body.

--- a/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTest
+class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestCase
 {
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetParentClass

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -58,10 +58,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @since 1.0.0
  *
  * @ticket 18459091
- * @covers \stdClass
  * @group regressiontest
  */
-class EndlessInheritanceBug18459091Test extends AbstractRegressionTest
+class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 {
     /**
      * Resets the execution time to -1.

--- a/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
+++ b/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
@@ -51,10 +51,9 @@ use PDepend\Input\ExcludePathFilter;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/191
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ExcludePathFilterShouldFilterByAbsolutePathBug191Test extends AbstractRegressionTest
+class ExcludePathFilterShouldFilterByAbsolutePathBug191Test extends AbstractRegressionTestCase
 {
     /**
      * testAbsoluteUnixPathAsFilterPattern

--- a/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
+++ b/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InconsistentObjectGraphBug073Test extends AbstractRegressionTest
+class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles the following code correct:

--- a/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
+++ b/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTest
+class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser sets the expected start and end line for a property.

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -51,10 +51,9 @@ use PDepend\Input\Iterator;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/164
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegressionTest
+class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegressionTestCase
 {
     /**
      * testIteratorOnlyPassesLocalPathToFilter

--- a/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
+++ b/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegressionTest
+class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles an interface within an instanceof operator

--- a/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InvalidNowdocSubstitutionBug150Test extends AbstractRegressionTest
+class InvalidNowdocSubstitutionBug150Test extends AbstractRegressionTestCase
 {
     /**
      * testTokenizerDoesNotDetectNowdocSyntaxInString

--- a/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegressionTest
+class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles function with reference return values

--- a/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressionTest
+class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesObjectPropertyAsForeachLoopKey

--- a/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
+++ b/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegressionTest
+class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegressionTestCase
 {
     /**
      * testParserNotThrowsAnExceptionForKeywordUse

--- a/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
+++ b/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
@@ -50,10 +50,9 @@ use PDepend\Metrics\Analyzer\InheritanceAnalyzer;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test extends AbstractRegressionTest
+class MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test extends AbstractRegressionTestCase
 {
     /**
      * testAnalyzerNotCountsImplementedAbstractMethodsAsOverwritten

--- a/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
+++ b/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
@@ -53,10 +53,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class NPathComplexityIsBrokenInVersion096Bug095Test extends AbstractRegressionTest
+class NPathComplexityIsBrokenInVersion096Bug095Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles an interface within an instanceof operator

--- a/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
@@ -54,10 +54,9 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends AbstractRegressionTest
+class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the analyzer calculates the expected result.

--- a/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTest
+class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesNamespaceKeywordInFunctionParameterTypeHint

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -55,10 +55,9 @@ use PDepend\Util\Cache\CacheDriver;
  * @link    https://github.com/pdepend/pdepend/issues/247
  *
  * @ticket 247
- * @covers \stdClass
  * @group regressiontest
  */
-class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
+class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTestCase
 {
     /**
      * testUseConst

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -54,10 +54,9 @@ use PDepend\Util\Configuration\ConfigurationFactory;
  * @link https://www.pivotaltracker.com/story/show/13405179
  *
  * @ticket 13405179
- * @covers \stdClass
  * @group regressiontest
  */
-class PHPDependBug13405179Test extends AbstractRegressionTest
+class PHPDependBug13405179Test extends AbstractRegressionTestCase
 {
     /**
      * testLogFileIsCreatedForUnstructuredCode

--- a/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
+++ b/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
@@ -52,10 +52,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ParameterStringDefaultValueBug103Test extends AbstractRegressionTest
+class ParameterStringDefaultValueBug103Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesStringDefaultValueWithEmbeddedExpression

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -50,10 +50,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTest
+class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles the parent type hint as expected.

--- a/src/test/php/PDepend/Bugs/ParserBug001Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug001Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 1
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug001Test extends AbstractRegressionTest
+class ParserBug001Test extends AbstractRegressionTestCase
 {
     /**
      * Test case for parser bug 01 that doesn't add dependencies for static

--- a/src/test/php/PDepend/Bugs/ParserBug006Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug006Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 006
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug006Test extends AbstractRegressionTest
+class ParserBug006Test extends AbstractRegressionTestCase
 {
     /**
      * testParserNotSetsReferenceForVariableObjectInstantiation

--- a/src/test/php/PDepend/Bugs/ParserBug007Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug007Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 7
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug007Test extends AbstractRegressionTest
+class ParserBug007Test extends AbstractRegressionTestCase
 {
     /**
      * testParserCurlyBrace

--- a/src/test/php/PDepend/Bugs/ParserBug008Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug008Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 8
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug008Test extends AbstractRegressionTest
+class ParserBug008Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles curly braces in strings correct.

--- a/src/test/php/PDepend/Bugs/ParserBug015Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug015Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 15
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug015Test extends AbstractRegressionTest
+class ParserBug015Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser ignores backtick expressions.

--- a/src/test/php/PDepend/Bugs/ParserBug016Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug016Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 16
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug016Test extends AbstractRegressionTest
+class ParserBug016Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser detect a type within an instance of operator.

--- a/src/test/php/PDepend/Bugs/ParserBug017Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug017Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 17
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug017Test extends AbstractRegressionTest
+class ParserBug017Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser detects a type within a catch block.

--- a/src/test/php/PDepend/Bugs/ParserBug030Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug030Test.php
@@ -51,10 +51,9 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 30
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug030Test extends AbstractRegressionTest
+class ParserBug030Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser sets the correct type tokens.

--- a/src/test/php/PDepend/Bugs/ParserBug033Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug033Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 33
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug033Test extends AbstractRegressionTest
+class ParserBug033Test extends AbstractRegressionTestCase
 {
     /**
      * The type hint detection was broken when a constant was used as default

--- a/src/test/php/PDepend/Bugs/ParserBug059Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug059Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 59
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug059Test extends AbstractRegressionTest
+class ParserBug059Test extends AbstractRegressionTestCase
 {
 
     /**

--- a/src/test/php/PDepend/Bugs/ParserBug069Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug069Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 69
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug069Test extends AbstractRegressionTest
+class ParserBug069Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that parser handles a php 5.3 static method call correct.

--- a/src/test/php/PDepend/Bugs/ParserBug124Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug124Test.php
@@ -51,10 +51,9 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 124
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug124Test extends AbstractRegressionTest
+class ParserBug124Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser detects the classname scalar.

--- a/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @link       https://www.pivotaltracker.com/story/show/17264279
  *
  * @ticket 17264279
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug17264279Test extends AbstractRegressionTest
+class ParserBug17264279Test extends AbstractRegressionTestCase
 {
     /**
      * testParserAcceptsUseAsClassName

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -55,10 +55,9 @@ use PDepend\Source\AST\ASTHeredoc;
  * @since 1.0.0
  *
  * @ticket 21500611
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug21500611Test extends AbstractRegressionTest
+class ParserBug21500611Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesNowdocInPropertyDeclaration

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -53,10 +53,9 @@ namespace PDepend\Bugs;
  * @since 0.10.8
  *
  * @ticket 23905939
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug23905939Test extends AbstractRegressionTest
+class ParserBug23905939Test extends AbstractRegressionTestCase
 {
     /**
      * testParserExtractsCorrectClassPackage

--- a/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -56,10 +56,9 @@ use PDepend\Source\AST\ASTInterface;
  * @since 0.10.9
  *
  * @ticket 23951621
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug23951621Test extends AbstractRegressionTest
+class ParserBug23951621Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesHeredocAsPropertyDefaultValue

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -53,10 +53,9 @@ use PDepend\Source\AST\ASTPropertyPostfix;
  * @link       https://www.pivotaltracker.com/story/show/8927377
  *
  * @ticket 8927377
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserBug8927377Test extends AbstractRegressionTest
+class ParserBug8927377Test extends AbstractRegressionTestCase
 {
     /**
      * testPropertyPostfixHasExpectedStartLine

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -50,10 +50,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTest
+class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
 {
     /**
      * This method tests that the parser handles reserved keywords in type

--- a/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
+++ b/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
@@ -49,10 +49,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserSetsIncorrectStartLineBug101Test extends AbstractRegressionTest
+class ParserSetsIncorrectStartLineBug101Test extends AbstractRegressionTestCase
 {
     /**
      * testParserSetsExpectedStartLineNumber

--- a/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
+++ b/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
@@ -43,13 +43,13 @@
 namespace PDepend\Bugs\Phpmd;
 
 
-use PDepend\Bugs\AbstractRegressionTest;
+use PDepend\Bugs\AbstractRegressionTestCase;
 use PDepend\Source\AST\ASTFunction;
 
 /**
  * https://github.com/phpmd/phpmd/issues/914
  */
-class FunctionDocBlockBugPhpmd914Test extends AbstractRegressionTest
+class FunctionDocBlockBugPhpmd914Test extends AbstractRegressionTestCase
 {
     public function testFunctionDocBlockCanBeRead()
     {

--- a/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
+++ b/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ReconfigureXdebugMaxNestingLevelBug133Test extends AbstractRegressionTest
+class ReconfigureXdebugMaxNestingLevelBug133Test extends AbstractRegressionTestCase
 {
     /**
      * testParserResetsReconfiguredXdebugMaxNestingLevel

--- a/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
+++ b/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
@@ -56,10 +56,9 @@ namespace PDepend\Bugs;
  *
  * @ticket 104
  * @ticket 95
- * @covers \stdClass
  * @group regressiontest
  */
-class ShortArraySyntaxInitializerBug00000104Test extends AbstractRegressionTest
+class ShortArraySyntaxInitializerBug00000104Test extends AbstractRegressionTestCase
 {
     /**
      * testPropertyDefaultValue

--- a/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
+++ b/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionTest
+class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles a parameter with a signed default value.

--- a/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
+++ b/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class StringWithDollarStringLiteralBug162Test extends AbstractRegressionTest
+class StringWithDollarStringLiteralBug162Test extends AbstractRegressionTestCase
 {
     /**
      * testParserDoesNotHandleDollarStringLiteralInDoubleQuoteString

--- a/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
+++ b/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRegressionTest
+class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRegressionTestCase
 {
     /**
      * testSummaryReportFiltersClassesNotFlaggedUserDefined

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegressionTest
+class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles a comma separated constant definition.

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
@@ -51,10 +51,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegressionTest
+class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser handles a comma separated property declaration.

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -53,10 +53,9 @@ use PDepend\Source\Tokenizer\Tokens;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTest
+class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
 {
     /**
      * This method tests that the parser does not substitute keyword tokens in

--- a/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
+++ b/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
@@ -50,10 +50,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       https://github.com/pdepend/pdepend/issues/100
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class TraitsNotHandledCorrrectBug00000100Test extends AbstractRegressionTest
+class TraitsNotHandledCorrrectBug00000100Test extends AbstractRegressionTestCase
 {
     /**
      * testHandlingOfSelfReferenceInTrait

--- a/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -48,10 +48,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTest
+class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTestCase
 {
     /**
      * testTrueKeywordInNamespace

--- a/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
+++ b/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
@@ -55,10 +55,9 @@ namespace PDepend\Bugs;
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class UnexpectedTokenAsciiChar39Bug181Test extends AbstractRegressionTest
+class UnexpectedTokenAsciiChar39Bug181Test extends AbstractRegressionTestCase
 {
     /**
      * testUnexpectedTokenDoesNotQuitPDepend

--- a/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
+++ b/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
@@ -50,10 +50,9 @@ namespace PDepend\Bugs;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTest
+class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesVariableVariableAsForeachValue

--- a/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
+++ b/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
@@ -53,10 +53,9 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTest
+class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the analyzer calculates the expected result.

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -43,7 +43,7 @@
 namespace PDepend\DependencyInjection;
 
 use Exception;
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\TestExtension;
 use ReflectionMethod;
 
@@ -57,7 +57,7 @@ use ReflectionMethod;
  * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
-class ConfigurationTest extends AbstractTest
+class ConfigurationTest extends AbstractTestCase
 {
     /**
      * @return bool

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\DependencyInjection;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -57,7 +57,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
-class ExtensionManagerTest extends AbstractTest
+class ExtensionManagerTest extends AbstractTestCase
 {
     public function testExtensionManager()
     {

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\DependencyInjection;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
-class TreeBuilderTest extends AbstractTest
+class TreeBuilderTest extends AbstractTestCase
 {
     public function testTreeBuilder()
     {

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTNamespace;
  * @covers \PDepend\Engine
  * @group unittest
  */
-class EngineTest extends AbstractTest
+class EngineTest extends AbstractTestCase
 {
     /**
      * Tests that the {@link \PDepend\Engine::addDirectory()} method

--- a/src/test/php/PDepend/Input/CompositeFilterTest.php
+++ b/src/test/php/PDepend/Input/CompositeFilterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Input;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the composite filter.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Input\CompositeFilter
  * @group unittest
  */
-class CompositeFilterTest extends AbstractTest
+class CompositeFilterTest extends AbstractTestCase
 {
     /**
      * testCompositeInvokesFirstAcceptInFilterChain

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Input;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the exclude path filter.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Input\ExcludePathFilter
  * @group unittest
  */
-class ExcludePathFilterTest extends AbstractTest
+class ExcludePathFilterTest extends AbstractTestCase
 {
     /**
      * testAbsoluteUnixPathAsFilterPatternMatches

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Input;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the file extension filter.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Input\ExtensionFilter
  * @group unittest
  */
-class ExtensionFilterTest extends AbstractTest
+class ExtensionFilterTest extends AbstractTestCase
 {
     /**
      * testExtensionFilterAcceptsOneFileExtension

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Input;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the php file filter iterator.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Input\Iterator
  * @group unittest
  */
-class IteratorTest extends AbstractTest
+class IteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorWithOneFileExtension

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Integration;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -54,10 +54,9 @@ use PDepend\Util\Cache\Driver\FileCacheDriver;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group integrationtest
  */
-class BuilderParserCacheTest extends AbstractTest
+class BuilderParserCacheTest extends AbstractTestCase
 {
     /**
      * The temporary cache directory.

--- a/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Integration;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Tests the integration of the {@link \PDepend\Engine} class and the
@@ -51,10 +51,9 @@ use PDepend\AbstractTest;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group integrationtest
  */
-class DependExcludePathFilterTest extends AbstractTest
+class DependExcludePathFilterTest extends AbstractTestCase
 {
 
     /**

--- a/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -55,7 +55,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class DoubleClassModifierIssue638Test extends AbstractFeatureTest
+class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that a class can have a readonly modifier

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -51,7 +51,7 @@ namespace PDepend\Issues;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatureTest
+class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser recognizes a inline type definition within a comment.

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -55,7 +55,7 @@ use PDepend\Source\AST\ASTType;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTest
+class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser sets the expected primitive type information.

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -51,7 +51,7 @@ namespace PDepend\Issues;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class NamespaceSupportIssue002Test extends AbstractFeatureTest
+class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser handles a simple use statement as expected.

--- a/src/test/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/src/test/php/PDepend/Issues/NewClassInstanceTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTStatement;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class NewClassInstanceTest extends AbstractFeatureTest
+class NewClassInstanceTest extends AbstractFeatureTestCase
 {
     /**
      * Tests that a new keyword can be followed by variable or parentheses expression.

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -53,7 +53,7 @@ use PDepend\Input\ExtensionFilter;
  * @covers \PDepend\Engine
  * @group unittest
  */
-class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTest
+class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the {@link \PDepend\Engine::getExceptions()} returns a

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -51,7 +51,7 @@ namespace PDepend\Issues;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTest
+class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 {
     /**
      * testParserSetsExpectedNumberOfFunctionParameters

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTNode;
  * @covers \PDepend\Source\AST\ASTParameter
  * @group unittest
  */
-class ReflectionCompatibilityIssue067Test extends AbstractFeatureTest
+class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser sets the parameter flag by reference.

--- a/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
+++ b/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
@@ -57,7 +57,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTest
+class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parameter contains the start line of the first token.

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -2,6 +2,8 @@
 /**
  * This file is part of PDepend.
  *
+ * PHP Version 5
+ *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -38,32 +40,53 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Source\Language\PHP\Features\PHP83;
+namespace PDepend\Metrics;
 
-use PDepend\AbstractTest;
-use PDepend\Source\Builder\Builder;
-use PDepend\Source\Tokenizer\Tokenizer;
-use PDepend\Util\Cache\CacheDriver;
+use PDepend\AbstractTestCase;
 
 /**
+ * Abstract base class for tests of the metrics package.
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
- * @group unittest
  */
-abstract class PHPParserVersion83Test extends AbstractTest
+abstract class AbstractMetricsTestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * Parses the given source file or directory with the default tokenizer
+     * and node builder implementations.
+     *
+     * @param string  $testCase
+     * @param boolean $ignoreAnnotations
+     * @return \PDepend\Source\AST\ASTNamespace[]
      */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
-        return $this->getAbstractClassMock(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion83',
-            array($tokenizer, $builder, $cache)
+        list($class, $method) = explode('::', $testCase);
+
+        $parts = explode('\\', $class);
+
+        try {
+            return parent::parseSource(
+                sprintf(
+                    'Metrics/%s/%s/%s.php',
+                    $parts[count($parts) - 2],
+                    substr($parts[count($parts) - 1], 0, -4),
+                    $method
+                ),
+                $ignoreAnnotations
+            );
+        } catch (\Exception $e) {
+        }
+        
+        return parent::parseSource(
+            sprintf(
+                'Metrics/%s/%s/%s',
+                $parts[count($parts) - 2],
+                substr($parts[count($parts) - 1], 0, -4),
+                $method
+            ),
+            $ignoreAnnotations
         );
     }
 }

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 
 /**
  * Tests the for the package metrics visitor.
@@ -53,7 +53,7 @@ use PDepend\Metrics\AbstractMetricsTest;
  * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
  * @group unittest
  */
-class ClassDependencyAnalyzerTest extends AbstractMetricsTest
+class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * The used node builder.

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
@@ -56,7 +56,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\ClassLevelAnalyzer
  * @group unittest
  */
-class ClassLevelAnalyzerTest extends AbstractMetricsTest
+class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * Tests that the {@link \PDepend\Metrics\Analyzer\ClassLevelAnalyzer::analyzer()}

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
  * @group unittest
  */
-class MethodStrategyTest extends AbstractTest
+class MethodStrategyTest extends AbstractTestCase
 {
     /**
      * testStrategyCountsCorrectTypes

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
    * @group unittest
  */
-class PropertyStrategyTest extends AbstractTest
+class PropertyStrategyTest extends AbstractTestCase
 {
     /**
      * testStrategyCountsCorrectTypes

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory;
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory
  * @group unittest
  */
-class StrategyFactoryTest extends AbstractTest
+class StrategyFactoryTest extends AbstractTestCase
 {
     /**
      * Tests that the factory throws the expected exception for an invalid

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTClass;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTClass;
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer
  * @group unittest
  */
-class CodeRankAnalyzerTest extends AbstractMetricsTest
+class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * Test input data.

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Metrics\Analyzer\CouplingAnalyzer;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  * @covers \PDepend\Metrics\Analyzer\CouplingAnalyzer
  * @group unittest
  */
-class CouplingAnalyzerTest extends AbstractMetricsTest
+class CouplingAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testGetNodeMetricsReturnsAnEmptyArrayByDefault

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 
 /**
  * Test cases for the {@link  \PDepend\Metrics\Analyzer\CrapIndexAnalyzer} class.
@@ -53,7 +53,7 @@ use PDepend\Metrics\AbstractMetricsTest;
  * @covers \PDepend\Metrics\Analyzer\CrapIndexAnalyzer
  * @group unittest
  */
-class CrapIndexAnalyzerTest extends AbstractMetricsTest
+class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testAnalyzerReturnsExpectedDependencies

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
  * @group unittest
  */
-class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTest
+class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 
 /**
  * Tests the for the package metrics visitor.
@@ -53,7 +53,7 @@ use PDepend\Metrics\AbstractMetricsTest;
  * @covers \PDepend\Metrics\Analyzer\DependencyAnalyzer
  * @group unittest
  */
-class DependencyAnalyzerTest extends AbstractMetricsTest
+class DependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * The used node builder.

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
  * @group unittest
  */
-class HalsteadAnalyzerTest extends AbstractMetricsTest
+class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTClass;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTClass;
  * @covers \PDepend\Metrics\Analyzer\HierarchyAnalyzer
    * @group unittest
  */
-class HierarchyAnalyzerTest extends AbstractMetricsTest
+class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testCalculatesExpectedNumberOfLeafClasses

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use PDepend\Source\AST\ASTClass;
@@ -56,7 +56,7 @@ use PDepend\Source\AST\ASTClass;
  * @covers \PDepend\Metrics\Analyzer\InheritanceAnalyzer
  * @group unittest
  */
-class InheritanceAnalyzerTest extends AbstractMetricsTest
+class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * Tests that the analyzer calculates the correct average number of derived

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
  * @group unittest
  */
-class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTest
+class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -56,7 +56,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
  * @group unittest
  */
-class NPathComplexityAnalyzerTest extends AbstractMetricsTest
+class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
@@ -55,7 +55,7 @@ use PDepend\Source\AST\ASTNamespace;
  * @covers \PDepend\Metrics\Analyzer\NodeCountAnalyzer
  * @group unittest
  */
-class NodeCountAnalyzerTest extends AbstractMetricsTest
+class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testVisitClassIgnoresClassesThatAreNotUserDefined

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics\Analyzer;
 
-use PDepend\Metrics\AbstractMetricsTest;
+use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -56,7 +56,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Metrics\Analyzer\NodeLocAnalyzer
  * @group unittest
  */
-class NodeLocAnalyzerTest extends AbstractMetricsTest
+class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Metrics;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Report\DummyAnalyzer;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Report\DummyAnalyzer;
  * @covers \PDepend\Metrics\AnalyzerIterator
  * @group unittest
  */
-class AnalyzerIteratorTest extends AbstractTest
+class AnalyzerIteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorReturnsEnabledAnalyzerInstances

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -49,10 +49,9 @@ namespace PDepend;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \stdClass
  * @group regressiontest
  */
-class ParserRegressionTest extends AbstractTest
+class ParserRegressionTest extends AbstractTestCase
 {
     /**
      * Tests that the parser handles the given source file.

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -64,7 +64,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ParserTest extends AbstractTest
+class ParserTest extends AbstractTestCase
 {
     /**
      * testParserHandlesMaxNestingLevel

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report\Dependencies;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTArtifactList;
  * @covers \PDepend\Report\Dependencies\Xml
  * @group unittest
  */
-class XmlTest extends AbstractTest
+class XmlTest extends AbstractTestCase
 {
     /**
      * Test code structure.

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report\Jdepend;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
 use PDepend\Source\AST\AbstractASTArtifact;
@@ -57,7 +57,7 @@ use PDepend\Source\AST\ASTArtifactList;
  * @covers \PDepend\Report\Jdepend\Chart
  * @group unittest
  */
-class ChartTest extends AbstractTest
+class ChartTest extends AbstractTestCase
 {
     /**
      * Temporary output file.

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report\Jdepend;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
 
@@ -55,7 +55,7 @@ use PDepend\Report\DummyAnalyzer;
  * @covers \PDepend\Report\Jdepend\Xml
  * @group unittest
  */
-class XmlTest extends AbstractTest
+class XmlTest extends AbstractTestCase
 {
     /**
      * Test code structure.

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report\Overview;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Report\DummyAnalyzer;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Report\DummyAnalyzer;
  * @covers \PDepend\Report\Overview\Pyramid
  * @group unittest
  */
-class PyramidTest extends AbstractTest
+class PyramidTest extends AbstractTestCase
 {
     /**
      * Tests that the logger returns the expected set of analyzers.

--- a/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
+++ b/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the logger factory.
@@ -50,7 +50,7 @@ use PDepend\AbstractTest;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ReportGeneratorFactoryTest extends AbstractTest
+class ReportGeneratorFactoryTest extends AbstractTestCase
 {
     private function createReportGeneratorFactory()
     {

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Report\Summary;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTArtifactList;
  * @covers \PDepend\Report\Summary\Xml
  * @group unittest
  */
-class XmlTest extends AbstractTest
+class XmlTest extends AbstractTestCase
 {
     /**
      * Test code structure.

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTAllocationExpression
  * @group unittest
  */
-class ASTAllocationExpressionTest extends ASTNodeTest
+class ASTAllocationExpressionTest extends ASTNodeTestCase
 {
     /**
      * Tests the implementation with an allocation expression without arguments.

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\AST\ASTAnonymousClass
  * @group unittest
  */
-class ASTAnonymousClassTest extends ASTNodeTest
+class ASTAnonymousClassTest extends ASTNodeTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTArguments
  * @group unittest
  */
-class ASTArgumentsTest extends ASTNodeTest
+class ASTArgumentsTest extends ASTNodeTestCase
 {
     /**
      * testArgumentsGraphWithMagicClassConstant

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -51,11 +51,10 @@ namespace PDepend\Source\AST;
  * @since 1.0.0
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTNode
  * @covers \PDepend\Source\AST\ASTArrayElement
  * @group unittest
  */
-class ASTArrayElementTest extends ASTNodeTest
+class ASTArrayElementTest extends ASTNodeTestCase
 {
     /**
      * testArrayElementGraphSimpleValue

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTArrayIndexExpression
  * @group unittest
  */
-class ASTArrayIndexExpressionTest extends ASTNodeTest
+class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 {
     /**
      * testArrayIndexGraphDereferencedFromFunctionCall

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTArray
  * @group unittest
  */
-class ASTArrayTest extends ASTNodeTest
+class ASTArrayTest extends ASTNodeTestCase
 {
     /**
      * testArrayGraphForEmptyArrayDefinition

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case the node iterator.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTArtifactList
  * @group unittest
  */
-class ASTArtifactListTest extends AbstractTest
+class ASTArtifactListTest extends AbstractTestCase
 {
     /**
      * Tests the ctor with an valid input array of {@link \PDepend\Source\AST\AbstractASTArtifact}

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\AbstractASTArtifact} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @group unittest
  */
-class ASTArtifactTest extends AbstractTest
+class ASTArtifactTest extends AbstractTestCase
 {
     /**
      * testGetNameReturnsValueOfFirstConstructorArgument

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTAssignmentExpression
  * @group unittest
  */
-class ASTAssignmentExpressionTest extends ASTNodeTest
+class ASTAssignmentExpressionTest extends ASTNodeTestCase
 {
     /**
      * testAssignmentExpressionFromMethodInvocation

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTBooleanAndExpression
  * @group unittest
  */
-class ASTBooleanAndExpressionTest extends ASTNodeTest
+class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 {
     /**
      * testBooleanAndExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTBooleanOrExpression
  * @group unittest
  */
-class ASTBooleanOrExpressionTest extends ASTNodeTest
+class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 {
     /**
      * testBooleanOrExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTBreakStatement
  * @group unittest
  */
-class ASTBreakStatementTest extends ASTNodeTest
+class ASTBreakStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Tokenizer\Token;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\Tokenizer\Token;
  * @covers \PDepend\Source\AST\AbstractASTCallable
  * @group unittest
  */
-class ASTCallableTest extends AbstractTest
+class ASTCallableTest extends AbstractTestCase
 {
     /**
      * testGetParametersReturnsEmptyArrayByDefault

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTCastExpression
  * @group unittest
  */
-class ASTCastExpressionTest extends ASTNodeTest
+class ASTCastExpressionTest extends ASTNodeTestCase
 {
     /**
      * testNormalizesWhitespacesInCastExpression

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTCatchStatement
  * @group unittest
  */
-class ASTCatchStatementTest extends ASTNodeTest
+class ASTCatchStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -56,7 +56,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClassFqnPostfix
  */
-class ASTClassFqnPostfixTest extends ASTNodeTest
+class ASTClassFqnPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImage

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\Builder\BuilderContext;
  * @covers \PDepend\Source\AST\ASTClassOrInterfaceReference
  * @group unittest
  */
-class ASTClassOrInterfaceReferenceTest extends ASTNodeTest
+class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 {
     /**
      * testReturnValueOfMagicSleepContainsContextProperty

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\Builder\BuilderContext;
  * @covers \PDepend\Source\AST\ASTClassReference
  * @group unittest
  */
-class ASTClassReferenceTest extends ASTNodeTest
+class ASTClassReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeDelegatesToBuilderContextGetClass

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -60,7 +60,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ASTClassTest extends AbstractASTArtifactTest
+class ASTClassTest extends AbstractASTArtifactTestCase
 {
     /**
      * testGetAllMethodsContainsMethodsOfImplementedInterface

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTCloneExpression
  * @group unittest
  */
-class ASTCloneExpressionTest extends ASTNodeTest
+class ASTCloneExpressionTest extends ASTNodeTestCase
 {
     /**
      * testCloneExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -49,11 +49,10 @@ namespace PDepend\Source\AST;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTNode
  * @covers \PDepend\Source\AST\ASTClosure
  * @group unittest
  */
-class ASTClosureTest extends ASTNodeTest
+class ASTClosureTest extends ASTNodeTestCase
 {
     /**
      * testReturnsByReferenceReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTComment
  * @group unittest
  */
-class ASTCommentTest extends ASTNodeTest
+class ASTCommentTest extends ASTNodeTestCase
 {
     /**
      * testSingleLineCommentHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the code file class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTCompilationUnit
  * @group unittest
  */
-class ASTCompilationUnitTest extends AbstractTest
+class ASTCompilationUnitTest extends AbstractTestCase
 {
     /**
      * testGetNameReturnsTheFileName

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTCompoundExpression
  * @group unittest
  */
-class ASTCompoundExpressionTest extends ASTNodeTest
+class ASTCompoundExpressionTest extends ASTNodeTestCase
 {
     /**
      * testExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTCompoundVariable
  * @group unittest
  */
-class ASTCompoundVariableTest extends ASTNodeTest
+class ASTCompoundVariableTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed compound variable has the expected object graph.

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTConditionalExpression
  * @group unittest
  */
-class ASTConditionalExpressionTest extends ASTNodeTest
+class ASTConditionalExpressionTest extends ASTNodeTestCase
 {
     /**
      * testConditionalExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
  * @group unittest
  */
-class ASTConstantDeclaratorTest extends ASTNodeTest
+class ASTConstantDeclaratorTest extends ASTNodeTestCase
 {
     /**
      * testReturnValueOfMagicSleepContainsValueProperty

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTConstantDefinition
  * @group unittest
  */
-class ASTConstantDefinitionTest extends ASTNodeTest
+class ASTConstantDefinitionTest extends ASTNodeTestCase
 {
     /**
      * Tests that the field declaration <b>setModifiers()</b> method accepts all

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTConstantPostfix
  * @group unittest
  */
-class ASTConstantPostfixTest extends ASTNodeTest
+class ASTConstantPostfixTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed constant postfix has the expected object structure.

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTConstant
  * @group unittest
  */
-class ASTConstantTest extends ASTNodeTest
+class ASTConstantTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed constant has the expected object graph.

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTContinueStatement
  * @group unittest
  */
-class ASTContinueStatementTest extends ASTNodeTest
+class ASTContinueStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTDeclareStatement
  * @group unittest
  */
-class ASTDeclareStatementTest extends ASTNodeTest
+class ASTDeclareStatementTest extends ASTNodeTestCase
 {
     /**
      * testDeclareStatementWithSingleParameter

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTDoWhileStatement
  * @group unittest
  */
-class ASTDoWhileStatementTest extends ASTNodeTest
+class ASTDoWhileStatementTest extends ASTNodeTestCase
 {
     /**
      * testDoWhileStatementHasExpectedNumberOfChildNodes

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTEchoStatement
  * @group unittest
  */
-class ASTEchoStatementTest extends ASTNodeTest
+class ASTEchoStatementTest extends ASTNodeTestCase
 {
     /**
      * testEchoStatementHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTElseIfStatement
  * @group unittest
  */
-class ASTElseIfStatementTest extends ASTNodeTest
+class ASTElseIfStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasElseMethodReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -57,7 +57,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\AST\ASTForInit
  * @group unittest
  */
-class ASTEnumTest extends AbstractASTArtifactTest
+class ASTEnumTest extends AbstractASTArtifactTestCase
 {
     /**
      * testForInitHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTEvalExpression
  * @group unittest
  */
-class ASTEvalExpressionTest extends ASTNodeTest
+class ASTEvalExpressionTest extends ASTNodeTestCase
 {
     /**
      * testEvalExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTExitExpression
  * @group unittest
  */
-class ASTExitExpressionTest extends ASTNodeTest
+class ASTExitExpressionTest extends ASTNodeTestCase
 {
     /**
      * testExitExpressionWithExitCode

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTExpression
  * @group unittest
  */
-class ASTExpressionTest extends ASTNodeTest
+class ASTExpressionTest extends ASTNodeTestCase
 {
     /**
      * testExpressionHasExpectedNumberOfChildNodes

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -55,7 +55,7 @@ use PDepend\Source\AST\ASTFieldDeclaration;
  * @covers \PDepend\Source\AST\ASTFieldDeclaration
  * @group unittest
  */
-class ASTFieldDeclarationTest extends ASTNodeTest
+class ASTFieldDeclarationTest extends ASTNodeTestCase
 {
     /**
      * Tests that a field declaration contains the expected class reference.

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTFinallyStatement
  * @group unittest
  */
-class ASTFinallyStatementTest extends ASTNodeTest
+class ASTFinallyStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTForInit
  * @group unittest
  */
-class ASTForInitTest extends ASTNodeTest
+class ASTForInitTest extends ASTNodeTestCase
 {
     /**
      * testForInitHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTForStatement
  * @group unittest
  */
-class ASTForStatementTest extends ASTNodeTest
+class ASTForStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTForUpdate
  * @group unittest
  */
-class ASTForUpdateTest extends ASTNodeTest
+class ASTForUpdateTest extends ASTNodeTestCase
 {
     /**
      * testForUpdateHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTForeachStatement
  * @group unittest
  */
-class ASTForeachStatementTest extends ASTNodeTest
+class ASTForeachStatementTest extends ASTNodeTestCase
 {
     /**
      * testThirdChildOfForeachStatementIsASTScopeStatement

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -49,11 +49,10 @@ namespace PDepend\Source\AST;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTNode
  * @covers \PDepend\Source\AST\ASTFormalParameter
  * @group unittest
  */
-class ASTFormalParameterTest extends ASTNodeTest
+class ASTFormalParameterTest extends ASTNodeTestCase
 {
     /**
      * testHasTypeReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTFormalParameters
  * @group unittest
  */
-class ASTFormalParametersTest extends ASTNodeTest
+class ASTFormalParametersTest extends ASTNodeTestCase
 {
     /**
      * testFormalParametersHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTFunctionPostfix
  * @group unittest
  */
-class ASTFunctionPostfixTest extends ASTNodeTest
+class ASTFunctionPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImageForVariableFunction

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -57,7 +57,7 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
  * @covers \PDepend\Source\AST\ASTFunction
  * @group unittest
  */
-class ASTFunctionTest extends AbstractASTArtifactTest
+class ASTFunctionTest extends AbstractASTArtifactTestCase
 {
     /**
      * testReturnsReferenceReturnsExpectedTrue

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTGlobalStatement
  * @group unittest
  */
-class ASTGlobalStatementTest extends ASTNodeTest
+class ASTGlobalStatementTest extends ASTNodeTestCase
 {
     /**
      * testGlobalStatementHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTGotoStatement
  * @group unittest
  */
-class ASTGotoStatementTest extends ASTNodeTest
+class ASTGotoStatementTest extends ASTNodeTestCase
 {
     /**
      * testGotoStatementHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTHeredoc
  * @group unittest
  */
-class ASTHeredocTest extends ASTNodeTest
+class ASTHeredocTest extends ASTNodeTestCase
 {
     /**
      * testHeredocAsArrayInitializeValue

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTIdentifier
  * @group unittest
  */
-class ASTIdentifierTest extends ASTNodeTest
+class ASTIdentifierTest extends ASTNodeTestCase
 {
     /**
      * testIdentifierHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTIfStatement
  * @group unittest
  */
-class ASTIfStatementTest extends ASTNodeTest
+class ASTIfStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasElseMethodReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTIncludeExpression
  * @group unittest
  */
-class ASTIncludeExpressionTest extends ASTNodeTest
+class ASTIncludeExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIsOnceReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTInstanceOfExpression
  * @group unittest
  */
-class ASTInstanceOfExpressionTest extends ASTNodeTest
+class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 {
     /**
      * Tests that the created instanceof object graph has the expected structure.

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -57,7 +57,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ASTInterfaceTest extends AbstractASTArtifactTest
+class ASTInterfaceTest extends AbstractASTArtifactTestCase
 {
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTIssetExpression
  * @group unittest
  */
-class ASTIssetExpressionTest extends ASTNodeTest
+class ASTIssetExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIssetExpressionGraphWithMultipleVariables

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTLabelStatement
  * @group unittest
  */
-class ASTLabelStatementTest extends ASTNodeTest
+class ASTLabelStatementTest extends ASTNodeTestCase
 {
     /**
      * testLabelStatementHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTListExpression
  * @group unittest
  */
-class ASTListExpressionTest extends ASTNodeTest
+class ASTListExpressionTest extends ASTNodeTestCase
 {
     /**
      * testListExpression

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTLiteral
  * @group unittest
  */
-class ASTLiteralTest extends ASTNodeTest
+class ASTLiteralTest extends ASTNodeTestCase
 {
     /**
      * testLiteralWithBooleanTrueExpression

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTLogicalAndExpression
  * @group unittest
  */
-class ASTLogicalAndExpressionTest extends ASTNodeTest
+class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalAndExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTLogicalOrExpression
  * @group unittest
  */
-class ASTLogicalOrExpressionTest extends ASTNodeTest
+class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalOrExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTLogicalXorExpression
  * @group unittest
  */
-class ASTLogicalXorExpressionTest extends ASTNodeTest
+class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalXorExpressionHasExpectedStartLine

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTMemberPrimaryPrefix
  * @group unittest
  */
-class ASTMemberPrimaryPrefixTest extends ASTNodeTest
+class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 {
     /**
      * testMemberPrimaryPrefixGraphDereferencedFromArray

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTMethodPostfix
  * @group unittest
  */
-class ASTMethodPostfixTest extends ASTNodeTest
+class ASTMethodPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImageForVariableMethod

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -55,7 +55,7 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
  * @covers \PDepend\Source\AST\ASTMethod
  * @group unittest
  */
-class ASTMethodTest extends AbstractASTArtifactTest
+class ASTMethodTest extends AbstractASTArtifactTestCase
 {
     /**
      * testIsCachedReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
 
 /**
@@ -54,7 +54,7 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
  * @covers \PDepend\Source\AST\ASTNamespace
  * @group unittest
  */
-class ASTNamespaceTest extends AbstractTest
+class ASTNamespaceTest extends AbstractTestCase
 {
     /**
      * testGetIdReturnsExpectedObjectHash

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Abstract test case for classes derived {@link \PDepend\Source\AST\ASTNode}ö
@@ -50,11 +50,10 @@ use PDepend\AbstractTest;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTNode
  * @covers \PDepend\Source\AST\AbstractASTNode
  * @group unittest
  */
-abstract class ASTNodeTest extends AbstractTest
+abstract class ASTNodeTestCase extends AbstractTestCase
 {
     /**
      * testGetImageReturnsExpectedNodeImage
@@ -754,7 +753,6 @@ abstract class ASTNodeTest extends AbstractTest
      * an exception for an undefined node offset.
      *
      * @return void
-     * @covers \PDepend\Source\AST\ASTNode
      */
     public function testGetChildThrowsExpectedExceptionForUndefinedOffset()
     {

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the code parameter class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTParameter
  * @group unittest
  */
-class ASTParameterTest extends AbstractTest
+class ASTParameterTest extends AbstractTestCase
 {
     /**
      * testGetIdReturnsExpectedObjectHash

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTParentReference
  * @group unittest
  */
-class ASTParentReferenceTest extends ASTNodeTest
+class ASTParentReferenceTest extends ASTNodeTestCase
 {
     /**
      * The mocked reference instance.

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTPostfixExpression
  * @group unittest
  */
-class ASTPostfixExpressionTest extends ASTNodeTest
+class ASTPostfixExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIncrementPostfixExpressionOnStaticClassMember

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTPreDecrementExpression
  * @group unittest
  */
-class ASTPreDecrementExpressionTest extends ASTNodeTest
+class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 {
     /**
      * testPreDecrementExpressionOnStaticClassMember

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTPreIncrementExpression
  * @group unittest
  */
-class ASTPreIncrementExpressionTest extends ASTNodeTest
+class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 {
     /**
      * testPreIncrementExpressionOnStaticClassMember

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTPrintExpression
  * @group unittest
  */
-class ASTPrintExpressionTest extends ASTNodeTest
+class ASTPrintExpressionTest extends ASTNodeTestCase
 {
     /**
      * @return \PDepend\Source\AST\ASTPrintExpression

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -56,7 +56,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPropertyPostfix
  */
-class ASTPropertyPostfixTest extends ASTNodeTest
+class ASTPropertyPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImageForArrayIndexedRegularProperty

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the code property class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTProperty
  * @group unittest
  */
-class ASTPropertyTest extends AbstractTest
+class ASTPropertyTest extends AbstractTestCase
 {
     /**
      * testGetDeclaringClass

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTRequireExpression
  * @group unittest
  */
-class ASTRequireExpressionTest extends ASTNodeTest
+class ASTRequireExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIsOnceReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTReturnStatement
  * @group unittest
  */
-class ASTReturnStatementTest extends ASTNodeTest
+class ASTReturnStatementTest extends ASTNodeTestCase
 {
     /**
      * testReturnStatement

--- a/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTScalarType
  * @group unittest
  */
-class ASTScalarTypeTest extends ASTNodeTest
+class ASTScalarTypeTest extends ASTNodeTestCase
 {
     /**
      * testIsArrayReturnsFalse

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTScopeStatement
  * @group unittest
  */
-class ASTScopeStatementTest extends ASTNodeTest
+class ASTScopeStatementTest extends ASTNodeTestCase
 {
     /**
      * testParserHandlesInlineScopeStatement

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -49,11 +49,10 @@ namespace PDepend\Source\AST;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTNode
  * @covers \PDepend\Source\AST\ASTScope
  * @group unittest
  */
-class ASTScopeTest extends ASTNodeTest
+class ASTScopeTest extends ASTNodeTestCase
 {
     /**
      * testScope

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -55,7 +55,7 @@ use PDepend\Source\Builder\BuilderContext;
  * @covers \PDepend\Source\AST\ASTSelfReference
  * @group unittest
  */
-class ASTSelfReferenceTest extends ASTNodeTest
+class ASTSelfReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeReturnsInjectedConstructorTargetArgument

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTShiftLeftExpression
  * @group unittest
  */
-class ASTShiftLeftExpressionTest extends ASTNodeTest
+class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 {
     /**
      * testShiftLeftExpressionReturnsExpectedImage

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTShiftRightExpression
  * @group unittest
  */
-class ASTShiftRightExpressionTest extends ASTNodeTest
+class ASTShiftRightExpressionTest extends ASTNodeTestCase
 {
     /**
      * testShiftRightExpressionReturnsExpectedImage

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTStatement
  * @group unittest
  */
-class ASTStatementTest extends ASTNodeTest
+class ASTStatementTest extends ASTNodeTestCase
 {
     /**
      * testStatement

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
  * @covers \PDepend\Source\AST\ASTStaticReference
  * @group unittest
  */
-class ASTStaticReferenceTest extends ASTNodeTest
+class ASTStaticReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeReturnsInjectedConstructorTargetArgument

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTStaticVariableDeclaration
  * @group unittest
  */
-class ASTStaticVariableDeclarationTest extends ASTNodeTest
+class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 {
     /**
      * testStaticVariableDeclaration

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -55,7 +55,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTStringIndexExpression
  * @group unittest
  */
-class ASTStringIndexExpressionTest extends ASTNodeTest
+class ASTStringIndexExpressionTest extends ASTNodeTestCase
 {
     /**
      * testStringIndexExpression

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTString
  * @group unittest
  */
-class ASTStringTest extends ASTNodeTest
+class ASTStringTest extends ASTNodeTestCase
 {
     /**
      * testDoubleQuoteStringContainsTwoChildNodes

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTSwitchLabel
  * @group unittest
  */
-class ASTSwitchLabelTest extends ASTNodeTest
+class ASTSwitchLabelTest extends ASTNodeTestCase
 {
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTSwitchStatement
  * @group unittest
  */
-class ASTSwitchStatementTest extends ASTNodeTest
+class ASTSwitchStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the generated object graph of a switch statement.

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTThrowStatement
  * @group unittest
  */
-class ASTThrowStatementTest extends ASTNodeTest
+class ASTThrowStatementTest extends ASTNodeTestCase
 {
     /**
      * testThrowStatement

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTraitAdaptationAlias
  * @group unittest
  */
-class ASTTraitAdaptationAliasTest extends ASTNodeTest
+class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 {
     /**
      * testGetNewNameReturnsNullByDefault

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTraitAdaptationPrecedence
  * @group unittest
  */
-class ASTTraitAdaptationPrecedenceTest extends ASTNodeTest
+class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 {
     /**
      * testTraitAdaptationPrecedenceHasExpectedNumberOfTraitReferences

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTraitAdaptation
  * @group unittest
  */
-class ASTTraitAdaptationTest extends ASTNodeTest
+class ASTTraitAdaptationTest extends ASTNodeTestCase
 {
     /**
      * testTraitAdaptation

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -56,7 +56,7 @@ use PDepend\Source\Builder\BuilderContext;
  * @covers \PDepend\Source\AST\ASTTraitReference
  * @group unittest
  */
-class ASTTraitReferenceTest extends ASTNodeTest
+class ASTTraitReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTraitDelegatesToContextGetTraitMethod

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -58,7 +58,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  * @covers \PDepend\Source\AST\AbstractASTType
  * @group unittest
  */
-class ASTTraitTest extends AbstractASTArtifactTest
+class ASTTraitTest extends AbstractASTArtifactTestCase
 {
     /**
      * testGetAllMethodsOnSimpleTraitReturnsExpectedResult

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -57,7 +57,7 @@ use ReflectionMethod;
  * @covers \PDepend\Source\AST\ASTTraitUseStatement
  * @group unittest
  */
-class ASTTraitUseStatementTest extends ASTNodeTest
+class ASTTraitUseStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasExcludeForReturnsFalseIfNoInsteadExists

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTryStatement
  * @group unittest
  */
-class ASTTryStatementTest extends ASTNodeTest
+class ASTTryStatementTest extends ASTNodeTestCase
 {
     /**
      * testTryStatement

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTypeArray
  * @group unittest
  */
-class ASTTypeArrayTest extends ASTNodeTest
+class ASTTypeArrayTest extends ASTNodeTestCase
 {
     /**
      * testArrayType

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -54,7 +54,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTypeCallable
  * @group unittest
  */
-class ASTTypeCallableTest extends ASTNodeTest
+class ASTTypeCallableTest extends ASTNodeTestCase
 {
     /**
      * testCallableTypeIsHandledCaseInsensitive

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTTypeIterable
  * @group unittest
  */
-class ASTTypeIterableTest extends ASTNodeTest
+class ASTTypeIterableTest extends ASTNodeTestCase
 {
     /**
      * testIterableType

--- a/src/test/php/PDepend/Source/AST/ASTTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeTest.php
@@ -51,7 +51,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTType
  * @group unittest
  */
-class ASTTypeTest extends ASTNodeTest
+class ASTTypeTest extends ASTNodeTestCase
 {
     /**
      * testIsArrayReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTUnaryExpression
  * @group unittest
  */
-class ASTUnaryExpressionTest extends ASTNodeTest
+class ASTUnaryExpressionTest extends ASTNodeTestCase
 {
     /**
      * testUnaryExpression

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTUnsetStatement
  * @group unittest
  */
-class ASTUnsetStatementTest extends ASTNodeTest
+class ASTUnsetStatementTest extends ASTNodeTestCase
 {
     /**
      * testUnsetStatement

--- a/src/test/php/PDepend/Source/AST/ASTValueTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTValueTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTValue} class.
@@ -55,7 +55,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTValue
  * @group unittest
  */
-class ASTValueTest extends AbstractTest
+class ASTValueTest extends AbstractTestCase
 {
     /**
      * testIsValueAvailableReturnsFalseByDefault

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTVariableDeclarator
  * @group unittest
  */
-class ASTVariableDeclaratorTest extends ASTNodeTest
+class ASTVariableDeclaratorTest extends ASTNodeTestCase
 {
     /**
      * testGetValueReturnsNullByDefault

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTVariable
  * @group unittest
  */
-class ASTVariableTest extends ASTNodeTest
+class ASTVariableTest extends ASTNodeTestCase
 {
     /**
      * testIsThisReturnsTrueForThisImageName

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTVariableVariable
  * @group unittest
  */
-class ASTVariableVariableTest extends ASTNodeTest
+class ASTVariableVariableTest extends ASTNodeTestCase
 {
     /**
      * testVariableVariable

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTWhileStatement
  * @group unittest
  */
-class ASTWhileStatementTest extends ASTNodeTest
+class ASTWhileStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the generated object graph of a while statement.

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\AST\ASTForeachStatement
  * @group unittest
  */
-class ASTYieldStatementTest extends ASTNodeTest
+class ASTYieldStatementTest extends ASTNodeTestCase
 {
     /**
      * testYield

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -2,6 +2,8 @@
 /**
  * This file is part of PDepend.
  *
+ * PHP Version 5
+ *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -36,34 +38,65 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- */
+  */
 
-namespace PDepend\Source\Language\PHP\Features\PHP82;
+namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
-use PDepend\Source\Builder\Builder;
-use PDepend\Source\Tokenizer\Tokenizer;
-use PDepend\Util\Cache\CacheDriver;
+use PDepend\AbstractTestCase;
 
 /**
+ * Base test case for abstract item implementations.
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
+ * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @group unittest
  */
-abstract class PHPParserVersion82Test extends AbstractTest
+abstract class AbstractASTArtifactTestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * testSetNameChangesPreviousName
+     *
+     * @return void
+     * @since 1.0.0
      */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    public function testSetNameChangesPreviousName()
     {
-        return $this->getAbstractClassMock(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion82',
-            array($tokenizer, $builder, $cache)
-        );
+        $item = $this->createItem();
+        $item->setName(__METHOD__);
+
+        $this->assertEquals(__METHOD__, $item->getName());
     }
+
+    /**
+     * Parses the given source file or directory with the default tokenizer
+     * and node builder implementations.
+     *
+     * @param string  $testCase
+     * @param boolean $ignoreAnnotations
+     * @return \PDepend\Source\AST\ASTNamespace[]
+     */
+    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    {
+        list($class, $method) = explode('::', $testCase);
+
+        $fileName = substr($class, strrpos($class, '\\') + 1, -4);
+        $fileName = 'code/' . $fileName . '/' . $method;
+
+        try {
+            $fileOrDirectory = self::createCodeResourceURI($fileName);
+        } catch (ErrorException $e) {
+            $fileOrDirectory = self::createCodeResourceURI($fileName . '.php');
+        }
+
+        return $this->parseSource($fileOrDirectory, $ignoreAnnotations);
+    }
+
+    /**
+     * Creates an abstract item instance.
+     *
+     * @return \PDepend\Source\AST\AbstractASTArtifact
+     */
+    abstract protected function createItem();
 }

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\AST\ASTArtifactList;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 
 /**
@@ -57,7 +57,7 @@ use PDepend\Source\AST\ASTClass;
  * @covers \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
  * @group unittest
  */
-class CollectionArtifactFilterTest extends AbstractTest
+class CollectionArtifactFilterTest extends AbstractTestCase
 {
     /**
      * testAcceptsReturnsTrueByDefault

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\AST\ASTArtifactList;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
@@ -62,7 +62,7 @@ use PDepend\Source\AST\ASTTrait;
  * @covers \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter
  * @group unittest
  */
-class NullArtifactFilterTest extends AbstractTest
+class NullArtifactFilterTest extends AbstractTestCase
 {
     /**
      * testAcceptsReturnsTrueForClass

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\AST\ASTArtifactList;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -58,7 +58,7 @@ use PDepend\Source\AST\ASTNamespace;
  * @covers \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter
  * @group unittest
  */
-class PackageArtifactFilterTest extends AbstractTest
+class PackageArtifactFilterTest extends AbstractTestCase
 {
     /**
      * Tests that the package filter accepts valid packages.

--- a/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator}
@@ -56,7 +56,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator
  * @group unittest
  */
-class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTest
+class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorReturnsExpectedClasses

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\ASTVisitor;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTTrait;
@@ -56,7 +56,7 @@ use PDepend\Source\AST\ASTTrait;
  * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @group unittest
  */
-class DefaultListenerTest extends AbstractTest
+class DefaultListenerTest extends AbstractTestCase
 {
     /**
      * testDefaultImplementationCallsListeners

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\ASTVisitor;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
@@ -57,7 +57,7 @@ use PDepend\Source\AST\ASTTrait;
  * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @group unittest
  */
-class DefaultVisitorTest extends AbstractTest
+class DefaultVisitorTest extends AbstractTestCase
 {
     /**
      * Tests the execution order of the default visitor implementation.

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\Builder\BuilderContext;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
@@ -58,7 +58,7 @@ use PDepend\Source\AST\ASTTrait;
  * @covers \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext
  * @group unittest
  */
-class GlobalBuilderContextTest extends AbstractTest
+class GlobalBuilderContextTest extends AbstractTestCase
 {
     /**
      * testRegisterTraitCallsRestoreClassOnBuilder

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -50,7 +50,7 @@ use PDepend\Source\AST\ASTMethod;
  * @group unittest
  * @group php8
  */
-class AttributeTest extends PHPParserVersion80Test
+class AttributeTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTNamedArgument;
  * @group unittest
  * @group php8
  */
-class ConstructorPropertyPromotionTest extends PHPParserVersion80Test
+class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP80;
  * @group unittest
  * @group php8.0
  */
-class ExplicitOctalNotationTest extends PHPParserVersion80Test
+class ExplicitOctalNotationTest extends PHPParserVersion80TestCase
 {
     /**
      */

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTReturnStatement;
  * @group unittest
  * @group php8
  */
-class MatchExpressionTest extends PHPParserVersion80Test
+class MatchExpressionTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTVariable;
  * @group unittest
  * @group php8
  */
-class NamedArgumentsTest extends PHPParserVersion80Test
+class NamedArgumentsTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8
  */
-class NullsafeOperatorTest extends PHPParserVersion80Test
+class NullsafeOperatorTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -40,74 +38,32 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Bugs;
+namespace PDepend\Source\Language\PHP\Features\PHP80;
 
-use PDepend\AbstractTest;
-use PDepend\Report\Summary\Xml;
+use PDepend\AbstractTestCase;
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Util\Cache\CacheDriver;
 
 /**
- * Abstract test case for the "Bugs" package.
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ * @group unittest
  */
-abstract class AbstractRegressionTest extends AbstractTest
+abstract class PHPParserVersion80TestCase extends AbstractTestCase
 {
     /**
-     * Creates the PDepend summary report for the source associated with the
-     * calling test case.
-     *
-     * @return string
-     * @since 0.10.0
+     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
+     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Util\Cache\CacheDriver $cache
+     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
-    protected function createSummaryXmlForCallingTest()
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
-        $this->changeWorkingDirectory(
-            self::createCodeResourceURI('config/')
-        );
-
-        $file = $this->createRunResourceURI('summary.xml');
-
-        $log = new Xml();
-        $log->setLogFile($file);
-
-        $pdepend = $this->createEngineFixture();
-        $pdepend->addFile($this->createCodeResourceUriForTest());
-        $pdepend->addReportGenerator($log);
-        $pdepend->analyze();
-
-        return $file;
-    }
-
-    /**
-     * Parses the source of a test case file.
-     *
-     * @param string $testCase
-     * @param boolean $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
-     */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
-    {
-        return $this->parseSource(
-            $this->getSourceFileForTestCase($testCase),
-            $ignoreAnnotations
-        );
-    }
-
-    /**
-     * Returns the source file for the given test case.
-     *
-     * @param string $testCase The qualified test case name.
-     * @return string
-     */
-    protected function getSourceFileForTestCase($testCase)
-    {
-        list($class, $method) = explode('::', $testCase);
-
-        preg_match('(Bug(\d+)Test$)', $class, $match);
-
-        return self::createCodeResourceURI(
-            sprintf('bugs/%s/%s.php', $match[1], $method)
+        return $this->getAbstractClassMock(
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion80',
+            array($tokenizer, $builder, $cache)
         );
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8
  */
-class ThrowExpressionTest extends PHPParserVersion80Test
+class ThrowExpressionTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8
  */
-class UnionTypesTest extends PHPParserVersion80Test
+class UnionTypesTest extends PHPParserVersion80TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
  * @group unittest
  * @group php8.1
  */
-class ArrayUnpackingWithStringKeysTest extends PHPParserVersion81Test
+class ArrayUnpackingWithStringKeysTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTParameter;
  * @group unittest
  * @group php8.1
  */
-class EnumTest extends PHPParserVersion81Test
+class EnumTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -50,7 +50,7 @@ use PDepend\Source\AST\ASTConstantDeclarator;
  * @group unittest
  * @group php8.1
  */
-class ExplicitOctalNotationTest extends PHPParserVersion81Test
+class ExplicitOctalNotationTest extends PHPParserVersion81TestCase
 {
     public function testExplicitOctalNotation()
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -49,7 +49,7 @@ use PDepend\Source\AST\State;
  * @group unittest
  * @group php8.1
  */
-class FinalClassConstantTest extends PHPParserVersion81Test
+class FinalClassConstantTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -49,7 +49,7 @@ use PDepend\Source\AST\ASTMethodPostfix;
  * @group unittest
  * @group php8.1
  */
-class FirstClassCallableSyntaxTest extends PHPParserVersion81Test
+class FirstClassCallableSyntaxTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
  * @group unittest
  * @group php8.1
  */
-class FirstClassCallableTest extends PHPParserVersion81Test
+class FirstClassCallableTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8.1
  */
-class InInitializersTest extends PHPParserVersion81Test
+class InInitializersTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTVariableDeclarator;
  * @group unittest
  * @group php8.1
  */
-class IntersectionTypesTest extends PHPParserVersion81Test
+class IntersectionTypesTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
  * @group unittest
  * @group php8.1
  */
-class NeverReturnTypeTest extends PHPParserVersion81Test
+class NeverReturnTypeTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -40,53 +38,32 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Metrics;
+namespace PDepend\Source\Language\PHP\Features\PHP81;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Util\Cache\CacheDriver;
 
 /**
- * Abstract base class for tests of the metrics package.
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @group unittest
  */
-abstract class AbstractMetricsTest extends AbstractTest
+abstract class PHPParserVersion81TestCase extends AbstractTestCase
 {
     /**
-     * Parses the given source file or directory with the default tokenizer
-     * and node builder implementations.
-     *
-     * @param string  $testCase
-     * @param boolean $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
+     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Util\Cache\CacheDriver $cache
+     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
-        list($class, $method) = explode('::', $testCase);
-
-        $parts = explode('\\', $class);
-
-        try {
-            return parent::parseSource(
-                sprintf(
-                    'Metrics/%s/%s/%s.php',
-                    $parts[count($parts) - 2],
-                    substr($parts[count($parts) - 1], 0, -4),
-                    $method
-                ),
-                $ignoreAnnotations
-            );
-        } catch (\Exception $e) {
-        }
-        
-        return parent::parseSource(
-            sprintf(
-                'Metrics/%s/%s/%s',
-                $parts[count($parts) - 2],
-                substr($parts[count($parts) - 1], 0, -4),
-                $method
-            ),
-            $ignoreAnnotations
+        return $this->getAbstractClassMock(
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion81',
+            array($tokenizer, $builder, $cache)
         );
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
  * @group unittest
  * @group php8.1
  */
-class ReadonlyClassTest extends PHPParserVersion81Test
+class ReadonlyClassTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -49,7 +49,7 @@ use PDepend\Source\AST\State;
  * @group unittest
  * @group php8.1
  */
-class ReadonlyPropertiesTest extends PHPParserVersion81Test
+class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -52,7 +52,7 @@ use PDepend\Source\AST\ASTParameter;
  * @group unittest
  * @group php8.2
  */
-class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82Test
+class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
  * @group unittest
  * @group php8.2
  */
-class DisjunctiveNormalFormTypesTest extends PHPParserVersion82Test
+class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -55,7 +55,7 @@ use PDepend\Source\AST\ASTPropertyPostfix;
  * @group unittest
  * @group php8.2
  */
-class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82Test
+class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -2,8 +2,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -38,65 +36,34 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
-  */
+ */
 
-namespace PDepend\Source\AST;
+namespace PDepend\Source\Language\PHP\Features\PHP82;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Util\Cache\CacheDriver;
 
 /**
- * Base test case for abstract item implementations.
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @covers \PDepend\Source\AST\AbstractASTArtifact
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @group unittest
  */
-abstract class AbstractASTArtifactTest extends AbstractTest
+abstract class PHPParserVersion82TestCase extends AbstractTestCase
 {
     /**
-     * testSetNameChangesPreviousName
-     *
-     * @return void
-     * @since 1.0.0
+     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
+     * @param \PDepend\Source\Builder\Builder $builder
+     * @param \PDepend\Util\Cache\CacheDriver $cache
+     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
-    public function testSetNameChangesPreviousName()
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
-        $item = $this->createItem();
-        $item->setName(__METHOD__);
-
-        $this->assertEquals(__METHOD__, $item->getName());
+        return $this->getAbstractClassMock(
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion82',
+            array($tokenizer, $builder, $cache)
+        );
     }
-
-    /**
-     * Parses the given source file or directory with the default tokenizer
-     * and node builder implementations.
-     *
-     * @param string  $testCase
-     * @param boolean $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
-     */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
-    {
-        list($class, $method) = explode('::', $testCase);
-
-        $fileName = substr($class, strrpos($class, '\\') + 1, -4);
-        $fileName = 'code/' . $fileName . '/' . $method;
-
-        try {
-            $fileOrDirectory = self::createCodeResourceURI($fileName);
-        } catch (ErrorException $e) {
-            $fileOrDirectory = self::createCodeResourceURI($fileName . '.php');
-        }
-
-        return $this->parseSource($fileOrDirectory, $ignoreAnnotations);
-    }
-
-    /**
-     * Creates an abstract item instance.
-     *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
-     */
-    abstract protected function createItem();
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
  * @group unittest
  * @group php8.2
  */
-class ReadonlyClassTest extends PHPParserVersion82Test
+class ReadonlyClassTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -53,7 +53,7 @@ use PDepend\Source\AST\ASTScalarType;
  * @group unittest
  * @group php8.2
  */
-class TrueTypeTest extends PHPParserVersion82Test
+class TrueTypeTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -47,7 +47,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
  * @group unittest
  * @group php8.2
  */
-class TypedClassConstantsTest extends PHPParserVersion82Test
+class TypedClassConstantsTest extends PHPParserVersion82TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -51,7 +51,7 @@ use PDepend\Source\AST\ASTScope;
  * @group unittest
  * @group php8.3
  */
-class DynamicClassConstantFetchTest extends PHPParserVersion83Test
+class DynamicClassConstantFetchTest extends PHPParserVersion83TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -38,9 +38,9 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Source\Language\PHP\Features\PHP81;
+namespace PDepend\Source\Language\PHP\Features\PHP83;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
@@ -48,10 +48,10 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @group unittest
  */
-abstract class PHPParserVersion81Test extends AbstractTest
+abstract class PHPParserVersion83TestCase extends AbstractTestCase
 {
     /**
      * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
@@ -62,7 +62,7 @@ abstract class PHPParserVersion81Test extends AbstractTest
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
         return $this->getAbstractClassMock(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion81',
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion83',
             array($tokenizer, $builder, $cache)
         );
     }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -58,7 +58,7 @@ use PDepend\Source\AST\ASTValue;
  * @group unittest
  * @group php8.3
  */
-class TypedClassConstantsTest extends PHPParserVersion83Test
+class TypedClassConstantsTest extends PHPParserVersion83TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -59,7 +59,7 @@ use PDepend\Source\AST\ASTValue;
  * @group unittest
  * @group php8.3
  */
-class UnionTypedClassConstantsTest extends PHPParserVersion83Test
+class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClassFqnPostfix;
 use PDepend\Source\AST\ASTComment;
 use PDepend\Source\AST\ASTConstantPostfix;
@@ -57,7 +57,7 @@ use PDepend\Source\AST\ASTFunction;
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @group unittest
  */
-class PHPBuilderTest extends AbstractTest
+class PHPBuilderTest extends AbstractTestCase
 {
     /**
      * testBuilderAddsMultiplePackagesForClassesToListOfPackages

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -55,7 +55,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
  * @group unittest
  */
-class PHPParserGenericTest extends AbstractTest
+class PHPParserGenericTest extends AbstractTestCase
 {
     /**
      * testParserAcceptsStringAsClassName

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -57,7 +57,7 @@ use PDepend\AbstractTest;
  * @group unittest
  * @link https://github.com/pdepend/pdepend/issues/180
  */
-class PHPParserGenericVersion56Test extends AbstractTest
+class PHPParserGenericVersion56Test extends AbstractTestCase
 {
     /**
      * testShiftLeftInConstantInitializer

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTNamespace;
 
@@ -56,7 +56,7 @@ use PDepend\Source\AST\ASTNamespace;
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
  * @group unittest
  */
-class PHPParserGenericVersion70Test extends AbstractTest
+class PHPParserGenericVersion70Test extends AbstractTestCase
 {
     /**
      * testFormalParameterScalarTypeHintInt

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -54,7 +54,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
  * @group unittest
  */
-class PHPParserGenericVersion71Test extends AbstractTest
+class PHPParserGenericVersion71Test extends AbstractTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion53Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Token;
@@ -63,7 +63,7 @@ use ReflectionMethod;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion53
  * @group unittest
  */
-class PHPParserVersion53Test extends AbstractTest
+class PHPParserVersion53Test extends AbstractTestCase
 {
     /**
      * testParserThrowsExpectedExceptionForStaticMemberExpressionSyntax

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion54Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion54Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
@@ -58,7 +58,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion54
  * @group unittest
  */
-class PHPParserVersion54Test extends AbstractTest
+class PHPParserVersion54Test extends AbstractTestCase
 {
     /**
      * testParserHandlesBinaryIntegerLiteral

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion55Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion55Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
@@ -58,7 +58,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion55
  * @group unittest
  */
-class PHPParserVersion55Test extends AbstractTest
+class PHPParserVersion55Test extends AbstractTestCase
 {
     /**
      * testParserThrowsExceptionForParameterWithExpressionValue

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion56Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTConstantDefinition;
@@ -69,7 +69,7 @@ use ReflectionMethod;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion56
  * @group unittest
  */
-class PHPParserVersion56Test extends AbstractTest
+class PHPParserVersion56Test extends AbstractTestCase
 {
     /**
      * testComplexExpressionInParameterInitializer

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion70Test.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTNamespace;
@@ -61,7 +61,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion70
  * @group unittest
  */
-class PHPParserVersion70Test extends AbstractTest
+class PHPParserVersion70Test extends AbstractTestCase
 {
     /**
      * testFormalParameterScalarTypeHintInt

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion71Test.php
@@ -40,7 +40,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArray;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
@@ -54,7 +54,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion71
  * @group unittest
  */
-class PHPParserVersion71Test extends AbstractTest
+class PHPParserVersion71Test extends AbstractTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -40,7 +40,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
@@ -57,7 +57,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
  * @group unittest
  */
-class PHPParserVersion72Test extends AbstractTest
+class PHPParserVersion72Test extends AbstractTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
@@ -40,7 +40,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
@@ -61,7 +61,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion73
  * @group unittest
  */
-class PHPParserVersion73Test extends AbstractTest
+class PHPParserVersion73Test extends AbstractTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -41,7 +41,7 @@
 namespace PDepend\Source\Language\PHP;
 
 use OutOfBoundsException;
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClosure;
@@ -67,7 +67,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion74
  * @group unittest
  */
-class PHPParserVersion74Test extends AbstractTest
+class PHPParserVersion74Test extends AbstractTestCase
 {
     /**
      * @return void

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -40,7 +40,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\Builder\Builder;
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
  * @group unittest
  */
-class PHPParserVersion80Test extends AbstractTest
+class PHPParserVersion80Test extends AbstractTestCase
 {
     /**
      * testCatchWithoutVariable

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\Language\PHP;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -55,7 +55,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @covers \PDepend\Source\Language\PHP\PHPTokenizerInternal
  * @group unittest
  */
-class PHPTokenizerInternalTest extends AbstractTest
+class PHPTokenizerInternalTest extends AbstractTestCase
 {
     /**
      * testTokenizerReturnsExpectedConstantForTraitKeyword

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -63,7 +63,7 @@ use PDepend\Source\AST\ASTVariableVariable;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ASTAllocationExpressionParsingTest extends AbstractParserTest
+class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 {
     /**
      * testAllocationExpressionForSelfProperty

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\Parser;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ASTArgumentsParsingTest extends AbstractParserTest
+class ASTArgumentsParsingTest extends AbstractParserTestCase
 {
     /**
      * Tests that the parser adds the expected children to an argument instance.

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTFormalParameter;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class ASTFormalParameterParsingTest extends AbstractParserTest
+class ASTFormalParameterParsingTest extends AbstractParserTestCase
 {
     /**
      * testWithParentTypeHint

--- a/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
+++ b/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Source\Parser;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Abstract test case class for this sub namespace.
@@ -52,6 +52,6 @@ use PDepend\AbstractTest;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
  */
-abstract class AbstractParserTest extends AbstractTest
+abstract class AbstractParserTestCase extends AbstractTestCase
 {
 }

--- a/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -54,7 +54,7 @@ use PDepend\Source\AST\ASTClassOrInterfaceReference;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class NamespaceResovingTest extends AbstractParserTest
+class NamespaceResovingTest extends AbstractParserTestCase
 {
     /**
      * testNamespacesAreCorrectlyLookedUp

--- a/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
+++ b/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\PDepend\Source\Parser;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\Parser\SymbolTable;
 
 /**
@@ -51,7 +51,7 @@ use PDepend\Source\Parser\SymbolTable;
  * @covers \PDepend\Source\Parser\SymbolTable
  * @group unittest
  */
-class SymbolTableTest extends AbstractTest
+class SymbolTableTest extends AbstractTestCase
 {
     /**
      * Tests that no symbol can be added to a symbol table without active scope.

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -55,7 +55,7 @@ use PDepend\Source\Tokenizer\Token;
  * @covers \PDepend\Source\Parser\TokenStack
  * @group unittest
  */
-class TokenStackTest extends AbstractParserTest
+class TokenStackTest extends AbstractParserTestCase
 {
     /**
      * testAddReturnsGivenTokenInstance

--- a/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -53,7 +53,7 @@ namespace PDepend\Source\Parser;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
-class UnstructuredCodeTest extends AbstractParserTest
+class UnstructuredCodeTest extends AbstractParserTestCase
 {
     /**
      * testParserHandlesNonPhpCodeInFileProlog

--- a/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
+++ b/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Source\Tokenizer;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Source\Tokenizer\Token} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Source\Tokenizer\Token
  * @group unittest
  */
-class TokenTest extends AbstractTest
+class TokenTest extends AbstractTestCase
 {
     /**
      * testConstructorSetsTypeProperty

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\TextUI;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\MockCommand;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
@@ -58,7 +58,7 @@ use ReflectionProperty;
  * @covers \PDepend\TextUI\Command
  * @group unittest
  */
-class CommandTest extends AbstractTest
+class CommandTest extends AbstractTestCase
 {
     /**
      * Expected output of the --version option.

--- a/src/test/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/src/test/php/PDepend/TextUI/ResultPrinterTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\TextUI;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Source\AST\ASTMethod;
@@ -58,7 +58,7 @@ use PDepend\Source\Language\PHP\PHPTokenizerInternal;
  * @covers \PDepend\TextUI\ResultPrinter
  * @group unittest
  */
-class ResultPrinterTest extends AbstractTest
+class ResultPrinterTest extends AbstractTestCase
 {
     /**
      * Tests the output for a single file entry.

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\TextUI;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Input\ExtensionFilter;
 use PDepend\Input\Filter;
 use PDepend\Report\ReportGeneratorFactory;
@@ -58,7 +58,7 @@ use Symfony\Component\DependencyInjection\Container;
  * @covers \PDepend\TextUI\Runner
  * @group unittest
  */
-class RunnerTest extends AbstractTest
+class RunnerTest extends AbstractTestCase
 {
     /**
      * Tests that the runner exits with an exception for an invalud source

--- a/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
+++ b/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Cache;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Abstract test case that validates the behavior of concrete driver
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  *
    * @group unittest
  */
-abstract class AbstractDriverTest extends AbstractTest
+abstract class AbstractDriverTestCase extends AbstractTestCase
 {
     /**
      * testTypeMethodReturnsSameObjectInstance

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Cache;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Util\Cache\Driver\FileCacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -55,7 +55,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Util\Cache\CacheFactory
  * @group unittest
  */
-class CacheFactoryTest extends AbstractTest
+class CacheFactoryTest extends AbstractTestCase
 {
     /**
      * testCreateReturnsDriverInstance

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Util\Cache\Driver\File;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
@@ -56,7 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @covers \PDepend\Util\Cache\Driver\File\FileCacheDirectory
  * @group unittest
  */
-class FileCacheDirectoryTest extends AbstractTest
+class FileCacheDirectoryTest extends AbstractTestCase
 {
     /**
      * Temporary cache directory.

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Cache\Driver\File;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector
  * @group unittest
  */
-class FileCacheGarbageCollectorTest extends AbstractTest
+class FileCacheGarbageCollectorTest extends AbstractTestCase
 {
     /**
      * Temporary cache directory.

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Cache\Driver;
 
-use PDepend\Util\Cache\AbstractDriverTest;
+use PDepend\Util\Cache\AbstractDriverTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\FileCacheDriver} class.
@@ -53,7 +53,7 @@ use PDepend\Util\Cache\AbstractDriverTest;
  * @covers \PDepend\Util\Cache\Driver\FileCacheDriver
  * @group unittest
  */
-class FileCacheDriverTest extends AbstractDriverTest
+class FileCacheDriverTest extends AbstractDriverTestCase
 {
     /**
      * Temporary cache directory.

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Cache\Driver;
 
-use PDepend\Util\Cache\AbstractDriverTest;
+use PDepend\Util\Cache\AbstractDriverTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\MemoryCacheDriver} class.
@@ -53,7 +53,7 @@ use PDepend\Util\Cache\AbstractDriverTest;
  * @covers \PDepend\Util\Cache\Driver\MemoryCacheDriver
  * @group unittest
  */
-class MemoryCacheDriverTest extends AbstractDriverTest
+class MemoryCacheDriverTest extends AbstractDriverTestCase
 {
     /**
      * Creates a test fixture.

--- a/src/test/php/PDepend/Util/ConfigurationTest.php
+++ b/src/test/php/PDepend/Util/ConfigurationTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Configuration} class.
@@ -55,7 +55,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\Configuration
  * @group unittest
  */
-class ConfigurationTest extends AbstractTest
+class ConfigurationTest extends AbstractTestCase
 {
     /**
      * testPropertyAccessForExistingValue

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Coverage;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\CloverReport} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\Coverage\CloverReport
  * @group unittest
  */
-class CloverReportTest extends AbstractTest
+class CloverReportTest extends AbstractTestCase
 {
     /**
      * testReportReturnsExpected0PercentCoverage

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util\Coverage;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\Factory} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\Coverage\Factory
  * @group unittest
  */
-class FactoryTest extends AbstractTest
+class FactoryTest extends AbstractTestCase
 {
     /**
      * testCreateReturnsCloverReportInstanceForCloverInputFile

--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the {@link \PDepend\Util\FileUtil} class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\FileUtil
  * @group unittest
  */
-class FileUtilTest extends AbstractTest
+class FileUtilTest extends AbstractTestCase
 {
     /**
      * testGetSysTempDirReturnsExpectedDirectory

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -43,7 +43,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
@@ -60,7 +60,7 @@ use PDepend\Source\AST\ASTMethod;
  * @covers \PDepend\Util\IdBuilder
  * @group unittest
  */
-class IdBuilderTest extends AbstractTest
+class IdBuilderTest extends AbstractTestCase
 {
     /**
      * testBuilderCreatesExpectedIdentifierForFile

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for the image convert utility class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\ImageConvert
  * @group unittest
  */
-class ImageConvertTest extends AbstractTest
+class ImageConvertTest extends AbstractTestCase
 {
     /**
      * Tests the copy behaviour for same mime types.

--- a/src/test/php/PDepend/Util/TypeTest.php
+++ b/src/test/php/PDepend/Util/TypeTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 
 /**
  * Test case for type utility class.
@@ -53,7 +53,7 @@ use PDepend\AbstractTest;
  * @covers \PDepend\Util\Type
  * @group unittest
  */
-class TypeTest extends AbstractTest
+class TypeTest extends AbstractTestCase
 {
     /**
      * testIsInternalTypeDetectsInternalClassPrefixedWithBackslash

--- a/src/test/php/PDepend/Util/Utf8UtilTest.php
+++ b/src/test/php/PDepend/Util/Utf8UtilTest.php
@@ -42,7 +42,7 @@
 
 namespace PDepend\Util;
 
-use PDepend\AbstractTest;
+use PDepend\AbstractTestCase;
 use ReflectionMethod;
 
 /**
@@ -54,7 +54,7 @@ use ReflectionMethod;
  * @covers \PDepend\Util\Utf8Util
  * @group unittest
  */
-class Utf8UtilTest extends AbstractTest
+class Utf8UtilTest extends AbstractTestCase
 {
     public function testEnsureEncoding()
     {


### PR DESCRIPTION
Type: bugfix
Breaking change: no

The way the cache is currently setup it will often not update dependencies, this caused the previous PR to pass despite there still being warnings for PHPUnit 10, as it was still loading and running PHPUnit 9.  This PR fixes both these issues.

- Fix caching not being invalidated when dependencies are updated
- Fix warnings causing PHPUnit 10 to emit an error code leading to GitHub Action failing the test
  - Remove use of `-v` as this argument has been removed and the version is now always printed
  - Renamed `abstract` test base classes to *Case as PHPUnit 10 will emit a warning if they end in *Test
  - Remove `@cover` that pointed at native PHP classes or interfaces as these cannot be covered
- Order dependencies to have less conflicts in later PRs