### PR TITLE
Apply CS: phpdoc_types_order

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -184,7 +184,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Offset to retrieve
      *
-     * @param string|int $offset
+     * @param int|string $offset
      *
      * @throws OutOfBoundsException
      *
@@ -204,7 +204,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Offset to set
      *
-     * @param string|int $offset
+     * @param int|string $offset
      * @param T $value
      *
      * @throws BadMethodCallException

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -98,14 +98,14 @@ interface ASTNode
      *
      * @throws OutOfBoundsException When no node exists at the given index.
      *
-     * @return ASTArtifact|AbstractASTNode
+     * @return AbstractASTNode|ASTArtifact
      */
     public function getChild($index);
 
     /**
      * This method returns all direct children of the actual node.
      *
-     * @return (ASTArtifact|AbstractASTNode)[]
+     * @return (AbstractASTNode|ASTArtifact)[]
      */
     public function getChildren();
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4847,7 +4847,7 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node Node that represents the image of the method postfix node.
      *
-     * @return ASTMethodPostfix|ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|ASTMethodPostfix
      *
      * @since 1.0.0
      */
@@ -7136,7 +7136,7 @@ abstract class AbstractPHPParser
     /**
      * @param array<string> $fragments
      *
-     * @return string|false
+     * @return false|string
      */
     protected function parseNamespaceImage(array $fragments)
     {
@@ -8207,7 +8207,7 @@ abstract class AbstractPHPParser
     /**
      * @param string $numberRepresentation
      *
-     * @return string|float|int
+     * @return float|int|string
      */
     private function getNumberFromImage($numberRepresentation)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -831,7 +831,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array<int|string> $token
      * @param string            $namespace
      *
-     * @return array<int, array<int, string|int>>
+     * @return array<int, array<int, int|string>>
      */
     private function splitRelativeNameToken($token, $namespace)
     {


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the phpdoc_types_order rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.