### PR TITLE
Set CodeCov token to enable upload of coverage again

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,3 +54,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: ./coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Type: documentation update 
Breaking change: no

Since about April CodeCov started requiring that the token be set for uploads to go through or else it will give a "throttled" error. This is why we haven't had coverage on any of the 3.x work we have done so far.

As a side note, I have tried running the test manually and uploading the results so we get some data on previous commits, it did add the coverage % to the commits and PRs, but the delta and some other things appear to be incorrect so I probably missed something there.