### PR TITLE
Enable PER-CS 2.0 (amended) code style

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,34 +1,99 @@
 <?php
+
 /*
  * This document has been generated with
- * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.4.0|configurator
+ * https://mlocati.github.io/php-cs-fixer-configurator/#version:3.54.0|configurator
  * you can change this configuration by importing this file.
  */
 $config = new PhpCsFixer\Config();
 return $config
     ->setRules([
-        'blank_line_after_namespace' => true,
+        '@PER-CS2.0' => true,
+        'ordered_class_elements' => [
+            'order' => [
+                'use_trait',
+                // Going beyond PER CS v2
+                'case',
+                'constant_public',
+                'constant_protected',
+                'constant_private',
+                'property_public',
+                'property_protected',
+                'property_private',
+                'construct',
+                'destruct',
+                'magic',
+                'phpunit',
+                // We do not want to order methods
+//                'method_public',
+//                'method_protected',
+//                'method_private',
+            ]
+        ],
+        'single_line_empty_body' => false, // Not adhering to PER CS v2
+        'trailing_comma_in_multiline' => [
+            'after_heredoc' => true,
+            'elements' => [
+                // Not adhering to PER CS v2; we don't want trailing commas for arguments
+//                'arguments',
+                'arrays',
+                'match',
+                // Not adhering to PER CS v2; we don't want trailing commas for parameters
+//                'parameters'
+            ]
+        ],
         'fully_qualified_strict_types' => true,
         'global_namespace_import' => true,
         'no_empty_phpdoc' => true,
-        'no_leading_import_slash' => true,
         'no_superfluous_phpdoc_tags' => true,
         'no_unused_imports' => true,
-        'ordered_imports' => true,
+        // Using sorting algo "alpha" instead of "none" defined in PER CS v2
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
         'phpdoc_align' => true,
         'phpdoc_indent' => true,
-        'phpdoc_order' => true,
+        'phpdoc_order' => [
+            'order' => [
+                'param', // Input, thus first
+                'return', // Output, thus second
+                'throws', // Important exceptional situations
+                'var', // For properties & inline type hints only
+                'global', // Hints for properties & methods in classes
+                'property', // Hints for properties & methods in classes
+                'property-read', // Hints for properties & methods in classes
+                'property-write', // Hints for properties & methods in classes
+                'method', // Hints for properties & methods in classes
+                'dataProvider', // For tests only, defines the input
+                'covers', // For tests only, defines the coverage
+                'author', // Normally comes before copyright
+                'copyright', // Normally comes before license
+                'license', // Should be after author and copyright
+                'see', // Links & examples
+                'link', // Links & examples
+                'example', // Links & examples
+                'internal', // Would be important, if present
+                'api', // Category & packages
+                'category', // Category & packages
+                'package', // Category & packages
+                'subpackage', // Category & packages
+                'uses', // Usage
+                'used-by', // Usage
+                'source', // Source & version
+                'version', // Source & version
+                'since', // Source & version
+                'filesource', // phpDocumentor specific
+                'ignore', // phpDocumentor specific
+                'deprecated', // Should be to the end to better notice them
+                'todo', // Should be last to better notice them
+            ],
+        ],
         'phpdoc_return_self_reference' => true,
         'phpdoc_scalar' => true,
         'phpdoc_separation' => true,
         'phpdoc_single_line_var_spacing' => true,
         'phpdoc_trim' => true,
         'phpdoc_trim_consecutive_blank_line_separation' => true,
-        'phpdoc_types_order' => ['null_adjustment'=>'always_last'],
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
         'phpdoc_var_annotation_correct_order' => true,
-        'single_blank_line_before_namespace' => true,
-        'single_import_per_statement' => true,
-        'single_line_after_imports' => true,
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -90,9 +90,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return Configuration
+     *
+     * @throws Exception
      */
     public function getConfiguration()
     {
@@ -103,9 +103,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return Engine
+     *
+     * @throws Exception
      */
     public function getEngine()
     {
@@ -116,9 +116,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return Runner
+     *
+     * @throws Exception
      */
     public function getRunner()
     {
@@ -129,9 +129,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return ReportGeneratorFactory
+     *
+     * @throws Exception
      */
     public function getReportGeneratorFactory()
     {
@@ -142,9 +142,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return AnalyzerFactory
+     *
+     * @throws Exception
      */
     public function getAnalyzerFactory()
     {
@@ -155,9 +155,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return TaggedContainerInterface
+     *
+     * @throws Exception
      */
     private function getContainer()
     {
@@ -169,9 +169,9 @@ class Application
     }
 
     /**
-     * @throws Exception
-     *
      * @return TaggedContainerInterface
+     *
+     * @throws Exception
      */
     private function createContainer()
     {
@@ -199,9 +199,9 @@ class Application
     /**
      * Returns available logger options and documentation messages.
      *
-     * @throws Exception
-     *
      * @return array<string, array<string, string>>
+     *
+     * @throws Exception
      */
     public function getAvailableLoggerOptions()
     {
@@ -211,9 +211,9 @@ class Application
     /**
      * Returns available analyzer options and documentation messages.
      *
-     * @throws Exception
-     *
      * @return array<string, array<string, string>>
+     *
+     * @throws Exception
      */
     public function getAvailableAnalyzerOptions()
     {
@@ -223,9 +223,9 @@ class Application
     /**
      * @param string $serviceTag
      *
-     * @throws Exception
-     *
      * @return array<string, array<string, string>>
+     *
+     * @throws Exception
      */
     private function getAvailableOptionsFor($serviceTag)
     {

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -91,12 +91,16 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
      *
      * @param Builder<mixed> $builder The used node builder instance.
      */
-    public function endParseProcess(Builder $builder): void {}
+    public function endParseProcess(Builder $builder): void
+    {
+    }
 
     /**
      * Is called when PDepend starts parsing of a new file.
      */
-    public function startFileParsing(Tokenizer $tokenizer): void {}
+    public function startFileParsing(Tokenizer $tokenizer): void
+    {
+    }
 
     /**
      * Is called when PDepend has finished a file.
@@ -109,17 +113,23 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts the analyzing process.
      */
-    public function startAnalyzeProcess(): void {}
+    public function startAnalyzeProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend has finished the analyzing process.
      */
-    public function endAnalyzeProcess(): void {}
+    public function endAnalyzeProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend starts the logging process.
      */
-    public function startLogProcess(): void {}
+    public function startLogProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend has finished the logging process.
@@ -130,7 +140,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
             return;
         }
 
-        $dbus  = new Dbus(Dbus::BUS_SESSION);
+        $dbus = new Dbus(Dbus::BUS_SESSION);
         $proxy = $dbus->createProxy(
             "org.freedesktop.Notifications", // connection name
             "/org/freedesktop/Notifications", // object
@@ -157,14 +167,18 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
      *
      * @param Analyzer $analyzer The context analyzer instance.
      */
-    public function startAnalyzer(Analyzer $analyzer): void {}
+    public function startAnalyzer(Analyzer $analyzer): void
+    {
+    }
 
     /**
      * Is called when PDepend has finished one analyzing process.
      *
      * @param Analyzer $analyzer The context analyzer instance.
      */
-    public function endAnalyzer(Analyzer $analyzer): void {}
+    public function endAnalyzer(Analyzer $analyzer): void
+    {
+    }
 }
 
 // @codeCoverageIgnoreEnd

--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -57,17 +57,16 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * @var TreeBuilderFactory
+     */
+    protected $treeBuilderFactory;
+    /**
      * @param array<Extension> $extensions
      */
     public function __construct(array $extensions)
     {
         $this->treeBuilderFactory = new TreeBuilderFactory($extensions);
     }
-
-    /**
-     * @var TreeBuilderFactory
-     */
-    protected $treeBuilderFactory;
 
     /**
      * {@inheritDoc}

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -56,9 +56,9 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  *
  * Copied from Behat
  *
- * @link   https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Extension/Extension.php
- *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ *
+ * @link   https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Extension/Extension.php
  */
 abstract class Extension
 {

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -122,16 +122,16 @@ class PdependExtension extends SymfonyExtension
     {
         $settings = new stdClass();
 
-        $settings->cache           = new stdClass();
+        $settings->cache = new stdClass();
         $settings->cache->driver = $config['cache']['driver'];
         $settings->cache->location = $config['cache']['location'];
         $settings->cache->ttl = $config['cache']['ttl'];
 
-        $settings->imageConvert             = new stdClass();
-        $settings->imageConvert->fontSize   = $config['image_convert']['font_size'];
+        $settings->imageConvert = new stdClass();
+        $settings->imageConvert->fontSize = $config['image_convert']['font_size'];
         $settings->imageConvert->fontFamily = $config['image_convert']['font_family'];
 
-        $settings->parser          = new stdClass();
+        $settings->parser = new stdClass();
         $settings->parser->nesting = $config['parser']['nesting'];
 
         return $settings;

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -321,9 +321,9 @@ class Engine
      * Analyzes the registered directories and returns the collection of
      * analyzed namespace.
      *
-     * @throws InvalidArgumentException
-     *
      * @return ASTArtifactList<ASTNamespace>
+     *
+     * @throws InvalidArgumentException
      */
     public function analyze()
     {
@@ -362,9 +362,9 @@ class Engine
     /**
      * Returns the number of analyzed php classes and interfaces.
      *
-     * @throws RuntimeException
-     *
      * @return int
+     *
+     * @throws RuntimeException
      */
     public function countClasses()
     {
@@ -394,9 +394,9 @@ class Engine
     /**
      * Returns the number of analyzed namespaces.
      *
-     * @throws RuntimeException
-     *
      * @return int
+     *
+     * @throws RuntimeException
      */
     public function countNamespaces()
     {
@@ -419,10 +419,10 @@ class Engine
      *
      * @param string $name
      *
+     * @return ASTNamespace
+     *
      * @throws OutOfBoundsException
      * @throws RuntimeException
-     *
-     * @return ASTNamespace
      */
     public function getNamespace($name)
     {
@@ -441,9 +441,9 @@ class Engine
     /**
      * Returns an array with the analyzed namespace.
      *
-     * @throws RuntimeException
-     *
      * @return ASTArtifactList<ASTNamespace>
+     *
+     * @throws RuntimeException
      */
     public function getNamespaces()
     {
@@ -623,9 +623,9 @@ class Engine
      * This method will create an iterator instance which contains all files
      * that are part of the parsing process.
      *
-     * @throws RuntimeException
-     *
      * @return ArrayIterator<int, string>
+     *
+     * @throws RuntimeException
      */
     private function createFileIterator()
     {
@@ -686,9 +686,9 @@ class Engine
     /**
      * @param array<string, mixed> $options
      *
-     * @throws InvalidArgumentException
-     *
      * @return Analyzer[]
+     *
+     * @throws InvalidArgumentException
      */
     private function createAnalyzers($options)
     {

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -80,7 +80,7 @@ class Iterator extends FilterIterator
     {
         parent::__construct($iterator);
 
-        $this->filter   = $filter;
+        $this->filter = $filter;
         $this->rootPath = $rootPath;
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -63,8 +63,13 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * Metrics provided by the analyzer implementation.
      */
     private const
-        M_AFFERENT_COUPLING          = 'ca',
-        M_EFFERENT_COUPLING          = 'ce';
+        M_AFFERENT_COUPLING = 'ca',
+        M_EFFERENT_COUPLING = 'ce';
+
+    /**
+     * @var array<string, ASTNamespace>
+     */
+    protected $nodeSet = [];
 
     /**
      * Hash with all calculated node metrics.
@@ -72,11 +77,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * @var array<string, array<string, array<string, string>>>
      */
     private $nodeMetrics = null;
-
-    /**
-     * @var array<string, ASTNamespace>
-     */
-    protected $nodeSet = [];
 
     /**
      * Nodes in which the current analyzed class is used.
@@ -241,8 +241,8 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
             $this->nodeSet[$id] = $type;
 
             $this->nodeMetrics[$id] = [
-                self::M_AFFERENT_COUPLING =>  [],
-                self::M_EFFERENT_COUPLING =>  [],
+                self::M_AFFERENT_COUPLING => [],
+                self::M_EFFERENT_COUPLING => [],
             ];
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -100,10 +100,10 @@ class StrategyFactory
      *
      * @param string $strategyName The strategy identifier.
      *
+     * @return CodeRankStrategyI
+     *
      * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
-     *
-     * @return CodeRankStrategyI
      */
     public function createStrategy($strategyName)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -66,16 +66,15 @@ use PDepend\Util\Coverage\Report;
 class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, AnalyzerNodeAware
 {
     /**
+     * The report option name.
+     */
+    public const REPORT_OPTION = 'coverage-report';
+    /**
      * Metrics provided by the analyzer implementation.
      */
     private const
         M_CRAP_INDEX = 'crap',
         M_COVERAGE = 'cov';
-
-    /**
-     * The report option name.
-     */
-    public const REPORT_OPTION = 'coverage-report';
 
     /**
      * Calculated crap metrics.

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -70,6 +70,11 @@ class DependencyAnalyzer extends AbstractAnalyzer
         M_ABSTRACTION                = 'a',
         M_INSTABILITY                = 'i',
         M_DISTANCE                   = 'd';
+
+    /**
+     * @var array<string, ASTNamespace>
+     */
+    protected $nodeSet = [];
     /**
      * Hash with all calculated node metrics.
      *
@@ -91,11 +96,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * @var array<string, array<string, mixed>>
      */
     private $nodeMetrics = null;
-
-    /**
-     * @var array<string, ASTNamespace>
-     */
-    protected $nodeSet = [];
 
     /**
      * Nodes in which the current analyzed dependency is used.

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -358,12 +358,12 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
     /**
      * Calculates Halstead measures from n1, n2, N1 & N2.
      *
-     * @see http://www.verifysoft.com/en_halstead_metrics.html
-     * @see http://www.grammatech.com/codesonar/workflow-features/halstead
-     *
      * @param array<string, int> $basis [n1, n2, N1, N2]
      *
      * @return array<string, float>
+     *
+     * @see http://www.verifysoft.com/en_halstead_metrics.html
+     * @see http://www.grammatech.com/codesonar/workflow-features/halstead
      */
     public function calculateHalsteadMeasures(array $basis)
     {

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -72,9 +72,9 @@ class AnalyzerFactory
      *
      * @param ReportGenerator[] $generators
      *
-     * @throws InvalidArgumentException
-     *
      * @return Analyzer[]
+     *
+     * @throws InvalidArgumentException
      */
     public function createRequiredForGenerators(array $generators)
     {

--- a/src/main/php/PDepend/Metrics/AnalyzerFilterAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFilterAware.php
@@ -51,4 +51,6 @@ namespace PDepend\Metrics;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-interface AnalyzerFilterAware extends Analyzer {}
+interface AnalyzerFilterAware extends Analyzer
+{
+}

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -71,13 +71,6 @@ use PDepend\Util\Utf8Util;
 class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGenerator
 {
     /**
-     * The log output file.
-     *
-     * @var string
-     */
-    private $logFile = null;
-
-    /**
      * The raw {@link ASTNamespace} instances.
      *
      * @var ASTArtifactList<ASTNamespace>
@@ -90,6 +83,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * @var ASTCompilationUnit[]
      */
     protected $fileSet = [];
+    /**
+     * The log output file.
+     *
+     * @var string
+     */
+    private $logFile = null;
 
     /**
      * @var ClassDependencyAnalyzer|null

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -243,7 +243,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
         // Sort items by size
         usort(
             $items,
-            static fn (array $a, array $b) => $a['size'] <=> $b['size'],
+            static fn(array $a, array $b) => $a['size'] <=> $b['size'],
         );
 
         if ($items) {

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -68,13 +68,6 @@ use PDepend\Util\Utf8Util;
 class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGenerator
 {
     /**
-     * The output log file.
-     *
-     * @var string
-     */
-    private $logFile = null;
-
-    /**
      * The raw {@link ASTNamespace} instances.
      *
      * @var ASTArtifactList<ASTNamespace>
@@ -136,6 +129,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * @var DOMElement
      */
     protected $abstractClasses = null;
+    /**
+     * The output log file.
+     *
+     * @var string
+     */
+    private $logFile = null;
 
     /**
      * Sets the output log file.

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -298,9 +298,9 @@ class Pyramid implements FileAwareGenerator
     /**
      * Aggregates the required metrics from the registered analyzers.
      *
-     * @throws RuntimeException If one of the required analyzers isn't set.
-     *
      * @return array<string, mixed>
+     *
+     * @throws RuntimeException If one of the required analyzers isn't set.
      */
     private function collectMetrics()
     {

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -63,6 +63,12 @@ use Symfony\Component\DependencyInjection\TaggedContainerInterface;
 class ReportGeneratorFactory
 {
     /**
+     * Set of created logger instances.
+     *
+     * @var ReportGenerator[]
+     */
+    protected $instances = [];
+    /**
      * @var TaggedContainerInterface
      */
     private $container;
@@ -82,9 +88,9 @@ class ReportGeneratorFactory
      * @param string $identifier The generator identifier.
      * @param string $fileName   The log output file name.
      *
-     * @throws RuntimeException
-     *
      * @return ReportGenerator
+     *
+     * @throws RuntimeException
      */
     public function createGenerator($identifier, $fileName)
     {
@@ -115,11 +121,4 @@ class ReportGeneratorFactory
         }
         return $this->instances[$identifier];
     }
-
-    /**
-     * Set of created logger instances.
-     *
-     * @var ReportGenerator[]
-     */
-    protected $instances = [];
 }

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -72,13 +72,6 @@ use PDepend\Util\Utf8Util;
 class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGenerator
 {
     /**
-     * The log output file.
-     *
-     * @var string
-     */
-    private $logFile = null;
-
-    /**
      * The raw {@link ASTNamespace} instances.
      *
      * @var ASTArtifactList<ASTNamespace>
@@ -91,6 +84,12 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * @var ASTCompilationUnit[]
      */
     protected $fileSet = [];
+    /**
+     * The log output file.
+     *
+     * @var string
+     */
+    private $logFile = null;
 
     /**
      * List of all analyzers that implement the node aware interface

--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -65,4 +65,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTAllocationExpression extends AbstractASTNode {}
+class ASTAllocationExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -74,6 +74,37 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     protected $metadata = ':::';
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array
+     *
+     * @since 0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['metadata'], parent::__sleep());
+    }
+
+    /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global class
+     * context.
+     */
+    public function __wakeup(): void
+    {
+        $this->methods = null;
+
+        foreach ($this->nodes as $node) {
+            $node->setParent($this);
+        }
+
+        parent::__wakeup();
+    }
+
+    /**
      * @param string $image
      */
     public function setImage($image): void
@@ -209,37 +240,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     public function isAnonymous()
     {
         return true;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array
-     *
-     * @since 0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['metadata'], parent::__sleep());
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global class
-     * context.
-     */
-    public function __wakeup(): void
-    {
-        $this->methods = null;
-
-        foreach ($this->nodes as $node) {
-            $node->setParent($this);
-        }
-
-        parent::__wakeup();
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 1.0.0
  */
-class ASTArray extends ASTExpression {}
+class ASTArray extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -88,8 +88,8 @@ class ASTArrayElement extends ASTExpression
      *
      * @return int
      *
-     * @since  0.10.4
      * @see    ASTNode#getMetadataSize()
+     * @since  0.10.4
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTArrayIndexExpression extends ASTIndexExpression {}
+class ASTArrayIndexExpression extends ASTIndexExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -123,9 +123,9 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
     /**
      * Returns the current node
      *
-     * @throws OutOfBoundsException
-     *
      * @return T
+     *
+     * @throws OutOfBoundsException
      */
     public function current(): false|ASTArtifact
     {
@@ -175,8 +175,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * @return bool Returns true on success or false on failure. The return
      *              value will be casted to boolean if non-boolean was returned.
      *
-     * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @since  1.0.0
      */
     public function offsetExists($offset): bool
     {
@@ -188,12 +188,12 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @param int|string $offset
      *
-     * @throws OutOfBoundsException
-     *
      * @return T Can return all value types.
      *
-     * @since  1.0.0
+     * @throws OutOfBoundsException
+     *
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php
+     * @since  1.0.0
      */
     public function offsetGet($offset): ASTArtifact
     {
@@ -211,8 +211,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @throws BadMethodCallException
      *
-     * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
+     * @since  1.0.0
      */
     public function offsetSet($offset, $value): void
     {
@@ -226,8 +226,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      *
      * @throws BadMethodCallException
      *
-     * @since  1.0.0
      * @link   http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @since  1.0.0
      */
     public function offsetUnset($offset): void
     {

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -63,6 +63,22 @@ final class CollectionArtifactFilter implements ArtifactFilter
     private static $instance = null;
 
     /**
+     * An optional configured filter instance.
+     *
+     * @var ArtifactFilter
+     */
+    private $filter = null;
+
+    /**
+     * Constructs a new static filter.
+     *
+     * @access private
+     */
+    public function __construct()
+    {
+    }
+
+    /**
      * Singleton method for this filter class.
      *
      * @return CollectionArtifactFilter
@@ -74,20 +90,6 @@ final class CollectionArtifactFilter implements ArtifactFilter
         }
         return self::$instance;
     }
-
-    /**
-     * Constructs a new static filter.
-     *
-     * @access private
-     */
-    public function __construct() {}
-
-    /**
-     * An optional configured filter instance.
-     *
-     * @var ArtifactFilter
-     */
-    private $filter = null;
 
     /**
      * Sets the used filter instance.

--- a/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
@@ -48,4 +48,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTAssignmentExpression extends AbstractASTNode {}
+class ASTAssignmentExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTBooleanAndExpression extends AbstractASTNode {}
+class ASTBooleanAndExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTBooleanOrExpression extends AbstractASTNode {}
+class ASTBooleanOrExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTBreakStatement extends ASTStatement {}
+class ASTBreakStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -48,4 +48,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTCatchStatement extends ASTStatement {}
+class ASTCatchStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -60,6 +60,22 @@ class ASTClass extends AbstractASTClassOrInterface
      */
     private $properties = null;
 
+
+    /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global class
+     * context.
+     *
+     * @since  0.10.0
+     */
+    public function __wakeup(): void
+    {
+        parent::__wakeup();
+
+        $this->context->registerClass($this);
+    }
+
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
      *
@@ -196,21 +212,5 @@ class ASTClass extends AbstractASTClassOrInterface
         }
 
         $this->modifiers = $modifiers;
-    }
-
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global class
-     * context.
-     *
-     * @since  0.10.0
-     */
-    public function __wakeup(): void
-    {
-        parent::__wakeup();
-
-        $this->context->registerClass($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 2.0.0
  */
-class ASTClassFqnPostfix extends AbstractASTNode {}
+class ASTClassFqnPostfix extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -84,6 +84,19 @@ class ASTClassOrInterfaceReference extends ASTType
     }
 
     /**
+     * Magic method which returns the names of all those properties that should
+     * be cached for this node instance.
+     *
+     * @return array
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['context'], parent::__sleep());
+    }
+
+    /**
      * Returns the concrete type instance associated with with this placeholder.
      *
      * @return AbstractASTClassOrInterface
@@ -96,18 +109,5 @@ class ASTClassOrInterfaceReference extends ASTType
             );
         }
         return $this->typeInstance;
-    }
-
-    /**
-     * Magic method which returns the names of all those properties that should
-     * be cached for this node instance.
-     *
-     * @return array
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['context'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTCloneExpression extends ASTExpression {}
+class ASTCloneExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -134,8 +134,8 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      *
      * @return int
      *
-     * @since  1.0.0
      * @see    ASTNode#getMetadataSize()
+     * @since  1.0.0
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTComment.php
+++ b/src/main/php/PDepend/Source/AST/ASTComment.php
@@ -48,4 +48,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTComment extends AbstractASTNode {}
+class ASTComment extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -142,6 +142,56 @@ class ASTCompilationUnit extends AbstractASTArtifact
     }
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before it serializes an instance of this class. This method returns an
+     * array with those property names that should be serialized.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return [
+            'cache',
+            'childNodes',
+            'comment',
+            'endLine',
+            'fileName',
+            'startLine',
+            'id',
+        ];
+    }
+
+    /**
+     * The magic wakeup method will is called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method restores the references between all parsed entities
+     * in this source file and this file instance.
+     *
+     * @see    ASTCompilationUnit::$childNodes
+     * @since  0.10.0
+     */
+    public function __wakeup(): void
+    {
+        $this->cached = true;
+
+        foreach ($this->childNodes as $childNode) {
+            $childNode->setCompilationUnit($this);
+        }
+    }
+
+    /**
+     * Returns the string representation of this class.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return ($this->fileName === null ? '' : $this->fileName);
+    }
+
+    /**
      * Returns the physical file name for this object.
      *
      * @return string|null
@@ -287,56 +337,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
     public function isCached()
     {
         return $this->cached;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before it serializes an instance of this class. This method returns an
-     * array with those property names that should be serialized.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return [
-            'cache',
-            'childNodes',
-            'comment',
-            'endLine',
-            'fileName',
-            'startLine',
-            'id',
-        ];
-    }
-
-    /**
-     * The magic wakeup method will is called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method restores the references between all parsed entities
-     * in this source file and this file instance.
-     *
-     * @since  0.10.0
-     * @see    ASTCompilationUnit::$childNodes
-     */
-    public function __wakeup(): void
-    {
-        $this->cached = true;
-
-        foreach ($this->childNodes as $childNode) {
-            $childNode->setCompilationUnit($this);
-        }
-    }
-
-    /**
-     * Returns the string representation of this class.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        return ($this->fileName === null ? '' : $this->fileName);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTCompoundExpression extends AbstractASTNode {}
+class ASTCompoundExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTCompoundVariable extends AbstractASTNode {}
+class ASTCompoundVariable extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -58,4 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTConditionalExpression extends AbstractASTNode {}
+class ASTConditionalExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTConstant.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstant.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTConstant extends AbstractASTNode {}
+class ASTConstant extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -94,6 +94,17 @@ class ASTConstantDeclarator extends AbstractASTNode
     protected $value = null;
 
     /**
+     * Magic sleep method that returns an array with those property names that
+     * should be cached for this node instance.
+     *
+     * @return array<string>
+     */
+    public function __sleep()
+    {
+        return array_merge(['value'], parent::__sleep());
+    }
+
+    /**
      * Returns the explicitly specified type of the constant.
      *
      * @return ASTType|null
@@ -127,16 +138,5 @@ class ASTConstantDeclarator extends AbstractASTNode
     public function setValue(?ASTValue $value = null): void
     {
         $this->value = $value;
-    }
-
-    /**
-     * Magic sleep method that returns an array with those property names that
-     * should be cached for this node instance.
-     *
-     * @return array<string>
-     */
-    public function __sleep()
-    {
-        return array_merge(['value'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -139,8 +139,8 @@ class ASTConstantDefinition extends AbstractASTNode
      *
      * @return int
      *
-     * @since  0.10.4
      * @see    ASTNode#getMetadataSize()
+     * @since  0.10.4
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -57,4 +57,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTConstantPostfix extends AbstractASTNode {}
+class ASTConstantPostfix extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTContinueStatement extends ASTStatement {}
+class ASTContinueStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -80,6 +80,20 @@ class ASTDeclareStatement extends ASTStatement
     protected $values = [];
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['values'], parent::__sleep());
+    }
+
+    /**
      * Returns all values/parameters for this declare statement.
      *
      * @return ASTValue[]
@@ -97,19 +111,5 @@ class ASTDeclareStatement extends ASTStatement
     public function addValue($name, ASTValue $value): void
     {
         $this->values[$name] = $value;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['values'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTDoWhileStatement extends ASTStatement {}
+class ASTDoWhileStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTEchoStatement extends ASTStatement {}
+class ASTEchoStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -71,6 +71,37 @@ class ASTEnum extends AbstractASTClassOrInterface
     }
 
     /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global class
+     * context.
+     *
+     * @since  0.10.0
+     */
+    public function __wakeup(): void
+    {
+        parent::__wakeup();
+
+        $this->context->registerEnum($this);
+    }
+
+    /**
+     * The magic sleep method is called by the PHP runtime environment before an
+     * instance of this class gets serialized. It returns an array with the
+     * names of all those properties that should be cached for this class or
+     * interface instance.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return array_merge(
+            ['type'],
+            parent::__sleep(),
+        );
+    }
+
+    /**
      * Returns ASTScalarType if backed enumeration: https://www.php.net/manual/en/language.enumerations.backed.php
      *   - either: ASTScalarType('string')
      *   - or:     ASTScalarType('int')
@@ -259,36 +290,5 @@ class ASTEnum extends AbstractASTClassOrInterface
         }
 
         $this->modifiers = $modifiers;
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global class
-     * context.
-     *
-     * @since  0.10.0
-     */
-    public function __wakeup(): void
-    {
-        parent::__wakeup();
-
-        $this->context->registerEnum($this);
-    }
-
-    /**
-     * The magic sleep method is called by the PHP runtime environment before an
-     * instance of this class gets serialized. It returns an array with the
-     * names of all those properties that should be cached for this class or
-     * interface instance.
-     *
-     * @return array
-     */
-    public function __sleep()
-    {
-        return array_merge(
-            ['type'],
-            parent::__sleep(),
-        );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTEvalExpression extends ASTExpression {}
+class ASTEvalExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTExitExpression extends ASTExpression {}
+class ASTExitExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTExpression extends AbstractASTNode {}
+class ASTExpression extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -185,8 +185,8 @@ class ASTFieldDeclaration extends AbstractASTNode
      *
      * @return int
      *
-     * @since  0.10.4
      * @see    ASTNode#getMetadataSize()
+     * @since  0.10.4
      */
     protected function getMetadataSize()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
@@ -48,4 +48,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTFinallyStatement extends ASTStatement {}
+class ASTFinallyStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -54,4 +54,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTForInit extends AbstractASTNode {}
+class ASTForInit extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTForStatement extends ASTStatement {}
+class ASTForStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -58,4 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTForUpdate extends AbstractASTNode {}
+class ASTForUpdate extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTForeachStatement extends ASTStatement {}
+class ASTForeachStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -69,6 +69,11 @@ class ASTFormalParameter extends AbstractASTNode
      */
     protected $modifiers = 0;
 
+    public function __sleep()
+    {
+        return array_merge(['modifiers'], parent::__sleep());
+    }
+
     /**
      * Checks if this parameter has a type.
      *
@@ -140,8 +145,8 @@ class ASTFormalParameter extends AbstractASTNode
      *
      * @return int
      *
-     * @since  0.10.4
      * @see    ASTNode#getMetadataSize()
+     * @since  0.10.4
      */
     protected function getMetadataSize()
     {
@@ -244,10 +249,5 @@ class ASTFormalParameter extends AbstractASTNode
     public function isPrivate()
     {
         return ($this->getModifiers() & State::IS_PRIVATE) === State::IS_PRIVATE;
-    }
-
-    public function __sleep()
-    {
-        return array_merge(['modifiers'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -69,4 +69,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTFormalParameters extends AbstractASTNode {}
+class ASTFormalParameters extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -53,15 +53,6 @@ use PDepend\Source\Builder\BuilderContext;
 class ASTFunction extends AbstractASTCallable
 {
     /**
-     * The parent namespace for this function.
-     *
-     * @var ASTNamespace|null
-     *
-     * @since 0.10.0
-     */
-    private $namespace = null;
-
-    /**
      * The currently used builder context.
      *
      * @var BuilderContext|null
@@ -77,6 +68,41 @@ class ASTFunction extends AbstractASTCallable
      * @var string|null
      */
     protected $namespaceName = null;
+    /**
+     * The parent namespace for this function.
+     *
+     * @var ASTNamespace|null
+     *
+     * @since 0.10.0
+     */
+    private $namespace = null;
+
+    /**
+     * The magic sleep method will be called by the PHP engine when this class
+     * gets serialized. It returns an array with those properties that should be
+     * cached for all function instances.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['context', 'namespaceName'], parent::__sleep());
+    }
+
+    /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global function
+     * context.
+     *
+     * @since  0.10.0
+     */
+    public function __wakeup(): void
+    {
+        $this->context->registerFunction($this);
+    }
 
     /**
      * Sets the currently active builder context.
@@ -134,32 +160,5 @@ class ASTFunction extends AbstractASTCallable
     public function getNamespaceName()
     {
         return $this->namespaceName;
-    }
-
-    /**
-     * The magic sleep method will be called by the PHP engine when this class
-     * gets serialized. It returns an array with those properties that should be
-     * cached for all function instances.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['context', 'namespaceName'], parent::__sleep());
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global function
-     * context.
-     *
-     * @since  0.10.0
-     */
-    public function __wakeup(): void
-    {
-        $this->context->registerFunction($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTFunctionPostfix extends ASTInvocation {}
+class ASTFunctionPostfix extends ASTInvocation
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTGlobalStatement extends ASTStatement {}
+class ASTGlobalStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTGotoStatement extends ASTStatement {}
+class ASTGotoStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -53,4 +53,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTIdentifier extends ASTExpression {}
+class ASTIdentifier extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -62,6 +62,20 @@ class ASTIncludeExpression extends ASTExpression
     protected $once = false;
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['once'], parent::__sleep());
+    }
+
+    /**
      * Does this node represent a <b>include_once</b>-expression?
      *
      * @return bool
@@ -77,19 +91,5 @@ class ASTIncludeExpression extends ASTExpression
     public function setOnce(): void
     {
         $this->once = true;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['once'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-abstract class ASTIndexExpression extends ASTExpression {}
+abstract class ASTIndexExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTInstanceOfExpression extends ASTExpression {}
+class ASTInstanceOfExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -61,6 +61,21 @@ class ASTInterface extends AbstractASTClassOrInterface
     protected $modifiers = State::IS_IMPLICIT_ABSTRACT;
 
     /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global class
+     * context.
+     *
+     * @since  0.10.0
+     */
+    public function __wakeup(): void
+    {
+        parent::__wakeup();
+
+        $this->context->registerInterface($this);
+    }
+
+    /**
      * Returns <b>true</b> if this is an abstract class or an interface.
      *
      * @return bool
@@ -113,20 +128,5 @@ class ASTInterface extends AbstractASTClassOrInterface
     public function getModifiers()
     {
         return $this->modifiers;
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global class
-     * context.
-     *
-     * @since  0.10.0
-     */
-    public function __wakeup(): void
-    {
-        parent::__wakeup();
-
-        $this->context->registerInterface($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -47,10 +47,10 @@ namespace PDepend\Source\AST;
 /**
  * This class represents an intersection type
  *
- * @see https://php.watch/versions/8.1/intersection-types
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @see https://php.watch/versions/8.1/intersection-types
  */
 class ASTIntersectionType extends AbstractASTCombinationType
 {

--- a/src/main/php/PDepend/Source/AST/ASTInvocation.php
+++ b/src/main/php/PDepend/Source/AST/ASTInvocation.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-abstract class ASTInvocation extends ASTExpression {}
+abstract class ASTInvocation extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTIssetExpression extends ASTExpression {}
+class ASTIssetExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTLabelStatement extends ASTStatement {}
+class ASTLabelStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTListExpression extends ASTExpression {}
+class ASTListExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTLiteral extends AbstractASTNode {}
+class ASTLiteral extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTLogicalAndExpression extends ASTExpression {}
+class ASTLogicalAndExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTLogicalOrExpression extends ASTExpression {}
+class ASTLogicalOrExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTLogicalXorExpression extends ASTExpression {}
+class ASTLogicalXorExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -61,4 +61,6 @@ namespace PDepend\Source\AST;
  *
  * @since 2.9.0
  */
-class ASTMatchBlock extends ASTExpression {}
+class ASTMatchBlock extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -57,4 +57,6 @@ namespace PDepend\Source\AST;
  *
  * @since 2.9.0
  */
-class ASTMatchEntry extends ASTExpression {}
+class ASTMatchEntry extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -67,6 +67,20 @@ class ASTMethod extends AbstractASTCallable
     protected $modifiers = 0;
 
     /**
+     * The magic sleep method will be called by the PHP engine when this class
+     * gets serialized. It returns an array with those properties that should be
+     * cached for method instances.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['modifiers'], parent::__sleep());
+    }
+
+    /**
      * This method returns a OR combined integer of the declared modifiers for
      * this method.
      *
@@ -196,9 +210,9 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the source file where this method was declared.
      *
-     * @throws ASTCompilationUnitNotFoundException When no parent was set.
-     *
      * @return ASTCompilationUnit
+     *
+     * @throws ASTCompilationUnitNotFoundException When no parent was set.
      *
      * @since  0.10.0
      */
@@ -209,19 +223,5 @@ class ASTMethod extends AbstractASTCallable
         }
 
         return $this->parent->getCompilationUnit();
-    }
-
-    /**
-     * The magic sleep method will be called by the PHP engine when this class
-     * gets serialized. It returns an array with those properties that should be
-     * cached for method instances.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['modifiers'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -62,4 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTMethodPostfix extends ASTInvocation {}
+class ASTMethodPostfix extends ASTInvocation
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -74,16 +74,16 @@ class ASTNamespace extends AbstractASTArtifact
     protected $functions = [];
 
     /**
+     * @var bool
+     */
+    protected $packageAnnotation = false;
+
+    /**
      * Does this namespace contain user defined functions, classes or interfaces?
      *
      * @var bool
      */
     private $userDefined = null;
-
-    /**
-     * @var bool
-     */
-    protected $packageAnnotation = false;
 
     /**
      * Constructs a new namespace for the given <b>$name</b>

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -96,9 +96,9 @@ interface ASTNode
      *
      * @param int $index
      *
-     * @throws OutOfBoundsException When no node exists at the given index.
-     *
      * @return AbstractASTNode|ASTArtifact
+     *
+     * @throws OutOfBoundsException When no node exists at the given index.
      */
     public function getChild($index);
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -112,6 +112,55 @@ class ASTParameter extends AbstractASTArtifact
     }
 
     /**
+     * This method returns a string representation of this parameter.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        $required  = $this->isOptional() ? 'optional' : 'required';
+        $reference = $this->isPassedByReference() ? '&' : '';
+
+        $typeHint = '';
+        if ($this->isArray() === true) {
+            $typeHint = ' array';
+        } elseif ($this->getClass() !== null) {
+            $typeHint = ' ' . $this->getClass()->getName();
+        }
+
+        $default = '';
+        if ($this->isDefaultValueAvailable()) {
+            $default = ' = ';
+
+            $value = $this->getDefaultValue();
+            if ($value === null) {
+                $default  .= 'NULL';
+                $typeHint .= ($typeHint !== '' ? ' or NULL' : '');
+            } elseif ($value === false) {
+                $default .= 'false';
+            } elseif ($value === true) {
+                $default .= 'true';
+            } elseif (is_array($value) === true) {
+                $default .= 'Array';
+            } elseif (is_string($value) === true) {
+                $default .= "'" . $value . "'";
+            } else {
+                $default .= $value;
+            }
+        }
+
+        return sprintf(
+            'Parameter #%d [ <%s>%s %s%s%s ]',
+            $this->position,
+            $required,
+            $typeHint,
+            $reference,
+            $this->getName(),
+            $default,
+        );
+    }
+
+    /**
      * Returns the item name.
      *
      * @return string
@@ -167,11 +216,11 @@ class ASTParameter extends AbstractASTArtifact
      * This method will return the class where the parent method was declared.
      * The returned value will be <b>null</b> if the parent is a function.
      *
-     * @todo Review this for refactoring, maybe create a empty getParent()?
-     *
      * @return AbstractASTClassOrInterface|null
      *
      * @since  0.9.5
+     *
+     * @todo Review this for refactoring, maybe create a empty getParent()?
      */
     public function getDeclaringClass()
     {
@@ -347,55 +396,6 @@ class ASTParameter extends AbstractASTArtifact
     public function getFormalParameter()
     {
         return $this->formalParameter;
-    }
-
-    /**
-     * This method returns a string representation of this parameter.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        $required  = $this->isOptional() ? 'optional' : 'required';
-        $reference = $this->isPassedByReference() ? '&' : '';
-
-        $typeHint = '';
-        if ($this->isArray() === true) {
-            $typeHint = ' array';
-        } elseif ($this->getClass() !== null) {
-            $typeHint = ' ' . $this->getClass()->getName();
-        }
-
-        $default = '';
-        if ($this->isDefaultValueAvailable()) {
-            $default = ' = ';
-
-            $value = $this->getDefaultValue();
-            if ($value === null) {
-                $default  .= 'NULL';
-                $typeHint .= ($typeHint !== '' ? ' or NULL' : '');
-            } elseif ($value === false) {
-                $default .= 'false';
-            } elseif ($value === true) {
-                $default .= 'true';
-            } elseif (is_array($value) === true) {
-                $default .= 'Array';
-            } elseif (is_string($value) === true) {
-                $default .= "'" . $value . "'";
-            } else {
-                $default .= $value;
-            }
-        }
-
-        return sprintf(
-            'Parameter #%d [ <%s>%s %s%s%s ]',
-            $this->position,
-            $required,
-            $typeHint,
-            $reference,
-            $this->getName(),
-            $default,
-        );
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -80,6 +80,20 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     }
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['reference'], parent::__sleep());
+    }
+
+    /**
      * Returns the visual representation for this node type.
      *
      * @return string
@@ -99,19 +113,5 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     public function getType()
     {
         return $this->reference->getType();
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['reference'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.10.0
  */
-class ASTPostfixExpression extends ASTExpression {}
+class ASTPostfixExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.10.0
  */
-class ASTPreDecrementExpression extends ASTUnaryExpression {}
+class ASTPreDecrementExpression extends ASTUnaryExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.10.0
  */
-class ASTPreIncrementExpression extends ASTUnaryExpression {}
+class ASTPreIncrementExpression extends ASTUnaryExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -93,6 +93,37 @@ class ASTProperty extends AbstractASTArtifact
     }
 
     /**
+     * This method returns a string representation of this parameter.
+     *
+     * @return string
+     *
+     * @since  0.9.6
+     */
+    public function __toString()
+    {
+        $static  = '';
+
+        if ($this->isStatic() === true) {
+            $static  = ' static';
+        }
+
+        $visibility = ' public';
+        if ($this->isProtected() === true) {
+            $visibility = ' protected';
+        } elseif ($this->isPrivate() === true) {
+            $visibility = ' private';
+        }
+
+        return sprintf(
+            'Property [%s%s %s ]%s',
+            $visibility,
+            $static,
+            $this->getName(),
+            PHP_EOL,
+        );
+    }
+
+    /**
      * Returns the item name.
      *
      * @return string
@@ -326,36 +357,5 @@ class ASTProperty extends AbstractASTArtifact
             return null;
         }
         return $value->getValue();
-    }
-
-    /**
-     * This method returns a string representation of this parameter.
-     *
-     * @return string
-     *
-     * @since  0.9.6
-     */
-    public function __toString()
-    {
-        $static  = '';
-
-        if ($this->isStatic() === true) {
-            $static  = ' static';
-        }
-
-        $visibility = ' public';
-        if ($this->isProtected() === true) {
-            $visibility = ' protected';
-        } elseif ($this->isPrivate() === true) {
-            $visibility = ' private';
-        }
-
-        return sprintf(
-            'Property [%s%s %s ]%s',
-            $visibility,
-            $static,
-            $this->getName(),
-            PHP_EOL,
-        );
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTPropertyPostfix extends AbstractASTNode {}
+class ASTPropertyPostfix extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -62,6 +62,20 @@ class ASTRequireExpression extends ASTExpression
     protected $once = false;
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['once'], parent::__sleep());
+    }
+
+    /**
      * Does this node represent a <b>require_once</b>-expression?
      *
      * @return bool
@@ -77,19 +91,5 @@ class ASTRequireExpression extends ASTExpression
     public function setOnce(): void
     {
         $this->once = true;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['once'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTReturnStatement extends ASTStatement {}
+class ASTReturnStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTScope extends AbstractASTNode {}
+class ASTScope extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTScopeStatement extends ASTStatement {}
+class ASTScopeStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -92,6 +92,23 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     }
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        $this->qualifiedName = $this->getType()->getNamespaceName() . '\\' .
+                               $this->getType()->getName();
+
+        return array_merge(['qualifiedName'], parent::__sleep());
+    }
+
+    /**
      * Returns the visual representation for this node type.
      *
      * @return string
@@ -117,22 +134,5 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
                 ->getClassOrInterface($this->qualifiedName);
         }
         return $this->typeInstance;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        $this->qualifiedName = $this->getType()->getNamespaceName() . '\\' .
-                               $this->getType()->getName();
-
-        return array_merge(['qualifiedName'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTStatement extends AbstractASTNode {}
+class ASTStatement extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTStaticVariableDeclaration extends ASTExpression {}
+class ASTStaticVariableDeclaration extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -64,4 +64,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.10
  */
-class ASTString extends AbstractASTNode {}
+class ASTString extends AbstractASTNode
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -58,4 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTStringIndexExpression extends ASTIndexExpression {}
+class ASTStringIndexExpression extends ASTIndexExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -62,6 +62,20 @@ class ASTSwitchLabel extends AbstractASTNode
     protected $default = false;
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['default'], parent::__sleep());
+    }
+
+    /**
      * Returns <b>true</b> when this node is the default label.
      *
      * @return bool
@@ -77,19 +91,5 @@ class ASTSwitchLabel extends AbstractASTNode
     public function setDefault(): void
     {
         $this->default = true;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['default'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -48,4 +48,6 @@ namespace PDepend\Source\AST;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ASTSwitchStatement extends ASTStatement {}
+class ASTSwitchStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTThrowStatement extends ASTStatement {}
+class ASTThrowStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -55,6 +55,18 @@ namespace PDepend\Source\AST;
 class ASTTrait extends ASTClass
 {
     /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a serialized instance of this class was unserialized. This implementation
+     * of the wakeup method will register this object in the the global class
+     * context.
+     */
+    public function __wakeup(): void
+    {
+        parent::__wakeup();
+
+        $this->context->registerTrait($this);
+    }
+    /**
      * Returns all properties for this class.
      *
      * @return ASTArtifactList<ASTProperty>
@@ -98,18 +110,5 @@ class ASTTrait extends ASTClass
     public function isSubtypeOf(AbstractASTType $type)
     {
         return false;
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a serialized instance of this class was unserialized. This implementation
-     * of the wakeup method will register this object in the the global class
-     * context.
-     */
-    public function __wakeup(): void
-    {
-        parent::__wakeup();
-
-        $this->context->registerTrait($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 1.0.0
  */
-class ASTTraitAdaptation extends ASTScope {}
+class ASTTraitAdaptation extends ASTScope
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -69,6 +69,18 @@ class ASTTraitAdaptationAlias extends ASTStatement
     protected $newModifier = -1;
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        return array_merge(['newName', 'newModifier'], parent::__sleep());
+    }
+
+    /**
      * Sets the new method modifier.
      *
      * @param int $newModifier The new method modifier.
@@ -108,17 +120,5 @@ class ASTTraitAdaptationAlias extends ASTStatement
     public function getNewName()
     {
         return $this->newName;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array
-     */
-    public function __sleep()
-    {
-        return array_merge(['newName', 'newModifier'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 1.0.0
  */
-class ASTTraitAdaptationPrecedence extends ASTStatement {}
+class ASTTraitAdaptationPrecedence extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTTryStatement extends ASTStatement {}
+class ASTTryStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.11
  */
-class ASTUnaryExpression extends ASTExpression {}
+class ASTUnaryExpression extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.12
  */
-class ASTUnsetStatement extends ASTStatement {}
+class ASTUnsetStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -64,6 +64,20 @@ class ASTVariableDeclarator extends ASTExpression
     protected $value = null;
 
     /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array<string>
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(['value'], parent::__sleep());
+    }
+
+    /**
      * Returns the initial declaration value for this node or <b>null</b> when
      * no default value exists.
      *
@@ -80,19 +94,5 @@ class ASTVariableDeclarator extends ASTExpression
     public function setValue(ASTValue $value): void
     {
         $this->value = $value;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array<string>
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(['value'], parent::__sleep());
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.6
  */
-class ASTVariableVariable extends ASTExpression {}
+class ASTVariableVariable extends ASTExpression
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @since 0.9.8
  */
-class ASTWhileStatement extends ASTStatement {}
+class ASTWhileStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -66,4 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @since @TODO
  */
-class ASTYieldStatement extends ASTStatement {}
+class ASTYieldStatement extends ASTStatement
+{
+}

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -126,6 +126,31 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     private $parameters = null;
 
     /**
+     * The magic sleep method will be called by the PHP engine when this class
+     * gets serialized. It returns an array with those properties that should be
+     * cached for all callable instances.
+     *
+     * @return array
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return [
+            'cache',
+            'id',
+            'name',
+            'nodes',
+            'startLine',
+            'endLine',
+            'comment',
+            'returnsReference',
+            'returnClassReference',
+            'exceptionClassReferences',
+        ];
+    }
+
+    /**
      * Setter method for the currently used token cache, where this callable
      * instance can store the associated tokens.
      *
@@ -497,30 +522,5 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         }
 
         $this->parameters = $parameters;
-    }
-
-    /**
-     * The magic sleep method will be called by the PHP engine when this class
-     * gets serialized. It returns an array with those properties that should be
-     * cached for all callable instances.
-     *
-     * @return array
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return [
-            'cache',
-            'id',
-            'name',
-            'nodes',
-            'startLine',
-            'endLine',
-            'comment',
-            'returnsReference',
-            'returnClassReference',
-            'exceptionClassReferences',
-        ];
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -83,11 +83,29 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     protected $constantDeclarators = null;
 
     /**
+     * The magic sleep method is called by the PHP runtime environment before an
+     * instance of this class gets serialized. It returns an array with the
+     * names of all those properties that should be cached for this class or
+     * interface instance.
+     *
+     * @return array
+     *
+     * @since  0.10.0
+     */
+    public function __sleep()
+    {
+        return array_merge(
+            ['constants', 'interfaceReferences', 'parentClassReference'],
+            parent::__sleep(),
+        );
+    }
+
+    /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
-     * @throws ASTClassOrInterfaceRecursiveInheritanceException
-     *
      * @return ASTClass|null
+     *
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function getParentClass()
     {
@@ -119,9 +137,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * direct parent of this class is the first element in the returned array
      * and parent of this parent the second element and so on.
      *
-     * @throws ASTClassOrInterfaceRecursiveInheritanceException
-     *
      * @return ASTClass[]
+     *
+     * @throws ASTClassOrInterfaceRecursiveInheritanceException
      *
      * @since  1.0.0
      */
@@ -401,23 +419,5 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
                 $this->constantDeclarators[$image] = $declarator;
             }
         }
-    }
-
-    /**
-     * The magic sleep method is called by the PHP runtime environment before an
-     * instance of this class gets serialized. It returns an array with the
-     * names of all those properties that should be cached for this class or
-     * interface instance.
-     *
-     * @return array
-     *
-     * @since  0.10.0
-     */
-    public function __sleep()
-    {
-        return array_merge(
-            ['constants', 'interfaceReferences', 'parentClassReference'],
-            parent::__sleep(),
-        );
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
@@ -47,10 +47,10 @@ namespace PDepend\Source\AST;
 /**
  * This class represents an intersection type
  *
- * @see https://php.watch/versions/8.1/intersection-types
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @see https://php.watch/versions/8.1/intersection-types
  */
 abstract class AbstractASTCombinationType extends ASTType
 {

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -91,6 +91,51 @@ abstract class AbstractASTNode implements ASTNode
     protected $metadata = '::::';
 
     /**
+     * Constructs a new ast node instance.
+     *
+     * @param string $image The source image for this node.
+     */
+    public function __construct($image = null)
+    {
+        $this->metadata = str_repeat(':', $this->getMetadataSize() - 1);
+
+        $this->setImage($image);
+    }
+
+    /**
+     * The magic sleep method will be called by PHP's runtime environment right
+     * before an instance of this class gets serialized. It should return an
+     * array with those property names that should be serialized for this class.
+     *
+     * @return array
+     *
+     * @since 0.10.0
+     */
+    public function __sleep()
+    {
+        return [
+            'comment',
+            'metadata',
+            'nodes',
+        ];
+    }
+
+    /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a previously serialized object gets unserialized. This implementation of
+     * the wakeup method restores the dependencies between an ast node and the
+     * node's children.
+     *
+     * @since 0.10.0
+     */
+    public function __wakeup(): void
+    {
+        foreach ($this->nodes as $node) {
+            $node->setParent($this);
+        }
+    }
+
+    /**
      * @template T of array<string, mixed>|string|null
      *
      * @param T $data
@@ -104,18 +149,6 @@ abstract class AbstractASTNode implements ASTNode
         assert(is_callable($callable));
 
         return call_user_func($callable, $this, $data);
-    }
-
-    /**
-     * Constructs a new ast node instance.
-     *
-     * @param string $image The source image for this node.
-     */
-    public function __construct($image = null)
-    {
-        $this->metadata = str_repeat(':', $this->getMetadataSize() - 1);
-
-        $this->setImage($image);
     }
 
     /**
@@ -318,9 +351,9 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param int $index
      *
-     * @throws OutOfBoundsException When no node exists at the given index.
-     *
      * @return ASTNode
+     *
+     * @throws OutOfBoundsException When no node exists at the given index.
      */
     public function getChild($index)
     {
@@ -473,38 +506,5 @@ abstract class AbstractASTNode implements ASTNode
     public function setComment($comment): void
     {
         $this->comment = $comment;
-    }
-
-    /**
-     * The magic sleep method will be called by PHP's runtime environment right
-     * before an instance of this class gets serialized. It should return an
-     * array with those property names that should be serialized for this class.
-     *
-     * @return array
-     *
-     * @since 0.10.0
-     */
-    public function __sleep()
-    {
-        return [
-            'comment',
-            'metadata',
-            'nodes',
-        ];
-    }
-
-    /**
-     * The magic wakeup method will be called by PHP's runtime environment when
-     * a previously serialized object gets unserialized. This implementation of
-     * the wakeup method restores the dependencies between an ast node and the
-     * node's children.
-     *
-     * @since 0.10.0
-     */
-    public function __wakeup(): void
-    {
-        foreach ($this->nodes as $node) {
-            $node->setParent($this);
-        }
     }
 }

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -63,6 +63,31 @@ use PDepend\Source\AST\ASTTrait;
 interface ASTVisitor
 {
     /**
+     * Magic call method used to provide simplified visitor implementations.
+     * With this method we can call <b>visit${NodeClassName}</b> on each node.
+     *
+     * <code>
+     * $visitor->visitAllocationExpression($alloc);
+     *
+     * $visitor->visitStatement($stmt);
+     * </code>
+     *
+     * All visit methods takes two argument. The first argument is the current
+     * context ast node and the second argument is a data array or object that
+     * is used to collect data.
+     *
+     * The return value of this method is the second input argument, modified
+     * by the concrete visit method.
+     *
+     * @param string            $method Name of the called method.
+     * @param array<int, mixed> $args   Array with method argument.
+     *
+     * @return array<string, mixed>|numeric-string
+     *
+     * @since  0.9.12
+     */
+    public function __call($method, $args);
+    /**
      * Adds a new listener to this node visitor.
      */
     public function addVisitListener(ASTVisitListener $listener): void;
@@ -118,32 +143,6 @@ interface ASTVisitor
      * Visits a property node.
      */
     public function visitProperty(ASTProperty $property): void;
-
-    /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
-     * @return array<string, mixed>|numeric-string
-     *
-     * @since  0.9.12
-     */
-    public function __call($method, $args);
 
     /**
      * @template T of array<string, mixed>|numeric-string

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
@@ -230,10 +230,14 @@ abstract class AbstractASTVisitListener implements ASTVisitListener
     /**
      * Generic notification method that is called for every node start.
      */
-    protected function startVisitNode(AbstractASTArtifact $node): void {}
+    protected function startVisitNode(AbstractASTArtifact $node): void
+    {
+    }
 
     /**
      * Generic notification method that is called when the node processing ends.
      */
-    protected function endVisitNode(AbstractASTArtifact $node): void {}
+    protected function endVisitNode(AbstractASTArtifact $node): void
+    {
+    }
 }

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -72,6 +72,38 @@ abstract class AbstractASTVisitor implements ASTVisitor
      */
     private $listeners = [];
 
+
+    /**
+     * Magic call method used to provide simplified visitor implementations.
+     * With this method we can call <b>visit${NodeClassName}</b> on each node.
+     *
+     * <code>
+     * $visitor->visitAllocationExpression($alloc);
+     *
+     * $visitor->visitStatement($stmt);
+     * </code>
+     *
+     * All visit methods takes two argument. The first argument is the current
+     * context ast node and the second argument is a data array or object that
+     * is used to collect data.
+     *
+     * The return value of this method is the second input argument, modified
+     * by the concrete visit method.
+     *
+     * @param string            $method Name of the called method.
+     * @param array<int, mixed> $args   Array with method argument.
+     *
+     * @since  0.9.12
+     */
+    public function __call($method, $args)
+    {
+        if (!isset($args[1])) {
+            throw new RuntimeException("No node to visit provided for $method.");
+        }
+
+        return $this->visit($args[0], $args[1]);
+    }
+
     /**
      * Returns an iterator with all registered visit listeners.
      *
@@ -245,38 +277,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartProperty($property);
         $this->fireEndProperty($property);
-    }
-
-
-    /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
-     * @since  0.9.12
-     */
-    public function __call($method, $args)
-    {
-        if (!isset($args[1])) {
-            throw new RuntimeException("No node to visit provided for $method.");
-        }
-
-        return $this->visit($args[0], $args[1]);
     }
 
     public function visit($node, $value)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -195,15 +195,6 @@ class PHPBuilder implements Builder
     protected $context = null;
 
     /**
-     * This property holds all packages found during the parsing phase.
-     *
-     * @var ASTNamespace[]
-     *
-     * @since 0.9.12
-     */
-    private $preparedNamespaces = null;
-
-    /**
      * Default package which contains all functions and classes with an unknown
      * scope.
      *
@@ -217,6 +208,15 @@ class PHPBuilder implements Builder
      * @var ASTCompilationUnit
      */
     protected $defaultCompilationUnit = null;
+
+    /**
+     * This property holds all packages found during the parsing phase.
+     *
+     * @var ASTNamespace[]
+     *
+     * @since 0.9.12
+     */
+    private $preparedNamespaces = null;
 
     /**
      * All generated {@link ASTTrait} objects

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -118,9 +118,9 @@ class PHPParserGeneric extends PHPParserVersion83
      *
      * @param ASTValue $value
      *
-     * @throws UnexpectedTokenException
-     *
      * @return ASTValue
+     *
+     * @throws UnexpectedTokenException
      *
      * @todo Handle shift left/right expressions in ASTValue
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -619,9 +619,9 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @throws UnexpectedTokenException
-     *
      * @return ASTNode
+     *
+     * @throws UnexpectedTokenException
      *
      * @since 2.2
      */
@@ -769,9 +769,9 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
     /**
      * Parses additional static values that are valid in the supported php version.
      *
-     * @throws UnexpectedTokenException
-     *
      * @return ASTValue|null
+     *
+     * @throws UnexpectedTokenException
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
     {
@@ -1234,9 +1234,9 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
     /**
      * Parses an integer value.
      *
-     * @throws UnexpectedTokenException
-     *
      * @return ASTLiteral
+     *
+     * @throws UnexpectedTokenException
      */
     protected function parseIntegerNumber()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -131,9 +131,9 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @throws UnexpectedTokenException
-     *
      * @return ASTNode
+     *
+     * @throws UnexpectedTokenException
      */
     protected function parseOptionalExpressionForVersion()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -62,6 +62,10 @@ use PDepend\Source\Tokenizer\Tokens;
  */
 abstract class PHPParserVersion82 extends PHPParserVersion81
 {
+    /**
+     * Since PHP 8.2, readonly is allowed as class modifier.
+     */
+    protected const READONLY_CLASS_ALLOWED = true;
     /** @var array<int, int> */
     protected $possiblePropertyTypes = [
         Tokens::T_STRING,
@@ -74,11 +78,6 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
         Tokens::T_FALSE,
         Tokens::T_TRUE,
     ];
-
-    /**
-     * Since PHP 8.2, readonly is allowed as class modifier.
-     */
-    protected const READONLY_CLASS_ALLOWED = true;
 
     /**
      * Tests if the given image is a PHP 8.2 type hint.
@@ -106,10 +105,10 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
     }
 
     /**
+     * @return ASTType
+     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
-     *
-     * @return ASTType
      */
     protected function parseSingleTypeHint()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
@@ -62,10 +62,10 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
     /**
      * Parse a typed constant (PHP >= 8.3).
      *
+     * @return ASTConstantDeclarator
+     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
-     *
-     * @return ASTConstantDeclarator
      *
      * @since  1.16.0
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -233,6 +233,10 @@ if (!defined('T_ENUM')) {
 class PHPTokenizerInternal implements FullTokenizer
 {
     /**
+     * Internally used transition token.
+     */
+    private const T_ELLIPSIS = 23006;
+    /**
      * Mapping between php internal tokens and php depend tokens.
      *
      * @var array<int, int>
@@ -378,11 +382,6 @@ class PHPTokenizerInternal implements FullTokenizer
         T_NULLSAFE_OBJECT_OPERATOR  => Tokens::T_NULLSAFE_OBJECT_OPERATOR,
         T_READONLY                  => Tokens::T_READONLY,
     ];
-
-    /**
-     * Internally used transition token.
-     */
-    private const T_ELLIPSIS = 23006;
 
     /**
      * Mapping between php internal text tokens an php depend numeric tokens.

--- a/src/main/php/PDepend/Source/Parser/ParserException.php
+++ b/src/main/php/PDepend/Source/Parser/ParserException.php
@@ -50,4 +50,6 @@ use RuntimeException;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
-class ParserException extends RuntimeException {}
+class ParserException extends RuntimeException
+{
+}

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -123,9 +123,9 @@ class SymbolTable
      *
      * @param string $key The key for a searched scope value.
      *
-     * @throws NoActiveScopeException
-     *
      * @return string|null
+     *
+     * @throws NoActiveScopeException
      */
     public function lookup($key)
     {

--- a/src/main/php/PDepend/Source/Parser/TokenException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenException.php
@@ -52,4 +52,6 @@ namespace PDepend\Source\Parser;
  *
  * @since 0.9.10
  */
-class TokenException extends ParserException {}
+class TokenException extends ParserException
+{
+}

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -475,9 +475,9 @@ class Command
      * Prints all available log options and returns the length of the longest
      * option.
      *
-     * @throws Exception
-     *
      * @return int
+     *
+     * @throws Exception
      */
     protected function printLogOptions()
     {
@@ -519,9 +519,9 @@ class Command
      *
      * @param int $length Length of the longest option.
      *
-     * @throws Exception
-     *
      * @return int
+     *
+     * @throws Exception
      */
     protected function printAnalyzerOptions($length)
     {

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -102,17 +102,23 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished a file.
      */
-    public function endFileParsing(Tokenizer $tokenizer): void {}
+    public function endFileParsing(Tokenizer $tokenizer): void
+    {
+    }
 
     /**
      * Is called when PDepend starts the analyzing process.
      */
-    public function startAnalyzeProcess(): void {}
+    public function startAnalyzeProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend has finished the analyzing process.
      */
-    public function endAnalyzeProcess(): void {}
+    public function endAnalyzeProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend starts the logging process.
@@ -125,7 +131,9 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished the logging process.
      */
-    public function endLogProcess(): void {}
+    public function endLogProcess(): void
+    {
+    }
 
     /**
      * Is called when PDepend starts a new analyzer.

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -238,10 +238,10 @@ class Runner
      * Starts the main PDepend process and returns <b>true</b> after a successful
      * execution.
      *
+     * @return int
+     *
      * @throws RuntimeException An exception with a readable error message and
      *                          an exit code.
-     *
-     * @return int
      */
     public function run()
     {

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -93,11 +93,11 @@ class CacheFactory
      *
      * @param string $cacheKey The name/identifier for the cache instance.
      *
+     * @return CacheDriver
+     *
      * @throws InvalidArgumentException
      * @throws RandomException
      * @throws RuntimeException
-     *
-     * @return CacheDriver
      */
     public function create($cacheKey = null)
     {
@@ -112,11 +112,11 @@ class CacheFactory
      *
      * @param string|null $cacheKey The name/identifier for the cache instance.
      *
+     * @return CacheDriver
+     *
      * @throws InvalidArgumentException If the configured cache driver is unknown.
      * @throws RandomException
      * @throws RuntimeException
-     *
-     * @return CacheDriver
      */
     protected function createCache($cacheKey = null)
     {
@@ -142,9 +142,9 @@ class CacheFactory
      * @param int         $ttl      Cache ttl
      * @param string|null $cacheKey The name/identifier for the cache instance.
      *
-     * @throws RuntimeException
-     *
      * @return FileCacheDriver
+     *
+     * @throws RuntimeException
      */
     protected function createFileCache($location, $ttl = self::DEFAULT_TTL, $cacheKey = null)
     {
@@ -154,9 +154,9 @@ class CacheFactory
     /**
      * Creates an in memory cache instance.
      *
-     * @throws RandomException
-     *
      * @return MemoryCacheDriver
+     *
+     * @throws RandomException
      */
     protected function createMemoryCache()
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -105,6 +105,30 @@ class MemoryCacheDriver implements CacheDriver
     }
 
     /**
+     * PHP's magic serialize sleep method.
+     *
+     * @return array
+     *
+     * @since  1.0.2
+     */
+    public function __sleep()
+    {
+        self::$staticCache[$this->staticId] = $this->cache;
+
+        return ['staticId'];
+    }
+
+    /**
+     * PHP's magic serialize wakeup method.
+     *
+     * @since  1.0.2
+     */
+    public function __wakeup(): void
+    {
+        $this->cache = self::$staticCache[$this->staticId];
+    }
+
+    /**
      * Sets the type for the next <em>store()</em> or <em>restore()</em> method
      * call. A type is something like a namespace or group for cache entries.
      *
@@ -189,29 +213,5 @@ class MemoryCacheDriver implements CacheDriver
         $this->type = self::ENTRY_TYPE;
 
         return "{$key}.{$type}";
-    }
-
-    /**
-     * PHP's magic serialize sleep method.
-     *
-     * @return array
-     *
-     * @since  1.0.2
-     */
-    public function __sleep()
-    {
-        self::$staticCache[$this->staticId] = $this->cache;
-
-        return ['staticId'];
-    }
-
-    /**
-     * PHP's magic serialize wakeup method.
-     *
-     * @since  1.0.2
-     */
-    public function __wakeup(): void
-    {
-        $this->cache = self::$staticCache[$this->staticId];
     }
 }

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -60,10 +60,10 @@ class Factory
      *
      * @param string $pathName Qualified path name of a coverage report file.
      *
+     * @return CloverReport
+     *
      * @throws RuntimeException When the given path name does not point to a
      *                          valid coverage file or onto an unsupported coverage format.
-     *
-     * @return CloverReport
      */
     public function create($pathName)
     {
@@ -80,10 +80,10 @@ class Factory
      *
      * @param string $pathName Qualified path name of a coverage report file.
      *
+     * @return SimpleXMLElement
+     *
      * @throws RuntimeException When the given path name does not point to a
      *                          valid xml file.
-     *
-     * @return SimpleXMLElement
      */
     private function loadXml($pathName)
     {

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -243,9 +243,9 @@ final class Type
      *
      * @param string $typeName The type name.
      *
-     * @throws ReflectionException
-     *
      * @return bool
+     *
+     * @throws ReflectionException
      */
     public static function isInternalType($typeName)
     {
@@ -263,9 +263,9 @@ final class Type
      *
      * @param string $typeName The type name.
      *
-     * @throws ReflectionException
-     *
      * @return string|null
+     *
+     * @throws ReflectionException
      */
     public static function getTypePackage($typeName)
     {
@@ -282,9 +282,9 @@ final class Type
     /**
      * Returns an array with all package/extension names.
      *
-     * @throws ReflectionException
-     *
      * @return array<string>
+     *
+     * @throws ReflectionException
      */
     public static function getInternalNamespaces()
     {
@@ -303,9 +303,9 @@ final class Type
      *
      * @param string $packageName Name of a package.
      *
-     * @throws ReflectionException
-     *
      * @return bool
+     *
+     * @throws ReflectionException
      */
     public static function isInternalPackage($packageName)
     {
@@ -396,9 +396,9 @@ final class Type
      * this type belongs to an extension or is internal. All internal and extension
      * classes are collected in an internal data structure.
      *
-     * @throws ReflectionException
-     *
      * @return array<string, string>
+     *
+     * @throws ReflectionException
      */
     private static function initTypeToExtension()
     {


### PR DESCRIPTION
Type: documentation  
Breaking change: no

This enables the amended PER-CS 2.0 rules in that has been configured for PHPMD, and applies the style to the code base.

There are two notable differences form PHPMD's style:
- `binary_operator_spaces` is set to the default config from PER-CS 2.0, changing it creates a lot of diff.
- `phpdoc_align` and `phpdoc_separation` are not disabled (they where already enabled).

I would like us to handle these two differences separately in followups.