### PR TITLE
Apply borring PSR-CS 2.0 code style

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -81,7 +81,7 @@ class Application
     {
         if (!file_exists($configurationFile)) {
             throw new InvalidArgumentException(
-                sprintf('The configuration file "%s" doesn\'t exist.', $configurationFile)
+                sprintf('The configuration file "%s" doesn\'t exist.', $configurationFile),
             );
         }
 
@@ -219,7 +219,7 @@ class Application
                 if (isset($loggerServiceTag['option'], $loggerServiceTag['message']) && is_string($loggerServiceTag['option']) && is_string($loggerServiceTag['message'])) {
                     $options[$loggerServiceTag['option']] = array(
                         'message' => $loggerServiceTag['message'],
-                        'value' => isset($loggerServiceTag['value']) && is_string($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file'
+                        'value' => isset($loggerServiceTag['value']) && is_string($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file',
                     );
                 }
             }

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -160,7 +160,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
         $proxy = $dbus->createProxy(
             "org.freedesktop.Notifications", // connection name
             "/org/freedesktop/Notifications", // object
-            "org.freedesktop.Notifications" // interface
+            "org.freedesktop.Notifications", // interface
         );
         $proxy->Notify(
             'PDepend',
@@ -170,11 +170,11 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
             sprintf(
                 '%d files analyzed in %s minutes...',
                 $this->parsedFiles,
-                (date('i:s', time() - $this->startTime))
+                (date('i:s', time() - $this->startTime)),
             ),
             new DBusArray(Dbus::STRING, array()),
             new DBusDict(Dbus::VARIANT, array()),
-            1000
+            1000,
         );
     }
 

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -72,16 +72,16 @@ class ExtensionManager
             throw new RuntimeException(
                 sprintf(
                     'Cannot find extension class "%s" for PDepend. Maybe the plugin is not installed?',
-                    $className
-                )
+                    $className,
+                ),
             );
         }
 
-        $extension = new $className;
+        $extension = new $className();
 
         if (!($extension instanceof Extension)) {
             throw new RuntimeException(
-                sprintf('Class "%s" is not a valid Extension', $className)
+                sprintf('Class "%s" is not a valid Extension', $className),
             );
         }
 

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -80,7 +80,7 @@ class PdependExtension extends SymfonyExtension
                 }
                 if (!is_a($config['class'], 'PDepend\DependencyInjection\Extension', true)) {
                     throw new RuntimeException(
-                        sprintf('Class "%s" is not a valid Extension', $config['class'])
+                        sprintf('Class "%s" is not a valid Extension', $config['class']),
                     );
                 }
 

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -212,7 +212,7 @@ class Engine
     public function __construct(
         Configuration $configuration,
         CacheFactory $cacheFactory,
-        AnalyzerFactory $analyzerFactory
+        AnalyzerFactory $analyzerFactory,
     ) {
         $this->configuration = $configuration;
 
@@ -592,7 +592,7 @@ class Engine
             $parser = new PHPParserGeneric(
                 $tokenizer,
                 $this->builder,
-                $this->cacheFactory->create()
+                $this->cacheFactory->create(),
             );
             $parser->setMaxNestingLevel($this->configuration->parser->nesting);
 
@@ -671,7 +671,7 @@ class Engine
             $fileIterator->append(
                 $this->isPhpStream($file)
                     ? new ArrayIterator(array(new SplFileObject($file)))
-                    : new Iterator(new GlobIterator($file), $this->fileFilter)
+                    : new Iterator(new GlobIterator($file), $this->fileFilter),
             );
         }
 
@@ -681,12 +681,12 @@ class Engine
                     new RecursiveIteratorIterator(
                         new RecursiveDirectoryIterator(
                             $directory . '/',
-                            RecursiveDirectoryIterator::FOLLOW_SYMLINKS
-                        )
+                            RecursiveDirectoryIterator::FOLLOW_SYMLINKS,
+                        ),
                     ),
                     $this->fileFilter,
-                    $directory
-                )
+                    $directory,
+                ),
             );
         }
 

--- a/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
@@ -58,7 +58,7 @@ interface AggregateAnalyzer extends Analyzer
      * @return array<string>
      */
     public function getRequiredAnalyzers();
-    
+
     /**
      * Adds a required sub analyzer.
      *

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -60,7 +60,7 @@ interface Analyzer
      *                                      can extract the required options.
      */
     public function __construct(array $options = array());
-    
+
     /**
      * Adds a listener to this analyzer.
      *
@@ -69,7 +69,7 @@ interface Analyzer
      * @return void
      */
     public function addAnalyzeListener(AnalyzerListener $listener);
