### PR TITLE
Remove unused parser toggles

### DIFF
--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1799,16 +1799,6 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * Return true if current PHP level supports keys in lists.
-     *
-     * @return bool
-     */
-    protected function supportsKeysInList()
-    {
-        return false;
-    }
-
-    /**
      * This method parses a single list-statement node.
      *
      * @return ASTListExpression
@@ -1867,19 +1857,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * Return true if the current node can be used as a list key.
-     *
-     * @param ASTNode|null $node
-     * @return bool
-     */
-    protected function canBeListKey($node)
-    {
-        return !$this->isReadWriteVariable($node);
-    }
-
-    /**
      * Parse individual slot of a list() expression.
-     *
      * @return ASTNode
      */
     private function parseListSlotExpression()
@@ -1887,11 +1865,7 @@ abstract class AbstractPHPParser
         $startToken = $this->tokenizer->currentToken();
         $node = $this->parseOptionalExpression();
 
-        if ($node && $this->canBeListKey($node) && $this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
-            if (!$this->supportsKeysInList()) {
-                throw $this->getUnexpectedTokenException($startToken);
-            }
-
+        if ($node && $this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
             $this->consumeComments();
             $this->consumeToken(Tokens::T_DOUBLE_ARROW);
             $this->consumeComments();
@@ -5424,16 +5398,6 @@ abstract class AbstractPHPParser
     abstract protected function parseArray(ASTArray $array, $static = false);
 
     /**
-     * Return true if [, $foo] or [$foo, , $bar] is allowed.
-     *
-     * @return bool
-     */
-    protected function canHaveCommaBetweenArrayElements()
-    {
-        return false;
-    }
-
-    /**
      * Parses all elements in an array.
      *
      * @param int $endDelimiter
@@ -5449,7 +5413,7 @@ abstract class AbstractPHPParser
         $this->consumeComments();
 
         while ($endDelimiter !== $this->tokenizer->peek()) {
-            while ($this->canHaveCommaBetweenArrayElements() && Tokens::T_COMMA === $this->tokenizer->peek()) {
+            while (Tokens::T_COMMA === $this->tokenizer->peek()) {
                 $this->consumeToken(Tokens::T_COMMA);
                 $this->consumeComments();
             }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -74,24 +74,6 @@ use PDepend\Source\Tokenizer\Tokens;
 abstract class PHPParserVersion72 extends AbstractPHPParser
 {
     /**
-     * use Foo\Bar\{TestA, TestB,} trailing comma is supported since PHP 7.2
-     */
-    protected function allowUseGroupDeclarationTrailingComma(): bool
-    {
-        return true;
-    }
-
-    /**
-     * Return true if current PHP level supports keys in lists.
-     *
-     * @return bool
-     */
-    protected function supportsKeysInList()
-    {
-        return true;
-    }
-
-    /**
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
      * @param int $tokenType
@@ -225,16 +207,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
         } while ($repeat === true);
     }
 
-    /**
-     * Return true if [, $foo] or [$foo, , $bar] is allowed.
-     *
-     * @return bool
-     */
-    protected function canHaveCommaBetweenArrayElements()
-    {
-        return true;
-    }
-
     private function consumeQuestionMark(): void
     {
         if ($this->tokenizer->peek() === Tokens::T_QUESTION_MARK) {
@@ -264,18 +236,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
         }
 
         return $modifiers;
-    }
-
-    /**
-     * Return true if the current node can be used as a list key.
-     *
-     * @param ASTExpression|null $node
-     * @return bool
-     */
-    protected function canBeListKey($node)
-    {
-        // Starting with PHP 7.1, any expression can be used as list key
-        return true;
     }
 
     /**
@@ -698,9 +658,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                     $this->consumeToken($nextToken);
             }
 
-            if ($this->allowUseGroupDeclarationTrailingComma() &&
-                Tokens::T_CURLY_BRACE_CLOSE === $this->tokenizer->peek()
-            ) {
+            if (Tokens::T_CURLY_BRACE_CLOSE === $this->tokenizer->peek()) {
                 break;
             }
 


### PR DESCRIPTION
Type: refactoring
Breaking change: no

These where there for backwards comparability to allow the parser to run at a lower feature level. Since we have already removed the relevant classes we can now also remove the flags.