### PR TITLE
Apply CS: fully_qualified_strict_types

### DIFF
--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -172,8 +172,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
                 $this->parsedFiles,
                 (date('i:s', time() - $this->startTime))
             ),
-            new DBusArray(DBus::STRING, array()),
-            new DBusDict(DBus::VARIANT, array()),
+            new DBusArray(Dbus::STRING, array()),
+            new DBusDict(Dbus::VARIANT, array()),
             1000
         );
     }

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -275,7 +275,7 @@ class Engine
      *
      * @return void
      */
-    public function addReportGenerator(Report\ReportGenerator $generator)
+    public function addReportGenerator(ReportGenerator $generator)
     {
         $this->generators[] = $generator;
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -347,7 +347,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                 case Tokens::T_METHOD_C:
                 case Tokens::T_NS_C:
                 case Tokens::T_DIR:
-                case TOKENS::T_ENCAPSED_AND_WHITESPACE: // content of HEREDOC
+                case Tokens::T_ENCAPSED_AND_WHITESPACE: // content of HEREDOC
                     $operands[] = $token->image;
                     break;
 

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -82,7 +82,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * The context analyzer instance.
      *
-     * @var Analyzer\DependencyAnalyzer
+     * @var DependencyAnalyzer
      */
     private $analyzer = null;
 

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -122,13 +122,13 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Returns the current node
      *
-     * @throws \OutOfBoundsException
+     * @throws OutOfBoundsException
      * @return T
      */
     public function current(): false|ASTArtifact
     {
         if ($this->offset >= $this->count) {
-            throw new \OutOfBoundsException("The offset does not exist.");
+            throw new OutOfBoundsException("The offset does not exist.");
         }
         return $this->artifacts[$this->offset];
     }


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Apply the fully_qualified_strict_types rule to the main code  using php-cs-fixer, done as a single PR to make it easy to evaluate the change so we can better agree if we should have this as a rule going forward.

This rule is part of the Symfony code style.

This was previously applied in https://github.com/pdepend/pdepend/pull/587 but there seems to still be some uncertainty if we want to follow this fule going forward.