### PR TITLE
Apply CS: phpdoc_scalar

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -70,7 +70,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     /**
      * Collected cohesion metrics for classes.
      *
-     * @var array<string, array<string, integer>>
+     * @var array<string, array<string, int>>
      */
     private $nodeMetrics = array();
 
@@ -87,7 +87,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * )
      * </code>
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -140,7 +140,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * for the given <b>$node</b>. If there are no metrics for the requested
      * node, this method will return an empty <b>array</b>.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
@@ -153,7 +153,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Provides the project summary metrics as an <b>array</b>.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getProjectMetrics()
     {
@@ -248,9 +248,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a boolean AND-expression.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -264,9 +264,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a boolean OR-expression.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -280,9 +280,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a switch label.
      *
      * @param ASTSwitchLabel         $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -299,9 +299,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a catch statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -317,9 +317,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits an elseif statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -335,9 +335,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a for statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -353,9 +353,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a foreach statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -371,9 +371,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits an if statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -389,9 +389,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a logical AND expression.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -405,9 +405,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a logical OR expression.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -421,9 +421,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a ternary operator.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -439,9 +439,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a while-statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.8
      */
@@ -457,9 +457,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * Visits a do/while-statement.
      *
      * @param ASTNode                $node The currently visited node.
-     * @param array<string, integer> $data The previously calculated ccn values.
+     * @param array<string, int> $data The previously calculated ccn values.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      *
      * @since  0.9.12
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -103,7 +103,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * for the given <b>$node</b> (n1, n2, N1, N2). If there are no metrics for
      * the requested node, this method will return an empty <b>array</b>.
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getNodeBasisMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -117,14 +117,14 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     /**
      * Number of all root classes within the analyzed source code.
      *
-     * @var array<string, boolean>
+     * @var array<string, bool>
      */
     private $roots = array();
 
     /**
      * Number of all none leaf classes within the analyzed source code
      *
-     * @var array<string, boolean>
+     * @var array<string, bool>
      */
     private $noneLeafs = array();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -85,7 +85,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * analyzed system. The array size is equal to the number of analyzed root
      * classes.
      *
-     * @var array<integer>
+     * @var array<int>
      */
     private $rootClasses = array();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -95,7 +95,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
     /**
      * Collected project metrics.
      *
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     private $projectMetrics = array(
         self::M_LINES_OF_CODE              =>  0,
@@ -139,7 +139,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
@@ -161,7 +161,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * )
      * </code>
      *
-     * @return array<string, integer>
+     * @return array<string, int>
      */
     public function getProjectMetrics()
     {
@@ -414,7 +414,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * @param array<int, Token> $tokens The raw token stream.
      * @param bool              $search Optional boolean flag, search start.
      *
-     * @return array<int, integer>
+     * @return array<int, int>
      */
     private function linesOfCode(array $tokens, $search = false)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -235,7 +235,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Mapping between php internal tokens and php depend tokens.
      *
-     * @var array<int, integer>
+     * @var array<int, int>
      */
     protected static $tokenMap = array(
         T_AS                        => Tokens::T_AS,
@@ -387,7 +387,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Mapping between php internal text tokens an php depend numeric tokens.
      *
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     protected static $literalMap = array(
         '@'              =>  Tokens::T_AT,
@@ -566,7 +566,7 @@ class PHPTokenizerInternal implements FullTokenizer
     );
 
     /**
-     * @var array<int, array<int, array<string, integer|string>>>
+     * @var array<int, array<int, array<string, int|string>>>
      */
     protected static $reductionMap = array(
         Tokens::T_CONCAT => array(
@@ -1085,7 +1085,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * returns the collected content. The returned value will be null if there
      * was no none php token.
      *
-     * @param array<array<int, integer|string>|string> $tokens Reference to the current token stream.
+     * @param array<array<int, int|string>|string> $tokens Reference to the current token stream.
      *
      * @return string|null
      */

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -142,7 +142,7 @@ class CloverReport implements Report
      *
      * @param string $fileName The source file name.
      *
-     * @return array<boolean>
+     * @return array<bool>
      */
     private function getLines($fileName)
     {


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the phpdoc_scalar rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.