### PR TITLE
Apply CS: no_superfluous_phpdoc_tags

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -369,8 +369,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     /**
      * Calculates the coupling between the given types.
      *
-     * @param AbstractASTType $coupledType
-     *
      * @return void
      *
      * @since  0.10.2

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -211,8 +211,6 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @throws BadMethodCallException
      *
-     * @return void
-     *
      * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
      */

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -419,8 +419,6 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * This method adds a new child node to this node instance.
      *
-     * @param ASTNode $node
-     *
      * @return void
      */
     public function addChild(ASTNode $node)


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the no_superfluous_phpdoc_tags rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.