### PR TITLE
Correct ASTArtifact not actually extending ASTNode

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -55,14 +55,6 @@ namespace PDepend\Source\AST;
 class ASTAnonymousClass extends ASTClass implements ASTNode
 {
     /**
-     * The parent node of this node or <b>null</b> when this node is the root
-     * of a node tree.
-     *
-     * @var ASTNode|null
-     */
-    protected $parent = null;
-
-    /**
      * Metadata for this node instance, serialized in a string. This string
      * contains the start, end line, and the start, end column and the node
      * image in a colon separated string.
@@ -179,47 +171,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
         $this->setMetadataInteger(1, $endLine);
         $this->setMetadataInteger(2, $startColumn);
         $this->setMetadataInteger(3, $endColumn);
-    }
-
-    /**
-     * Returns the parent node of this node or <b>null</b> when this node is
-     * the root of a node tree.
-     *
-     * @return ?ASTNode
-     */
-    public function getParent()
-    {
-        return $this->parent;
-    }
-
-    /**
-     * Sets the parent node of this node.
-     */
-    public function setParent(ASTNode $node): void
-    {
-        $this->parent = $node;
-    }
-
-    /**
-     * Traverses up the node tree and finds all parent nodes that are instances
-     * of <b>$parentType</b>.
-     *
-     * @param string $parentType
-     *
-     * @return ASTNode[]
-     */
-    public function getParentsOfType($parentType)
-    {
-        $parents = [];
-
-        $parentNode = $this->parent;
-        while (is_object($parentNode)) {
-            if ($parentNode instanceof $parentType) {
-                array_unshift($parents, $parentNode);
-            }
-            $parentNode = $parentNode->getParent();
-        }
-        return $parents;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -42,15 +42,13 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
-
 /**
  * Abstract base class for code item.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-interface ASTArtifact /* extends ASTNode */
+interface ASTArtifact extends ASTNode
 {
     /**
      * Returns the artifact name.
@@ -67,15 +65,4 @@ interface ASTArtifact /* extends ASTNode */
      * @return string
      */
     public function getId();
-
-    /**
-     * ASTVisitor method for node tree traversal.
-     *
-     * @template T of array<string, mixed>|string|null
-     *
-     * @param T $data
-     *
-     * @return T
-     */
-    public function accept(ASTVisitor $visitor, $data = null);
 }

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -48,7 +48,7 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-interface ASTCallable
+interface ASTCallable extends ASTNode
 {
     /**
      * @return ASTType

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -291,6 +291,11 @@ class ASTCompilationUnit extends AbstractASTArtifact
         $this->childNodes[$artifact->getId()] = $artifact;
     }
 
+    public function getChildren()
+    {
+        return $this->childNodes;
+    }
+
     /**
      * Returns the start line number for this source file. For an existing file
      * this value must always be <em>1</em>, while it can be <em>0</em> for a

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -52,12 +52,7 @@ use InvalidArgumentException;
  */
 class ASTMethod extends AbstractASTCallable
 {
-    /**
-     * The parent type object.
-     *
-     * @var AbstractASTClassOrInterface
-     */
-    protected $parent = null;
+    protected ?AbstractASTClassOrInterface $parentClass = null;
 
     /**
      * Defined modifiers for this property node.
@@ -194,7 +189,7 @@ class ASTMethod extends AbstractASTCallable
      */
     public function getParent()
     {
-        return $this->parent;
+        return $this->parentClass;
     }
 
     /**
@@ -202,9 +197,9 @@ class ASTMethod extends AbstractASTCallable
      *
      * @param AbstractASTClassOrInterface|null $parent
      */
-    public function setParent(?AbstractASTType $parent = null): void
+    public function setParent(?ASTNode $parent): void
     {
-        $this->parent = $parent;
+        $this->parentClass = $parent;
     }
 
     /**
@@ -218,10 +213,10 @@ class ASTMethod extends AbstractASTCallable
      */
     public function getCompilationUnit()
     {
-        if ($this->parent === null) {
+        if ($this->parentClass === null) {
             throw new ASTCompilationUnitNotFoundException($this);
         }
 
-        return $this->parent->getCompilationUnit();
+        return $this->parentClass->getCompilationUnit();
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -45,6 +45,7 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is an abstract base implementation of the ast node interface.
@@ -56,6 +57,17 @@ use OutOfBoundsException;
  */
 interface ASTNode
 {
+    /**
+     * ASTVisitor method for node tree traversal.
+     *
+     * @template T of array<string, mixed>|numeric-string
+     *
+     * @param T $data
+     *
+     * @return T
+     */
+    public function accept(ASTVisitor $visitor, $data = []);
+
     /**
      * Returns the source image of this ast node.
      *
@@ -96,7 +108,7 @@ interface ASTNode
      *
      * @param int $index
      *
-     * @return AbstractASTNode|ASTArtifact
+     * @return ASTNode
      *
      * @throws OutOfBoundsException When no node exists at the given index.
      */
@@ -105,7 +117,7 @@ interface ASTNode
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return (AbstractASTNode|ASTArtifact)[]
+     * @return ASTNode[]
      */
     public function getChildren();
 
@@ -148,7 +160,7 @@ interface ASTNode
     /**
      * Sets the parent node of this node.
      */
-    public function setParent(ASTNode $node): void;
+    public function setParent(?ASTNode $node): void;
 
     /**
      * Traverses up the node tree and finds all parent nodes that are instances

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -191,59 +191,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     }
 
     /**
-     * This method will search recursive for the first child node that is an
-     * instance of the given <b>$targetType</b>. The returned value will be
-     * <b>null</b> if no child exists for that.
-     *
-     * @template T of ASTNode
-     *
-     * @param class-string<T> $targetType Searched class or interface type.
-     *
-     * @return T|null
-     *
-     * @access private
-     *
-     * @since  0.9.6
-     */
-    public function getFirstChildOfType($targetType)
-    {
-        foreach ($this->nodes as $node) {
-            if ($node instanceof $targetType) {
-                return $node;
-            }
-            if (($child = $node->getFirstChildOfType($targetType)) !== null) {
-                return $child;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Will find all children for the given type.
-     *
-     * @template T of ASTNode
-     *
-     * @param class-string<T> $targetType Searched class or interface type.
-     * @param T[]             $results    The found children.
-     *
-     * @return T[]
-     *
-     * @access private
-     *
-     * @since  0.9.6
-     */
-    public function findChildrenOfType($targetType, array &$results = [])
-    {
-        foreach ($this->nodes as $node) {
-            if ($node instanceof $targetType) {
-                $results[] = $node;
-            }
-            $node->findChildrenOfType($targetType, $results);
-        }
-        return $results;
-    }
-
-    /**
      * Returns the tokens found in the function body.
      *
      * @return array<mixed>

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -482,7 +482,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Sets the parent node of this node.
      */
-    public function setParent(ASTNode $node): void
+    public function setParent(?ASTNode $node): void
     {
         $this->parent = $node;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1949,7 +1949,7 @@ abstract class AbstractPHPParser
     /**
      * Parse individual slot of a list() expression.
      *
-     * @return ASTListExpression|ASTNode
+     * @return ASTNode
      */
     private function parseListSlotExpression()
     {
@@ -6098,7 +6098,7 @@ abstract class AbstractPHPParser
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
      *
-     * @return ASTFormalParameter|ASTNode
+     * @return ASTNode
      */
     protected function parseFormalParameterOrPrefix(ASTCallable $callable)
     {
@@ -6585,7 +6585,7 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional statement or returns <b>null</b>.
      *
-     * @return AbstractASTClassOrInterface|ASTCallable|ASTNode|null
+     * @return ASTNode|null
      *
      * @throws ParserException
      *
@@ -8234,7 +8234,7 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return AbstractASTNode|null
+     * @return ASTNode|null
      */
     private function parseEnumCaseValue()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -44,7 +44,6 @@ namespace PDepend\Source\Language\PHP;
 
 use BadMethodCallException;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\AbstractASTType;
 use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTAnonymousClass;
@@ -2590,12 +2589,12 @@ class PHPBuilder implements Builder
     /**
      * Builds an enum definition.
      *
-     * @param string           $name  The enum case name.
-     * @param ?AbstractASTNode $value The enum case value if backed.
+     * @param string   $name  The enum case name.
+     * @param ?ASTNode $value The enum case value if backed.
      *
      * @return ASTEnumCase The created class object.
      */
-    public function buildEnumCase($name, ?AbstractASTNode $value = null)
+    public function buildEnumCase($name, ?ASTNode $value = null)
     {
         $this->checkBuilderState();
 

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -394,7 +394,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
     {
         $class = $this->getFirstClassForTestCase();
-        $this->assertCount(2, $class->getChildren());
+        $this->assertCount(3, $class->getChildren());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -671,7 +671,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
     {
         $interface = $this->getFirstInterfaceForTestCase();
-        $this->assertCount(2, $interface->getChildren());
+        $this->assertCount(3, $interface->getChildren());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -290,7 +290,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
     {
         $trait = $this->getFirstTraitForTest();
-        $this->assertCount(2, $trait->getChildren());
+        $this->assertCount(3, $trait->getChildren());
     }
 
     /**


### PR DESCRIPTION
Type: bugfix / refactoring
Breaking change: yes

This resolves the issue where the `ASTArtifact` interface does not actually extend the `ASTNode`.

https://github.com/pdepend/pdepend/blob/2be3cbbdbb4d4397b0b8e7511090ab9f41cbc7ae/src/main/php/PDepend/Source/AST/ASTArtifact.php#L53

This also fixes Classes, Interfaces, and Traits not seeing there methods as children and needing some workarounds. Previously they where returning the wrong count which has now been corrected by this.

Also this resolves various type issues where multiple types had to be hinted as either expected or returned as some types did not implement `ASTNode`. This lead to a situation where I'm not sure it would have been feasible to get things to pass under PHPStan level 7, but these are now resolved with this PR.
The same issue prevents PHPMD from progressing past level 5.

Lastly this also takes care of on of the last two functions marked for deprecation.