### PR TITLE
Apply CS: phpdoc_align

### DIFF
--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -62,6 +62,7 @@ class PdependExtension extends SymfonyExtension
      * @param array<array<array<array<string>>>> $configs
      *
      * @return void
+     *
      * {@inheritDoc}
      */
     public function load(array $configs, ContainerBuilder $container)

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -211,7 +211,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param string   $typeIdentifier
+     * @param string $typeIdentifier
      *
      * @return void
      */

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -303,7 +303,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int $index
+     * @param int    $index
      * @param string $value
      *
      * @return void

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -205,7 +205,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Offset to set
      *
      * @param string|int $offset
-     * @param T $value
+     * @param T          $value
      *
      * @throws BadMethodCallException
      *

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -296,7 +296,7 @@ abstract class AbstractASTNode implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int $index
+     * @param int    $index
      * @param string $value
      *
      * @return void

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -172,7 +172,7 @@ interface ASTVisitor
      * @template T of array<string, mixed>|numeric-string
      *
      * @param ASTNode $node
-     * @param T $value
+     * @param T       $value
      *
      * @return T
      */

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2806,8 +2806,8 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      *
-     * @param T   $node
-     * @param int $closeToken
+     * @param T        $node
+     * @param int      $closeToken
      * @param int|null $separatorToken
      *
      * @throws TokenStreamEndException
@@ -5330,7 +5330,7 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      *
-     * @param T $node The context parent node.
+     * @param T    $node   The context parent node.
      * @param bool $inCall
      *
      * @return T The prepared entire node.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2485,7 +2485,7 @@ class PHPBuilder implements Builder
      * @template T of AbstractASTType
      *
      * @param array<string, array<string, array<string, T>>> $originalTypes The original types created during the parsing
-     *                                                                   process.
+     *                                                                      process.
      *
      * @return array<string, array<string, array<string, T>>>
      */


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the phpdoc_align rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.