### PR TITLE
Backport for 2.x of fixes from 3.x

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,6 +56,8 @@ jobs:
         XDEBUG_MODE: coverage
 
     - name: Archive Code Coverage Results
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         files: ./coverage.xml
+        disable_search: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   coverage:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,9 +37,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: vendor
-        key: ${{ runner.os }}-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-
+        key: ${{ runner.os }}-coverage-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1]
+        php: [5.3]
         setup: [prefer-stable]
 
     name: Release phar

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -56,6 +56,7 @@ jobs:
           ./pdepend.phar --version;
 
       - name: Sign phar
+        if: github.repository == 'pdepend/pdepend' && github.event_name == 'release'
         env:
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
           SECRET_KEY: ${{ secrets.SECRET_KEY }}

--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -2,9 +2,9 @@ name: Generate phar
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
   release:
     types:
       - created

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1' ]
+        php: [ '7.4' ]
         setup: [ 'stable' ]
         phpstan: [1.10.57]
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -2,9 +2,9 @@ name: PHPStan
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -38,8 +38,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-phpstan${{ matrix.phpstan }}-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('**/composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -7,9 +7,9 @@ name: Symfony
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -43,16 +43,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('composer.json') }}
 
       - name: Cache test packages
         id: composer-test-cache
         uses: actions/cache@v3
         with:
           path: src/test/vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-test-${{ matrix.symfony }}-${{ hashFiles('src/test/composer.json') }}
 
       - name: Set Symfony version
         run: |

--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -61,6 +61,10 @@ jobs:
             symfony/filesystem:^${{ matrix.symfony }} \
             symfony/config:^${{ matrix.symfony }}
 