-    
+
     /**
      * Processes all {@link ASTNamespace} code nodes.
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -231,7 +231,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
             self::M_PROPERTIES_NON_PRIVATE       => 0,
             self::M_WEIGHTED_METHODS             => 0,
             self::M_WEIGHTED_METHODS_INHERIT     => $wmci,
-            self::M_WEIGHTED_METHODS_NON_PRIVATE => 0
+            self::M_WEIGHTED_METHODS_NON_PRIVATE => 0,
         );
 
         foreach ($trait->getProperties() as $property) {
@@ -418,7 +418,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
             self::M_PROPERTIES_NON_PRIVATE       => 0,
             self::M_WEIGHTED_METHODS             => 0,
             self::M_WEIGHTED_METHODS_INHERIT     => $wmci,
-            self::M_WEIGHTED_METHODS_NON_PRIVATE => 0
+            self::M_WEIGHTED_METHODS_NON_PRIVATE => 0,
         );
 
         if ($class instanceof ASTClass) {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -188,7 +188,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         foreach (array_keys($this->nodes) as $id) {
             $this->nodeMetrics[$id] = array(
                 self::M_CODE_RANK          =>  0,
-                self::M_REVERSE_CODE_RANK  =>  0
+                self::M_REVERSE_CODE_RANK  =>  0,
             );
         }
         foreach ($this->computeCodeRank('out', 'in') as $id => $rank) {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -139,7 +139,7 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
                 'in'    =>  array(),
                 'out'   =>  array(),
                 'name'  =>  $node->getName(),
-                'type'  =>  get_class($node)
+                'type'  =>  get_class($node),
             );
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -137,7 +137,7 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
                 'in'   =>  array(),
                 'out'  =>  array(),
                 'name'  =>  $node->getName(),
-                'type'  =>  get_class($node)
+                'type'  =>  get_class($node),
             );
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -121,7 +121,7 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
                 'in'   =>  array(),
                 'out'  =>  array(),
                 'name'  =>  $node->getName(),
-                'type'  =>  get_class($node)
+                'type'  =>  get_class($node),
             );
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -82,7 +82,7 @@ class StrategyFactory
     private $validStrategies = array(
         self::STRATEGY_INHERITANCE,
         self::STRATEGY_METHOD,
-        self::STRATEGY_PROPERTY
+        self::STRATEGY_PROPERTY,
     );
 
     /**
@@ -109,7 +109,7 @@ class StrategyFactory
     {
         if (in_array($strategyName, $this->validStrategies) === false) {
             throw new InvalidArgumentException(
-                sprintf('Cannot load file for identifier "%s".', $strategyName)
+                sprintf('Cannot load file for identifier "%s".', $strategyName),
             );
         }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -150,7 +150,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
     {
         return array(
             self::M_CALLS   =>  $this->calls,
-            self::M_FANOUT  =>  $this->fanout
+            self::M_FANOUT  =>  $this->fanout,
         );
     }
 
@@ -246,7 +246,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
             $this->nodeMetrics[$id] = array(
                 self::M_CA   =>  $afferentCoupling,
                 self::M_CBO  =>  $efferentCoupling,
-                self::M_CE   =>  $efferentCoupling
+                self::M_CE   =>  $efferentCoupling,
             );
 
             $this->fanout += $efferentCoupling;
@@ -334,7 +334,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
 
         $this->calculateCoupling(
             $declaringClass,
-            $method->getReturnClass()
+            $method->getReturnClass(),
         );
 
         foreach ($method->getExceptionClasses() as $type) {
@@ -360,7 +360,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
 
         $this->calculateCoupling(
             $property->getDeclaringClass(),
-            $property->getClass()
+            $property->getClass(),
         );
 
         $this->fireEndProperty($property);
@@ -375,7 +375,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      */
     private function calculateCoupling(
         AbstractASTType $declaringType,
-        AbstractASTType $coupledType = null
+        AbstractASTType $coupledType = null,
     ) {
         $this->initDependencyMap($declaringType);
 
@@ -419,7 +419,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
 
         $this->dependencyMap[$type->getId()] = array(
             'ce' => array(),
-            'ca' => array()
+            'ca' => array(),
         );
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -208,7 +208,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     {
         $this->metrics[$callable->getId()] = array(
             self::M_CRAP_INDEX => $this->calculateCrapIndex($callable),
-            self::M_COVERAGE   => $this->calculateCoverage($callable)
+            self::M_COVERAGE   => $this->calculateCoverage($callable),
         );
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -159,7 +159,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     {
         return array(
             self::M_CYCLOMATIC_COMPLEXITY_1  =>  $this->ccn,
-            self::M_CYCLOMATIC_COMPLEXITY_2  =>  $this->ccn2
+            self::M_CYCLOMATIC_COMPLEXITY_2  =>  $this->ccn2,
         );
     }
 
@@ -218,7 +218,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     {
         $data = array(
             self::M_CYCLOMATIC_COMPLEXITY_1 => 1,
-            self::M_CYCLOMATIC_COMPLEXITY_2 => 1
+            self::M_CYCLOMATIC_COMPLEXITY_2 => 1,
         );
 
         foreach ($callable->getChildren() as $child) {

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -311,7 +311,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
         foreach ($type->getDependencies() as $dependency) {
             $this->collectDependencies(
                 $type->getNamespace(),
-                $dependency->getNamespace()
+                $dependency->getNamespace(),
             );
         }
 
@@ -363,7 +363,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
                 self::M_EFFERENT_COUPLING           =>  array(),
                 self::M_ABSTRACTION                 =>  0,
                 self::M_INSTABILITY                 =>  0,
-                self::M_DISTANCE                    =>  0
+                self::M_DISTANCE                    =>  0,
             );
         }
     }
@@ -446,7 +446,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
     {
         foreach ($this->nodeMetrics as $id => $metrics) {
             $this->nodeMetrics[$id][self::M_DISTANCE] = abs(
-                ($metrics[self::M_ABSTRACTION] + $metrics[self::M_INSTABILITY]) - 1
+                ($metrics[self::M_ABSTRACTION] + $metrics[self::M_INSTABILITY]) - 1,
             );
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -281,7 +281,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
                 case Tokens::T_OBJECT_OPERATOR:
                 case Tokens::T_DOUBLE_COLON:
                     // Glue ->/:: and before & after parts together.
-                    $image = array_pop($operands).$token->image.$tokens[$i + 1]->image;
+                    $image = array_pop($operands) . $token->image . $tokens[$i + 1]->image;
                     $operands[] = $image;
 
                     // Skip next part (would be seen as operand)
@@ -388,7 +388,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
         $measures[self::M_HALSTEAD_EFFORT] =
             $measures[self::M_HALSTEAD_VOLUME] * $measures[self::M_HALSTEAD_DIFFICULTY];
         $measures[self::M_HALSTEAD_TIME] = $measures[self::M_HALSTEAD_EFFORT] / 18;
-        $measures[self::M_HALSTEAD_BUGS] = pow($measures[self::M_HALSTEAD_EFFORT], (2/3)) / 3000;
+        $measures[self::M_HALSTEAD_BUGS] = pow($measures[self::M_HALSTEAD_EFFORT], (2 / 3)) / 3000;
         $measures[self::M_HALSTEAD_CONTENT] =
             $measures[self::M_HALSTEAD_VOLUME] / ($measures[self::M_HALSTEAD_DIFFICULTY] ?: 1);
 

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -221,7 +221,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
         $this->fireStartClass($class);
 
         $this->initNodeMetricsForClass($class);
-        
+
         $this->calculateNumberOfDerivedClasses($class);
         $this->calculateNumberOfAddedAndOverwrittenMethods($class);
         $this->calculateDepthOfInheritanceTree($class);
@@ -268,7 +268,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
             ++$dit;
             $root = $parent->getId();
         }
-        
+
         // Collect max dit value
         $this->maxDIT = max($this->maxDIT, $dit);
 
@@ -305,7 +305,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
             if ($method->getParent() !== $class) {
                 continue;
             }
-            
+
             if (isset($parentMethodNames[$method->getName()])) {
                 if (!$parentMethodNames[$method->getName()]) {
                     ++$numberOfOverwrittenMethods;
@@ -341,7 +341,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
             self::M_DEPTH_OF_INHERITANCE_TREE     => 0,
             self::M_NUMBER_OF_ADDED_METHODS       => 0,
             self::M_NUMBER_OF_DERIVED_CLASSES     => 0,
-            self::M_NUMBER_OF_OVERWRITTEN_METHODS => 0
+            self::M_NUMBER_OF_OVERWRITTEN_METHODS => 0,
         );
 
         foreach ($class->getParentClasses() as $parent) {

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -159,7 +159,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
             self::M_NUMBER_OF_CLASSES     =>  $this->noc,
             self::M_NUMBER_OF_INTERFACES  =>  $this->noi,
             self::M_NUMBER_OF_METHODS     =>  $this->nom,
-            self::M_NUMBER_OF_FUNCTIONS   =>  $this->nof
+            self::M_NUMBER_OF_FUNCTIONS   =>  $this->nof,
         );
     }
 
@@ -204,7 +204,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ++$this->nodeMetrics[$id][self::M_NUMBER_OF_CLASSES];
 
         $this->nodeMetrics[$class->getId()] = array(
-            self::M_NUMBER_OF_METHODS  =>  0
+            self::M_NUMBER_OF_METHODS  =>  0,
         );
 
         foreach ($class->getMethods() as $method) {
@@ -252,7 +252,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         ++$this->nodeMetrics[$id][self::M_NUMBER_OF_INTERFACES];
 
         $this->nodeMetrics[$interface->getId()] = array(
-            self::M_NUMBER_OF_METHODS  =>  0
+            self::M_NUMBER_OF_METHODS  =>  0,
         );
 
         foreach ($interface->getMethods() as $method) {
@@ -301,7 +301,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
             self::M_NUMBER_OF_CLASSES     =>  0,
             self::M_NUMBER_OF_INTERFACES  =>  0,
             self::M_NUMBER_OF_METHODS     =>  0,
-            self::M_NUMBER_OF_FUNCTIONS   =>  0
+            self::M_NUMBER_OF_FUNCTIONS   =>  0,
         );
 
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -102,7 +102,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         self::M_COMMENT_LINES_OF_CODE      =>  0,
         self::M_EXECUTABLE_LINES_OF_CODE   =>  0,
         self::M_LOGICAL_LINES_OF_CODE      =>  0,
-        self::M_NON_COMMENT_LINES_OF_CODE  =>  0
+        self::M_NON_COMMENT_LINES_OF_CODE  =>  0,
     );
 
     /**
@@ -263,7 +263,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             self::M_COMMENT_LINES_OF_CODE      =>  $cloc,
             self::M_EXECUTABLE_LINES_OF_CODE   =>  $eloc,
             self::M_LOGICAL_LINES_OF_CODE      =>  $lloc,
-            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc
+            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc,
         );
 
         $this->updateProjectMetrics($id);
@@ -289,7 +289,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
 
         list($cloc, $eloc, $lloc) = $this->linesOfCode(
             $function->getTokens(),
-            true
+            true,
         );
 
         $loc   = $function->getEndLine() - $function->getStartLine() + 1;
@@ -300,7 +300,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             self::M_COMMENT_LINES_OF_CODE      =>  $cloc,
             self::M_EXECUTABLE_LINES_OF_CODE   =>  $eloc,
             self::M_LOGICAL_LINES_OF_CODE      =>  $lloc,
-            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc
+            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc,
         );
 
         $this->fireEndFunction($function);
@@ -336,7 +336,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             self::M_COMMENT_LINES_OF_CODE      =>  $cloc,
             self::M_EXECUTABLE_LINES_OF_CODE   =>  0,
             self::M_LOGICAL_LINES_OF_CODE      =>  0,
-            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc
+            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc,
         );
 
         $this->fireEndInterface($interface);
@@ -355,7 +355,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             $this->fireEndMethod($method);
             return;
         }
-        
+
         if ($method->isAbstract()) {
             $cloc = 0;
             $eloc = 0;
@@ -363,7 +363,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         } else {
             list($cloc, $eloc, $lloc) = $this->linesOfCode(
                 $method->getTokens(),
-                true
+                true,
             );
         }
         $loc   = $method->getEndLine() - $method->getStartLine() + 1;
@@ -374,7 +374,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             self::M_COMMENT_LINES_OF_CODE      =>  $cloc,
             self::M_EXECUTABLE_LINES_OF_CODE   =>  $eloc,
             self::M_LOGICAL_LINES_OF_CODE      =>  $lloc,
-            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc
+            self::M_NON_COMMENT_LINES_OF_CODE  =>  $ncloc,
         );
 
         $this->classExecutableLines += $eloc;
@@ -441,9 +441,9 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
             if ($token->type === Tokens::T_COMMENT
                 || $token->type === Tokens::T_DOC_COMMENT
             ) {
-                $lines =& $clines;
+                $lines = &$clines;
             } else {
-                $lines =& $elines;
+                $lines = &$elines;
             }
 
             switch ($token->type) {

--- a/src/main/php/PDepend/Metrics/AnalyzerListener.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerListener.php
@@ -61,7 +61,7 @@ interface AnalyzerListener extends ASTVisitListener
      * @return void
      */
     public function startAnalyzer(Analyzer $analyzer);
-    
+
     /**
      * This method is called when the analyzer has finished code processing.
      *

--- a/src/main/php/PDepend/ProcessListener.php
+++ b/src/main/php/PDepend/ProcessListener.php
@@ -64,7 +64,7 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
      * @return void
      */
     public function startParseProcess(Builder $builder);
-    
+
     /**
      * Is called when PDepend has finished the file parsing process.
      *
@@ -73,42 +73,42 @@ interface ProcessListener extends ASTVisitListener, AnalyzerListener
      * @return void
      */
     public function endParseProcess(Builder $builder);
-    
+
     /**
      * Is called when PDepend starts parsing of a new file.
      *
      * @return void
      */
     public function startFileParsing(Tokenizer $tokenizer);
-    
+
     /**
      * Is called when PDepend has finished a file.
      *
      * @return void
      */
     public function endFileParsing(Tokenizer $tokenizer);
-    
+
     /**
      * Is called when PDepend starts the analyzing process.
      *
      * @return void
      */
     public function startAnalyzeProcess();
-    
+
     /**
      * Is called when PDepend has finished the analyzing process.
      *
      * @return void
      */
     public function endAnalyzeProcess();
-    
+
     /**
      * Is called when PDepend starts the logging process.
      *
      * @return void
      */
     public function startLogProcess();
-    
+
     /**
      * Is called when PDepend has finished the logging process.
      *

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -198,8 +198,8 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
                 $angle = rand(0, 314) / 100 - 1.57;
                 $legend = $legendTemplate->cloneNode(true);
                 if ($legend instanceof DOMElement) {
-                    $legend->setAttribute('x', (string)($e + $item['ratio'] * (1 + cos($angle))));
-                    $legend->setAttribute('y', (string)($f + $item['ratio'] * (1 + sin($angle))));
+                    $legend->setAttribute('x', (string) ($e + $item['ratio'] * (1 + cos($angle))));
+                    $legend->setAttribute('y', (string) ($f + $item['ratio'] * (1 + sin($angle))));
                     $legend->nodeValue = $found[1];
                     $legendTemplate->parentNode->appendChild($legend);
                 }
@@ -242,7 +242,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
                 'abstraction'  =>  $metrics['a'],
                 'instability'  =>  $metrics['i'],
                 'distance'     =>  $metrics['d'],
-                'name'         =>  Utf8Util::ensureEncoding($namespace->getName())
+                'name'         =>  Utf8Util::ensureEncoding($namespace->getName()),
             );
         }
 
@@ -251,7 +251,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
             $items,
             function ($a, $b) {
                 return ($a['size'] - $b['size']);
-            }
+            },
         );
 
         if ($items) {

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -239,8 +239,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $classXml->setAttribute('sourceFile', (string) $class->getCompilationUnit());
         $classXml->appendChild(
             $doc->createTextNode(
-                Utf8Util::ensureEncoding($class->getName())
-            )
+                Utf8Util::ensureEncoding($class->getName()),
+            ),
         );
 
         if ($class->isAbstract()) {
@@ -267,8 +267,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $classXml->setAttribute('sourceFile', (string) $interface->getCompilationUnit());
         $classXml->appendChild(
             $doc->createTextNode(
-                Utf8Util::ensureEncoding($interface->getName())
-            )
+                Utf8Util::ensureEncoding($interface->getName()),
+            ),
         );
 
         $this->abstractClasses->appendChild($classXml);
@@ -321,8 +321,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $efferentXml = $doc->createElement('Package');
             $efferentXml->appendChild(
                 $doc->createTextNode(
-                    Utf8Util::ensureEncoding($efferent->getName())
-                )
+                    Utf8Util::ensureEncoding($efferent->getName()),
+                ),
             );
 
             $dependsUpon->appendChild($efferentXml);
@@ -333,8 +333,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $afferentXml = $doc->createElement('Package');
             $afferentXml->appendChild(
                 $doc->createTextNode(
-                    Utf8Util::ensureEncoding($afferent->getName())
-                )
+                    Utf8Util::ensureEncoding($afferent->getName()),
+                ),
             );
 
             $usedBy->appendChild($afferentXml);
@@ -354,8 +354,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
                 $cycleXml->appendChild($doc->createElement('Package'))
                     ->appendChild(
                         $doc->createTextNode(
-                            Utf8Util::ensureEncoding($cycle->getName())
-                        )
+                            Utf8Util::ensureEncoding($cycle->getName()),
+                        ),
                     );
             }
 

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -122,7 +122,7 @@ class Pyramid implements FileAwareGenerator
         'calls-nom'     =>  array(2.01, 2.62, 3.2),
         'fanout-calls'  =>  array(0.56, 0.62, 0.68),
         'andc'          =>  array(0.25, 0.41, 0.57),
-        'ahh'           =>  array(0.09, 0.21, 0.32)
+        'ahh'           =>  array(0.09, 0.21, 0.32),
     );
 
     /**
@@ -278,7 +278,7 @@ class Pyramid implements FileAwareGenerator
     {
         $orders = array(
             array('cyclo', 'loc', 'nom', 'noc', 'nop'),
-            array('fanout', 'calls', 'nom')
+            array('fanout', 'calls', 'nom'),
         );
 
         $proportions = array();
@@ -339,7 +339,7 @@ class Pyramid implements FileAwareGenerator
             'ahh'     =>  round($inheritance['ahh'], 3),
             'andc'    =>  round($inheritance['andc'], 3),
             'fanout'  =>  $coupling['fanout'],
-            'calls'   =>  $coupling['calls']
+            'calls'   =>  $coupling['calls'],
         );
     }
 }

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -61,7 +61,7 @@ interface ReportGenerator
      * @return bool
      */
     public function log(Analyzer $analyzer);
-    
+
     /**
      * Closes the logger process and writes the output file.
      *
@@ -70,7 +70,7 @@ interface ReportGenerator
      * @return void
      */
     public function close();
-    
+
     /**
      * Returns an <b>array</b> with accepted analyzer types. These types can be
      * concrete analyzer classes or one of the descriptive analyzer interfaces.

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -251,7 +251,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         foreach ($this->projectAwareAnalyzers as $analyzer) {
             $projectMetrics = array_merge(
                 $projectMetrics,
-                $analyzer->getProjectMetrics()
+                $analyzer->getProjectMetrics(),
             );
         }
         ksort($projectMetrics);
@@ -302,8 +302,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $typeXml = $doc->createElement($typeIdentifier);
         $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
         $typeXml->setAttribute('fqname', Utf8Util::ensureEncoding($type->getNamespacedName()));
-        $typeXml->setAttribute('start', (string)$type->getStartLine());
-        $typeXml->setAttribute('end', (string)$type->getEndLine());
+        $typeXml->setAttribute('start', (string) $type->getStartLine());
+        $typeXml->setAttribute('end', (string) $type->getEndLine());
 
         $this->writeNodeMetrics($typeXml, $type);
         $this->writeFileReference($typeXml, $type->getCompilationUnit());
@@ -338,8 +338,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         $functionXml = $doc->createElement('function');
         $functionXml->setAttribute('name', Utf8Util::ensureEncoding($function->getName()));
-        $functionXml->setAttribute('start', (string)$function->getStartLine());
-        $functionXml->setAttribute('end', (string)$function->getEndLine());
+        $functionXml->setAttribute('start', (string) $function->getStartLine());
+        $functionXml->setAttribute('end', (string) $function->getEndLine());
 
         $this->writeNodeMetrics($functionXml, $function);
         $this->writeFileReference($functionXml, $function->getCompilationUnit());
@@ -373,8 +373,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         $methodXml = $doc->createElement('method');
         $methodXml->setAttribute('name', Utf8Util::ensureEncoding($method->getName()));
-        $methodXml->setAttribute('start', (string)$method->getStartLine());
-        $methodXml->setAttribute('end', (string)$method->getEndLine());
+        $methodXml->setAttribute('start', (string) $method->getStartLine());
+        $methodXml->setAttribute('end', (string) $method->getEndLine());
 
         $this->writeNodeMetrics($methodXml, $method);
 

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -279,7 +279,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      */
     protected function setMetadataInteger($index, $value)
     {
-        $this->setMetadata($index, (string)$value);
+        $this->setMetadata($index, (string) $value);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -184,7 +184,7 @@ class ASTClass extends AbstractASTClassOrInterface
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(
-                'Cannot overwrite previously set class modifiers.'
+                'Cannot overwrite previously set class modifiers.',
             );
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -66,8 +66,8 @@ class ASTClassOrInterfaceRecursiveInheritanceException extends RuntimeException
             sprintf(
                 'Type %s\%s is part of an endless inheritance hierarchy.',
                 preg_replace('(\W+)', '\\', $type->getNamespace()->getName()),
-                $type->getName()
-            )
+                $type->getName(),
+            ),
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -92,7 +92,7 @@ class ASTClassOrInterfaceReference extends ASTType
     {
         if ($this->typeInstance === null) {
             $this->typeInstance = $this->context->getClassOrInterface(
-                $this->getImage()
+                $this->getImage(),
             );
         }
         return $this->typeInstance;

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -87,7 +87,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      */
     public function setReturnsByReference($returnsReference)
     {
-        $this->setMetadataBoolean(5, (boolean) $returnsReference);
+        $this->setMetadataBoolean(5, (bool) $returnsReference);
     }
 
     /**
@@ -130,7 +130,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      */
     public function setStatic($static)
     {
-        $this->setMetadataBoolean(6, (boolean) $static);
+        $this->setMetadataBoolean(6, (bool) $static);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -313,7 +313,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
             'endLine',
             'fileName',
             'startLine',
-            'id'
+            'id',
         );
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -66,8 +66,8 @@ class ASTCompilationUnitNotFoundException extends RuntimeException
             sprintf(
                 'The mandatory parent was not defined for the %s named %s.',
                 get_class($owner),
-                $owner->getName()
-            )
+                $owner->getName(),
+            ),
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -96,7 +96,7 @@ class ASTConstantDefinition extends AbstractASTNode
         if (($expected & $modifiers) !== 0) {
             throw new InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
-                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_FINAL.'
+                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_FINAL.',
             );
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -133,7 +133,7 @@ class ASTEnum extends AbstractASTClassOrInterface
     public function getCases()
     {
         return new ASTArtifactList(
-            $this->findChildrenOfType('PDepend\\Source\\AST\\ASTEnumCase')
+            $this->findChildrenOfType('PDepend\\Source\\AST\\ASTEnumCase'),
         );
     }
 
@@ -248,7 +248,7 @@ class ASTEnum extends AbstractASTClassOrInterface
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(
-                'Cannot overwrite previously set class modifiers.'
+                'Cannot overwrite previously set class modifiers.',
             );
         }
 
@@ -292,7 +292,7 @@ class ASTEnum extends AbstractASTClassOrInterface
     {
         return array_merge(
             array('type'),
-            parent::__sleep()
+            parent::__sleep(),
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -131,7 +131,7 @@ class ASTFieldDeclaration extends AbstractASTNode
         if (($expected & $modifiers) !== 0) {
             throw new InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
-                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_STATIC.'
+                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_STATIC.',
             );
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -184,7 +184,7 @@ class ASTFormalParameter extends AbstractASTNode
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(
-                'Cannot overwrite previously set constructor property modifiers.'
+                'Cannot overwrite previously set constructor property modifiers.',
             );
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -82,7 +82,7 @@ class ASTInterface extends AbstractASTClassOrInterface
     public function setParentClassReference(ASTClassReference $classReference)
     {
         throw new BadMethodCallException(
-            'Unsupported method ' . __METHOD__ . '() called.'
+            'Unsupported method ' . __METHOD__ . '() called.',
         );
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -105,7 +105,7 @@ class ASTParameter extends AbstractASTArtifact
     {
         $this->formalParameter    = $formalParameter;
         $this->variableDeclarator = $formalParameter->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+            'PDepend\\Source\\AST\\ASTVariableDeclarator',
         );
 
         $this->id = spl_object_hash($this);
@@ -216,7 +216,7 @@ class ASTParameter extends AbstractASTArtifact
     public function getClass()
     {
         $classReference = $this->formalParameter->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
         );
         if ($classReference === null) {
             return null;
@@ -309,7 +309,7 @@ class ASTParameter extends AbstractASTArtifact
      */
     public function setOptional($optional)
     {
-        $this->optional = (boolean) $optional;
+        $this->optional = (bool) $optional;
     }
 
     /**
@@ -400,7 +400,7 @@ class ASTParameter extends AbstractASTArtifact
             $typeHint,
             $reference,
             $this->getName(),
-            $default
+            $default,
         );
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -84,7 +84,7 @@ class ASTProperty extends AbstractASTArtifact
      */
     public function __construct(
         ASTFieldDeclaration $fieldDeclaration,
-        ASTVariableDeclarator $variableDeclarator
+        ASTVariableDeclarator $variableDeclarator,
     ) {
         $this->fieldDeclaration   = $fieldDeclaration;
         $this->variableDeclarator = $variableDeclarator;
@@ -170,7 +170,7 @@ class ASTProperty extends AbstractASTArtifact
     public function isArray()
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType'
+            'PDepend\\Source\\AST\\ASTType',
         );
         if ($typeNode === null) {
             return false;
@@ -189,7 +189,7 @@ class ASTProperty extends AbstractASTArtifact
     public function isScalar()
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType'
+            'PDepend\\Source\\AST\\ASTType',
         );
         if ($typeNode === null) {
             return false;
@@ -208,7 +208,7 @@ class ASTProperty extends AbstractASTArtifact
     public function getClass()
     {
         $reference = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
         );
         if ($reference === null) {
             return null;
@@ -357,7 +357,7 @@ class ASTProperty extends AbstractASTArtifact
             $visibility,
             $static,
             $this->getName(),
-            PHP_EOL
+            PHP_EOL,
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -37,8 +37,8 @@ class ASTTraitMethodCollisionException extends RuntimeException
                 'collisions with other trait methods on %s\%s.',
                 $method->getName(),
                 preg_replace('(\W+)', '\\', $type->getNamespace()->getName()),
-                $type->getName()
-            )
+                $type->getName(),
+            ),
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -287,8 +287,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     {
         return new ASTClassOrInterfaceReferenceIterator(
             $this->findChildrenOfType(
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
-            )
+                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
+            ),
         );
     }
 
@@ -370,7 +370,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @since  0.9.5
      */
     public function addExceptionClassReference(
-        ASTClassOrInterfaceReference $classReference
+        ASTClassOrInterfaceReference $classReference,
     ) {
         $this->exceptionClassReferences[] = $classReference;
     }
@@ -384,7 +384,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     public function getExceptionClasses()
     {
         return new ASTClassOrInterfaceReferenceIterator(
-            $this->exceptionClassReferences
+            $this->exceptionClassReferences,
         );
     }
 
@@ -440,11 +440,11 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         $staticVariables = array();
 
         $declarations = $this->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTStaticVariableDeclaration'
+            'PDepend\\Source\\AST\\ASTStaticVariableDeclaration',
         );
         foreach ($declarations as $declaration) {
             $variables = $declaration->findChildrenOfType(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator'
+                'PDepend\\Source\\AST\\ASTVariableDeclarator',
             );
             foreach ($variables as $variable) {
                 $image = $variable->getImage();
@@ -485,11 +485,11 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         $parameters = array();
 
         $formalParameters = $this->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameters'
+            'PDepend\\Source\\AST\\ASTFormalParameters',
         );
 
         $formalParameters = $formalParameters->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            'PDepend\\Source\\AST\\ASTFormalParameter',
         );
 
         foreach ($formalParameters as $formalParameter) {
@@ -532,7 +532,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
             'comment',
             'returnsReference',
             'returnClassReference',
-            'exceptionClassReferences'
+            'exceptionClassReferences',
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -394,7 +394,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         foreach ($this->getInterfaces() as $interface) {
             $this->constantDeclarators = array_merge(
                 $this->constantDeclarators,
-                $interface->getConstantDeclarators()
+                $interface->getConstantDeclarators(),
             );
         }
 
@@ -425,7 +425,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     {
         return array_merge(
             array('constants', 'interfaceReferences', 'parentClassReference'),
-            parent::__sleep()
+            parent::__sleep(),
         );
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -209,7 +209,7 @@ abstract class AbstractASTNode implements ASTNode
         $startLine,
         $endLine,
         $startColumn,
-        $endColumn
+        $endColumn,
     ) {
         $this->setMetadataInteger(0, $startLine);
         $this->setMetadataInteger(1, $endLine);
@@ -244,7 +244,7 @@ abstract class AbstractASTNode implements ASTNode
      */
     protected function setMetadataInteger($index, $value)
     {
-        $this->setMetadata($index, (string)$value);
+        $this->setMetadata($index, (string) $value);
     }
 
     /**
@@ -341,8 +341,8 @@ abstract class AbstractASTNode implements ASTNode
             sprintf(
                 'No node found at index %d in node of type: %s',
                 $index,
-                get_class($this)
-            )
+                get_class($this),
+            ),
         );
     }
 
@@ -507,7 +507,7 @@ abstract class AbstractASTNode implements ASTNode
         return array(
             'comment',
             'metadata',
-            'nodes'
+            'nodes',
         );
     }
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -182,8 +182,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
             sprintf(
                 'No node found at index %d in node of type: %s',
                 $index,
-                get_class($this)
-            )
+                get_class($this),
+            ),
         );
     }
 
@@ -341,7 +341,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
         /** @var ASTTraitUseStatement[] */
         $uses = $this->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            'PDepend\\Source\\AST\\ASTTraitUseStatement',
         );
 
         foreach ($uses as $use) {
@@ -529,7 +529,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
             'namespaceName',
             'startLine',
             'userDefined',
-            'id'
+            'id',
         );
     }
 

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -527,7 +527,7 @@ abstract class AbstractPHPParser
         $this->cache->store(
             $this->compilationUnit->getId(),
             $this->compilationUnit,
-            $hash ?: null
+            $hash ?: null,
         );
 
         $this->tearDownEnvironment();
@@ -542,7 +542,7 @@ abstract class AbstractPHPParser
      */
     protected function setUpEnvironment()
     {
-        ini_set('xdebug.max_nesting_level', (string)$this->getMaxNestingLevel());
+        ini_set('xdebug.max_nesting_level', (string) $this->getMaxNestingLevel());
 
         $this->useSymbolTable->createScope();
 
@@ -920,7 +920,7 @@ abstract class AbstractPHPParser
         $validModifiers = array(
             Tokens::T_ABSTRACT,
             Tokens::T_FINAL,
-            Tokens::T_READONLY
+            Tokens::T_READONLY,
         );
 
         $finalAllowed = true;
@@ -975,9 +975,9 @@ abstract class AbstractPHPParser
         $class->setParentClassReference(
             $this->setNodePositionsAndReturn(
                 $this->builder->buildAstClassReference(
-                    $this->parseQualifiedName()
-                )
-            )
+                    $this->parseQualifiedName(),
+                ),
+            ),
         );
 
         return $class;
@@ -998,9 +998,9 @@ abstract class AbstractPHPParser
             $abstractType->addInterfaceReference(
                 $this->setNodePositionsAndReturn(
                     $this->builder->buildAstClassOrInterfaceReference(
-                        $this->parseQualifiedName()
-                    )
-                )
+                        $this->parseQualifiedName(),
+                    ),
+                ),
             );
 
             $this->consumeComments();
