### PR TITLE
Pds composer script names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,24 @@
 {
     "name": "pdepend/pdepend",
     "description": "Official version of pdepend to be handled with Composer",
+    "license": "BSD-3-Clause",
+    "type": "library",
     "keywords": [
         "dev",
         "pdepend",
         "PHP Depend",
         "PHP_Depend"
     ],
-    "license": "BSD-3-Clause",
-    "type": "library",
     "require": {
         "php": ">=8.1",
-        "symfony/config": "^5.4|^6.0|^7.0",
-        "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-        "symfony/filesystem": "^5.4|^6.0|^7.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
         "brianium/paratest": "^7.3",
-        "easy-doc/easy-doc": "0.0.0|^1.2.3",
+        "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.54",
         "gregwar/rst": "^1.0",
         "phpstan/phpstan": "~1.10.67",
@@ -28,29 +28,42 @@
     "replace": {
         "symfony/polyfill-php80": "*"
     },
-    "bin": ["src/bin/pdepend"],
     "autoload": {
-        "psr-4": {"PDepend\\": "src/main/php/PDepend"}
+        "psr-4": {
+            "PDepend\\": "src/main/php/PDepend"
+        }
+    },
+    "bin": [
+        "src/bin/pdepend"
+    ],
+    "config": {
+        "process-timeout": 900,
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev"
+        }
     },
     "scripts": {
         "analyse": [
             "@phpstan"
         ],
         "analyze": "@analyse",
+        "build-website": [
+            "php src/site/release-news-generator.php",
+            "easy-doc build src/site/config.php --verbose"
+        ],
         "check": [
             "@cs-fix",
             "@test-coverage",
             "@analyse"
         ],
-        "test": "paratest --no-coverage",
-        "test-coverage": "paratest",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "phpstan": "vendor/bin/phpstan",
-        "build-website": [
-            "php src/site/release-news-generator.php",
-            "easy-doc build src/site/config.php --verbose"
-        ]
+        "test": "paratest --no-coverage",
+        "test-coverage": "paratest"
     },
     "scripts-descriptions": {
         "analyse": "Run the analyse steps (PHPStan)",
@@ -62,14 +75,5 @@
         "phpstan": "Analyse the code with PHPStan.",
         "test": "Run the tests without coverage.",
         "test-coverage": "Run the tests with coverage."
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "2.x-dev"
-        }
-    },
-    "config": {
-        "process-timeout": 900,
-        "sort-packages": true
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,13 +33,35 @@
         "psr-4": {"PDepend\\": "src/main/php/PDepend"}
     },
     "scripts": {
+        "analyse": [
+            "@phpstan"
+        ],
+        "analyze": "@analyse",
+        "check": [
+            "@cs-fix",
+            "@test-coverage",
+            "@analyse"
+        ],
         "test": "paratest --no-coverage",
+        "test-coverage": "paratest",
         "cs-check": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
         "cs-fix": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 ./src/main/php ./src/test/php",
+        "phpstan": "vendor/bin/phpstan",
         "build-website": [
             "php src/site/release-news-generator.php",
             "easy-doc build src/site/config.php --verbose"
         ]
+    },
+    "scripts-descriptions": {
+        "analyse": "Run the analyse steps (PHPStan)",
+        "analyze": "See analyse",
+        "build-website": "Build the website",
+        "check": "Runs @cs-fix, @test-coverage and @analyse.",
+        "cs-check": "Check the codestyle with phpcs.",
+        "cs-fix": "Check the codestyle with phpcbf and if possible fix the found issues.",
+        "phpstan": "Analyse the code with PHPStan.",
+        "test": "Run the tests without coverage.",
+        "test-coverage": "Run the tests with coverage."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Type: Composer scripts 
Issue: -
Breaking change: no

With this PR I have added the composer scripts as defined in: https://github.com/php-pds/composer-script-names  
By using that names we can more standardize the names between projects.

I also added the descriptions for the scripts.

The second commit is after running composer normalize ( https://github.com/ergebnis/composer-normalize ) if that isn't wanted I can revert it.