+      - name: Upgrade PHPUnit
+        if: matrix.php >= 7.2
+        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
+
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --prefer-dist --no-progress --prefer-stable --ignore-platform-req=php+

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -40,8 +40,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-composer-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests-with-composer.yml
+++ b/.github/workflows/tests-with-composer.yml
@@ -5,9 +5,9 @@ name: Composer test script
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         setup: [ 'lowest', 'stable' ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
@@ -56,6 +56,10 @@ jobs:
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
+
+      - name: Upgrade PHPUnit
+        if: matrix.php >= 7.2
+        run: cd src/test && composer require phpunit/phpunit:^5.7.27 --no-update --no-interaction --dev
 
       - name: Install test dependencies
         if: steps.composer-test-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,9 +6,9 @@ name: Tests
 
 on:
   push:
-    branches: [ '**' ]
+    branches: [ '*', '2.x', '3.x' ]
   pull_request:
-    branches: [ '**' ]
+    branches: [ '*' ]
 
 jobs:
   tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,16 +42,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: vendor
-          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Cache test packages
         id: composer-test-cache
         uses: actions/cache@v3
         with:
           path: src/test/vendor
-          key: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.lock') }}
-          restore-keys: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-
+          key: ${{ runner.os }}-php-test-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('src/test/composer.json') }}
 
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1]
+        php: [7.4]
         setup: [prefer-stable]
 
     name: Build website

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -216,10 +216,10 @@ class Application
 
         foreach ($loggerServices as $loggerServiceTags) {
             foreach ($loggerServiceTags as $loggerServiceTag) {
-                if (isset($loggerServiceTag['option']) && isset($loggerServiceTag['message'])) {
+                if (isset($loggerServiceTag['option'], $loggerServiceTag['message']) && is_string($loggerServiceTag['option']) && is_string($loggerServiceTag['message'])) {
                     $options[$loggerServiceTag['option']] = array(
                         'message' => $loggerServiceTag['message'],
-                        'value' => isset($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file'
+                        'value' => isset($loggerServiceTag['value']) && is_string($loggerServiceTag['value']) ? $loggerServiceTag['value'] : 'file'
                     );
                 }
             }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -77,12 +77,12 @@ class StrategyFactory
     /**
      * List of all valid properties.
      *
-     * @var array<string>
+     * @var array<string, class-string<CodeRankStrategyI>>
      */
     private $validStrategies = array(
-        self::STRATEGY_INHERITANCE,
-        self::STRATEGY_METHOD,
-        self::STRATEGY_PROPERTY
+        self::STRATEGY_INHERITANCE => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\InheritanceStrategy',
+        self::STRATEGY_METHOD => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\MethodStrategy',
+        self::STRATEGY_PROPERTY => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\PropertyStrategy',
     );
 
     /**
@@ -107,19 +107,16 @@ class StrategyFactory
      */
     public function createStrategy($strategyName)
     {
-        if (in_array($strategyName, $this->validStrategies) === false) {
+        if (!isset($this->validStrategies[$strategyName])) {
             throw new InvalidArgumentException(
                 sprintf('Cannot load file for identifier "%s".', $strategyName)
             );
         }
 
-        // Prepare identifier
-        $name = ucfirst(strtolower($strategyName));
+        $className = $this->validStrategies[$strategyName];
 
-        $className = "PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\{$name}Strategy";
-
-        if (false === class_exists($className)) {
-            $fileName = "PDepend/Metrics/Analyzer/CodeRankAnalyzer/{$name}Strategy.php";
+        if (!class_exists($className)) {
+            $fileName = str_replace('\\', '/', $className) . '.php';
 
             include_once $fileName;
         }

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -160,7 +160,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent()
     {

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -141,7 +141,7 @@ interface ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent();
 
@@ -166,7 +166,7 @@ interface ASTNode
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment();
 

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -221,7 +221,7 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the doc comment for this item or <b>null</b>.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -78,7 +78,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * An <b>array</b> with all constant declarators defined in this class or interface.
      *
-     * @var array<string, mixed>
+     * @var array<string, ASTConstantDeclarator>
      */
     protected $constantDeclarators = null;
 
@@ -222,7 +222,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns an <b>array</b> with all constant declarators defined in this class or interface.
      *
-     * @return array<string, mixed>
+     * @return array<string, ASTConstantDeclarator>
      */
     public function getConstantDeclarators()
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -433,7 +433,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
      *
-     * @return ASTNode
+     * @return ?ASTNode
      */
     public function getParent()
     {
@@ -476,7 +476,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
      *
-     * @return string
+     * @return ?string
      */
     public function getComment()
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -5386,7 +5386,7 @@ abstract class AbstractPHPParser
      * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return ASTExpression
+     * @return ASTCompoundVariable|ASTVariableVariable|ASTVariable
      *
      * @since 0.9.6
      */
@@ -5440,7 +5440,7 @@ abstract class AbstractPHPParser
      * @throws ParserException
      * @throws UnexpectedTokenException
      *
-     * @return ASTExpression
+     * @return ASTCompoundVariable|ASTVariableVariable
      *
      * @since 0.9.6
      */

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -4342,7 +4342,7 @@ abstract class AbstractPHPParser
      *
      * @param T $expr
      *
-     * @return ASTMemberPrimaryPrefix|T
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T
      */
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
     {
@@ -4481,7 +4481,7 @@ abstract class AbstractPHPParser
      *
      * @param T $node The previously parsed node.
      *
-     * @return ASTFunctionPostfix|T The original input node or this node wrapped with a function postfix instance.
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T The original input node or this node wrapped with a function postfix instance.
      *
      * @since 1.0.0
      */
@@ -4508,7 +4508,7 @@ abstract class AbstractPHPParser
      *
      * @throws ParserException
      *
-     * @return ASTFunctionPostfix
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
      *
      * @since 0.9.6
      */
@@ -4560,7 +4560,7 @@ abstract class AbstractPHPParser
      *
      * @throws ParserException
      *
-     * @return ASTMemberPrimaryPrefix|T
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T
      *
      * @since 0.9.6
      */
@@ -4593,7 +4593,7 @@ abstract class AbstractPHPParser
      *
      * @throws ParserException
      *
-     * @return ASTMemberPrimaryPrefix
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
      *
      * @since 0.9.6
      */
@@ -4694,7 +4694,7 @@ abstract class AbstractPHPParser
      *
      * @throws ParserException
      *
-     * @return ASTMemberPrimaryPrefix
+     * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
      *
      * @since 0.9.6
      */
@@ -4847,7 +4847,7 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node Node that represents the image of the method postfix node.
      *
-     * @return ASTMethodPostfix
+     * @return ASTMethodPostfix|ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
      *
      * @since 1.0.0
      */

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -82,7 +82,7 @@ interface Tokenizer
      * Returns the next token or {@link Tokenizer::T_EOF} if
      * there is no next token.
      *
-     * @return int|Token
+     * @return Tokenizer::T_*|Token
      */
     public function next();
 
@@ -111,7 +111,7 @@ interface Tokenizer
      * @return int
      */
     public function peek();
-    
+
     /**
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.

--- a/src/test/composer.json
+++ b/src/test/composer.json
@@ -4,9 +4,7 @@
     "license": "BSD-3-Clause",
     "type": "library",
     "require": {
-        "php": ">=8.1"
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^5.7.27"
+        "php": ">=5.3.7",
+        "phpunit/phpunit": "^4.8.36|^5.7.27"
     }
 }


### PR DESCRIPTION
Type: bugfix
Breaking change: no

- Revert eb176040b8701fbb81fa5647928f0f476217626c which got merged to the wrong branch.
- Fix uploading coverage to CodeCov
- Fix getting stale cache when running tests
- Only run actions once per branch
- Only sign phar when key is avalible
- Correct various return types
- Check log option type before loading them
- Map strategy classes