### PR TITLE
Fix PHP 8.4 deprecation issues

### DIFF
--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -337,12 +337,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement         $xml             The parent xml element.
-     * @param ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement          $xml             The parent xml element.
+     * @param ?ASTCompilationUnit $compilationUnit The code file instance.
      *
      * @return void
      */
-    protected function writeFileReference(DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
+    protected function writeFileReference(DOMElement $xml, ?ASTCompilationUnit $compilationUnit = null)
     {
         if (in_array($compilationUnit, $this->fileSet, true) === false) {
             $this->fileSet[] = $compilationUnit;

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -445,12 +445,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement         $xml             The parent xml element.
-     * @param ASTCompilationUnit $compilationUnit The code file instance.
+     * @param DOMElement          $xml             The parent xml element.
+     * @param ?ASTCompilationUnit $compilationUnit The code file instance.
      *
      * @return void
      */
-    protected function writeFileReference(DOMElement $xml, ASTCompilationUnit $compilationUnit = null)
+    protected function writeFileReference(DOMElement $xml, ?ASTCompilationUnit $compilationUnit = null)
     {
         if (in_array($compilationUnit, $this->fileSet, true) === false) {
             $this->fileSet[] = $compilationUnit;

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -94,13 +94,13 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * Sets the used filter instance.
      *
-     * @param ArtifactFilter $filter
+     * @param ?ArtifactFilter $filter
      *
      * @return void
      *
      * @since  0.9.12
      */
-    public function setFilter(ArtifactFilter $filter = null)
+    public function setFilter(?ArtifactFilter $filter = null)
     {
         $this->filter = $filter;
     }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -108,7 +108,7 @@ class ASTConstantDeclarator extends AbstractASTNode
      *
      * @return void
      */
-    public function setType(ASTType $type = null)
+    public function setType(?ASTType $type = null)
     {
         $this->type = $type;
     }
@@ -128,7 +128,7 @@ class ASTConstantDeclarator extends AbstractASTNode
      *
      * @return void
      */
-    public function setValue(ASTValue $value = null)
+    public function setValue(?ASTValue $value = null)
     {
         $this->value = $value;
     }

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -64,7 +64,7 @@ class ASTEnum extends AbstractASTClassOrInterface
      */
     private $type;
 
-    public function __construct($name, ASTScalarType $type = null)
+    public function __construct($name, ?ASTScalarType $type = null)
     {
         parent::__construct($name);
 

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -61,7 +61,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * class Foo {
  *     //                 -----------------
- *     public function bar(Foo $obj = null) {}
+ *     public function bar(?Foo $obj = null) {}
  *     //                 -----------------
  * }
  * </code>

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -193,7 +193,7 @@ class ASTMethod extends AbstractASTCallable
      *
      * @return void
      */
-    public function setParent(AbstractASTType $parent = null)
+    public function setParent(?AbstractASTType $parent = null)
     {
         $this->parent = $parent;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -398,7 +398,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return void
      */
-    public function setTokens(array $tokens, Token $startToken = null)
+    public function setTokens(array $tokens, ?Token $startToken = null)
     {
         if ($tokens === array()) {
             throw new InvalidArgumentException('An AST node should contain at least one token');

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2387,7 +2387,7 @@ abstract class AbstractPHPParser
      *
      * @since 0.9.8
      */
-    protected function setNodePositionsAndReturn(ASTNode $node, array &$tokens = null)
+    protected function setNodePositionsAndReturn(ASTNode $node, ?array &$tokens = null)
     {
         $tokens = $this->stripTrailingComments($this->tokenStack->pop());
 
@@ -8075,7 +8075,7 @@ abstract class AbstractPHPParser
      * @deprecated 3.0.0 Use throw $this->getUnexpectedTokenException($token) instead
      * @codeCoverageIgnore
      */
-    protected function throwUnexpectedTokenException(Token $token = null)
+    protected function throwUnexpectedTokenException(?Token $token = null)
     {
         throw $this->getUnexpectedTokenException($token);
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2582,12 +2582,12 @@ class PHPBuilder implements Builder
     /**
      * Builds an enum definition.
      *
-     * @param string        $name The enum name.
-     * @param ASTScalarType $type The enum type ('string', 'int', or null if not backed).
+     * @param string         $name The enum name.
+     * @param ?ASTScalarType $type The enum type ('string', 'int', or null if not backed).
      *
      * @return ASTEnum The created class object.
      */
-    public function buildEnum($name, ASTScalarType $type = null)
+    public function buildEnum($name, ?ASTScalarType $type = null)
     {
         $this->checkBuilderState();
 
@@ -2602,12 +2602,12 @@ class PHPBuilder implements Builder
     /**
      * Builds an enum definition.
      *
-     * @param string          $name  The enum case name.
-     * @param AbstractASTNode $value The enum case value if backed.
+     * @param string           $name  The enum case name.
+     * @param ?AbstractASTNode $value The enum case value if backed.
      *
      * @return ASTEnumCase The created class object.
      */
-    public function buildEnumCase($name, AbstractASTNode $value = null)
+    public function buildEnumCase($name, ?AbstractASTNode $value = null)
     {
         $this->checkBuilderState();
 

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -70,11 +70,11 @@ class ConfigurationInstance
     /**
      * Sets the configuration instance.
      *
-     * @param Configuration $configuration The config instance.
+     * @param ?Configuration $configuration The config instance.
      *
      * @return void
      */
-    public static function set(Configuration $configuration = null)
+    public static function set(?Configuration $configuration = null)
     {
         self::$configuration = $configuration;
     }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -116,12 +116,15 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
         $children = $type->getChildren();
 
-        $this->assertCount(2, $children);
+        $this->assertCount(3, $children);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
         $this->assertSame('A&B', $children[0]->getImage());
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[1]);
         $this->assertSame('D', $children[1]->getImage());
+
+        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[1]);
+        $this->assertSame('null', $children[2]->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -47,7 +47,7 @@ use PDepend\MockCommand;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
+use ReflectionClass;
 
 /**
  * Test case for the text ui command.
@@ -577,9 +577,8 @@ class CommandTest extends AbstractTestCase
     public function testDebugErrorDisplay()
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
-        $streamProperty = new ReflectionProperty('PDepend\\Util\\Log', 'stream');
-        $streamProperty->setAccessible(true);
-        $streamProperty->setValue(fopen($file, 'a+'));
+        $streamProperty = new ReflectionClass('PDepend\\Util\\Log');
+        $streamProperty->setStaticPropertyValue('stream', fopen($file, 'a+'));
 
         Log::setSeverity(Log::DEBUG);
 
@@ -591,7 +590,7 @@ class CommandTest extends AbstractTestCase
         Log::setSeverity(2);
         $error = file_get_contents($file);
         unlink($file);
-        $streamProperty->setValue(STDERR);
+        $streamProperty->setStaticPropertyValue('stream', STDERR);
 
         $this->assertSame('Critical error:' . PHP_EOL . '===============' . PHP_EOL . 'Bad usage', trim($output));
         $this->assertSame(42, $exitCode);
@@ -636,11 +635,11 @@ class CommandTest extends AbstractTestCase
      * Executes the text ui command and returns the exit code and the output as
      * an array <b>array($exitCode, $output)</b>.
      *
-     * @param array $argv The cli parameters.
+     * @param ?array $argv The cli parameters.
      *
      * @return array<mixed>
      */
-    private function executeCommand(array $argv = null)
+    private function executeCommand(?array $argv = null)
     {
         $this->prepareArgv($argv);
 
@@ -655,11 +654,11 @@ class CommandTest extends AbstractTestCase
     /**
      * Prepares a fake <b>$argv</b>.
      *
-     * @param array $argv The cli parameters.
+     * @param ?array $argv The cli parameters.
      *
      * @return void
      */
-    private function prepareArgv(array $argv = null)
+    private function prepareArgv(?array $argv = null)
     {
         unset($_SERVER['argv']);
 

--- a/src/test/resources/files/Engine/testAddDirectory/package2.php
+++ b/src/test/resources/files/Engine/testAddDirectory/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testAnalyze/package2.php
+++ b/src/test/resources/files/Engine/testAnalyze/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testAnalyzeMethodReturnsAnIterator/package2.php
+++ b/src/test/resources/files/Engine/testAnalyzeMethodReturnsAnIterator/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testAnalyzeReturnsEmptyIteratorWhenNoPackageExists/package2.php
+++ b/src/test/resources/files/Engine/testAnalyzeReturnsEmptyIteratorWhenNoPackageExists/package2.php
@@ -4,7 +4,7 @@ interface pkg2FooI extends pkg1FooI {
 }
 
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testCountClasses/package2.php
+++ b/src/test/resources/files/Engine/testCountClasses/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testCountClassesWithoutAnalyzeFail/package2.php
+++ b/src/test/resources/files/Engine/testCountClassesWithoutAnalyzeFail/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testCountNamespaces/package2.php
+++ b/src/test/resources/files/Engine/testCountNamespaces/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testCountNamespacesWithoutAnalyzeFail/package2.php
+++ b/src/test/resources/files/Engine/testCountNamespacesWithoutAnalyzeFail/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testGetNamespace/package2.php
+++ b/src/test/resources/files/Engine/testGetNamespace/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testGetNamespaceWithoutAnalyzeFail/package2.php
+++ b/src/test/resources/files/Engine/testGetNamespaceWithoutAnalyzeFail/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testGetNamespaces/package2.php
+++ b/src/test/resources/files/Engine/testGetNamespaces/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testGetNamespacesWithUnknownPackageFail/package2.php
+++ b/src/test/resources/files/Engine/testGetNamespacesWithUnknownPackageFail/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Engine/testGetNamespacesWithoutAnalyzeFail/package2.php
+++ b/src/test/resources/files/Engine/testGetNamespacesWithoutAnalyzeFail/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/testGetNodeMetrics/package2.php
+++ b/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/testGetNodeMetrics/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/testGetNodeMetricsInvalidIdentifier/package2.php
+++ b/src/test/resources/files/Metrics/Analyzer/CodeRankAnalyzer/testGetNodeMetricsInvalidIdentifier/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Report/Jdepend/Xml/testXmlLogWithoutMetrics/package2.php
+++ b/src/test/resources/files/Report/Jdepend/Xml/testXmlLogWithoutMetrics/package2.php
@@ -10,7 +10,7 @@ interface pkg2FooI extends pkg1FooI {
  * @package package2
  */
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/Source/AST/ASTParameter/testParameterAllowsNullForArrayHintVariableIssue67.php
+++ b/src/test/resources/files/Source/AST/ASTParameter/testParameterAllowsNullForArrayHintVariableIssue67.php
@@ -1,7 +1,7 @@
 <?php
 class Foo
 {
-    public function bar(array $baz = null)
+    public function bar(?array $baz = null)
     {
         
     }

--- a/src/test/resources/files/Source/AST/ASTParameter/testParameterAllowsNullForTypeHintVariableIssue67.php
+++ b/src/test/resources/files/Source/AST/ASTParameter/testParameterAllowsNullForTypeHintVariableIssue67.php
@@ -1,7 +1,7 @@
 <?php
 class Foo
 {
-    public function bar(Baz $baz = null)
+    public function bar(?Baz $baz = null)
     {
         
     }

--- a/src/test/resources/files/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypes/testParameterParenthesesFirst.php
+++ b/src/test/resources/files/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypes/testParameterParenthesesFirst.php
@@ -1,5 +1,5 @@
 <?php
 
 interface ITest {
-    public function stuff((A&B)|D $var = null);
+    public function stuff((A&B)|D|null $var = null);
 }

--- a/src/test/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
+++ b/src/test/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
@@ -4,7 +4,7 @@ interface pkg2FooI extends pkg1FooI {
 }
 
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/TextUI/Runner/testRunnerThrowsRuntimeExceptionIfNoLoggerIsSpecified/package2.php
+++ b/src/test/resources/files/TextUI/Runner/testRunnerThrowsRuntimeExceptionIfNoLoggerIsSpecified/package2.php
@@ -4,7 +4,7 @@ interface pkg2FooI extends pkg1FooI {
 }
 
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
+++ b/src/test/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
@@ -4,7 +4,7 @@ interface pkg2FooI extends pkg1FooI {
 }
 
 abstract class pkg2Bar extends pkg1Bar {
-    public static function doIt(Bar $foo = null)
+    public static function doIt(?Bar $foo = null)
     {
         $foo = new pkg1Foobar();
     }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedNumberOfFunctionParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedNumberOfFunctionParameters.php
@@ -3,10 +3,10 @@
  * Function comment block.
  *
  * @param string  $foo    A foo string.
- * @param Bar     $bar    A bar instance.
+ * @param ?Bar    $bar    A bar instance.
  * @param integer $foobar A foobar integer.
  * 
  * @return void
  */
-function pdepend($foo, Bar &$bar = null, $foobar = 23) {
+function pdepend($foo, ?Bar &$bar = null, $foobar = 23) {
 }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedNumberOfMethodParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedNumberOfMethodParameters.php
@@ -5,11 +5,11 @@ class PHP_Depend_Parser
      * Method comment block.
      *
      * @param string  $foo    A foo string.
-     * @param Bar     $bar    A bar instance.
+     * @param ?Bar    $bar    A bar instance.
      * @param integer $foobar A foobar integer.
      * 
      * @return void
      */
-    public function parse($foo, Bar &$bar = null, $foobar = 23) {
+    public function parse($foo, ?Bar &$bar = null, $foobar = 23) {
     }
 }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedPositionOfFunctionParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedPositionOfFunctionParameters.php
@@ -3,10 +3,10 @@
  * Function comment block.
  *
  * @param string  $foo    A foo string.
- * @param Bar     $bar    A bar instance.
+ * @param ?Bar    $bar    A bar instance.
  * @param integer $foobar A foobar integer.
  * 
  * @return void
  */
-function pdepend($foo, Bar &$bar = null, $foobar = 23) {
+function pdepend($foo, ?Bar &$bar = null, $foobar = 23) {
 }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedPositionOfMethodParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedPositionOfMethodParameters.php
@@ -5,11 +5,11 @@ class PHP_Depend_Parser
      * Method comment block.
      *
      * @param string  $foo    A foo string.
-     * @param Bar     $bar    A bar instance.
+     * @param ?Bar    $bar    A bar instance.
      * @param integer $foobar A foobar integer.
      * 
      * @return void
      */
-    public function parse($foo, Bar &$bar = null, $foobar = 23) {
+    public function parse($foo, ?Bar &$bar = null, $foobar = 23) {
     }
 }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedTypeHintsForFunctionParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedTypeHintsForFunctionParameters.php
@@ -3,10 +3,10 @@
  * Function comment block.
  *
  * @param string  $foo    A foo string.
- * @param Bar     $bar    A bar instance.
+ * @param ?Bar    $bar    A bar instance.
  * @param integer $foobar A foobar integer.
  * 
  * @return void
  */
-function pdepend($foo, Bar &$bar = null, $foobar = 23) {
+function pdepend($foo, ?Bar &$bar = null, $foobar = 23) {
 }

--- a/src/test/resources/files/issues/032/testParserSetsExpectedTypeHintsForMethodParameters.php
+++ b/src/test/resources/files/issues/032/testParserSetsExpectedTypeHintsForMethodParameters.php
@@ -5,11 +5,11 @@ class PHP_Depend_Parser
      * Method comment block.
      *
      * @param string  $foo    A foo string.
-     * @param Bar     $bar    A bar instance.
+     * @param ?Bar    $bar    A bar instance.
      * @param integer $foobar A foobar integer.
      * 
      * @return void
      */
-    public function parse($foo, Bar &$bar = null, $foobar = 23) {
+    public function parse($foo, ?Bar &$bar = null, $foobar = 23) {
     }
 }

--- a/src/test/resources/files/issues/032/testParserSetsFunctionParametersInExpectedOrder.php
+++ b/src/test/resources/files/issues/032/testParserSetsFunctionParametersInExpectedOrder.php
@@ -3,10 +3,10 @@
  * Function comment block.
  *
  * @param string  $foo    A foo string.
- * @param Bar     $bar    A bar instance.
+ * @param ?Bar    $bar    A bar instance.
  * @param integer $foobar A foobar integer.
  * 
  * @return void
  */
-function pdepend($foo, Bar &$bar = null, $foobar = 23) {
+function pdepend($foo, ?Bar &$bar = null, $foobar = 23) {
 }

--- a/src/test/resources/files/issues/032/testParserSetsMethodParametersInExpectedOrder.php
+++ b/src/test/resources/files/issues/032/testParserSetsMethodParametersInExpectedOrder.php
@@ -5,11 +5,11 @@ class PHP_Depend_Parser
      * Method comment block.
      *
      * @param string  $foo    A foo string.
-     * @param Bar     $bar    A bar instance.
+     * @param ?Bar    $bar    A bar instance.
      * @param integer $foobar A foobar integer.
      * 
      * @return void
      */
-    public function parse($foo, Bar &$bar = null, $foobar = 23) {
+    public function parse($foo, ?Bar &$bar = null, $foobar = 23) {
     }
 }

--- a/src/test/resources/files/issues/067-026-parameter-__toString.php
+++ b/src/test/resources/files/issues/067-026-parameter-__toString.php
@@ -1,3 +1,3 @@
 <?php
-function foo_067_026(FilterIterator $bar = null) {}
+function foo_067_026(?FilterIterator $bar = null) {}
 ?>

--- a/src/test/resources/files/issues/067-027-parameter-__toString.php
+++ b/src/test/resources/files/issues/067-027-parameter-__toString.php
@@ -1,3 +1,3 @@
 <?php
-function foo_067_027(array $bar = null) {}
+function foo_067_027(?array $bar = null) {}
 ?>


### PR DESCRIPTION
Type: bugfix / refactoring
Breaking change: no

This fixes various things that are marked as deprecated in PHP 8.4:
- Implicit nullable
- Setting static properties using `ReflectionProperty`