### PR TITLE
Fix return types affecting phpmd

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -160,7 +160,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent()
     {

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -141,7 +141,7 @@ interface ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent();
 
@@ -166,7 +166,7 @@ interface ASTNode
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment();
 

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -221,7 +221,7 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the doc comment for this item or <b>null</b>.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -433,7 +433,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent()
     {
@@ -476,7 +476,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment()
     {


### PR DESCRIPTION
Type: documentation update 
Breaking change: no

This fixes a few PHPDoc types that prevents phpmd from passing PHPStan level 4