### PR TITLE
Correct GitHub actions for 3.x

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -2,16 +2,14 @@ name: Codestyle
 
 on:
   push:
-    branches:
-      - "*"
+    branches: [ '*', '2.x', '3.x' ]
     paths:
       - '**.php'
       - 'composer.json'
       - '.php-cs-fixer.php'
       - '.github/workflows/codestyle.yml'
   pull_request:
-    branches:
-      - "*"
+    branches: [ '*' ]
     paths:
       - '**.php'
       - 'composer.json'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,8 @@ jobs:
         XDEBUG_MODE: coverage
 
     - name: Archive Code Coverage Results
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
+        disable_search: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -2,9 +2,9 @@ name: Generate phar
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
   release:
     types:
       - created

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ name: Tests
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:


### PR DESCRIPTION
Type: documentation update
Breaking change: no

- Only run an action once per branch when PR is form a local branch
- Fix uploading to CodeCov when PR is from an external branch