### PR TITLE
Run test in parallel

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,7 +46,7 @@ jobs:
         composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
     - name: Coverage
-      run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-text --coverage-html=coverage
+      run: vendor/bin/paratest --coverage-clover=coverage.xml --coverage-text --coverage-html=coverage
       env:
         XDEBUG_MODE: coverage
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,13 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.4'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
+
+      # For now we need to overwrite the PHP version check on the 8.4 beta as paratest has not been releasd for it yet
+      - name: Install dependencies (PHP 8.4 beta)
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
+        run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
       - name: Check Symfony version
         run: php src/test/symfony-version.php

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ composer.phar
 composer.lock
 dist
 /clover.xml
+.phpunit.cache
+coverage.xml
+coverage

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
+        "brianium/paratest": "^7.3",
         "easy-doc/easy-doc": "0.0.0|^1.2.3",
         "gregwar/rst": "^1.0",
         "phpunit/phpunit": "^10.5.20",
@@ -27,7 +28,7 @@
         "psr-4": {"PDepend\\": "src/main/php/PDepend"}
     },
     "scripts": {
-        "test": "phpunit --no-coverage",
+        "test": "paratest --no-coverage",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "build-website": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="src/test/php/PDepend/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
-  <coverage includeUncoveredFiles="true">
+  <coverage includeUncoveredFiles="true" cacheDirectory=".phpunit.cache">
     <report>
       <clover outputFile="clover.xml"/>
     </report>

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -669,11 +669,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function createRunResourceURI($fileName = null)
     {
-        $uri = __DIR__ . '/_run/' . ($fileName ? $fileName : uniqid());
-        if (file_exists($uri) === true) {
-            throw new \ErrorException("File '{$fileName}' already exists.");
-        }
-        return $uri;
+        return tempnam(sys_get_temp_dir(), $fileName ?: uniqid());
     }
 
     /**

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -400,8 +400,10 @@ class EngineTest extends AbstractTestCase
     public function testAddFileMethodThrowsExpectedExceptionForFileThatNotExists()
     {
         $this->expectException(\InvalidArgumentException::class);
+        $filePath = $this->createRunResourceURI('pdepend_');
+        unlink($filePath);
 
         $engine = $this->createEngineFixture();
-        $engine->addFile($this->createRunResourceURI('pdepend_'));
+        $engine->addFile($filePath);
     }
 }

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -89,6 +89,7 @@ class BuilderParserCacheTest extends AbstractTestCase
         parent::setUp();
 
         $this->cacheDir = $this->createRunResourceURI('cacheDir');
+        unlink($this->cacheDir);
         $this->cacheTtl = FileCacheDriver::DEFAULT_TTL;
         $this->testFile = $this->createRunResourceURI('testFile');
     }

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -75,7 +75,7 @@ class ChartTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->outputFile = $this->createRunResourceURI('jdepend-test-out.svg');
+        $this->outputFile = $this->createRunResourceURI('jdepend-test-out') . '.svg';
         if (file_exists($this->outputFile)) {
             unlink($this->outputFile);
         }
@@ -296,7 +296,7 @@ class ChartTest extends AbstractTestCase
     {
         $this->requireImagick();
 
-        $fileName = $this->createRunResourceURI('jdepend-test-out.png');
+        $fileName = $this->createRunResourceURI('jdepend-test-out') . '.png';
         if (file_exists($fileName)) {
             unlink($fileName);
         }

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -230,7 +230,7 @@ class PyramidTest extends AbstractTestCase
      */
     public function testCollectedAndComputedValuesInOutputSVG()
     {
-        $output = $this->createRunResourceURI('temp.svg');
+        $output = $this->createRunResourceURI('temp') . '.svg';
         if (file_exists($output)) {
             unlink($output);
         }

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -497,8 +497,10 @@ class CommandTest extends AbstractTestCase
      */
     public function testTextUiCommandFailesWithExpectedErrorCodeWhenCoverageReportFileDoesNotExist()
     {
+        $filePath = $this->createRunResourceURI('foobar');
+        unlink($filePath);
         $argv = array(
-            '--coverage-report=' . $this->createRunResourceURI('foobar'),
+            '--coverage-report=' . $filePath,
             '--dummy-logger=' . $this->createRunResourceURI(),
             __FILE__,
         );
@@ -534,7 +536,7 @@ class CommandTest extends AbstractTestCase
      */
     public function testCommandFailsIfAnInvalidConfigFileWasSpecified()
     {
-        $configFile = $this->createRunResourceURI('config.xml');
+        $configFile = $this->createRunResourceURI('config') . '.xml';
 
         $argv = array('--configuration=' . $configFile, __FILE__);
 

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -82,6 +82,7 @@ class FileCacheDirectoryTest extends AbstractTestCase
         parent::setUp();
 
         $this->cacheDir    = $this->createRunResourceURI('cache');
+        unlink($this->cacheDir);
         $this->versionFile = "{$this->cacheDir}/_version";
     }
 

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -78,7 +78,9 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
     {
         parent::setUp();
 
-        $this->cacheDir = $this->createRunResourceURI('cache') . '/';
+        $tmp = $this->createRunResourceURI('cache');
+        unlink($tmp);
+        $this->cacheDir = $tmp . '/';
         $this->cacheTtl = FileCacheGarbageCollector::DEFAULT_TTL;
         mkdir($this->cacheDir);
     }

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -79,6 +79,7 @@ class FileCacheDriverTest extends AbstractDriverTestCase
         parent::setUp();
 
         $this->cacheDir = $this->createRunResourceURI('cache');
+        unlink($this->cacheDir);
         $this->cacheTtl = FileCacheDriver::DEFAULT_TTL;
     }
 

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -63,7 +63,7 @@ class ImageConvertTest extends AbstractTestCase
     public function testConvertMakesCopyForSameMimeType()
     {
         $input  = $this->createInputSvg();
-        $output = $this->createRunResourceURI('pdepend.out.svg');
+        $output = $this->createRunResourceURI('pdepend.out') . '.svg';
 
         ImageConvert::convert($input, $output);
         $this->assertFileEquals($input, $output);
@@ -79,7 +79,7 @@ class ImageConvertTest extends AbstractTestCase
         $this->requireImagick();
 
         $input  = $this->createInputSvg();
-        $output = $this->createRunResourceURI('pdepend.out.png');
+        $output = $this->createRunResourceURI('pdepend.out') . '.png';
 
         ImageConvert::convert($input, $output);
         $this->assertFileExists($output);
@@ -130,7 +130,7 @@ class ImageConvertTest extends AbstractTestCase
         ConfigurationInstance::set($config);
 
         $input  = $this->createInputSvg();
-        $output = $this->createRunResourceURI('pdepend.svg');
+        $output = $this->createRunResourceURI('pdepend') . '.svg';
 
         ImageConvert::convert($input, $output);
 
@@ -165,7 +165,7 @@ class ImageConvertTest extends AbstractTestCase
         ConfigurationInstance::set($config);
 
         $input  = $this->createInputSvg();
-        $output = $this->createRunResourceURI('pdepend.svg');
+        $output = $this->createRunResourceURI('pdepend') . '.svg';
 
         ImageConvert::convert($input, $output);
 


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Use brianium/paratest to run test in parallel across CPU threads. This greatly speeds up the time to run the full test suite from around 2 minutes to about 10 sec.