@@ -1054,7 +1054,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_VARIABLE:
                 case Tokens::T_VAR:
                     $methodOrProperty = $this->parseMethodOrFieldDeclaration(
-                        $defaultModifier
+                        $defaultModifier,
                     );
 
                     if ($methodOrProperty instanceof ASTNode) {
@@ -1085,7 +1085,7 @@ abstract class AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $classOrInterface->addChild($comment);
@@ -1098,7 +1098,7 @@ abstract class AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $classOrInterface->addChild($comment);
@@ -1111,7 +1111,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_CASE:
                     if (!($classOrInterface instanceof ASTEnum)) {
                         throw new TokenException(
-                            'Enum case should be located only inside enum classes'
+                            'Enum case should be located only inside enum classes',
                         );
                     }
 
@@ -1288,7 +1288,7 @@ abstract class AbstractPHPParser
 
         if ($this->isNextTokenFormalParameterList()) {
             return $this->setNodePositionsAndReturn(
-                $this->parseClosureDeclaration()
+                $this->parseClosureDeclaration(),
             );
         }
 
@@ -1518,7 +1518,7 @@ abstract class AbstractPHPParser
         }
 
         return $this->setNodePositionsAndReturn(
-            $this->parseOptionalTraitAdaptation($useStatement)
+            $this->parseOptionalTraitAdaptation($useStatement),
         );
     }
 
