### PR TITLE
Trace captured exceptions

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,8 @@ parameters:
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
     level: 6
+    exceptions:
+        reportUncheckedExceptionDeadCatch: true
+        implicitThrows: false
+        check:
+            tooWideThrowType: true

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -42,6 +42,7 @@
 
 namespace PDepend;
 
+use Exception;
 use InvalidArgumentException;
 use PDepend\DependencyInjection\PdependExtension;
 use PDepend\Metrics\AnalyzerFactory;
@@ -74,6 +75,8 @@ class Application
 
     /**
      * @param string $configurationFile
+     *
+     * @throws InvalidArgumentException
      */
     public function setConfigurationFile($configurationFile): void
     {
@@ -87,6 +90,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return Configuration
      */
     public function getConfiguration()
@@ -98,6 +103,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return Engine
      */
     public function getEngine()
@@ -109,6 +116,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return Runner
      */
     public function getRunner()
@@ -120,6 +129,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return ReportGeneratorFactory
      */
     public function getReportGeneratorFactory()
@@ -131,6 +142,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return AnalyzerFactory
      */
     public function getAnalyzerFactory()
@@ -142,6 +155,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return TaggedContainerInterface
      */
     private function getContainer()
@@ -154,6 +169,8 @@ class Application
     }
 
     /**
+     * @throws Exception
+     *
      * @return TaggedContainerInterface
      */
     private function createContainer()
@@ -182,6 +199,8 @@ class Application
     /**
      * Returns available logger options and documentation messages.
      *
+     * @throws Exception
+     *
      * @return array<string, array<string, string>>
      */
     public function getAvailableLoggerOptions()
@@ -192,6 +211,8 @@ class Application
     /**
      * Returns available analyzer options and documentation messages.
      *
+     * @throws Exception
+     *
      * @return array<string, array<string, string>>
      */
     public function getAvailableAnalyzerOptions()
@@ -201,6 +222,8 @@ class Application
 
     /**
      * @param string $serviceTag
+     *
+     * @throws Exception
      *
      * @return array<string, array<string, string>>
      */

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -217,6 +217,8 @@ class Engine
      * Adds the specified directory to the list of directories to be analyzed.
      *
      * @param string $directory The php source directory.
