### PR TITLE
Return type will change

### DIFF
--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -76,10 +76,8 @@ class CompositeFilter implements Filter
      *
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
-     *
-     * @return bool
      */
-    public function accept($relative, $absolute)
+    public function accept($relative, $absolute): bool
     {
         foreach ($this->filters as $filter) {
             if (!$filter->accept($relative, $absolute)) {

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -81,10 +81,8 @@ class ExcludePathFilter implements Filter
      *
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
-     *
-     * @return bool
      */
-    public function accept($relative, $absolute)
+    public function accept($relative, $absolute): bool
     {
         return $this->notRelative($relative) && $this->notAbsolute($absolute);
     }

--- a/src/main/php/PDepend/Input/ExtensionFilter.php
+++ b/src/main/php/PDepend/Input/ExtensionFilter.php
@@ -73,10 +73,8 @@ class ExtensionFilter implements Filter
      *
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
-     *
-     * @return bool
      */
-    public function accept($relative, $absolute)
+    public function accept($relative, $absolute): bool
     {
         if (strpos($absolute, 'php://') === 0) {
             return true;

--- a/src/main/php/PDepend/Input/Filter.php
+++ b/src/main/php/PDepend/Input/Filter.php
@@ -55,8 +55,6 @@ interface Filter
      *
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
-     *
-     * @return bool
      */
-    public function accept($relative, $absolute);
+    public function accept($relative, $absolute): bool;
 }

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -43,7 +43,6 @@
 namespace PDepend\Input;
 
 use FilterIterator;
-use ReturnTypeWillChange;
 use SplFileInfo;
 
 /**
@@ -87,11 +86,8 @@ class Iterator extends FilterIterator
 
     /**
      * Returns <b>true</b> if the file name ends with '.php'.
-     *
-     * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function accept()
+    public function accept(): bool
     {
         if ($this->getInnerIterator()->current()->isDir()) {
             return false;

--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -46,7 +46,6 @@ namespace PDepend\Metrics;
 
 use ArrayIterator;
 use FilterIterator;
-use ReturnTypeWillChange;
 
 /**
  * Filter iterator that only returns enabled {@link Analyzer}
@@ -71,11 +70,8 @@ class AnalyzerIterator extends FilterIterator
 
     /**
      * Returns <b>true</b> when the current analyzer instance is enabled.
-     *
-     * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function accept()
+    public function accept(): bool
     {
         return $this->getInnerIterator()->current()->isEnabled();
     }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -48,7 +48,6 @@ use Countable;
 use Iterator;
 use OutOfBoundsException;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
-use ReturnTypeWillChange;
 
 /**
  * Iterator for code nodes.
@@ -114,11 +113,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Returns the number of {@link ASTArtifact}
      * objects in this iterator.
-     *
-     * @return int
      */
-    #[ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->artifacts);
     }
@@ -128,8 +124,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @return false|T
      */
-    #[ReturnTypeWillChange]
-    public function current()
+    public function current(): false|ASTArtifact
     {
         if ($this->offset >= $this->count) {
             return false;
@@ -139,44 +134,32 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
 
     /**
      * Returns the name of the current {@link ASTArtifact}.
-     *
-     * @return string
      */
-    #[ReturnTypeWillChange]
-    public function key()
+    public function key(): string
     {
         return $this->artifacts[$this->offset]->getName();
     }
 
     /**
      * Moves the internal pointer to the next {@link ASTArtifact}.
-     *
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         ++$this->offset;
     }
 
     /**
      * Rewinds the internal pointer.
-     *
-     * @return void
      */
-    #[ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         $this->offset = 0;
     }
 
     /**
      * Returns <b>true</b> while there is a next {@link ASTArtifact}.
-     *
-     * @return bool
      */
-    #[ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return ($this->offset < $this->count);
     }
@@ -192,8 +175,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
      */
-    #[ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->artifacts[$offset]);
     }
@@ -210,8 +192,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php
      */
-    #[ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): ASTArtifact
     {
         if (isset($this->artifacts[$offset])) {
             return $this->artifacts[$offset];
@@ -232,8 +213,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
      */
-    #[ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new BadMethodCallException('Not supported operation.');
     }
@@ -245,13 +225,10 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @throws BadMethodCallException
      *
-     * @return void
-     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetunset.php
      */
-    #[ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new BadMethodCallException('Not supported operation.');
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -165,7 +165,6 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Log;
 use PDepend\Util\Type;
-use ReturnTypeWillChange;
 
 /**
  * Default code tree builder implementation.
@@ -2147,8 +2146,7 @@ class PHPBuilder implements Builder
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    #[ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): ASTArtifactList
     {
         return $this->getNamespaces();
     }

--- a/src/test/php/PDepend/Input/DummyFilter.php
+++ b/src/test/php/PDepend/Input/DummyFilter.php
@@ -79,9 +79,8 @@ class DummyFilter implements Filter
      *
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
-     * @return boolean
      */
-    public function accept($relative, $absolute)
+    public function accept($relative, $absolute): bool
     {
         $this->invoked = true;
 


### PR DESCRIPTION
Correct the return types for functions where `ReturnTypeWillChange` was used to suppres the type violation warning.

Depends on:
- https://github.com/pdepend/pdepend/pull/727