@@ -1536,8 +1536,8 @@ abstract class AbstractPHPParser
 
         return $this->setNodePositionsAndReturn(
             $this->builder->buildAstTraitReference(
-                $this->parseQualifiedName()
-            )
+                $this->parseQualifiedName(),
+            ),
         );
     }
 
@@ -1626,7 +1626,7 @@ abstract class AbstractPHPParser
 
         if (Tokens::T_DOUBLE_COLON === $this->tokenizer->peek()) {
             $traitReference = $this->setNodePositionsAndReturn(
-                $this->builder->buildAstTraitReference($qualifiedName)
+                $this->builder->buildAstTraitReference($qualifiedName),
             );
 
             $this->consumeToken(Tokens::T_DOUBLE_COLON);
@@ -1701,7 +1701,7 @@ abstract class AbstractPHPParser
             throw new InvalidStateException(
                 $this->requireNextToken()->startLine,
                 $this->compilationUnit->getFileName(),
-                'Expecting full qualified trait method name.'
+                'Expecting full qualified trait method name.',
             );
         }
 
@@ -2090,7 +2090,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $expr;
@@ -2134,7 +2134,7 @@ abstract class AbstractPHPParser
             $child->getStartLine(),
             $token->endLine,
             $child->getStartColumn(),
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $expr;
@@ -2156,7 +2156,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $expr;
@@ -2200,7 +2200,7 @@ abstract class AbstractPHPParser
             $child->getStartLine(),
             $token->endLine,
             $child->getStartColumn(),
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $expr;
@@ -2222,7 +2222,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $expr;
@@ -2286,7 +2286,7 @@ abstract class AbstractPHPParser
         ASTNode $node,
         ASTExpression $expr,
         $open,
-        $close
+        $close,
     ) {
         $this->consumeToken($open);
 
@@ -2300,7 +2300,7 @@ abstract class AbstractPHPParser
             $node->getStartLine(),
             $token->endLine,
             $node->getStartColumn(),
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $this->parseOptionalIndexExpression($expr);
@@ -2330,7 +2330,7 @@ abstract class AbstractPHPParser
             $node,
             $expr,
             Tokens::T_SQUARED_BRACKET_OPEN,
-            Tokens::T_SQUARED_BRACKET_CLOSE
+            Tokens::T_SQUARED_BRACKET_CLOSE,
         );
     }
 
@@ -2358,7 +2358,7 @@ abstract class AbstractPHPParser
             $node,
             $expr,
             Tokens::T_CURLY_BRACE_OPEN,
-            Tokens::T_CURLY_BRACE_CLOSE
+            Tokens::T_CURLY_BRACE_CLOSE,
         );
     }
 
@@ -2398,7 +2398,7 @@ abstract class AbstractPHPParser
             $start->startLine,
             $end->endLine,
             $start->startColumn,
-            $end->endColumn
+            $end->endColumn,
         );
 
         return $node;
@@ -2460,7 +2460,7 @@ abstract class AbstractPHPParser
 
         return $this->parseExpressionTypeReference(
             $this->builder->buildAstInstanceOfExpression($token->image),
-            false
+            false,
         );
     }
 
