### PR TITLE
Apply CS: no_unused_imports

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * An instance of this class represents an object allocation.

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php class node.

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -45,7 +45,6 @@
 namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents arguments as they are supplied to functions or

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an array expression.

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a single array element expression.

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a array-expression.

--- a/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents any kind of assignment.

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a boolean and-expression.

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a boolean or-expression.

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a break-statement.

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a cast-expression node.

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a catch-statement.

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -44,7 +44,6 @@ namespace PDepend\Source\AST;
 
 use BadMethodCallException;
 use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php class node.

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents the full qualified class name postfix.

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
 
 /**

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is a classes only version of the class or interface reference .

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a closure-expression.

--- a/src/main/php/PDepend/Source/AST/ASTComment.php
+++ b/src/main/php/PDepend/Source/AST/ASTComment.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a comment.

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -42,8 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 use RuntimeException;

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a compound expression node.

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a compound variable node.

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a conditional expression.

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -43,7 +43,6 @@
 namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a single constant definition as it can occure in

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a constant postfix expression..

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a continue-statement.

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a declare-statement.

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a do/while-statement.

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an echo-statement.

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an elseif-statement.

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -44,7 +44,6 @@ namespace PDepend\Source\AST;
 
 use BadMethodCallException;
 use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php class node.

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php enum definition.

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an eval-expression.

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an exit-expression.

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -46,7 +46,6 @@ namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a field or property declaration of a class.

--- a/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a finally-statement.

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represent the init part of a for-statement.

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a for-statement.

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represent the update part of a for-statement.

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a foreach-statement.

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
 use BadMethodCallException;
 use InvalidArgumentException;
 use OutOfBoundsException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a formal parameter within the signature of a function,

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This ast class represents a list for formal parameters. This means the

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
 
 /**

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a function postfix expression.

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a global-statement.

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a goto-statement.

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a here-/nowdoc node.

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * A static identifier as it can be used to access a function, method, constant

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an if-statement.

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a <b>include</b>- or <b>include_once</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an instanceof expression node.

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -43,7 +43,6 @@
 namespace PDepend\Source\AST;
 
 use BadMethodCallException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Representation of a code interface.

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an intersection type

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents an isste-expression/function.

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a label-statement.

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a list-expression.

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a literal node.

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a logical <b>and</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a logical <b>or</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a logical <b>xor</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents match expression argument container.

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a block of elements for a match expression.

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a single match key-expression pair.

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -43,7 +43,6 @@
 namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php method node.

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a method postfix expression..

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class encapsultes any expression.

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Represents a php namespace node.

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * An instance of this class represents a function or method parameter within

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is a special reference container that is used whenever the keyword

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a postfix-expression.

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a pre-decrement-expression.

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a pre-increment-expression.

--- a/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a print node.

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This code class represents a class property.

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a property postfix expression..

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a <b>require</b>- or <b>require_once</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a return statement node.

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents primitive types like integer, float, boolean, string

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a method/function scope.

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a program scope statement.

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
 
 /**

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class encapsultes a shift left expression.

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class encapsultes a shift right expression.

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is node represents a single statement.

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is a special reference container that is used whenever the keyword

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a static variable declaration.

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents PHP strings that can embed various other expressions.

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a <b>string index</b>-expression.

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a switch-label.

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a switch statement.

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a throw-statement.

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -44,8 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
-use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * Representation of a trait.

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a trait adaptation scope.

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a trait adaptation alias.

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a trait adaptation precedence.

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This is a trait only version of the type reference .

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a trait use statement.

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node class represents a try-statement.

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Abstract base class for a type node.

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an array type node.

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a callable type node.

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an array type node.

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents an unary expression node.

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents primitive types like integer, float, boolean, string

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a unset-statement node.

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a variable node.

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This node type represents a variable declarator. A variable declarator always

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a variable variable node.

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a while-statement.

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * This class represents a yield statement node.

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -43,7 +43,6 @@
 namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
-use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -46,7 +46,6 @@ namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
 use OutOfBoundsException;
-use PDepend\Source\AST\ASTTraitUseStatement;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\CacheDriver;

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Source\ASTVisitor;
 
-use PDepend\Source\AST\ASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTEnum;

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -44,7 +44,6 @@ namespace PDepend\Source\ASTVisitor;
 
 use ArrayIterator;
 use Iterator;
-use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTEnum;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -45,9 +45,6 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\Source\AST\ASTClosure;
-use PDepend\Source\AST\ASTFieldDeclaration;
-use PDepend\Source\AST\ASTType;
-use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the no_unused_imports rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.