### PR TITLE
Apply CS: phpdoc_separation

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -84,6 +84,7 @@ class ASTArguments extends AbstractASTNode
      * This method can be used to mark the argument list as variadic placeholder
      *
      * @return void
+     *
      * @since 2.11.0
      */
     public function setVariadicPlaceholder()

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -56,6 +56,7 @@ use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @template T of ASTArtifact
+ *
  * @implements \Iterator<int|string, T>
  * @implements \ArrayAccess<int|string, T>
  */
@@ -123,6 +124,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Returns the current node
      *
      * @throws \OutOfBoundsException
+     *
      * @return T
      */
     public function current(): false|ASTArtifact

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -50,6 +50,7 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  * This class represents an intersection type
  *
  * @see https://php.watch/versions/8.1/intersection-types
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -146,6 +146,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @param AbstractASTNode $node A parsed child node instance.
      *
      * @return void
+     *
      * @access private
      *
      * @since  0.9.6
@@ -177,6 +178,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @param class-string<T> $targetType Searched class or interface type.
      *
      * @return T|null
+     *
      * @access private
      *
      * @since  0.9.6
@@ -203,6 +205,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @param T[]             $results    The found children.
      *
      * @return T[]
+     *
      * @access private
      *
      * @since  0.9.6

--- a/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
@@ -48,6 +48,7 @@ namespace PDepend\Source\AST;
  * This class represents an intersection type
  *
  * @see https://php.watch/versions/8.1/intersection-types
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -157,6 +157,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Adds a parsed child node to this node.
      *
      * @return void
+     *
      * @access private
      */
     public function addChild(ASTNode $node)
@@ -207,6 +208,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * @param class-string<T> $targetType Searched class or interface type.
      *
      * @return T|null
+     *
      * @access private
      *
      * @todo   Refactor $_methods property to getAllMethods() when it exists.
@@ -241,6 +243,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * @param R[]             $results    The found children.
      *
      * @return T[]
+     *
      * @access private
      *
      * @todo   Refactor $_methods property to getAllMethods() when it exists.

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -163,6 +163,7 @@ use PDepend\Util\Cache\CacheDriver;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @template T of mixed
+ *
  * @extends \IteratorAggregate<T>
  */
 interface Builder extends IteratorAggregate

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8155,6 +8155,7 @@ abstract class AbstractPHPParser
      * Peek the next token if it's of the given type, add it to current tokenStack, and return it if so.
      *
      * @param string $type
+     *
      * @psalm-param Tokens::T_* $type
      *
      * @return Token|null
@@ -8277,6 +8278,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param string $type
+     *
      * @psalm-param Tokens::T_* $type
      *
      * @return string


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the phpdoc_separation rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.