### PR TITLE
Check log option type

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -216,10 +216,10 @@ class Application
 
         foreach ($loggerServices as $loggerServiceTags) {
             foreach ($loggerServiceTags as $loggerServiceTag) {
-                if (isset($loggerServiceTag['option']) && isset($loggerServiceTag['message'])) {
+                if (isset($loggerServiceTag['option'], $loggerServiceTag['message']) && is_string($loggerServiceTag['option']) && is_string($loggerServiceTag['message'])) {
                     $options[$loggerServiceTag['option']] = array(
                         'message' => $loggerServiceTag['message'],
-                        'value' => isset($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file'
+                        'value' => isset($loggerServiceTag['value']) && is_string($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file'
                     );
                 }
             }


### PR DESCRIPTION
Type: refactor
Breaking change: no

Check that the values are strings before accepting them. Resolves 1/40 remaining PHPStan level 7 issues.
As a later refactor for 3.x it would be nice to use DTOs for things like this rather then associative arrays. I can look in to that once we get the higher levels passing.