### PR TITLE
Simple return types corrections

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -78,7 +78,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * An <b>array</b> with all constant declarators defined in this class or interface.
      *
-     * @var array<string, mixed>
+     * @var array<string, ASTConstantDeclarator>
      */
     protected $constantDeclarators = null;
 
@@ -222,7 +222,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns an <b>array</b> with all constant declarators defined in this class or interface.
      *
-     * @return array<string, mixed>
+     * @return array<string, ASTConstantDeclarator>
      */
     public function getConstantDeclarators()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5386,7 +5386,7 @@ abstract class AbstractPHPParser
      * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return ASTExpression
+     * @return ASTCompoundVariable|ASTVariableVariable|ASTVariable
      *
      * @since 0.9.6
      */
@@ -5440,7 +5440,7 @@ abstract class AbstractPHPParser
      * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return ASTExpression
+     * @return ASTCompoundVariable|ASTVariableVariable
      *
      * @since 0.9.6
      */

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -82,7 +82,7 @@ interface Tokenizer
      * Returns the next token or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return int|Token
+     * @return Tokenizer::T_*|Token
      */
     public function next();
 
@@ -111,7 +111,7 @@ interface Tokenizer
      * @return int
      */
     public function peek();
-    
+
     /**
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.


### PR DESCRIPTION
Type: documentation
Breaking change: no

Correct a few incorrect types picked up by PHPStan at level 7. Resolves 3/34 remaining issues.