@@ -2500,7 +2500,7 @@ abstract class AbstractPHPParser
             $startToken->startLine,
             $stopToken->endLine,
             $startToken->startColumn,
-            $stopToken->endColumn
+            $stopToken->endColumn,
         );
 
         return $expr;
@@ -2575,9 +2575,9 @@ abstract class AbstractPHPParser
         $expr->addChild(
             $this->parseOptionalMemberPrimaryPrefix(
                 $this->parseOptionalStaticMemberPrimaryPrefix(
-                    $this->parseStandAloneExpressionType($classRef)
-                )
-            )
+                    $this->parseStandAloneExpressionType($classRef),
+                ),
+            ),
         );
 
         return $expr;
@@ -2629,7 +2629,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2650,7 +2650,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2671,7 +2671,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2692,7 +2692,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2713,7 +2713,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2734,7 +2734,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2755,7 +2755,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $expr;
     }
@@ -2776,8 +2776,8 @@ abstract class AbstractPHPParser
         return $this->setNodePositionsAndReturn(
             $this->builder->buildAstNeededReference(
                 $this->parseQualifiedName(),
-                $classReference
-            )
+                $classReference,
+            ),
         );
     }
 
@@ -2820,7 +2820,7 @@ abstract class AbstractPHPParser
         ASTNode $node,
         Token $start,
         $closeToken,
-        $separatorToken = null
+        $separatorToken = null,
     ) {
         if (is_object($expr = $this->parseOptionalExpression())) {
             $node->addChild($expr);
@@ -2844,7 +2844,7 @@ abstract class AbstractPHPParser
             $start->startLine,
             $end->endLine,
             $start->startColumn,
-            $end->endColumn
+            $end->endColumn,
         );
         return $node;
     }
@@ -2972,8 +2972,8 @@ abstract class AbstractPHPParser
                 Tokens::T_ENDFOREACH,
                 Tokens::T_ENDIF,
                 Tokens::T_ENDSWITCH,
-                Tokens::T_ENDWHILE
-            )
+                Tokens::T_ENDWHILE,
+            ),
         );
     }
 
@@ -3066,7 +3066,7 @@ abstract class AbstractPHPParser
             throw new InvalidStateException(
                 $token->startLine,
                 $this->compilationUnit->getFileName(),
-                'Mandatory expression expected.'
+                'Mandatory expression expected.',
             );
         }
         return $expr;
@@ -3199,7 +3199,7 @@ abstract class AbstractPHPParser
                     $expressions[] = $this->parseBraceExpression(
                         $this->builder->buildAstExpression(),
                         $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN),
-                        Tokens::T_CURLY_BRACE_CLOSE
+                        Tokens::T_CURLY_BRACE_CLOSE,
                     );
                     break;
                 case Tokens::T_INCLUDE:
@@ -3258,7 +3258,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_CONCAT_EQUAL:
                 case Tokens::T_COALESCE_EQUAL:
                     $expressions[] = $this->parseAssignmentExpression(
-                        array_pop($expressions)
+                        array_pop($expressions),
                     );
                     break;
                 // TODO: Handle comments here
@@ -3274,7 +3274,7 @@ abstract class AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $expressions[] = $expr;
@@ -3309,7 +3309,7 @@ abstract class AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $expressions[] = $expr;
@@ -3323,7 +3323,7 @@ abstract class AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $expressions[] = $expr;
@@ -3354,7 +3354,7 @@ abstract class AbstractPHPParser
             $expressions[0]->getStartLine(),
             $expressions[$count - 1]->getEndLine(),
             $expressions[0]->getStartColumn(),
-            $expressions[$count - 1]->getEndColumn()
+            $expressions[$count - 1]->getEndColumn(),
         );
 
         return $expr;
@@ -3414,7 +3414,7 @@ abstract class AbstractPHPParser
                     $expr->getStartLine(),
                     $child->getEndLine(),
                     $expr->getStartColumn(),
-                    $child->getEndColumn()
+                    $child->getEndColumn(),
                 );
 
                 unset($expressions[$i + 1]);
@@ -3710,7 +3710,7 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_COLON);
 
         return $this->setNodePositionsAndReturn(
-            $this->builder->buildAstLabelStatement($token->image)
+            $this->builder->buildAstLabelStatement($token->image),
         );
     }
 
@@ -3817,8 +3817,8 @@ abstract class AbstractPHPParser
     {
         $stmt->addChild(
             $this->builder->buildAstClassOrInterfaceReference(
-                $this->parseQualifiedName()
-            )
+                $this->parseQualifiedName(),
+            ),
         );
     }
 
@@ -4048,7 +4048,7 @@ abstract class AbstractPHPParser
         }
 
         $children = array(
-            $this->parseVariableOrConstantOrPrimaryPrefix()
+            $this->parseVariableOrConstantOrPrimaryPrefix(),
         );
 
         if ($this->tokenizer->peek() === Tokens::T_DOUBLE_ARROW) {
@@ -4092,7 +4092,7 @@ abstract class AbstractPHPParser
         $this->consumeToken(Tokens::T_PARENTHESIS_CLOSE);
 
         return $this->setNodePositionsAndReturn(
-            $this->parseStatementBody($foreach)
+            $this->parseStatementBody($foreach),
         );
     }
 
@@ -4112,7 +4112,7 @@ abstract class AbstractPHPParser
         $stmt->addChild($this->parseParenthesisExpression());
 
         return $this->setNodePositionsAndReturn(
-            $this->parseStatementBody($stmt)
+            $this->parseStatementBody($stmt),
         );
     }
 
@@ -4247,7 +4247,7 @@ abstract class AbstractPHPParser
         $this->tokenStack->push();
 
         $stmt = $this->buildReturnStatement(
-            $this->consumeToken(Tokens::T_RETURN)
+            $this->consumeToken(Tokens::T_RETURN),
         );
 
         $this->parseStatementTermination();
@@ -4310,7 +4310,7 @@ abstract class AbstractPHPParser
         $token = $this->consumeToken(Tokens::T_ECHO);
 
         $stmt = $this->parseExpressionList(
-            $this->builder->buildAstEchoStatement($token->image)
+            $this->builder->buildAstEchoStatement($token->image),
         );
 
         $this->parseStatementTermination();
@@ -4333,7 +4333,7 @@ abstract class AbstractPHPParser
     protected function parseParenthesisExpressionOrPrimaryPrefix()
     {
         return $this->parseParenthesisExpressionOrPrimaryPrefixForVersion(
-            $this->parseParenthesisExpression()
+            $this->parseParenthesisExpression(),
         );
     }
 
@@ -4391,7 +4391,7 @@ abstract class AbstractPHPParser
         $expr = $this->parseBraceExpression(
             $expr,
             $this->consumeToken(Tokens::T_PARENTHESIS_OPEN),
-            Tokens::T_PARENTHESIS_CLOSE
+            Tokens::T_PARENTHESIS_CLOSE,
         );
 
         return $this->setNodePositionsAndReturn($expr);
@@ -4521,7 +4521,7 @@ abstract class AbstractPHPParser
         $function->addChild($this->parseArguments());
 
         return $this->parseOptionalMemberPrimaryPrefix(
-            $this->parseOptionalIndexExpression($function)
+            $this->parseOptionalIndexExpression($function),
         );
     }
 
@@ -4632,12 +4632,12 @@ abstract class AbstractPHPParser
 
         $prefix->addChild(
             $this->parseMethodOrPropertyPostfix(
-                $this->parseOptionalIndexExpression($child)
-            )
+                $this->parseOptionalIndexExpression($child),
+            ),
         );
 
         return $this->parseOptionalMemberPrimaryPrefix(
-            $this->parseOptionalIndexExpression($prefix)
+            $this->parseOptionalIndexExpression($prefix),
         );
     }
 
@@ -4716,7 +4716,7 @@ abstract class AbstractPHPParser
                 break;
             default:
                 $postfix = $this->parseMethodOrPropertyPostfix(
-                    $this->parsePostfixIdentifier()
+                    $this->parsePostfixIdentifier(),
                 );
                 break;
         }
@@ -4724,7 +4724,7 @@ abstract class AbstractPHPParser
         $prefix->addChild($postfix);
 
         return $this->parseOptionalMemberPrimaryPrefix(
-            $this->parseOptionalIndexExpression($prefix)
+            $this->parseOptionalIndexExpression($prefix),
         );
     }
 
@@ -4804,7 +4804,7 @@ abstract class AbstractPHPParser
             $node->getStartLine(),
             $node->getEndLine(),
             $node->getStartColumn(),
-            $node->getEndColumn()
+            $node->getEndColumn(),
         );
 
         return $postfix;
@@ -4864,7 +4864,7 @@ abstract class AbstractPHPParser
             $node->getStartLine(),
             $args->getEndLine(),
             $node->getStartColumn(),
-            $args->getEndColumn()
+            $args->getEndColumn(),
         );
 
         return $this->parseOptionalMemberPrimaryPrefix($postfix);
@@ -4886,7 +4886,7 @@ abstract class AbstractPHPParser
         $this->tokenStack->push();
 
         return $this->parseArgumentsParenthesesContent(
-            $this->builder->buildAstArguments()
+            $this->builder->buildAstArguments(),
         );
     }
 
@@ -5028,7 +5028,7 @@ abstract class AbstractPHPParser
             $left->getStartLine(),
             $expr->getEndLine(),
             $left->getStartColumn(),
-            $expr->getEndColumn()
+            $expr->getEndColumn(),
         );
 
         return $node;
@@ -5055,7 +5055,7 @@ abstract class AbstractPHPParser
             throw new InvalidStateException(
                 $token->startLine,
                 (string) $this->compilationUnit,
-                'The keyword "static" was used outside of a class/method scope.'
+                'The keyword "static" was used outside of a class/method scope.',
             );
         }
 
@@ -5064,7 +5064,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $ref;
@@ -5088,7 +5088,7 @@ abstract class AbstractPHPParser
             throw new InvalidStateException(
                 $token->startLine,
                 (string) $this->compilationUnit,
-                'The keyword "self" was used outside of a class/method scope.'
+                'The keyword "self" was used outside of a class/method scope.',
             );
         }
 
@@ -5097,7 +5097,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $ref;
@@ -5127,7 +5127,7 @@ abstract class AbstractPHPParser
                 $token = $this->consumeToken($type);
 
                 return $this->setNodePositionsAndReturn(
-                    $this->builder->buildAstConstant($token->image)
+                    $this->builder->buildAstConstant($token->image),
                 );
         }
 
