### PR TITLE
Add php-cs-fixer to the dev tools

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,0 +1,62 @@
+name: Codestyle
+
+on:
+  push:
+    branches:
+      - "*"
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - '.php-cs-fixer.php'
+      - '.github/workflows/codestyle.yml'
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - '.php-cs-fixer.php'
+      - '.github/workflows/codestyle.yml'
+
+jobs:
+  php-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      COMPOSER_NO_INTERACTION: 1
+
+    strategy:
+      matrix:
+        php: [8.3]
+        dependency-version: [prefer-stable]
+
+    name: Codestyle check
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: composer:v2, cs2pr
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            vendor
+            .php-cs-fixer.cache
+          key: ${{ runner.os }}-php-cs-fixer-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
+
+      - name: Install dependencies
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run PHP Coding Standards Fixer
+        run: |
+          vendor/bin/php-cs-fixer fix --dry-run --diff --ansi || true
+          vendor/bin/php-cs-fixer fix --dry-run --format=checkstyle | cs2pr

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist
 .phpunit.cache
 coverage.xml
 coverage
+.php-cs-fixer.cache

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,28 @@
+<?php
+/*
+ * This document has been generated with
+ * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.4.0|configurator
+ * you can change this configuration by importing this file.
+ */
+$config = new PhpCsFixer\Config();
+return $config
+    ->setRules([
+        'blank_line_after_namespace' => true,
+        'no_empty_phpdoc' => true,
+        'no_leading_import_slash' => true,
+        'phpdoc_indent' => true,
+        'phpdoc_order' => true,
+        'phpdoc_return_self_reference' => true,
+        'phpdoc_single_line_var_spacing' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_var_annotation_correct_order' => true,
+        'single_blank_line_before_namespace' => true,
+        'single_import_per_statement' => true,
+        'single_line_after_imports' => true,
+    ])
+    ->setFinder(PhpCsFixer\Finder::create()
+        ->exclude('vendor')
+        ->in(__DIR__ . '/src/main/php/PDepend')
+    )
+;

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require-dev": {
         "brianium/paratest": "^7.3",
         "easy-doc/easy-doc": "0.0.0|^1.2.3",
+        "friendsofphp/php-cs-fixer": "^3.54",
         "gregwar/rst": "^1.0",
         "phpstan/phpstan": "~1.10.67",
         "phpunit/phpunit": "^10.5.20",


### PR DESCRIPTION
Breaking change: no

This adds the php-cs-fixer tool as a dev dependency, and uses it to check for the rules that we still fully comply with.
Besides being used for checking that a PR complies with the project style it can also be used by a developer to apply the code style by running the following command:

```
vendor/bin/php-cs-fixer fix
```

It is also helpful for applying various upgrades to the code like migrating to never versions of PHPUnit or PHP it self:
```
vendor/bin/php-cs-fixer fix --rules=array_syntax
```

It has a rich config format and can be adjust to fit most style, you can find a handy online tool for doing so here:
https://mlocati.github.io/php-cs-fixer-configurator

The following is a list of what code style the applied rules are part of:

PSR-2+
- blank_line_after_namespace
- single_import_per_statement
- single_line_after_imports

PSR-12+
- blank_lines_before_namespace
- no_leading_import_slash

Symfony
- no_empty_phpdoc
- phpdoc_indent
- phpdoc_order
- phpdoc_return_self_reference
- phpdoc_single_line_var_spacing
- phpdoc_trim
- phpdoc_trim_consecutive_blank_line_separation

Other
- phpdoc_var_annotation_correct_order
