### PR TITLE
Apply CS: global_namespace_import

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -122,13 +122,13 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Returns the current node
      *
-     * @throws \OutOfBoundsException
+     * @throws OutOfBoundsException
      * @return T
      */
     public function current(): false|ASTArtifact
     {
         if ($this->offset >= $this->count) {
-            throw new \OutOfBoundsException("The offset does not exist.");
+            throw new OutOfBoundsException("The offset does not exist.");
         }
         return $this->artifacts[$this->offset];
     }

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -48,6 +48,7 @@ use PDepend\DbusUI\ResultPrinter as DbusResultPrinter;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
 use RuntimeException;
+use Throwable;
 
 /**
  * Handles the command line stuff and starts the text ui runner.
@@ -629,7 +630,7 @@ class Command
     }
 
     /**
-     * @param Exception|\Throwable $exception
+     * @param Exception|Throwable $exception
      *
      * @return string
      */


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the global_namespace_import rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.