@@ -5155,7 +5155,7 @@ abstract class AbstractPHPParser
 
         if ($this->tokenizer->peek() == Tokens::T_DOUBLE_COLON) {
             return $this->parseStaticMemberPrimaryPrefix(
-                $this->parseSelfReference($token)
+                $this->parseSelfReference($token),
             );
         }
 
@@ -5181,7 +5181,7 @@ abstract class AbstractPHPParser
                 $token->startLine,
                 (string) $this->compilationUnit,
                 'The keyword "parent" was used as type hint but the parameter ' .
-                'declaration is not in a class scope.'
+                'declaration is not in a class scope.',
             );
         }
 
@@ -5196,8 +5196,8 @@ abstract class AbstractPHPParser
                 sprintf(
                     'The keyword "parent" was used as type hint but the ' .
                     'class "%s" does not declare a parent.',
-                    $this->classOrInterface->getName()
-                )
+                    $this->classOrInterface->getName(),
+                ),
             );
         }
 
@@ -5206,7 +5206,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $ref;
@@ -5233,7 +5233,7 @@ abstract class AbstractPHPParser
 
         if ($this->tokenizer->peek() == Tokens::T_DOUBLE_COLON) {
             return $this->parseStaticMemberPrimaryPrefix(
-                $this->parseParentReference($token)
+                $this->parseParentReference($token),
             );
         }
 
@@ -5318,7 +5318,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $variable;
@@ -5462,7 +5462,7 @@ abstract class AbstractPHPParser
             case Tokens::T_VARIABLE:
                 $variable = $this->builder->buildAstVariableVariable($token->image);
                 $variable->addChild(
-                    $this->parseCompoundVariableOrVariableVariableOrVariable()
+                    $this->parseCompoundVariableOrVariableVariableOrVariable(),
                 );
                 break;
             default:
@@ -5493,7 +5493,7 @@ abstract class AbstractPHPParser
         return $this->parseBraceExpression(
             $this->builder->buildAstCompoundVariable($token->image),
             $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN),
-            Tokens::T_CURLY_BRACE_CLOSE
+            Tokens::T_CURLY_BRACE_CLOSE,
         );
     }
 
@@ -5529,7 +5529,7 @@ abstract class AbstractPHPParser
                 return $this->parseBraceExpression(
                     $this->builder->buildAstCompoundExpression(),
                     $token,
-                    Tokens::T_CURLY_BRACE_CLOSE
+                    Tokens::T_CURLY_BRACE_CLOSE,
                 );
         }
 
@@ -5538,7 +5538,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $literal;
@@ -5567,7 +5567,7 @@ abstract class AbstractPHPParser
         return $this->parseBraceExpression(
             $this->builder->buildAstCompoundExpression(),
             $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN),
-            Tokens::T_CURLY_BRACE_CLOSE
+            Tokens::T_CURLY_BRACE_CLOSE,
         );
     }
 
@@ -5590,7 +5590,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $node;
@@ -5622,7 +5622,7 @@ abstract class AbstractPHPParser
                     $token->startLine,
                     $token->endLine,
                     $token->startColumn,
-                    $token->endColumn
+                    $token->endColumn,
                 );
                 return $literal;
             case Tokens::T_LNUMBER:
@@ -5648,7 +5648,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $literal;
@@ -5670,8 +5670,8 @@ abstract class AbstractPHPParser
         return $this->setNodePositionsAndReturn(
             $this->parseArray(
                 $this->builder->buildAstArray(),
-                $static
-            )
+                $static,
+            ),
         );
     }
 
@@ -5994,7 +5994,7 @@ abstract class AbstractPHPParser
             $startLine,
             $endLine,
             $startColumn,
-            $endColumn
+            $endColumn,
         );
 
         return $string;
@@ -6069,7 +6069,7 @@ abstract class AbstractPHPParser
             }
         }
         return $this->setNodePositionsAndReturn(
-            $this->builder->buildAstLiteral($image)
+            $this->builder->buildAstLiteral($image),
         );
     }
 
@@ -6090,7 +6090,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $node;
@@ -6150,7 +6150,7 @@ abstract class AbstractPHPParser
             }
 
             $formalParameters->addChild(
-                $this->parseFormalParameterOrPrefix($callable)
+                $this->parseFormalParameterOrPrefix($callable),
             );
 
             $this->consumeComments();
@@ -6209,7 +6209,7 @@ abstract class AbstractPHPParser
         $this->tokenStack->push();
 
         return $this->setNodePositionsAndReturn(
-            $this->parseFormalParameterFromType($tokenType)
+            $this->parseFormalParameterFromType($tokenType),
         );
     }
 
@@ -6278,7 +6278,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $type;
@@ -6533,7 +6533,7 @@ abstract class AbstractPHPParser
             case Tokens::T_NAMESPACE:
             case Tokens::T_CLASS:
                 return $this->builder->buildAstClassOrInterfaceReference(
-                    $this->parseQualifiedName()
+                    $this->parseQualifiedName(),
                 );
         }
 
@@ -6658,7 +6658,7 @@ abstract class AbstractPHPParser
                 return $this->parseCommentWithOptionalInlineClassOrInterfaceReference();
             case Tokens::T_DOC_COMMENT:
                 return $this->builder->buildAstComment(
-                    $this->consumeToken(Tokens::T_DOC_COMMENT)->image
+                    $this->consumeToken(Tokens::T_DOC_COMMENT)->image,
                 );
             case Tokens::T_CURLY_BRACE_OPEN:
                 return $this->parseRegularScope();
@@ -6775,7 +6775,7 @@ abstract class AbstractPHPParser
             $image = $this->useSymbolTable->lookup($match[1]) ?: $match[1];
 
             $comment->addChild(
-                $this->builder->buildAstClassOrInterfaceReference($image)
+                $this->builder->buildAstClassOrInterfaceReference($image),
             );
         }
 
@@ -6783,7 +6783,7 @@ abstract class AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
         return $comment;
     }
@@ -6800,7 +6800,7 @@ abstract class AbstractPHPParser
      * @since 1.0.0
      */
     protected function parseOptionalBoundVariables(
-        ASTClosure $closure
+        ASTClosure $closure,
     ) {
         $this->consumeComments();
 
@@ -7347,8 +7347,8 @@ abstract class AbstractPHPParser
         ) {
             return $this->setNodePositionsAndReturn(
                 $this->parseStaticMemberPrimaryPrefix(
-                    $this->parseStaticReference($token)
-                )
+                    $this->parseStaticReference($token),
+                ),
             );
         } elseif ($tokenType === Tokens::T_FUNCTION) {
             $closure = $this->parseClosureDeclaration();
@@ -7363,7 +7363,7 @@ abstract class AbstractPHPParser
         }
 
         return $this->setNodePositionsAndReturn(
-            $this->parseStaticVariableDeclaration($token)
+            $this->parseStaticVariableDeclaration($token),
         );
     }
 
@@ -7393,7 +7393,7 @@ abstract class AbstractPHPParser
     private function parseStaticVariableDeclaration(Token $token)
     {
         $staticDeclaration = $this->builder->buildAstStaticVariableDeclaration(
-            $token->image
+            $token->image,
         );
 
         // Strip optional comments
@@ -7539,12 +7539,12 @@ abstract class AbstractPHPParser
                     break;
                 case Tokens::T_LNUMBER:
                     $defaultValue->setValue($signed * $this->parseIntegerNumberImage(
-                        $this->parseNumber(Tokens::T_LNUMBER)
+                        $this->parseNumber(Tokens::T_LNUMBER),
                     ));
                     break;
                 case Tokens::T_DNUMBER:
-                    $defaultValue->setValue($signed * (double) $this->getNumberFromImage(
-                        $this->parseNumber(Tokens::T_DNUMBER)
+                    $defaultValue->setValue($signed * (float) $this->getNumberFromImage(
+                        $this->parseNumber(Tokens::T_DNUMBER),
                     ));
                     break;
                 case Tokens::T_CONSTANT_ENCAPSED_STRING:
@@ -7585,7 +7585,7 @@ abstract class AbstractPHPParser
                 case Tokens::T_STRING:
                 case Tokens::T_BACKSLASH:
                     $node = $this->builder->buildAstClassOrInterfaceReference(
-                        $this->parseQualifiedName()
+                        $this->parseQualifiedName(),
                     );
 
                     if ($this->tokenizer->peek() === Tokens::T_DOUBLE_COLON) {
@@ -7609,7 +7609,7 @@ abstract class AbstractPHPParser
                     break;
                 case Tokens::T_START_HEREDOC:
                     $defaultValue->setValue(
-                        $this->parseHeredoc()->getChild(0)->getImage()
+                        $this->parseHeredoc()->getChild(0)->getImage(),
                     );
                     break;
                 default:
@@ -7770,7 +7770,7 @@ abstract class AbstractPHPParser
             Tokens::T_TRAIT,
             Tokens::T_ABSTRACT,
             Tokens::T_FUNCTION,
-            Tokens::T_INTERFACE
+            Tokens::T_INTERFACE,
         );
 
         return !in_array($this->tokenizer->peek(), $notExpectedTags, true);
@@ -7841,7 +7841,7 @@ abstract class AbstractPHPParser
                 function ($image) use ($useSymbolTable) {
                     return $useSymbolTable->lookup($image) ?: $image;
                 },
-                array_map('trim', explode('|', end($match) ?: ''))
+                array_map('trim', explode('|', end($match) ?: '')),
             );
         }
 
@@ -7875,7 +7875,7 @@ abstract class AbstractPHPParser
         foreach ($annotations as $annotation) {
             if (Type::isPrimitiveType($annotation) === true) {
                 return $this->builder->buildAstScalarType(
-                    Type::getPrimitiveType($annotation)
+                    Type::getPrimitiveType($annotation),
                 );
             }
 
@@ -7902,7 +7902,7 @@ abstract class AbstractPHPParser
         foreach ($annotations as $annotation) {
             if (Type::isScalarType($annotation) === false) {
                 return $this->builder->buildAstClassOrInterfaceReference(
-                    $annotation
+                    $annotation,
                 );
             }
         }
@@ -7966,7 +7966,7 @@ abstract class AbstractPHPParser
 
         foreach ($throws as $qualifiedName) {
             $callable->addExceptionClassReference(
-                $this->builder->buildAstClassOrInterfaceReference($qualifiedName)
+                $this->builder->buildAstClassOrInterfaceReference($qualifiedName),
             );
         }
 
@@ -7980,7 +7980,7 @@ abstract class AbstractPHPParser
 
         if ($qualifiedName !== null) {
             $callable->setReturnClassReference(
-                $this->builder->buildAstClassOrInterfaceReference($qualifiedName)
+                $this->builder->buildAstClassOrInterfaceReference($qualifiedName),
             );
         }
     }
@@ -8128,7 +8128,7 @@ abstract class AbstractPHPParser
                 !in_array($type->getImage(), array('int', 'string'), true)
             ) {
                 throw new TokenException(
-                    "Enum backing type must be 'int' or 'string'"
+                    "Enum backing type must be 'int' or 'string'",
                 );
             }
         }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -324,7 +324,7 @@ class PHPBuilder implements Builder
         Log::debug(
             'Creating: \\PDepend\\Source\\AST\\ASTClassOrInterfaceReference(' .
             $qualifiedName .
-            ')'
+            ')',
         );
 
         return new ASTClassOrInterfaceReference($this->context, $qualifiedName);
