### PR TITLE
Add nullable types based on textual description

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -206,7 +206,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * returns <b>null</b> if no cycle exists .
      *
      * @param ASTNamespace $node
-     * @return AbstractASTArtifact[]
+     * @return AbstractASTArtifact[]|null
      */
     public function getCycle(AbstractASTArtifact $node)
     {

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -60,7 +60,7 @@ class ASTEnumCase extends AbstractASTNode implements ASTArtifact
     /**
      * Returns the enum definition of this case or <b>null</b>.
      *
-     * @return ASTEnum
+     * @return ?ASTEnum
      */
     public function getEnum()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -148,7 +148,7 @@ class ASTFunction extends AbstractASTCallable
      * Returns the name of the parent namespace/package or <b>NULL</b> when this
      * function does not belong to a namespace.
      *
-     * @return string
+     * @return ?string
      * @since  0.10.0
      */
     public function getNamespaceName()

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -193,7 +193,7 @@ class ASTParameter extends AbstractASTArtifact
     /**
      * Returns the parent function or method instance or <b>null</b>
      *
-     * @return AbstractASTCallable
+     * @return ?AbstractASTCallable
      * @since  0.9.5
      */
     public function getDeclaringFunction()

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -113,7 +113,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      * Returns the new aliased method name or <b>NULL</b> when this alias does
      * not specify a new method name.
      *
-     * @return string
+     * @return ?string
      */
     public function getNewName()
     {

--- a/src/test/resources/files/Report/Jdepend/Xml/testXmlLogWithoutMetrics/package2.php
+++ b/src/test/resources/files/Report/Jdepend/Xml/testXmlLogWithoutMetrics/package2.php
@@ -27,7 +27,7 @@ class pkg2Foobar extends pkg1Bar {
      * Command manager singleton method which returns a configured instance
      * or <b>null</b>.
      *
-     * @return pkg2Foobar
+     * @return ?pkg2Foobar
      */
     public static function get()
     {

--- a/src/test/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
+++ b/src/test/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
@@ -18,7 +18,7 @@ class pkg2Foobar extends pkg1Bar {
      * Command manager singleton method which returns a configured instance
      * or <b>null</b>.
      *
-     * @return pkg2Foobar
+     * @return ?pkg2Foobar
      */
     public static function get()
     {

--- a/src/test/resources/files/TextUI/Runner/testRunnerThrowsRuntimeExceptionIfNoLoggerIsSpecified/package2.php
+++ b/src/test/resources/files/TextUI/Runner/testRunnerThrowsRuntimeExceptionIfNoLoggerIsSpecified/package2.php
@@ -18,7 +18,7 @@ class pkg2Foobar extends pkg1Bar {
      * Command manager singleton method which returns a configured instance
      * or <b>null</b>.
      *
-     * @return pkg2Foobar
+     * @return ?pkg2Foobar
      */
     public static function get()
     {

--- a/src/test/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
+++ b/src/test/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
@@ -18,7 +18,7 @@ class pkg2Foobar extends pkg1Bar {
      * Command manager singleton method which returns a configured instance
      * or <b>null</b>.
      *
-     * @return pkg2Foobar
+     * @return ?pkg2Foobar
      */
     public static function get()
     {


### PR DESCRIPTION
Type:  documentation update
Breaking change: no

Found a few that had not yet been corrected by analysis. This gets us a bit closer to PHPStan level 8 and being able to convert PHPDoc to native type hints.