+     *
+     * @throws InvalidArgumentException
      */
     public function addDirectory($directory): void
     {
@@ -233,6 +235,8 @@ class Engine
      * Adds a single source code file to the list of files to be analysed.
      *
      * @param string $file The source file name.
+     *
+     * @throws InvalidArgumentException
      */
     public function addFile($file): void
     {
@@ -317,6 +321,8 @@ class Engine
      * Analyzes the registered directories and returns the collection of
      * analyzed namespace.
      *
+     * @throws InvalidArgumentException
+     *
      * @return ASTArtifactList<ASTNamespace>
      */
     public function analyze()
@@ -356,6 +362,8 @@ class Engine
     /**
      * Returns the number of analyzed php classes and interfaces.
      *
+     * @throws RuntimeException
+     *
      * @return int
      */
     public function countClasses()
@@ -384,7 +392,9 @@ class Engine
     }
 
     /**
-     *  Returns the number of analyzed namespaces.
+     * Returns the number of analyzed namespaces.
+     *
+     * @throws RuntimeException
      *
      * @return int
      */
@@ -575,6 +585,8 @@ class Engine
      * This method performs the analysing process of the parsed source files. It
      * creates the required analyzers for the registered listeners and then
      * applies them to the source tree.
+     *
+     * @throws InvalidArgumentException
      */
     private function performAnalyzeProcess(): void
     {
@@ -610,6 +622,8 @@ class Engine
     /**
      * This method will create an iterator instance which contains all files
      * that are part of the parsing process.
+     *
+     * @throws RuntimeException
      *
      * @return ArrayIterator<int, string>
      */
@@ -671,6 +685,8 @@ class Engine
 
     /**
      * @param array<string, mixed> $options
+     *
+     * @throws InvalidArgumentException
      *
      * @return Analyzer[]
      */

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -451,6 +451,8 @@ abstract class AbstractPHPParser
     /**
      * Parses the contents of the tokenizer and generates a node tree based on
      * the found tokens.
+     *
+     * @throws ParserException
      */
     public function parse(): void
     {
@@ -1721,6 +1723,8 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
+     * @throws ParserException
+     *
      * @return ASTAllocationExpression
      *
      * @since 0.9.6
@@ -1745,6 +1749,8 @@ abstract class AbstractPHPParser
      *
      * @param T $allocation
      *
+     * @throws ParserException
+     *
      * @return T
      *
      * @since 2.3
@@ -1756,6 +1762,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parse the instanciation for new keyword without arguments.
+     *
+     * @throws ParserException
      *
      * @return ASTAllocationExpression
      */
@@ -2516,6 +2524,8 @@ abstract class AbstractPHPParser
     /**
      * @param bool $classRef
      *
+     * @throws ParserException
+     *
      * @return ASTNode
      */
     private function parseStandAloneExpressionType($classRef)
@@ -2547,6 +2557,8 @@ abstract class AbstractPHPParser
      *
      * @param T    $expr
      * @param bool $classRef
+     *
+     * @throws ParserException
      *
      * @return T
      */
@@ -2859,6 +2871,8 @@ abstract class AbstractPHPParser
     /**
      * Parse a scope enclosed by curly braces.
      *
+     * @throws ParserException
+     *
      * @return ASTScopeStatement
      *
      * @since 0.9.12
@@ -2898,6 +2912,8 @@ abstract class AbstractPHPParser
     /**
      * Parses all statements that exist in a scope an adds them to a scope
      * instance.
+     *
+     * @throws ParserException
      *
      * @return ASTScopeStatement
      *
@@ -3401,6 +3417,8 @@ abstract class AbstractPHPParser
     /**
      * This method parses a switch statement.
      *
+     * @throws ParserException
+     *
      * @return ASTSwitchStatement
      *
      * @since 0.9.8
@@ -3421,6 +3439,8 @@ abstract class AbstractPHPParser
      * Parses the body of a switch statement.
      *
      * @param ASTSwitchStatement $switch The parent switch stmt.
+     *
+     * @throws ParserException
      *
      * @return ASTSwitchStatement
      *
@@ -3466,6 +3486,8 @@ abstract class AbstractPHPParser
 
     /**
      * This method parses a case label of a switch statement.
+     *
+     * @throws ParserException
      *
      * @return ASTSwitchLabel
      *
@@ -3521,6 +3543,8 @@ abstract class AbstractPHPParser
      * Parses the body of an switch label node.
      *
      * @param ASTSwitchLabel $label The context switch label.
+     *
+     * @throws ParserException
      *
      * @return ASTSwitchLabel
      */
@@ -3591,6 +3615,8 @@ abstract class AbstractPHPParser
 
     /**
      * This method parses a try-statement + associated catch-statements.
+     *
+     * @throws ParserException
      *
      * @return ASTTryStatement
      *
@@ -3886,6 +3912,8 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single for-statement node.
      *
+     * @throws ParserException
+     *
      * @return ASTForStatement
      *
      * @since 0.9.8
@@ -3949,6 +3977,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parses the expression part of a for-statement.
+     *
+     * @throws ParserException
      *
      * @return ASTNode|null
      *
@@ -4700,8 +4730,6 @@ abstract class AbstractPHPParser
     /**
      * This method parses a method- or constant-postfix expression. This expression
      * will contain an identifier node as nested child.
-     *
-     * @throws ParserException
      *
      * @return ASTNode
      *
@@ -6300,8 +6328,6 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @throws InvalidStateException
-     *
      * @return ASTFormalParameter
      *
      * @since 0.9.6
@@ -6558,6 +6584,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parses an optional statement or returns <b>null</b>.
+     *
+     * @throws ParserException
      *
      * @return AbstractASTClassOrInterface|ASTCallable|ASTNode|null
      *

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -332,6 +332,8 @@ class Command
 
     /**
      * Assign CLI arguments to current runner instance
+     *
+     * @throws Exception
      */
     protected function assignArguments(): void
     {
@@ -417,6 +419,8 @@ class Command
 
     /**
      * Outputs the main help of PDepend.
+     *
+     * @throws Exception
      */
     protected function printHelp(): void
     {
@@ -471,6 +475,8 @@ class Command
      * Prints all available log options and returns the length of the longest
      * option.
      *
+     * @throws Exception
+     *
      * @return int
      */
     protected function printLogOptions()
@@ -512,6 +518,8 @@ class Command
      * Prints the analyzer options.
      *
      * @param int $length Length of the longest option.
+     *
+     * @throws Exception
      *
      * @return int
      */


### PR DESCRIPTION
Type: documentation update
Breaking change: no

This documents at least one of the paths exceptions can travel to hit any of the try-catch blocks in the code, allowing us to enable checks for dead try catches and treat more strictly.

It also correct tow cases where the dokumentation incorrectly stated that an exception could happen.