@@ -429,7 +429,7 @@ class PHPBuilder implements Builder
         $this->checkBuilderState();
 
         Log::debug(
-            'Creating: \\PDepend\\Source\\AST\\ASTTraitReference(' . $qualifiedName . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTTraitReference(' . $qualifiedName . ')',
         );
 
         return new ASTTraitReference($this->context, $qualifiedName);
@@ -519,7 +519,7 @@ class PHPBuilder implements Builder
 
         // Debug method creation
         Log::debug(
-            'Creating: \\PDepend\\Source\\AST\\ASTClassReference(' . $qualifiedName . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTClassReference(' . $qualifiedName . ')',
         );
 
         return new ASTClassReference($this->context, $qualifiedName);
@@ -624,7 +624,7 @@ class PHPBuilder implements Builder
         if (!isset($this->namespaces[$name])) {
             // Debug package creation
             Log::debug(
-                'Creating: \\PDepend\\Source\\AST\\ASTNamespace(' . $name . ')'
+                'Creating: \\PDepend\\Source\\AST\\ASTNamespace(' . $name . ')',
             );
 
             $this->namespaces[$name] = new ASTNamespace($name);
@@ -665,7 +665,7 @@ class PHPBuilder implements Builder
     public function buildAstSelfReference(AbstractASTClassOrInterface $type)
     {
         Log::debug(
-            'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getName() . ')'
+            'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getName() . ')',
         );
 
         return new ASTSelfReference($this->context, $type);
@@ -2223,7 +2223,7 @@ class PHPBuilder implements Builder
 
         $trait = $this->buildTrait($qualifiedName);
         $trait->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName))
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
         );
 
         $this->restoreTrait($trait);
@@ -2249,7 +2249,7 @@ class PHPBuilder implements Builder
         /** @var ASTTrait|null $trait */
         $trait = $this->findType(
             $this->frozenTraits,
-            $qualifiedName
+            $qualifiedName,
         );
 
         if ($trait === null) {
@@ -2300,7 +2300,7 @@ class PHPBuilder implements Builder
 
         $interface = $this->buildInterface($qualifiedName);
         $interface->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName))
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
         );
 
         $this->restoreInterface($interface);
@@ -2326,13 +2326,13 @@ class PHPBuilder implements Builder
         /** @var ASTInterface|null $interface */
         $interface = $this->findType(
             $this->frozenInterfaces,
-            $qualifiedName
+            $qualifiedName,
         );
 
         if ($interface === null) {
             $interface = $this->findType(
                 $this->interfaces,
-                $qualifiedName
+                $qualifiedName,
             );
         }
         return $interface;
@@ -2374,7 +2374,7 @@ class PHPBuilder implements Builder
 
         $class = $this->buildClass($qualifiedName);
         $class->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName))
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
         );
 
         $this->restoreClass($class);
@@ -2400,7 +2400,7 @@ class PHPBuilder implements Builder
         /** @var ASTClass|ASTEnum|null $class */
         $class = $this->findType(
             $this->frozenClasses,
-            $qualifiedName
+            $qualifiedName,
         );
 
         if ($class === null) {
@@ -2527,7 +2527,7 @@ class PHPBuilder implements Builder
         $this->storeTrait(
             $trait->getName(),
             $trait->getNamespaceName(),
-            $trait
+            $trait,
         );
     }
 
@@ -2543,7 +2543,7 @@ class PHPBuilder implements Builder
         $this->storeClass(
             $class->getName(),
             $class->getNamespaceName(),
-            $class
+            $class,
         );
     }
 
@@ -2559,7 +2559,7 @@ class PHPBuilder implements Builder
         $this->storeEnum(
             $enum->getName(),
             $enum->getNamespaceName(),
-            $enum
+            $enum,
         );
     }
 
@@ -2575,7 +2575,7 @@ class PHPBuilder implements Builder
         $this->storeInterface(
             $interface->getName(),
             $interface->getNamespaceName(),
-            $interface
+            $interface,
         );
     }
 
@@ -2724,7 +2724,7 @@ class PHPBuilder implements Builder
     {
         if ($this->frozen === true && $this->internal === false) {
             throw new BadMethodCallException(
-                'Cannot create new nodes, when internal state is frozen.'
+                'Cannot create new nodes, when internal state is frozen.',
             );
         }
         $this->internal = $internal;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -269,8 +269,8 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                 (string) $this->compilationUnit,
                 sprintf(
                     'Constant can\'t be declared private or protected in interface "%s".',
-                    $this->classOrInterface->getName()
-                )
+                    $this->classOrInterface->getName(),
+                ),
             );
         }
 
@@ -368,7 +368,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                 return true;
         }
 
-        return $this->isFunctionName($tokenType);;
+        return $this->isFunctionName($tokenType);
     }
 
 
@@ -472,7 +472,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
             $expr,
             $this->consumeToken(Tokens::T_PARENTHESIS_OPEN),
             Tokens::T_PARENTHESIS_CLOSE,
-            Tokens::T_COMMA
+            Tokens::T_COMMA,
         );
 
         while ($this->tokenizer->peek() === Tokens::T_PARENTHESIS_OPEN) {
@@ -550,8 +550,8 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
             sprintf(
                 'class@anonymous%s0x%s',
                 $this->compilationUnit->getFileName(),
-                uniqid('')
-            )
+                uniqid(''),
+            ),
         );
         $class->setCompilationUnit($this->compilationUnit);
         $class->setUserDefined();
@@ -578,8 +578,8 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
         $allocation->addChild(
             $this->setNodePositionsAndReturn(
                 $this->parseTypeBody($class),
-                $tokens
-            )
+                $tokens,
+            ),
         );
         $class->setTokens($tokens);
 
@@ -646,7 +646,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                     $token->startLine,
                     $token->endLine,
                     $token->startColumn,
-                    $token->endColumn
+                    $token->endColumn,
                 );
 
                 return $expr;
@@ -881,7 +881,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $expressions[] = $expr;
@@ -900,7 +900,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                 case Tokens::T_CONCAT_EQUAL:
                 case Tokens::T_COALESCE_EQUAL:
                     $expressions[] = $this->parseAssignmentExpression(
-                        array_pop($expressions)
+                        array_pop($expressions),
                     );
                     break;
                 case Tokens::T_DIR:
@@ -926,7 +926,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
                         $token->startLine,
                         $token->endLine,
                         $token->startColumn,
-                        $token->endColumn
+                        $token->endColumn,
                     );
 
                     $expressions[] = $expr;
@@ -956,7 +956,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
             $expressions[0]->getStartLine(),
             $expressions[$count - 1]->getEndLine(),
             $expressions[0]->getStartColumn(),
-            $expressions[$count - 1]->getEndColumn()
+            $expressions[$count - 1]->getEndColumn(),
         );
 
         // @todo ASTValue must be a valid node.
@@ -1120,7 +1120,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
         $this->consumeToken(Tokens::T_CLASS_FQN);
 
         return $this->setNodePositionsAndReturn(
-            $this->builder->buildAstClassFqnPostfix()
+            $this->builder->buildAstClassFqnPostfix(),
         );
     }
 
@@ -1271,7 +1271,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
         if (!preg_match('(^b[01]+$)i', $token1->image)) {
             throw new UnexpectedTokenException(
                 $token1,
-                $this->tokenizer->getSourceFile()
+                $this->tokenizer->getSourceFile(),
             );
         }
 
@@ -1286,7 +1286,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
             $token->startLine,
             $token->endLine,
             $token->startColumn,
-            $token->endColumn
+            $token->endColumn,
         );
 
         return $literal;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -122,8 +122,8 @@ abstract class PHPParserVersion74 extends PHPParserVersion73
 
         $closure->addChild(
             $this->buildReturnStatement(
-                $this->consumeToken(Tokens::T_DOUBLE_ARROW)
-            )
+                $this->consumeToken(Tokens::T_DOUBLE_ARROW),
+            ),
         );
 
         return $this->setNodePositionsAndReturn($closure);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -160,7 +160,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
                     $token->startLine,
                     $token->endLine,
                     $token->startColumn,
-                    $token->endColumn
+                    $token->endColumn,
                 );
 
                 return $expr;
@@ -244,7 +244,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
             return $this->builder->buildAstNamedArgument(
                 $constant->getImage(),
-                $this->parseOptionalExpression()
+                $this->parseOptionalExpression(),
             );
         }
 
@@ -268,8 +268,8 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
         $function->addChild(
             $this->parseArgumentsParenthesesContent(
-                $this->builder->buildAstMatchArgument()
-            )
+                $this->builder->buildAstMatchArgument(),
+            ),
         );
 
         $this->consumeComments();
@@ -408,7 +408,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
             throw new ParserException(
                 $type->getImage() . ' can not be used as a standalone type',
                 0,
-                $this->getUnexpectedTokenException($token)
+                $this->getUnexpectedTokenException($token),
             );
         }
 
@@ -461,7 +461,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
         return $this->consumeToken(
             $this->tokenizer->peek() === Tokens::T_NULLSAFE_OBJECT_OPERATOR
                 ? Tokens::T_NULLSAFE_OBJECT_OPERATOR
-                : Tokens::T_OBJECT_OPERATOR
+                : Tokens::T_OBJECT_OPERATOR,
         );
     }
 
@@ -473,7 +473,7 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
                 Tokens::T_COMMA,
                 Tokens::T_COLON,
                 Tokens::T_PARENTHESIS_CLOSE,
-                Tokens::T_SQUARED_BRACKET_CLOSE
+                Tokens::T_SQUARED_BRACKET_CLOSE,
             ));
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -182,7 +182,7 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
                 throw new ParserException(
                     $type->getImage() . ' can not be used in an intersection type',
                     0,
-                    $this->getUnexpectedTokenException($token)
+                    $this->getUnexpectedTokenException($token),
                 );
             }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -577,28 +577,28 @@ class PHPTokenizerInternal implements FullTokenizer
             self::T_ELLIPSIS  =>  array(
                 'type'  => Tokens::T_ELLIPSIS,
                 'image' => '...',
-            )
+            ),
         ),
 
         Tokens::T_ANGLE_BRACKET_CLOSE => array(
             Tokens::T_IS_SMALLER_OR_EQUAL => array(
                 'type'  => Tokens::T_SPACESHIP,
                 'image' => '<=>',
-            )
+            ),
         ),
 
         Tokens::T_QUESTION_MARK => array(
             Tokens::T_QUESTION_MARK => array(
                 'type'  => Tokens::T_COALESCE,
                 'image' => '??',
-            )
+            ),
         ),
 
         Tokens::T_MUL => array(
             Tokens::T_MUL => array(
                 'type'  => Tokens::T_POW,
                 'image' => '**',
-            )
+            ),
         ),
     );
 
@@ -994,7 +994,7 @@ class PHPTokenizerInternal implements FullTokenizer
                     $startColumn += strlen($token[1]);
                 } else {
                     $startColumn = strlen(
-                        substr($token[1], strrpos($token[1], "\n") + 1)
+                        substr($token[1], strrpos($token[1], "\n") + 1),
                     ) + 1;
                 }
 
@@ -1042,7 +1042,7 @@ class PHPTokenizerInternal implements FullTokenizer
                     $endColumn = $startColumn + strlen($rtrim) - 1;
                 } else {
                     $endColumn = strlen(
-                        substr($rtrim, strrpos($rtrim, "\n") + 1)
+                        substr($rtrim, strrpos($rtrim, "\n") + 1),
                     );
                 }
 
@@ -1062,7 +1062,7 @@ class PHPTokenizerInternal implements FullTokenizer
                     $startColumn += strlen($image);
                 } else {
                     $startColumn = strlen(
-                        substr($image, strrpos($image, "\n") + 1)
+                        substr($image, strrpos($image, "\n") + 1),
                     ) + 1;
                 }
 

--- a/src/main/php/PDepend/Source/Parser/InvalidStateException.php
+++ b/src/main/php/PDepend/Source/Parser/InvalidStateException.php
@@ -66,8 +66,8 @@ class InvalidStateException extends ParserException
                 '"%s". Please check the following conditions: %s',
                 $lineNumber,
                 $fileName,
-                $reason
-            )
+                $reason,
+            ),
         );
     }
 }

--- a/src/main/php/PDepend/Source/Parser/MissingValueException.php
+++ b/src/main/php/PDepend/Source/Parser/MissingValueException.php
@@ -68,7 +68,7 @@ class MissingValueException extends ParserException
             'Missing default value on line: %d, col: %d, file: %s.',
             $token->startLine,
             $token->startColumn,
-            $tokenizer->getSourceFile()
+            $tokenizer->getSourceFile(),
         );
 
         parent::__construct($message);

--- a/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
@@ -61,8 +61,8 @@ class TokenStreamEndException extends TokenException
         parent::__construct(
             sprintf(
                 'Unexpected end of token stream in file: %s.',
-                $tokenizer->getSourceFile()
-            )
+                $tokenizer->getSourceFile(),
+            ),
         );
     }
 }

--- a/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
+++ b/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
@@ -68,7 +68,7 @@ class UnexpectedTokenException extends TokenException
             $token->startLine,
             $token->startColumn,
             $fileName,
-            "\n".$exception->getTraceAsString()
+            "\n" . $exception->getTraceAsString(),
         );
 
         parent::__construct($message);

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -216,7 +216,7 @@ class Command
 
         if (isset($options['--notify-me'])) {
             $this->runner->addProcessListener(
-                new DbusResultPrinter()
+                new DbusResultPrinter(),
             );
             unset($options['--notify-me']);
         }
@@ -244,7 +244,7 @@ class Command
                     '%sThe following error%s occurred:%s',
                     PHP_EOL,
                     count($errors) > 1 ? 's' : '',
-                    PHP_EOL
+                    PHP_EOL,
                 );
 
                 foreach ($errors as $error) {
@@ -281,7 +281,7 @@ class Command
     protected function parseArguments()
     {
         if (!isset($_SERVER['argv'])) {
-            if (false === (boolean) ini_get('register_argc_argv')) {
+            if (false === (bool) ini_get('register_argc_argv')) {
                 // @codeCoverageIgnoreStart
                 echo 'Please enable register_argc_argv in your php.ini.';
             } else {
@@ -308,9 +308,9 @@ class Command
 
         for ($i = 0, $c = count($argv); $i < $c; ++$i) {
             // Is it an ini_set option?
-            $arg = (string)$argv[$i];
+            $arg = (string) $argv[$i];
             if ($arg === '-d' && isset($argv[$i + 1])) {
-                $arg = (string)$argv[++$i];
+                $arg = (string) $argv[++$i];
                 if (strpos($arg, '=') === false) {
                     ini_set($arg, 'on');
                 } else {
@@ -436,31 +436,31 @@ class Command
         $this->printOption(
             '--configuration=<file>',
             'Optional PDepend configuration file.',
-            $length
+            $length,
         );
         echo PHP_EOL;
 
         $this->printOption(
             '--suffix=<ext[,...]>',
             'List of valid PHP file extensions.',
-            $length
+            $length,
         );
         $this->printOption(
             '--ignore=<dir[,...]>',
             'List of exclude directories.',
-            $length
+            $length,
         );
         $this->printOption(
             '--exclude=<pkg[,...]>',
             'List of exclude namespaces.',
-            $length
+            $length,
         );
         echo PHP_EOL;
 
         $this->printOption(
             '--without-annotations',
             'Do not parse doc comment annotations.',
-            $length
+            $length,
         );
         echo PHP_EOL;
 
@@ -637,7 +637,7 @@ class Command
     private function getErrorTrace($exception)
     {
         return get_class($exception) . '(' . $exception->getMessage() . ')' . PHP_EOL .
-            '## ' . $exception->getFile() .'(' . $exception->getLine() . ')' . PHP_EOL .
+            '## ' . $exception->getFile() . '(' . $exception->getLine() . ')' . PHP_EOL .
             $exception->getTraceAsString();
     }
 }

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -117,13 +117,13 @@ class CacheFactory
                 return $this->createFileCache(
                     $this->configuration->cache->location,
                     $this->configuration->cache->ttl,
-                    $cacheKey
+                    $cacheKey,
                 );
             case 'memory':
                 return $this->createMemoryCache();
         }
         throw new InvalidArgumentException(
-            "Unknown cache driver '{$this->configuration->cache->driver}' given."
+            "Unknown cache driver '{$this->configuration->cache->driver}' given.",
         );
     }
 

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
@@ -94,7 +94,7 @@ class FileCacheGarbageCollector
 
         try {
             $files = new RecursiveIteratorIterator(
-                new RecursiveDirectoryIterator($this->cacheDir)
+                new RecursiveDirectoryIterator($this->cacheDir),
             );
             foreach ($files as $file) {
                 if ($this->isCollectibleFile($file)) {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -98,7 +98,7 @@ class MemoryCacheDriver implements CacheDriver
      */
     public function __construct()
     {
-        $this->staticId = sha1(uniqid((string)rand(0, PHP_INT_MAX)));
+        $this->staticId = sha1(uniqid((string) rand(0, PHP_INT_MAX)));
     }
 
     /**

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -94,7 +94,7 @@ class Configuration
             return $this->settings->{$name};
         }
         throw new OutOfRangeException(
-            sprintf("A configuration option '%s' not exists.", $name)
+            sprintf("A configuration option '%s' not exists.", $name),
         );
     }
 
@@ -116,7 +116,7 @@ class Configuration
     public function __set($name, $value)
     {
         throw new OutOfRangeException(
-            sprintf("A configuration option '%s' not exists.", $name)
+            sprintf("A configuration option '%s' not exists.", $name),
         );
     }
 

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -95,7 +95,7 @@ class IdBuilder
     {
         return $this->forOffsetItem(
             $type,
-            ltrim(strrchr(strtolower(get_class($type)), '_') ?: '', '_')
+            ltrim(strrchr(strtolower(get_class($type)), '_') ?: '', '_'),
         );
     }
 
@@ -126,7 +126,7 @@ class IdBuilder
         return sprintf(
             '%s-%s',
             $method->getParent()->getId(),
-            $this->hash(strtolower($method->getName()))
+            $this->hash(strtolower($method->getName())),
         );
     }
 
@@ -160,7 +160,7 @@ class IdBuilder
         }
         return sprintf(
             '%02s',
-            base_convert((string)$this->offsetInFile[$file][$string], 10, 36)
+            base_convert((string) $this->offsetInFile[$file][$string], 10, 36),
         );
     }
 }

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -94,10 +94,10 @@ class ImageConvert
         } else {
             $fallback = substr($output, 0, -strlen($outputType)) . $inputType;
 
-            echo "WARNING: Cannot generate image of type '{$outputType}'. This",
-                 " feature needs either the\n         pecl/imagick extension or",
-                 " the ImageMagick cli tool 'convert'.\n\n",
-                 "Writing alternative image:\n{$fallback}\n\n";
+            echo "WARNING: Cannot generate image of type '{$outputType}'. This"
+                . " feature needs either the\n         pecl/imagick extension or"
+                . " the ImageMagick cli tool 'convert'.\n\n"
+                . "Writing alternative image:\n{$fallback}\n\n";
 
             file_put_contents($fallback, file_get_contents($input));
         }

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -114,7 +114,7 @@ final class Type
           IMAGE_SOUNDEX_STRING       = 'S365',
           IMAGE_SOUNDEX_STDCLASS     = 'S324',
           IMAGE_SOUNDEX_UNKNOWN      = 'U525';
- 
+
     /**
      * Constants for other types/keywords frequently used.
      */


### PR DESCRIPTION
Breaking change: no

Apply the majority of PSR-CS 2.0 code style rules. We already comply with most of them meaning there are actually very little changes, mostly trailing commas and a little bit of white space.