### PR TITLE
Remove deprecated getName() (use getImage())

### DIFF
--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -412,7 +412,7 @@ class Engine
             throw new RuntimeException($msg);
         }
         foreach ($this->namespaces as $namespace) {
-            if ($namespace->getName() === $name) {
+            if ($namespace->getImage() === $name) {
                 return $namespace;
             }
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -313,13 +313,13 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         $properties = [];
         // Collect all properties of the context class
         foreach ($class->getProperties() as $prop) {
-            $properties[$prop->getName()] = true;
+            $properties[$prop->getImage()] = true;
         }
 
         foreach ($class->getParentClasses() as $parent) {
             foreach ($parent->getProperties() as $prop) {
-                if (!$prop->isPrivate() && !isset($properties[$prop->getName()])) {
-                    $properties[$prop->getName()] = true;
+                if (!$prop->isPrivate() && !isset($properties[$prop->getImage()])) {
+                    $properties[$prop->getImage()] = true;
                 }
             }
         }
@@ -342,7 +342,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
                 if ($method->isPrivate()) {
                     continue;
                 }
-                if (isset($ccn[$name = $method->getName()])) {
+                if (isset($ccn[$name = $method->getImage()])) {
                     continue;
                 }
                 $ccn[$name] = $this->cyclomaticAnalyzer->getCcn2($method);
@@ -374,7 +374,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         $ccn = [];
 
         foreach ($type->getMethods() as $method) {
-            $ccn[$method->getName()] = $this->cyclomaticAnalyzer->getCcn2($method);
+            $ccn[$method->getImage()] = $this->cyclomaticAnalyzer->getCcn2($method);
         }
 
         return $ccn;

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -130,7 +130,7 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
             $this->nodes[$node->getId()] = [
                 'in' => [],
                 'out' => [],
-                'name' => $node->getName(),
+                'name' => $node->getImage(),
                 'type' => $node::class,
             ];
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -130,7 +130,7 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
             $this->nodes[$node->getId()] = [
                 'in' => [],
                 'out' => [],
-                'name' => $node->getName(),
+                'name' => $node->getImage(),
                 'type' => $node::class,
             ];
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -117,7 +117,7 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
             $this->nodes[$node->getId()] = [
                 'in' => [],
                 'out' => [],
-                'name' => $node->getName(),
+                'name' => $node->getImage(),
                 'type' => $node::class,
             ];
         }

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -111,7 +111,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
     public function visitProperty(ASTProperty $property)
     {
         $this->fireStartProperty($property);
-        echo ltrim($property->getName(), '$'), PHP_EOL;
+        echo ltrim($property->getImage(), '$'), PHP_EOL;
         $this->fireEndProperty($property);
     }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -282,7 +282,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
 
         $parentMethodNames = [];
         foreach ($parentClass->getAllMethods() as $method) {
-            $parentMethodNames[$method->getName()] = $method->isAbstract();
+            $parentMethodNames[$method->getImage()] = $method->isAbstract();
         }
 
         $numberOfAddedMethods = 0;
@@ -293,8 +293,8 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
                 continue;
             }
 
-            if (isset($parentMethodNames[$method->getName()])) {
-                if (!$parentMethodNames[$method->getName()]) {
+            if (isset($parentMethodNames[$method->getImage()])) {
+                if (!$parentMethodNames[$method->getImage()]) {
                     ++$numberOfOverwrittenMethods;
                 }
             } else {

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -218,7 +218,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $typeXml = $doc->createElement($typeIdentifier);
-        $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+        $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getImage()));
         $xml->appendChild($typeXml);
 
         $this->xmlStack[] = $typeXml;
@@ -259,7 +259,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $packageXml = $doc->createElement('package');
-        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getName()));
+        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getImage()));
 
         $this->xmlStack[] = $packageXml;
 
@@ -301,7 +301,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         foreach ($this->dependencyAnalyzer->getEfferents($node) as $type) {
             $typeXml = $doc->createElement('type');
             $typeXml->setAttribute('namespace', Utf8Util::ensureEncoding($type->getNamespaceName()));
-            $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+            $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getImage()));
 
             $efferentXml->appendChild($typeXml);
         }
@@ -311,7 +311,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         foreach ($this->dependencyAnalyzer->getAfferents($node) as $type) {
             $typeXml = $doc->createElement('type');
             $typeXml->setAttribute('namespace', Utf8Util::ensureEncoding($type->getNamespaceName()));
-            $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+            $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getImage()));
 
             $afferentXml->appendChild($typeXml);
         }

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -241,7 +241,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
                 'abstraction' => $metrics['a'],
                 'instability' => $metrics['i'],
                 'distance' => $metrics['d'],
-                'name' => Utf8Util::ensureEncoding($namespace->getName()),
+                'name' => Utf8Util::ensureEncoding($namespace->getImage()),
             ];
         }
 

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -213,7 +213,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $classXml->setAttribute('sourceFile', (string) $class->getCompilationUnit());
         $classXml->appendChild(
             $doc->createTextNode(
-                Utf8Util::ensureEncoding($class->getName()),
+                Utf8Util::ensureEncoding($class->getImage()),
             ),
         );
 
@@ -244,7 +244,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $classXml->setAttribute('sourceFile', (string) $interface->getCompilationUnit());
         $classXml->appendChild(
             $doc->createTextNode(
-                Utf8Util::ensureEncoding($interface->getName()),
+                Utf8Util::ensureEncoding($interface->getImage()),
             ),
         );
 
@@ -276,7 +276,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         $this->abstractClasses = $doc->createElement('AbstractClasses');
 
         $packageXml = $doc->createElement('Package');
-        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getName()));
+        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getImage()));
 
         $statsXml = $doc->createElement('Stats');
         $statsXml->appendChild($doc->createElement('TotalClasses'))
@@ -301,7 +301,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $efferentXml = $doc->createElement('Package');
             $efferentXml->appendChild(
                 $doc->createTextNode(
-                    Utf8Util::ensureEncoding($efferent->getName()),
+                    Utf8Util::ensureEncoding($efferent->getImage()),
                 ),
             );
 
@@ -313,7 +313,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $afferentXml = $doc->createElement('Package');
             $afferentXml->appendChild(
                 $doc->createTextNode(
-                    Utf8Util::ensureEncoding($afferent->getName()),
+                    Utf8Util::ensureEncoding($afferent->getImage()),
                 ),
             );
 
@@ -328,13 +328,13 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
         if (($cycles = $this->analyzer->getCycle($namespace)) !== null) {
             $cycleXml = $doc->createElement('Package');
-            $cycleXml->setAttribute('Name', Utf8Util::ensureEncoding($namespace->getName()));
+            $cycleXml->setAttribute('Name', Utf8Util::ensureEncoding($namespace->getImage()));
 
             foreach ($cycles as $cycle) {
                 $cycleXml->appendChild($doc->createElement('Package'))
                     ->appendChild(
                         $doc->createTextNode(
-                            Utf8Util::ensureEncoding($cycle->getName()),
+                            Utf8Util::ensureEncoding($cycle->getImage()),
                         ),
                     );
             }

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -288,7 +288,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $typeXml = $doc->createElement($typeIdentifier);
-        $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getName()));
+        $typeXml->setAttribute('name', Utf8Util::ensureEncoding($type->getImage()));
         $typeXml->setAttribute('fqname', Utf8Util::ensureEncoding($type->getNamespacedName()));
         $typeXml->setAttribute('start', (string) $type->getStartLine());
         $typeXml->setAttribute('end', (string) $type->getEndLine());
@@ -328,7 +328,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $functionXml = $doc->createElement('function');
-        $functionXml->setAttribute('name', Utf8Util::ensureEncoding($function->getName()));
+        $functionXml->setAttribute('name', Utf8Util::ensureEncoding($function->getImage()));
         $functionXml->setAttribute('start', (string) $function->getStartLine());
         $functionXml->setAttribute('end', (string) $function->getEndLine());
 
@@ -364,7 +364,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $methodXml = $doc->createElement('method');
-        $methodXml->setAttribute('name', Utf8Util::ensureEncoding($method->getName()));
+        $methodXml->setAttribute('name', Utf8Util::ensureEncoding($method->getImage()));
         $methodXml->setAttribute('start', (string) $method->getStartLine());
         $methodXml->setAttribute('end', (string) $method->getEndLine());
 
@@ -391,7 +391,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
         }
 
         $packageXml = $doc->createElement('package');
-        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getName()));
+        $packageXml->setAttribute('name', Utf8Util::ensureEncoding($namespace->getImage()));
 
         $this->writeNodeMetrics($packageXml, $namespace);
 

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -101,16 +101,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
     }
 
     /**
-     * Returns the source image of this ast node.
-     *
-     * @return string
-     */
-    public function getImage()
-    {
-        return $this->getName();
-    }
-
-    /**
      * Returns the start line for this ast node.
      *
      * @return int

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -51,14 +51,6 @@ namespace PDepend\Source\AST;
 interface ASTArtifact extends ASTNode
 {
     /**
-     * Returns the artifact name.
-     *
-     * @return string
-     * @deprecated Use getImage() inherit from ASTNode class.
-     */
-    public function getName();
-
-    /**
      * Returns a id for this code node.
      *
      * @return string

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -140,7 +140,7 @@ class ASTArtifactList implements ArrayAccess, Countable, Iterator
      */
     public function key(): string
     {
-        return $this->artifacts[$this->offset]->getName();
+        return $this->artifacts[$this->offset]->getImage();
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -89,11 +89,11 @@ class PackageArtifactFilter implements ArtifactFilter
         //       ASTMethod and ASTProperty, but when PDepend supports more node
         //       types, this could produce errors.
         if ($node instanceof AbstractASTClassOrInterface) {
-            $namespace = $node->getNamespace()->getName();
+            $namespace = $node->getNamespace()->getImage();
         } elseif ($node instanceof ASTFunction) {
-            $namespace = $node->getNamespace()->getName();
+            $namespace = $node->getNamespace()->getImage();
         } elseif ($node instanceof ASTNamespace) {
-            $namespace = $node->getName();
+            $namespace = $node->getImage();
         } else {
             return false;
         }

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -63,8 +63,8 @@ class ASTClassOrInterfaceRecursiveInheritanceException extends RuntimeException
         parent::__construct(
             sprintf(
                 'Type %s\%s is part of an endless inheritance hierarchy.',
-                preg_replace('(\W+)', '\\', $type->getNamespace()->getName()),
-                $type->getName(),
+                preg_replace('(\W+)', '\\', $type->getNamespace()->getImage()),
+                $type->getImage(),
             ),
         );
     }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -151,7 +151,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      *
      * @return string|null
      */
-    public function getName()
+    public function getImage()
     {
         return $this->fileName;
     }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -64,7 +64,7 @@ class ASTCompilationUnitNotFoundException extends RuntimeException
             sprintf(
                 'The mandatory parent was not defined for the %s named %s.',
                 $owner::class,
-                $owner->getName(),
+                $owner->getImage(),
             ),
         );
     }

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -90,9 +90,4 @@ class ASTEnumCase extends AbstractASTNode implements ASTArtifact
 
         return null;
     }
-
-    public function getName()
-    {
-        return $this->getImage();
-    }
 }

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -127,7 +127,7 @@ class ASTFunction extends AbstractASTCallable
      */
     public function setNamespace(ASTNamespace $namespace): void
     {
-        $this->namespaceName = $namespace->getName();
+        $this->namespaceName = $namespace->getImage();
         $this->namespace = $namespace;
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -113,7 +113,7 @@ class ASTParameter extends AbstractASTArtifact
         if ($this->isArray() === true) {
             $typeHint = ' array';
         } elseif ($this->getClass() !== null) {
-            $typeHint = ' ' . $this->getClass()->getName();
+            $typeHint = ' ' . $this->getClass()->getImage();
         }
 
         $default = '';
@@ -143,7 +143,7 @@ class ASTParameter extends AbstractASTArtifact
             $required,
             $typeHint,
             $reference,
-            $this->getName(),
+            $this->getImage(),
             $default,
         );
     }
@@ -153,7 +153,7 @@ class ASTParameter extends AbstractASTArtifact
      *
      * @return string
      */
-    public function getName()
+    public function getImage()
     {
         return $this->variableDeclarator->getImage();
     }

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -109,7 +109,7 @@ class ASTProperty extends AbstractASTArtifact
             'Property [%s%s %s ]%s',
             $visibility,
             $static,
-            $this->getName(),
+            $this->getImage(),
             PHP_EOL,
         );
     }
@@ -119,7 +119,7 @@ class ASTProperty extends AbstractASTArtifact
      *
      * @return string
      */
-    public function getName()
+    public function getImage()
     {
         return $this->variableDeclarator->getImage();
     }

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -93,7 +93,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     public function __sleep()
     {
         $this->qualifiedName = $this->getType()->getNamespaceName() . '\\' .
-                               $this->getType()->getName();
+                               $this->getType()->getImage();
 
         return array_merge(['qualifiedName'], parent::__sleep());
     }

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -91,7 +91,7 @@ class ASTTrait extends ASTClass
         $methods = $this->getTraitMethods();
 
         foreach ($this->getMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[strtolower($method->getImage())] = $method;
         }
 
         return $methods;

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -33,9 +33,9 @@ class ASTTraitMethodCollisionException extends RuntimeException
             sprintf(
                 'Trait method %s has not been applied, because there are ' .
                 'collisions with other trait methods on %s\%s.',
-                $method->getName(),
-                preg_replace('(\W+)', '\\', $type->getNamespace()->getName()),
-                $type->getName(),
+                $method->getImage(),
+                preg_replace('(\W+)', '\\', $type->getNamespace()->getImage()),
+                $type->getImage(),
             ),
         );
     }

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -85,7 +85,7 @@ class ASTTraitUseStatement extends ASTStatement
      */
     public function hasExcludeFor(ASTMethod $method)
     {
-        $methodName = strtolower($method->getName());
+        $methodName = strtolower($method->getImage());
         $methodParent = $method->getParent();
 
         $precedences = $this->findChildrenOfType(ASTTraitAdaptationPrecedence::class);
@@ -133,7 +133,7 @@ class ASTTraitUseStatement extends ASTStatement
      */
     private function getAliasesFor(ASTMethod $method)
     {
-        $name = strtolower($method->getName());
+        $name = strtolower($method->getImage());
 
         $newNames = [];
         foreach ($this->getAliases() as $alias) {
@@ -152,7 +152,7 @@ class ASTTraitUseStatement extends ASTStatement
                 $modifier |= $alias->getNewModifier();
             }
 
-            $newName = $method->getName();
+            $newName = $method->getImage();
             if ($alias->getNewName()) {
                 $newName = $alias->getNewName();
             }

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -106,16 +106,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
     }
 
     /**
-     * Returns the item name.
-     *
-     * @return string
-     */
-    public function getName()
-    {
-        return $this->name;
-    }
-
-    /**
      * Sets the item name.
      *
      * @param string $name The item name.
@@ -166,7 +156,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      */
     public function setCompilationUnit(ASTCompilationUnit $compilationUnit): void
     {
-        if ($this->compilationUnit?->getName() === null) {
+        if ($this->compilationUnit?->getFileName() === null) {
             $this->compilationUnit = $compilationUnit;
         }
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -282,7 +282,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         $methods = [];
         foreach ($this->getInterfaces() as $interface) {
             foreach ($interface->getAllMethods() as $method) {
-                $methods[strtolower($method->getName())] = $method;
+                $methods[strtolower($method->getImage())] = $method;
             }
         }
 
@@ -293,11 +293,11 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         }
 
         foreach ($this->getTraitMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[strtolower($method->getImage())] = $method;
         }
 
         foreach ($this->getMethods() as $method) {
-            $methods[strtolower($method->getName())] = $method;
+            $methods[strtolower($method->getImage())] = $method;
         }
 
         return $methods;

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -333,7 +333,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     public function setNamespace(ASTNamespace $namespace): void
     {
         $this->namespace = $namespace;
-        $this->namespaceName = $namespace->getName();
+        $this->namespaceName = $namespace->getImage();
     }
 
     /**
@@ -403,7 +403,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
                     }
                 }
 
-                $name = strtolower($method->getName());
+                $name = strtolower($method->getImage());
 
                 if (!isset($methods[$name]) || isset($priorMethods[$name])) {
                     $methods[$name] = $method;

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -505,7 +505,7 @@ abstract class AbstractPHPParser
                 (string) $this->compilationUnit,
                 sprintf(
                     'Constant can\'t be declared private or protected in interface "%s".',
-                    $this->classOrInterface->getName()
+                    $this->classOrInterface->getImage()
                 )
             );
         }
@@ -5692,7 +5692,7 @@ abstract class AbstractPHPParser
                 sprintf(
                     'The keyword "parent" was used as type hint but the ' .
                     'class "%s" does not declare a parent.',
-                    $this->classOrInterface->getName(),
+                    $this->classOrInterface->getImage(),
                 ),
             );
         }
@@ -6673,7 +6673,7 @@ abstract class AbstractPHPParser
     {
         $modifier = 0;
 
-        if ($callable instanceof ASTMethod && $callable->getName() === '__construct') {
+        if ($callable instanceof ASTMethod && $callable->getImage() === '__construct') {
             $modifier = $this->parseConstructFormalParameterModifiers();
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -633,7 +633,7 @@ class PHPBuilder implements Builder
     public function buildAstSelfReference(AbstractASTClassOrInterface $type)
     {
         Log::debug(
-            'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getName() . ')',
+            'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getImage() . ')',
         );
 
         return new ASTSelfReference($this->context, $type);
@@ -2331,7 +2331,7 @@ class PHPBuilder implements Builder
     public function restoreTrait(ASTTrait $trait): void
     {
         $this->storeTrait(
-            $trait->getName(),
+            $trait->getImage(),
             $trait->getNamespaceName(),
             $trait,
         );
@@ -2345,7 +2345,7 @@ class PHPBuilder implements Builder
     public function restoreClass(ASTClass $class): void
     {
         $this->storeClass(
-            $class->getName(),
+            $class->getImage(),
             $class->getNamespaceName(),
             $class,
         );
@@ -2359,7 +2359,7 @@ class PHPBuilder implements Builder
     public function restoreEnum(ASTEnum $enum): void
     {
         $this->storeEnum(
-            $enum->getName(),
+            $enum->getImage(),
             $enum->getNamespaceName(),
             $enum,
         );
@@ -2373,7 +2373,7 @@ class PHPBuilder implements Builder
     public function restoreInterface(ASTInterface $interface): void
     {
         $this->storeInterface(
-            $interface->getName(),
+            $interface->getImage(),
             $interface->getNamespaceName(),
             $interface,
         );

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -104,7 +104,7 @@ class IdBuilder
     protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
     {
         $fileHash = $artifact->getCompilationUnit()?->getId() ?? 'default';
-        $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getName()));
+        $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getImage()));
 
         $offset = $this->getOffsetInFile($fileHash, $itemHash);
 
@@ -118,7 +118,7 @@ class IdBuilder
      */
     public function forMethod(ASTMethod $method)
     {
-        $hash = $this->hash(strtolower($method->getName()));
+        $hash = $this->hash(strtolower($method->getImage()));
 
         $parent = $method->getParent();
         if (!$parent) {

--- a/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -106,9 +106,9 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
             ->current()
             ->getFunctions();
 
-        static::assertEquals('bar', $functions->current()->getName());
+        static::assertEquals('bar', $functions->current()->getImage());
         $functions->next();
-        static::assertEquals('foo', $functions->current()->getName());
+        static::assertEquals('foo', $functions->current()->getImage());
     }
 
     /**
@@ -121,6 +121,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
             ->getFunctions()
             ->current();
 
-        static::assertEquals('foo', $function->getName());
+        static::assertEquals('foo', $function->getImage());
     }
 }

--- a/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
+++ b/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
@@ -65,11 +65,11 @@ class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegression
 
         static::assertSame(1, $namespace->getClasses()->count());
         $class = $namespace->getClasses()->current();
-        static::assertSame('Bar', $class->getName());
+        static::assertSame('Bar', $class->getImage());
 
         static::assertSame(1, $namespace->getInterfaces()->count());
         $interface = $namespace->getInterfaces()->current();
-        static::assertSame('IFoo', $interface->getName());
+        static::assertSame('IFoo', $interface->getImage());
 
         static::assertSame(1, $class->getMethods()->count());
         $method = $class->getMethods()->current();
@@ -91,10 +91,10 @@ class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegression
         $classes = $namespace->getClasses();
         static::assertSame(2, $classes->count());
         $class1 = $classes->current();
-        static::assertSame('Foo', $class1->getName());
+        static::assertSame('Foo', $class1->getImage());
         $classes->next();
         $class2 = $classes->current();
-        static::assertSame('Bar', $class2->getName());
+        static::assertSame('Bar', $class2->getImage());
 
         static::assertSame(1, $class2->getMethods()->count());
         $method = $class2->getMethods()->current();

--- a/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
@@ -63,7 +63,7 @@ class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegr
             ->getFunctions()
             ->current();
 
-        static::assertEquals('barBug08', $function->getName());
+        static::assertEquals('barBug08', $function->getImage());
     }
 
     /**
@@ -79,6 +79,6 @@ class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegr
             ->getMethods()
             ->current();
 
-        static::assertEquals('fooBug08', $method->getName());
+        static::assertEquals('fooBug08', $method->getImage());
     }
 }

--- a/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
@@ -63,7 +63,7 @@ class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTe
         $parameters = $this->getFirstFunctionForTestCase()
             ->getParameters();
 
-        static::assertEquals('foo\bar', $parameters[0]->getClass()->getNamespace()->getName());
+        static::assertEquals('foo\bar', $parameters[0]->getClass()->getNamespace()->getImage());
     }
 
     /**
@@ -74,6 +74,6 @@ class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTe
         $parameters = $this->getFirstClassMethodForTestCase()
             ->getParameters();
 
-        static::assertEquals('foo\bar', $parameters[0]->getClass()->getNamespace()->getName());
+        static::assertEquals('foo\bar', $parameters[0]->getClass()->getNamespace()->getImage());
     }
 }

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -69,7 +69,7 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
             ->current()
             ->getParameters();
 
-        static::assertSame('Bar', $parameters[0]->getClass()->getName());
+        static::assertSame('Bar', $parameters[0]->getClass()->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Bugs/ParserBug016Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug016Test.php
@@ -71,7 +71,7 @@ class ParserBug016Test extends AbstractRegressionTestCase
         $dependencies = $function->getDependencies();
 
         static::assertEquals(1, $dependencies->count());
-        static::assertEquals('SplObjectStorage', $dependencies[0]->getName());
+        static::assertEquals('SplObjectStorage', $dependencies[0]->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Bugs/ParserBug017Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug017Test.php
@@ -70,6 +70,6 @@ class ParserBug017Test extends AbstractRegressionTestCase
         $function = $this->getFirstFunctionForTestCase();
         $dependencies = $function->getDependencies();
 
-        static::assertEquals('OutOfBoundsException', $dependencies[0]->getName());
+        static::assertEquals('OutOfBoundsException', $dependencies[0]->getImage());
     }
 }

--- a/src/test/php/PDepend/Bugs/ParserBug033Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug033Test.php
@@ -85,7 +85,7 @@ class ParserBug033Test extends AbstractRegressionTestCase
             ->getMethods()
             ->current();
 
-        static::assertEquals('parse', $method->getName());
+        static::assertEquals('parse', $method->getImage());
         static::assertEquals(1, $method->getDependencies()->count());
     }
 }

--- a/src/test/php/PDepend/Bugs/ParserBug069Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug069Test.php
@@ -68,7 +68,7 @@ class ParserBug069Test extends AbstractRegressionTestCase
             ->current()
             ->getNamespace();
 
-        static::assertEquals('PDepend', $namespace->getName());
+        static::assertEquals('PDepend', $namespace->getImage());
     }
 
     /**
@@ -85,7 +85,7 @@ class ParserBug069Test extends AbstractRegressionTestCase
             ->current()
             ->getNamespace();
 
-        static::assertEquals('PDepend', $namespace->getName());
+        static::assertEquals('PDepend', $namespace->getImage());
     }
 
     /**
@@ -119,7 +119,7 @@ class ParserBug069Test extends AbstractRegressionTestCase
             ->current()
             ->getNamespace();
 
-        static::assertEquals('PDepend', $namespace->getName());
+        static::assertEquals('PDepend', $namespace->getImage());
     }
 
     /**
@@ -136,6 +136,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
             ->current()
             ->getNamespace();
 
-        static::assertEquals('PDepend', $namespace->getName());
+        static::assertEquals('PDepend', $namespace->getImage());
     }
 }

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -70,7 +70,7 @@ class ParserBug23905939Test extends AbstractRegressionTestCase
             ->getClasses()
             ->current();
 
-        static::assertEquals('my.package', $class->getNamespace()->getName());
+        static::assertEquals('my.package', $class->getNamespace()->getImage());
     }
 
     /**
@@ -85,6 +85,6 @@ class ParserBug23905939Test extends AbstractRegressionTestCase
             ->getInterfaces()
             ->current();
 
-        static::assertEquals('my.package', $interface->getNamespace()->getName());
+        static::assertEquals('my.package', $interface->getNamespace()->getImage());
     }
 }

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -113,7 +113,7 @@ class EngineTest extends AbstractTestCase
         ];
 
         foreach ($metrics as $metric) {
-            unset($expected[$metric->getName()]);
+            unset($expected[$metric->getImage()]);
         }
 
         static::assertCount(0, $expected);
@@ -156,12 +156,12 @@ class EngineTest extends AbstractTestCase
         $namespaces = $engine->analyze();
 
         static::assertEquals(2, $namespaces->count());
-        static::assertEquals('pdepend.test', $namespaces->current()->getName());
+        static::assertEquals('pdepend.test', $namespaces->current()->getImage());
 
         $function = $namespaces->current()->getFunctions()->current();
 
         static::assertNotNull($function);
-        static::assertEquals('foo', $function->getName());
+        static::assertEquals('foo', $function->getImage());
         static::assertEquals(0, $function->getExceptionClasses()->count());
     }
 

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -70,7 +70,7 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
         $function = $this->getFirstFunctionForTestCase();
         $dependency = $function->getDependencies()->current();
 
-        static::assertSame('Bar', $dependency->getName());
+        static::assertSame('Bar', $dependency->getImage());
     }
 
     /**
@@ -90,7 +90,7 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
         $function = $this->getFirstFunctionForTestCase();
         $dependency = $function->getDependencies()->current();
 
-        static::assertSame('Bar', $dependency->getName());
+        static::assertSame('Bar', $dependency->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -64,7 +64,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getParentClass()
             ->getNamespace();
 
-        static::assertEquals('foo', $namespace->getName());
+        static::assertEquals('foo', $namespace->getImage());
     }
 
     /**
@@ -78,12 +78,12 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->current();
 
         $parentClass = $class->getParentClass();
-        static::assertEquals('FooBar', $parentClass->getName());
-        static::assertEquals('foo', $parentClass->getNamespace()->getName());
+        static::assertEquals('FooBar', $parentClass->getImage());
+        static::assertEquals('foo', $parentClass->getNamespace()->getImage());
 
         $interface = $class->getInterfaces()->current();
-        static::assertEquals('Bar', $interface->getName());
-        static::assertEquals('foo', $interface->getNamespace()->getName());
+        static::assertEquals('Bar', $interface->getImage());
+        static::assertEquals('foo', $interface->getNamespace()->getImage());
     }
 
     /**
@@ -98,8 +98,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->current();
 
         $parentClass = $class->getParentClass();
-        static::assertEquals('Bar', $parentClass->getName());
-        static::assertEquals('foo\bar', $parentClass->getNamespace()->getName());
+        static::assertEquals('Bar', $parentClass->getImage());
+        static::assertEquals('foo\bar', $parentClass->getNamespace()->getImage());
     }
 
     /**
@@ -124,7 +124,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     public function testParserHandlesNamespaceDeclarationWithIdentifierAndCurlyBraceSyntax(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
-        static::assertEquals('foo', $namespaces->current()->getName());
+        static::assertEquals('foo', $namespaces->current()->getImage());
     }
 
     /**
@@ -143,7 +143,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     public function testParserHandlesNamespaceDeclarationWithIdentifierAndSemicolonSyntax(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
-        static::assertEquals(__FUNCTION__, $namespaces->current()->getName());
+        static::assertEquals(__FUNCTION__, $namespaces->current()->getImage());
     }
 
     /**
@@ -154,7 +154,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     {
         $namespaces = $this->parseSource('issues/002-007-namespace-declaration.php');
 
-        static::assertEquals('', $namespaces->current()->getName());
+        static::assertEquals('', $namespaces->current()->getImage());
     }
 
     /**
@@ -201,7 +201,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getClasses()
             ->current();
 
-        static::assertEquals('bar', $class->getNamespace()->getName());
+        static::assertEquals('bar', $class->getNamespace()->getImage());
     }
 
     /**
@@ -216,7 +216,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getClasses()
             ->current();
 
-        static::assertEquals('bar', $class->getNamespace()->getName());
+        static::assertEquals('bar', $class->getNamespace()->getImage());
     }
 
     /**
@@ -230,22 +230,22 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('bar', $namespace->getName());
-        static::assertEquals('BarFoo', $types->current()->getName());
+        static::assertEquals('bar', $namespace->getImage());
+        static::assertEquals('BarFoo', $types->current()->getImage());
 
         $namespaces->next();
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('foo', $namespace->getName());
-        static::assertEquals('FooBar', $types->current()->getName());
+        static::assertEquals('foo', $namespace->getImage());
+        static::assertEquals('FooBar', $types->current()->getImage());
 
         $namespaces->next();
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('baz', $namespace->getName());
-        static::assertEquals('FooBaz', $types->current()->getName());
+        static::assertEquals('baz', $namespace->getImage());
+        static::assertEquals('FooBaz', $types->current()->getImage());
     }
 
     /**
@@ -259,22 +259,22 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('bar', $namespace->getName());
-        static::assertEquals('BarFoo', $types->current()->getName());
+        static::assertEquals('bar', $namespace->getImage());
+        static::assertEquals('BarFoo', $types->current()->getImage());
 
         $namespaces->next();
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('foo', $namespace->getName());
-        static::assertEquals('FooBar', $types->current()->getName());
+        static::assertEquals('foo', $namespace->getImage());
+        static::assertEquals('FooBar', $types->current()->getImage());
 
         $namespaces->next();
 
         $namespace = $namespaces->current();
         $types = $namespace->getTypes();
-        static::assertEquals('baz', $namespace->getName());
-        static::assertEquals('FooBaz', $types->current()->getName());
+        static::assertEquals('baz', $namespace->getImage());
+        static::assertEquals('FooBaz', $types->current()->getImage());
     }
 
     /**
@@ -287,7 +287,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getFunctions()
             ->current();
 
-        static::assertEquals('foo\bar', $function->getNamespace()->getName());
+        static::assertEquals('foo\bar', $function->getNamespace()->getImage());
     }
 
     /**
@@ -307,7 +307,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -328,10 +328,10 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
         $dependency = $function->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
         static::assertStringContainsString(
-            $function->getNamespace()->getName(),
-            $dependency->getNamespace()->getName()
+            $function->getNamespace()->getImage(),
+            $dependency->getNamespace()->getImage()
         );
     }
 
@@ -352,7 +352,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -372,7 +372,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -392,7 +392,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -412,7 +412,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -432,7 +432,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**
@@ -452,7 +452,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->getDependencies()
             ->current();
 
-        static::assertEquals($namespaceName, $dependency->getNamespace()->getName());
+        static::assertEquals($namespaceName, $dependency->getNamespace()->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -83,7 +83,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
     {
         $actual = [];
         foreach ($this->getParametersOfFirstFunction() as $parameter) {
-            $actual[] = $parameter->getName();
+            $actual[] = $parameter->getImage();
         }
         static::assertEquals(['$foo', '$bar', '$foobar'], $actual);
     }
@@ -128,7 +128,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
     {
         $actual = [];
         foreach ($this->getParametersOfFirstMethod() as $parameter) {
-            $actual[] = $parameter->getName();
+            $actual[] = $parameter->getImage();
         }
         static::assertEquals(['$foo', '$bar', '$foobar'], $actual);
     }

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -81,7 +81,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
         $expected = ['$foo' => true, '$bar' => false, '$foobar' => true];
         $actual = [];
         foreach ($parameters as $parameter) {
-            $actual[$parameter->getName()] = $parameter->isPassedByReference();
+            $actual[$parameter->getImage()] = $parameter->isPassedByReference();
         }
         static::assertEquals($expected, $actual);
     }
@@ -105,7 +105,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
         $expected = ['$foo' => true, '$bar' => true];
         $actual = [];
         foreach ($this->getParametersOfFirstFunction() as $parameter) {
-            $actual[$parameter->getName()] = $parameter->isPassedByReference();
+            $actual[$parameter->getImage()] = $parameter->isPassedByReference();
         }
         static::assertEquals($expected, $actual);
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -114,12 +114,12 @@ class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
         $actual = [];
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getTypes() as $type) {
-                $actual[$type->getName()]['efferent'] = array_map(
-                    static fn($type) => $type->getName(),
+                $actual[$type->getImage()]['efferent'] = array_map(
+                    static fn($type) => $type->getImage(),
                     $visitor->getEfferents($type)
                 );
-                $actual[$type->getName()]['afferent'] = array_map(
-                    static fn($type) => $type->getName(),
+                $actual[$type->getImage()]['afferent'] = array_map(
+                    static fn($type) => $type->getImage(),
                     $visitor->getAfferents($type)
                 );
             }

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -74,11 +74,11 @@ class MethodStrategyTest extends AbstractTestCase
 
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getClasses() as $class) {
-                static::assertArrayHasKey($class->getName(), $idMap);
-                $idMap[$class->getName()] = $class->getId();
+                static::assertArrayHasKey($class->getImage(), $idMap);
+                $idMap[$class->getImage()] = $class->getId();
             }
-            if (array_key_exists($namespace->getName(), $idMap)) {
-                $idMap[$namespace->getName()] = $namespace->getId();
+            if (array_key_exists($namespace->getImage(), $idMap)) {
+                $idMap[$namespace->getImage()] = $namespace->getId();
             }
         }
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -74,11 +74,11 @@ class PropertyStrategyTest extends AbstractTestCase
 
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getClasses() as $class) {
-                static::assertArrayHasKey($class->getName(), $idMap);
-                $idMap[$class->getName()] = $class->getId();
+                static::assertArrayHasKey($class->getImage(), $idMap);
+                $idMap[$class->getImage()] = $class->getId();
             }
-            if (array_key_exists($namespace->getName(), $idMap)) {
-                $idMap[$namespace->getName()] = $namespace->getId();
+            if (array_key_exists($namespace->getImage(), $idMap)) {
+                $idMap[$namespace->getImage()] = $namespace->getId();
             }
         }
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -393,9 +393,9 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
             if (count($namespace->getTypes()) === 0) {
                 continue;
             }
-            $expected[] = [$namespace, $this->input[$namespace->getName()]];
+            $expected[] = [$namespace, $this->input[$namespace->getImage()]];
             foreach ($namespace->getTypes() as $type) {
-                $expected[] = [$type, $this->input[$type->getName()]];
+                $expected[] = [$type, $this->input[$type->getImage()]];
             }
         }
 
@@ -454,7 +454,7 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
         $actual = [];
         foreach ($namespaces[0]->getTypes() as $type) {
             $metrics = $analyzer->getNodeMetrics($type);
-            $actual[$type->getName()] = round($metrics[$metricName], 5);
+            $actual[$type->getImage()] = round($metrics[$metricName], 5);
         }
 
         return $actual;

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -114,7 +114,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($namespaces[0]->getFunctions() as $function) {
-            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+            $actual[$function->getImage()] = $analyzer->getNodeMetrics($function);
         }
 
         ksort($expected);
@@ -157,7 +157,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($methods as $method) {
-            $actual[$method->getName()] = $analyzer->getNodeMetrics($method);
+            $actual[$method->getImage()] = $analyzer->getNodeMetrics($method);
         }
 
         ksort($expected);

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -119,7 +119,7 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
 
         $actual = [];
         foreach ($namespaces as $namespace) {
-            $actual[$namespace->getName()] = $visitor->getStats($namespace);
+            $actual[$namespace->getImage()] = $visitor->getStats($namespace);
         }
 
         static::assertEquals($this->input, $actual);

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -104,7 +104,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($namespaces[0]->getFunctions() as $function) {
-            $actual[$function->getName()] = $analyzer->getNodeBasisMetrics($function);
+            $actual[$function->getImage()] = $analyzer->getNodeBasisMetrics($function);
         }
 
         ksort($expected);
@@ -151,7 +151,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($namespaces[0]->getFunctions() as $function) {
-            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+            $actual[$function->getImage()] = $analyzer->getNodeMetrics($function);
         }
 
         ksort($expected);
@@ -181,7 +181,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($methods as $method) {
-            $actual[$method->getName()] = $analyzer->getNodeBasisMetrics($method);
+            $actual[$method->getImage()] = $analyzer->getNodeBasisMetrics($method);
         }
 
         ksort($expected);
@@ -231,7 +231,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($methods as $method) {
-            $actual[$method->getName()] = $analyzer->getNodeMetrics($method);
+            $actual[$method->getImage()] = $analyzer->getNodeMetrics($method);
         }
 
         ksort($expected);

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -188,7 +188,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
         foreach ($namespaces[0]->getClasses() as $class) {
             $metrics = $analyzer->getNodeMetrics($class);
 
-            $actual[$class->getName()] = $metrics['dit'];
+            $actual[$class->getImage()] = $metrics['dit'];
         }
         ksort($actual);
 

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -104,7 +104,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($namespaces[0]->getFunctions() as $function) {
-            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+            $actual[$function->getImage()] = $analyzer->getNodeMetrics($function);
         }
 
         ksort($expected);
@@ -135,7 +135,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
         ];
 
         foreach ($methods as $method) {
-            $actual[$method->getName()] = $analyzer->getNodeMetrics($method);
+            $actual[$method->getImage()] = $analyzer->getNodeMetrics($method);
         }
 
         ksort($expected);

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -164,7 +164,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
         $metrics = [];
         foreach ($namespaces as $namespace) {
-            $metrics[$namespace->getName()] = $analyzer->getNodeMetrics($namespace);
+            $metrics[$namespace->getImage()] = $analyzer->getNodeMetrics($namespace);
         }
 
         static::assertEquals(
@@ -201,7 +201,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
         $metrics = [];
         foreach ($namespaces as $namespace) {
-            $metrics[$namespace->getName()] = $analyzer->getNodeMetrics($namespace);
+            $metrics[$namespace->getImage()] = $analyzer->getNodeMetrics($namespace);
         }
 
         static::assertEquals(
@@ -238,7 +238,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
         $metrics = [];
         foreach ($namespaces as $namespace) {
-            $metrics[$namespace->getName()] = $analyzer->getNodeMetrics($namespace);
+            $metrics[$namespace->getImage()] = $analyzer->getNodeMetrics($namespace);
         }
 
         static::assertEquals(
@@ -275,7 +275,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
         $metrics = [];
         foreach ($namespaces as $namespace) {
-            $metrics[$namespace->getName()] = $analyzer->getNodeMetrics($namespace);
+            $metrics[$namespace->getImage()] = $analyzer->getNodeMetrics($namespace);
         }
 
         static::assertEquals(

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -120,7 +120,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
         $actual = [];
         foreach ($functions as $function) {
-            $actual[$function->getName()] = $analyzer->getNodeMetrics($function);
+            $actual[$function->getImage()] = $analyzer->getNodeMetrics($function);
         }
 
         ksort($expected);

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -113,9 +113,9 @@ class ParserTest extends AbstractTestCase
         static::assertCount(4, $tmp);
 
         foreach ($tmp as $namespace) {
-            static::assertArrayHasKey($namespace->getName(), $expected);
-            unset($expected[$namespace->getName()]);
-            $namespaces[$namespace->getName()] = $namespace;
+            static::assertArrayHasKey($namespace->getImage(), $expected);
+            unset($expected[$namespace->getImage()]);
+            $namespaces[$namespace->getImage()] = $namespace;
         }
         static::assertCount(0, $expected);
 
@@ -263,7 +263,7 @@ class ParserTest extends AbstractTestCase
         static::assertEquals(1, $namespaces->count()); // default
 
         $namespace = $namespaces[0];
-        static::assertEquals('default\package', $namespace->getName());
+        static::assertEquals('default\package', $namespace->getImage());
 
         $class = $namespace->getClasses()->current();
         static::assertNotNull($class);
@@ -291,7 +291,7 @@ class ParserTest extends AbstractTestCase
         static::assertEquals(1, $namespaces->count()); // +global
 
         $namespace = $namespaces[0];
-        static::assertEquals('+global', $namespace->getName());
+        static::assertEquals('+global', $namespace->getImage());
 
         $class = $namespace->getClasses()->current();
         static::assertNotNull($class);
@@ -309,7 +309,7 @@ class ParserTest extends AbstractTestCase
         static::assertEquals(1, $namespaces->count()); // +global
 
         $namespace = $namespaces[0];
-        static::assertEquals('+global', $namespace->getName());
+        static::assertEquals('+global', $namespace->getImage());
 
         $function = $namespace->getFunctions()->current();
         static::assertNotNull($function);
@@ -480,9 +480,9 @@ class ParserTest extends AbstractTestCase
             ->current();
 
         $dependencies = $function->getDependencies();
-        static::assertEquals('PDepend1', $dependencies->current()->getNamespace()->getName());
+        static::assertEquals('PDepend1', $dependencies->current()->getNamespace()->getImage());
         $dependencies->next();
-        static::assertEquals('PDepend2', $dependencies->current()->getNamespace()->getName());
+        static::assertEquals('PDepend2', $dependencies->current()->getNamespace()->getImage());
     }
 
     /**
@@ -524,7 +524,7 @@ class ParserTest extends AbstractTestCase
                 'returnClass' => null,
             ],
             [
-                'function' => $functions[0]->getName(),
+                'function' => $functions[0]->getImage(),
                 'returnClass' => $functions[0]->getReturnClass(),
             ]
         );
@@ -543,8 +543,8 @@ class ParserTest extends AbstractTestCase
                 'returnClass' => 'SplObjectStore',
             ],
             [
-                'function' => $functions[1]->getName(),
-                'returnClass' => $functions[1]->getReturnClass()->getName(),
+                'function' => $functions[1]->getImage(),
+                'returnClass' => $functions[1]->getReturnClass()->getImage(),
             ]
         );
     }
@@ -562,8 +562,8 @@ class ParserTest extends AbstractTestCase
                 'returnClass' => 'SplObjectStore',
             ],
             [
-                'function' => $functions[2]->getName(),
-                'returnClass' => $functions[2]->getReturnClass()->getName(),
+                'function' => $functions[2]->getImage(),
+                'returnClass' => $functions[2]->getReturnClass()->getImage(),
             ]
         );
     }
@@ -580,7 +580,7 @@ class ParserTest extends AbstractTestCase
         $actual = [];
         foreach ($functions as $function) {
             foreach ($function->getExceptionClasses() as $exception) {
-                $actual[] = "{$function->getName()} throws {$exception->getName()}";
+                $actual[] = "{$function->getImage()} throws {$exception->getImage()}";
             }
         }
 
@@ -639,8 +639,8 @@ class ParserTest extends AbstractTestCase
 
         $actual = [];
         foreach ($nodes as $method) {
-            $actual[] = $method->getName();
-            $actual[] = $method->getReturnClass() ? $method->getReturnClass()->getName() : null;
+            $actual[] = $method->getImage();
+            $actual[] = $method->getReturnClass() ? $method->getReturnClass()->getImage() : null;
         }
 
         static::assertEquals(
@@ -662,9 +662,9 @@ class ParserTest extends AbstractTestCase
 
         $actual = [];
         foreach ($nodes as $method) {
-            $actual[] = $method->getName();
+            $actual[] = $method->getImage();
             foreach ($method->getExceptionClasses() as $exception) {
-                $actual[] = $exception->getName();
+                $actual[] = $exception->getImage();
             }
         }
 
@@ -759,8 +759,8 @@ class ParserTest extends AbstractTestCase
 
         $actual = [];
         foreach ($nodes as $node) {
-            $className = $node->getClass() ? $node->getClass()->getName() : null;
-            $actual[$node->getName()] = $className;
+            $className = $node->getClass() ? $node->getClass()->getImage() : null;
+            $actual[$node->getImage()] = $className;
         }
 
         static::assertEquals(
@@ -796,7 +796,7 @@ class ParserTest extends AbstractTestCase
             ->current()
             ->getClass();
 
-        static::assertEquals('Runtime', $class->getName());
+        static::assertEquals('Runtime', $class->getImage());
     }
 
     /**
@@ -819,7 +819,7 @@ class ParserTest extends AbstractTestCase
             ->current()
             ->getClass();
 
-        static::assertEquals('Session', $type->getName());
+        static::assertEquals('Session', $type->getImage());
     }
 
     /**
@@ -842,7 +842,7 @@ class ParserTest extends AbstractTestCase
             ->current()
             ->getReturnClass();
 
-        static::assertSame('Runtime', $type->getName());
+        static::assertSame('Runtime', $type->getImage());
     }
 
     /**
@@ -865,7 +865,7 @@ class ParserTest extends AbstractTestCase
             ->current()
             ->getReturnClass();
 
-        static::assertSame('Session', $type->getName());
+        static::assertSame('Session', $type->getImage());
     }
 
     /**
@@ -915,7 +915,7 @@ class ParserTest extends AbstractTestCase
     public function testParserSubpackageSupport(): void
     {
         $namespace = $this->parseCodeResourceForTest()->current();
-        static::assertEquals('PHP\Depend', $namespace->getName());
+        static::assertEquals('PHP\Depend', $namespace->getImage());
     }
 
     /**
@@ -963,7 +963,7 @@ class ParserTest extends AbstractTestCase
     {
         $functions = $namespaces[0]->getFunctions();
 
-        static::assertEquals('PHP\\Depend', $functions[0]->getNamespace()->getName());
+        static::assertEquals('PHP\\Depend', $functions[0]->getNamespace()->getImage());
     }
 
     /**
@@ -975,7 +975,7 @@ class ParserTest extends AbstractTestCase
     {
         $functions = $namespaces[0]->getFunctions();
 
-        static::assertEquals('PHP\\Depend', $functions[1]->getNamespace()->getName());
+        static::assertEquals('PHP\\Depend', $functions[1]->getNamespace()->getImage());
     }
 
     /**
@@ -987,7 +987,7 @@ class ParserTest extends AbstractTestCase
     {
         $functions = $namespaces[1]->getFunctions();
 
-        static::assertEquals('PDepend\\Test', $functions[0]->getNamespace()->getName());
+        static::assertEquals('PDepend\\Test', $functions[0]->getNamespace()->getImage());
     }
 
     /**
@@ -1200,7 +1200,7 @@ class ParserTest extends AbstractTestCase
     public function testParserStripsLeadingSlashFromNamespacedClassName(): void
     {
         $namespace = $this->parseCodeResourceForTest()->current();
-        static::assertEquals('foo', $namespace->getName());
+        static::assertEquals('foo', $namespace->getImage());
     }
 
     /**
@@ -1212,7 +1212,7 @@ class ParserTest extends AbstractTestCase
             ->getParentClass()
             ->getNamespace();
 
-        static::assertEquals('foo\bar\baz', $namespace->getName());
+        static::assertEquals('foo\bar\baz', $namespace->getImage());
     }
 
     /**
@@ -1224,7 +1224,7 @@ class ParserTest extends AbstractTestCase
             ->getParentClass()
             ->getNamespace();
 
-        static::assertEquals('bar', $namespace->getName());
+        static::assertEquals('bar', $namespace->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -184,7 +184,7 @@ class XmlTest extends AbstractTestCase
             ->getMock();
         $type
             ->expects(static::any())
-            ->method('getName')
+            ->method('getImage')
             ->will(static::returnValue('class'));
         $type
             ->expects(static::any())

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -96,8 +96,8 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {
-        if (isset($this->nodeMetrics[$artifact->getName()])) {
-            return $this->nodeMetrics[$artifact->getName()];
+        if (isset($this->nodeMetrics[$artifact->getImage()])) {
+            return $this->nodeMetrics[$artifact->getImage()];
         }
 
         return [];

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -212,7 +212,7 @@ class ASTArtifactListTest extends AbstractTestCase
         $this->expectException(OutOfBoundsException::class);
 
         $iterator = new ASTArtifactList([]);
-        $iterator[0]->getName();
+        $iterator[0]->getImage();
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -61,7 +61,7 @@ class ASTArtifactTest extends AbstractTestCase
     public function testGetNameReturnsValueOfFirstConstructorArgument(): void
     {
         $item = $this->getItemMock();
-        static::assertEquals(__CLASS__, $item->getName());
+        static::assertEquals(__CLASS__, $item->getImage());
     }
 
     /**
@@ -74,7 +74,7 @@ class ASTArtifactTest extends AbstractTestCase
         $item = $this->getItemMock();
         $item->setName(__FUNCTION__);
 
-        static::assertEquals(__FUNCTION__, $item->getName());
+        static::assertEquals(__FUNCTION__, $item->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -319,7 +319,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         static::assertEquals(
             'testGetAllMethodsHandlesTraitMethodPrecedenceUsedTraitOne',
-            $methods['foo']->getParent()->getName()
+            $methods['foo']->getParent()->getImage()
         );
     }
 
@@ -777,7 +777,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     public function testCreateNewClassInstance(): void
     {
         $class = new ASTClass(__CLASS__);
-        static::assertEquals(__CLASS__, $class->getName());
+        static::assertEquals(__CLASS__, $class->getImage());
     }
 
     /**
@@ -935,7 +935,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($class->getInterfaces() as $interface) {
-            $actual[] = $interface->getName();
+            $actual[] = $interface->getImage();
         }
         sort($actual);
 
@@ -957,7 +957,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($class->getInterfaces() as $interface) {
-            $actual[$interface->getName()] = $interface->getName();
+            $actual[$interface->getImage()] = $interface->getImage();
         }
         sort($actual);
 
@@ -974,7 +974,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($class->getInterfaces() as $interface) {
-            $actual[] = $interface->getName();
+            $actual[] = $interface->getImage();
         }
         sort($actual);
 
@@ -994,7 +994,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($types as $type) {
-            $actual[$type->getName()] = $class->isSubtypeOf($type);
+            $actual[$type->getImage()] = $class->isSubtypeOf($type);
         }
         ksort($actual);
 
@@ -1023,7 +1023,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($types as $type) {
-            $actual[$type->getName()] = $class->isSubtypeOf($type);
+            $actual[$type->getImage()] = $class->isSubtypeOf($type);
         }
         ksort($actual);
 
@@ -1052,7 +1052,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($types as $type) {
-            $actual[$type->getName()] = $class->isSubtypeOf($type);
+            $actual[$type->getImage()] = $class->isSubtypeOf($type);
         }
         ksort($actual);
 
@@ -1282,7 +1282,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getParentClasses();
 
         foreach ($classes as $i => $class) {
-            $classes[$i] = $class->getName();
+            $classes[$i] = $class->getImage();
         }
 
         static::assertEquals(

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -57,15 +57,6 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
 class ASTCompilationUnitTest extends AbstractTestCase
 {
     /**
-     * testGetNameReturnsTheFileName
-     */
-    public function testGetNameReturnsTheFileName(): void
-    {
-        $file = new ASTCompilationUnit(__FILE__);
-        static::assertEquals(__FILE__, $file->getName());
-    }
-
-    /**
      * testGetFileNameReturnsTheFileName
      */
     public function testGetFileNameReturnsTheFileName(): void

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -72,7 +72,7 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
         $deserializedEnum = unserialize($serializedClass);
 
         static::assertInstanceOf(ASTEnum::class, $deserializedEnum);
-        static::assertSame('test', $deserializedEnum->getName());
+        static::assertSame('test', $deserializedEnum->getImage());
         static::assertInstanceOf(ASTScalarType::class, $deserializedEnum->getType());
         static::assertSame('string', $deserializedEnum->getType()->getImage());
     }
@@ -124,7 +124,7 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
 
         $method = new ASTMethod('foobar');
         $method->addChild(new ASTFormalParameters());
-        $method->setReturnClassReference($builder->buildAstClassOrInterfaceReference($enum->getName()));
+        $method->setReturnClassReference($builder->buildAstClassOrInterfaceReference($enum->getImage()));
 
         $enum->addMethod($method);
 

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -64,7 +64,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
         $declaration = $this->getFirstFieldDeclarationInClass();
 
         $reference = $declaration->getChild(0);
-        static::assertEquals(__FUNCTION__, $reference->getType()->getName());
+        static::assertEquals(__FUNCTION__, $reference->getType()->getImage());
     }
 
     /**
@@ -101,7 +101,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
         $type = $reference->getType();
 
-        static::assertEquals('Sindelfingen', $type->getName());
+        static::assertEquals('Sindelfingen', $type->getImage());
 
         return $type;
     }

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -114,7 +114,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     public function testCreateNewFunctionInstance(): void
     {
         $function = $this->createItem();
-        static::assertEquals('createItem', $function->getName());
+        static::assertEquals('createItem', $function->getImage());
     }
 
     /**
@@ -162,7 +162,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $function = $this->getFirstFunctionForTestCaseInternal();
         $type = $function->getReturnClass();
 
-        static::assertEquals('Sindelfingen', $type->getName());
+        static::assertEquals('Sindelfingen', $type->getImage());
 
         return $type;
     }
@@ -531,7 +531,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
         static::assertEquals(
             'Baz',
-            $copy->getNamespace()->getClasses()->current()->getName()
+            $copy->getNamespace()->getClasses()->current()->getImage()
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -296,7 +296,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
         $actual = [];
         foreach ($namespace->getInterfaces() as $interface) {
-            $actual[$interface->getName()] = $current->isSubtypeOf($interface);
+            $actual[$interface->getImage()] = $current->isSubtypeOf($interface);
         }
 
         ksort($expected);

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -126,7 +126,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     public function testGetReturnClassForMethodWithNamespacedRootClass(): void
     {
         $method = $this->getFirstMethodInClass();
-        static::assertEquals('Foo', $method->getReturnClass()->getName());
+        static::assertEquals('Foo', $method->getReturnClass()->getImage());
     }
 
     /**
@@ -135,7 +135,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     public function testGetReturnClassForMethodWithNamespacedClass(): void
     {
         $method = $this->getFirstMethodInClass();
-        static::assertEquals('Baz', $method->getReturnClass()->getName());
+        static::assertEquals('Baz', $method->getReturnClass()->getImage());
     }
 
     /**
@@ -144,7 +144,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     public function testGetReturnClassForMethodWithNamespacedArrayRootClass(): void
     {
         $method = $this->getFirstMethodInClass();
-        static::assertEquals('Foo', $method->getReturnClass()->getName());
+        static::assertEquals('Foo', $method->getReturnClass()->getImage());
     }
 
     /**
@@ -153,7 +153,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     public function testGetReturnClassForMethodWithNamespacedArrayClass(): void
     {
         $method = $this->getFirstMethodInClass();
-        static::assertEquals('Baz', $method->getReturnClass()->getName());
+        static::assertEquals('Baz', $method->getReturnClass()->getImage());
     }
 
     /**
@@ -164,7 +164,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         $method = $this->getFirstMethodInClass();
         static::assertEquals(
             'Exception',
-            $method->getExceptionClasses()->current()->getName()
+            $method->getExceptionClasses()->current()->getImage()
         );
     }
 
@@ -176,7 +176,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         $method = $this->getFirstMethodInClass();
         static::assertEquals(
             'ErrorException',
-            $method->getExceptionClasses()->current()->getName()
+            $method->getExceptionClasses()->current()->getImage()
         );
     }
 
@@ -188,7 +188,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         $method = $this->getFirstMethodInClass();
         static::assertEquals(
             'ASTBuilder',
-            $method->getDependencies()->current()->getName()
+            $method->getDependencies()->current()->getImage()
         );
     }
 
@@ -200,7 +200,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         $method = $this->getFirstMethodInClass();
         static::assertEquals(
             'ASTBuilder',
-            $method->getDependencies()->current()->getName()
+            $method->getDependencies()->current()->getImage()
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -64,7 +64,7 @@ class ASTPropertyTest extends AbstractTestCase
     public function testGetDeclaringClass(): void
     {
         $property = $this->getFirstPropertyInClass();
-        static::assertEquals(__FUNCTION__, $property->getDeclaringClass()->getName());
+        static::assertEquals(__FUNCTION__, $property->getDeclaringClass()->getImage());
     }
 
     /**
@@ -73,7 +73,7 @@ class ASTPropertyTest extends AbstractTestCase
     public function testGetClassForPropertyWithNamespacedRootType(): void
     {
         $property = $this->getFirstPropertyInClass();
-        static::assertEquals('Foo', $property->getClass()->getName());
+        static::assertEquals('Foo', $property->getClass()->getImage());
     }
 
     /**
@@ -82,7 +82,7 @@ class ASTPropertyTest extends AbstractTestCase
     public function testGetClassForPropertyWithNamespacedType(): void
     {
         $property = $this->getFirstPropertyInClass();
-        static::assertEquals('Baz', $property->getClass()->getName());
+        static::assertEquals('Baz', $property->getClass()->getImage());
     }
 
     /**
@@ -91,7 +91,7 @@ class ASTPropertyTest extends AbstractTestCase
     public function testGetClassForPropertyWithNamespacedArrayRootType(): void
     {
         $property = $this->getFirstPropertyInClass();
-        static::assertEquals('Foo', $property->getClass()->getName());
+        static::assertEquals('Foo', $property->getClass()->getImage());
     }
 
     /**
@@ -100,7 +100,7 @@ class ASTPropertyTest extends AbstractTestCase
     public function testGetClassForPropertyWithNamespacedArrayType(): void
     {
         $property = $this->getFirstPropertyInClass();
-        static::assertEquals('Baz', $property->getClass()->getName());
+        static::assertEquals('Baz', $property->getClass()->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -199,7 +199,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
         static::assertEquals(
             'testGetAllMethodsHandlesTraitMethodPrecedenceUsedTraitOne',
-            $methods['foo']->getParent()->getName()
+            $methods['foo']->getParent()->getImage()
         );
     }
 
@@ -289,7 +289,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     public function testTraitHasExpectedPackage(): void
     {
         $trait = $this->getFirstTraitForTest();
-        static::assertEquals('org.pdepend', $trait->getNamespace()->getName());
+        static::assertEquals('org.pdepend', $trait->getNamespace()->getImage());
     }
 
     /**
@@ -298,7 +298,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     public function testTraitHasExpectedNamespace(): void
     {
         $trait = $this->getFirstTraitForTest();
-        static::assertEquals('org\pdepend\code', $trait->getNamespace()->getName());
+        static::assertEquals('org\pdepend\code', $trait->getNamespace()->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -191,7 +191,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
         $useStmt = $this->getFirstTraitUseStatementInClass();
         $methods = $useStmt->getAllMethods();
 
-        static::assertEquals('foo', $methods[0]->getName());
+        static::assertEquals('foo', $methods[0]->getImage());
     }
 
     /**
@@ -292,7 +292,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
         static::assertEquals(
             'testGetAllMethodsHandlesTraitMethodPrecedenceUsedTraitOne',
-            $methods[0]->getParent()->getName()
+            $methods[0]->getParent()->getImage()
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -65,7 +65,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
         $item = $this->createItem();
         $item->setName(__METHOD__);
 
-        static::assertEquals(__METHOD__, $item->getName());
+        static::assertEquals(__METHOD__, $item->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
@@ -56,14 +56,14 @@ class StubAbstractASTVisitListener extends AbstractASTVisitListener
 
     public function startVisitNode(AbstractASTArtifact $node): void
     {
-        $this->nodes[$node->getName() . '#start'] = true;
+        $this->nodes[$node->getImage() . '#start'] = true;
 
         parent::startVisitNode($node);
     }
 
     public function endVisitNode(AbstractASTArtifact $node): void
     {
-        $this->nodes[$node->getName() . '#end'] = true;
+        $this->nodes[$node->getImage() . '#end'] = true;
 
         parent::endVisitNode($node);
     }

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
@@ -70,7 +70,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitClass(ASTClass $class): void
     {
-        $this->visits[] = $class->getName();
+        $this->visits[] = $class->getImage();
 
         parent::visitClass($class);
     }
@@ -90,7 +90,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitFunction(ASTFunction $function): void
     {
-        $this->visits[] = $function->getName();
+        $this->visits[] = $function->getImage();
 
         parent::visitFunction($function);
     }
@@ -100,7 +100,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitInterface(ASTInterface $interface): void
     {
-        $this->visits[] = $interface->getName();
+        $this->visits[] = $interface->getImage();
 
         parent::visitInterface($interface);
     }
@@ -110,7 +110,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitMethod(ASTMethod $method): void
     {
-        $this->visits[] = $method->getName();
+        $this->visits[] = $method->getImage();
 
         parent::visitMethod($method);
     }
@@ -122,7 +122,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitNamespace(ASTNamespace $namespace): void
     {
-        $this->visits[] = $namespace->getName();
+        $this->visits[] = $namespace->getImage();
 
         parent::visitNamespace($namespace);
     }
@@ -132,7 +132,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
      */
     public function visitProperty(ASTProperty $property): void
     {
-        $this->visits[] = $property->getName();
+        $this->visits[] = $property->getImage();
 
         parent::visitProperty($property);
     }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -66,6 +66,6 @@ class AttributeTest extends PHPParserVersion81TestCase
         $bMethod = $methods['b'];
         $parameters = $bMethod->getParameters();
 
-        static::assertSame('$bar', $parameters[0]->getName());
+        static::assertSame('$bar', $parameters[0]->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -65,25 +65,25 @@ class EnumTest extends PHPParserVersion81TestCase
 
         static::assertCount(4, $types);
         static::assertInstanceOf(ASTInterface::class, $types[0]);
-        static::assertSame('HasColor', $types[0]->getName());
+        static::assertSame('HasColor', $types[0]->getImage());
         static::assertInstanceOf(ASTEnum::class, $types[1]);
-        static::assertSame('Suit', $types[1]->getName());
+        static::assertSame('Suit', $types[1]->getImage());
         static::assertInstanceOf(ASTClass::class, $types[2]);
-        static::assertSame('UseEnum', $types[2]->getName());
+        static::assertSame('UseEnum', $types[2]->getImage());
         static::assertInstanceOf(ASTEnum::class, $types[3]);
-        static::assertSame('SpecialCases', $types[3]->getName());
+        static::assertSame('SpecialCases', $types[3]->getImage());
 
         $methods = $types[1]->getMethods();
 
         static::assertCount(1, $methods);
-        static::assertSame('getColor', $methods[0]->getName());
+        static::assertSame('getColor', $methods[0]->getImage());
 
         $methods = $types[2]->getMethods();
 
         static::assertCount(3, $methods);
-        static::assertSame('foo', $methods[0]->getName());
-        static::assertSame('getSuiteColor', $methods[1]->getName());
-        static::assertSame('areDiamondsRed', $methods[2]->getName());
+        static::assertSame('foo', $methods[0]->getImage());
+        static::assertSame('getSuiteColor', $methods[1]->getImage());
+        static::assertSame('areDiamondsRed', $methods[2]->getImage());
 
         /** @var ASTParameter[] $parameters */
         $parameters = $methods[1]->getParameters();
@@ -93,7 +93,7 @@ class EnumTest extends PHPParserVersion81TestCase
         $enum = $parameters[0]->getClass();
 
         static::assertInstanceOf(ASTEnum::class, $enum);
-        static::assertSame('Suit', $enum->getName());
+        static::assertSame('Suit', $enum->getImage());
         static::assertSame('string', $enum->getType()->getImage());
         static::assertTrue($enum->isBacked());
         static::assertTrue($enum->isFinal());
@@ -107,7 +107,7 @@ class EnumTest extends PHPParserVersion81TestCase
                 'HasColor' => 'HasColor',
             ],
             array_map(
-                static fn(ASTInterface $interface) => $interface->getName(),
+                static fn(ASTInterface $interface) => $interface->getImage(),
                 iterator_to_array($enum->getInterfaces())
             )
         );
@@ -119,7 +119,7 @@ class EnumTest extends PHPParserVersion81TestCase
                 'getcolor' => 'getColor',
             ],
             array_map(
-                static fn(ASTMethod $interface) => $interface->getName(),
+                static fn(ASTMethod $interface) => $interface->getImage(),
                 $enum->getAllMethods()
             )
         );

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -69,7 +69,7 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
     {
         $class = $this->getFirstClassForTestCase();
         $constructor = $class->getMethods()->offsetGet(0);
-        static::assertSame('__construct', $constructor->getName());
+        static::assertSame('__construct', $constructor->getImage());
 
         $parameters = $constructor->getParameters();
         $parameter = $parameters[0];
@@ -104,7 +104,7 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
 
         /** @var ASTMethod $constructor */
         $constructor = $class->getMethods()->offsetGet(0);
-        static::assertSame('__construct', $constructor->getName());
+        static::assertSame('__construct', $constructor->getImage());
         $constructorNodes = $constructor->getChildren();
         $assignment = $constructorNodes[1]->getChild(0)->getChild(0);
 
@@ -117,7 +117,7 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
         static::assertSame('readonly', $methodPostfix->getImage());
 
         $method = $class->getMethods()->offsetGet(1);
-        static::assertSame('readonly', $method->getName());
+        static::assertSame('readonly', $method->getImage());
 
         $methodNodes = $method->getChildren();
         $constantCall = $methodNodes[1]->getChild(0)->getChild(0);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -89,10 +89,10 @@ class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82Tes
             ->getClasses();
 
         $d = $classes[0];
-        static::assertSame('D', $d->getName());
+        static::assertSame('D', $d->getImage());
 
         $f = $classes[1];
-        static::assertSame('F', $f->getName());
+        static::assertSame('F', $f->getImage());
 
         $properties = $f->getProperties();
         static::assertSame(1, $properties->count());
@@ -102,7 +102,7 @@ class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82Tes
         static::assertSame('E::Foo->name', $this->constructImage($property->getDefaultValue()));
 
         $g = $classes[2];
-        static::assertSame('G', $g->getName());
+        static::assertSame('G', $g->getImage());
 
         /** @var ASTConstantDefinition[] $constants */
         $constants = $g->getChildren();

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -254,7 +254,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testGetTraitReturnsDummyIfNoMatchingTraitExists(): void
     {
         $builder = $this->createBuilder();
-        static::assertEquals(__FUNCTION__, $builder->getTrait(__FUNCTION__)->getName());
+        static::assertEquals(__FUNCTION__, $builder->getTrait(__FUNCTION__)->getImage());
     }
 
     /**
@@ -317,7 +317,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         static::assertEquals(
             __FUNCTION__,
-            $builder->getClass(__FUNCTION__)->getName()
+            $builder->getClass(__FUNCTION__)->getImage()
         );
     }
 
@@ -382,7 +382,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         static::assertEquals(
             __FUNCTION__,
-            $builder->getInterface(__FUNCTION__)->getName()
+            $builder->getInterface(__FUNCTION__)->getImage()
         );
     }
 
@@ -611,7 +611,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         static::assertEquals(
             __FUNCTION__,
-            $builder->getClassOrInterface(__FUNCTION__)->getName()
+            $builder->getClassOrInterface(__FUNCTION__)->getImage()
         );
     }
 
@@ -625,7 +625,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         static::assertEquals(
             '+reflection',
-            $builder->getClassOrInterface('Reflection')->getNamespace()->getName()
+            $builder->getClassOrInterface('Reflection')->getNamespace()->getImage()
         );
     }
 
@@ -639,7 +639,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         static::assertEquals(
             'foo\bar',
-            $builder->getClassOrInterface('\foo\bar\Baz')->getNamespace()->getName()
+            $builder->getClassOrInterface('\foo\bar\Baz')->getNamespace()->getImage()
         );
     }
 

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -75,7 +75,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsStringAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('SimpleClassName', $class->getName());
+        static::assertSame('SimpleClassName', $class->getImage());
     }
 
     /**
@@ -84,7 +84,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsStringAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('SimpleInterfaceName', $interface->getName());
+        static::assertSame('SimpleInterfaceName', $interface->getImage());
     }
 
     /**
@@ -93,7 +93,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNullAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('Null', $class->getName());
+        static::assertSame('Null', $class->getImage());
     }
 
     /**
@@ -102,7 +102,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNullAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('Null', $interface->getName());
+        static::assertSame('Null', $interface->getImage());
     }
 
     /**
@@ -111,7 +111,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTrueAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('True', $class->getName());
+        static::assertSame('True', $class->getImage());
     }
 
     /**
@@ -120,7 +120,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTrueAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('True', $interface->getName());
+        static::assertSame('True', $interface->getImage());
     }
 
     /**
@@ -129,7 +129,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsFalseAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('False', $class->getName());
+        static::assertSame('False', $class->getImage());
     }
 
     /**
@@ -138,7 +138,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsFalseAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('False', $interface->getName());
+        static::assertSame('False', $interface->getImage());
     }
 
     /**
@@ -147,7 +147,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsInsteadofAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('insteadof', $class->getName());
+        static::assertSame('insteadof', $class->getImage());
     }
 
     /**
@@ -156,7 +156,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsInsteadofAsFunctionName(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        static::assertSame('insteadOf', $function->getName());
+        static::assertSame('insteadOf', $function->getImage());
     }
 
     /**
@@ -165,7 +165,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsInsteadofAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('insteadof', $interface->getName());
+        static::assertSame('insteadof', $interface->getImage());
     }
 
     /**
@@ -174,7 +174,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsInsteadofAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertSame('insteadOf', $method->getName());
+        static::assertSame('insteadOf', $method->getImage());
     }
 
     /**
@@ -192,7 +192,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsUseAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('Use', $class->getName());
+        static::assertSame('Use', $class->getImage());
     }
 
     /**
@@ -201,7 +201,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsUseAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('Use', $interface->getName());
+        static::assertSame('Use', $interface->getImage());
     }
 
     /**
@@ -212,7 +212,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('Namespace', $class->getName());
+        static::assertSame('Namespace', $class->getImage());
     }
 
     /**
@@ -223,7 +223,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('Namespace', $interface->getName());
+        static::assertSame('Namespace', $interface->getImage());
     }
 
     /**
@@ -234,7 +234,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceConstantAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('__NAMESPACE__', $class->getName());
+        static::assertSame('__NAMESPACE__', $class->getImage());
     }
 
     /**
@@ -245,7 +245,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceConstantAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('__NAMESPACE__', $interface->getName());
+        static::assertSame('__NAMESPACE__', $interface->getImage());
     }
 
     /**
@@ -256,7 +256,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('Trait', $class->getName());
+        static::assertSame('Trait', $class->getImage());
     }
 
     /**
@@ -267,7 +267,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('Trait', $interface->getName());
+        static::assertSame('Trait', $interface->getImage());
     }
 
     /**
@@ -278,7 +278,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitConstantAsClassName(): void
     {
         $class = $this->getFirstTypeForTestCase();
-        static::assertSame('__TRAIT__', $class->getName());
+        static::assertSame('__TRAIT__', $class->getImage());
     }
 
     /**
@@ -289,7 +289,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitConstantAsInterfaceName(): void
     {
         $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('__TRAIT__', $interface->getName());
+        static::assertSame('__TRAIT__', $interface->getImage());
     }
 
     /**
@@ -298,7 +298,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsGotoKeywordAsClassName(): void
     {
         $class = $this->getFirstClassForTestCase();
-        static::assertEquals('Goto', $class->getName());
+        static::assertEquals('Goto', $class->getImage());
     }
 
     /**
@@ -307,7 +307,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsGotoKeywordAsInterfaceName(): void
     {
         $class = $this->getFirstInterfaceForTestCase();
-        static::assertEquals('Goto', $class->getName());
+        static::assertEquals('Goto', $class->getImage());
     }
 
     /**
@@ -318,7 +318,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsDirConstantAsClassName(): void
     {
         $class = $this->getFirstClassForTestCase();
-        static::assertEquals('__DIR__', $class->getName());
+        static::assertEquals('__DIR__', $class->getImage());
     }
 
     /**
@@ -329,7 +329,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsDirConstantAsInterfaceName(): void
     {
         $class = $this->getFirstInterfaceForTestCase();
-        static::assertEquals('__DIR__', $class->getName());
+        static::assertEquals('__DIR__', $class->getImage());
     }
 
     /**
@@ -362,7 +362,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsStringAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('myMethodName', $method->getName());
+        static::assertEquals('myMethodName', $method->getImage());
     }
 
     /**
@@ -371,7 +371,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsUseKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('Use', $method->getName());
+        static::assertEquals('Use', $method->getImage());
     }
 
     /**
@@ -380,7 +380,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsGotoKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('Goto', $method->getName());
+        static::assertEquals('Goto', $method->getImage());
     }
 
     /**
@@ -389,7 +389,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsSelfKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('self', $method->getName());
+        static::assertEquals('self', $method->getImage());
     }
 
     /**
@@ -398,7 +398,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNullAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('null', $method->getName());
+        static::assertEquals('null', $method->getImage());
     }
 
     /**
@@ -407,7 +407,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTrueAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('true', $method->getName());
+        static::assertEquals('true', $method->getImage());
     }
 
     /**
@@ -416,7 +416,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsFalseAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('false', $method->getName());
+        static::assertEquals('false', $method->getImage());
     }
 
     /**
@@ -425,7 +425,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsDirConstantAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('__DIR__', $method->getName());
+        static::assertEquals('__DIR__', $method->getImage());
     }
 
     /**
@@ -436,7 +436,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('nameSpace', $method->getName());
+        static::assertEquals('nameSpace', $method->getImage());
     }
 
     /**
@@ -447,7 +447,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceConstantAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('__NAMESPACE__', $method->getName());
+        static::assertEquals('__NAMESPACE__', $method->getImage());
     }
 
     /**
@@ -456,7 +456,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsParentKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('Parent', $method->getName());
+        static::assertEquals('Parent', $method->getImage());
     }
 
     /**
@@ -609,7 +609,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsGotoAsFunctionName(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        static::assertEquals('goto', $function->getName());
+        static::assertEquals('goto', $function->getImage());
     }
 
     /**
@@ -620,7 +620,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsDirConstantAsFunctionName(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        static::assertEquals('__DIR__', $function->getName());
+        static::assertEquals('__DIR__', $function->getImage());
     }
 
     /**
@@ -631,7 +631,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceKeywordAsFunctionName(): void
     {
         $method = $this->getFirstFunctionForTestCase();
-        static::assertEquals('namespace', $method->getName());
+        static::assertEquals('namespace', $method->getImage());
     }
 
     /**
@@ -642,7 +642,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsNamespaceConstantAsFunctionName(): void
     {
         $method = $this->getFirstFunctionForTestCase();
-        static::assertEquals('__NAMESPACE__', $method->getName());
+        static::assertEquals('__NAMESPACE__', $method->getImage());
     }
 
     /**
@@ -651,7 +651,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('trait', $method->getName());
+        static::assertEquals('trait', $method->getImage());
     }
 
     /**
@@ -660,7 +660,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitConstantAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        static::assertEquals('__trait__', $method->getName());
+        static::assertEquals('__trait__', $method->getImage());
     }
 
     /**
@@ -669,7 +669,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitAsFunctionName(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        static::assertEquals('trait', $function->getName());
+        static::assertEquals('trait', $function->getImage());
     }
 
     /**
@@ -678,7 +678,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserAcceptsTraitConstantAsFunctionName(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        static::assertEquals('__TRAIT__', $function->getName());
+        static::assertEquals('__TRAIT__', $function->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -809,9 +809,9 @@ class PHPParserVersion81Test extends AbstractTestCase
         $classes = $namespaces[0]->getClasses();
         $methods = $classes[0]->getMethods();
 
-        static::assertSame('trait', $methods[0]->getName());
-        static::assertSame('callable', $methods[1]->getName());
-        static::assertSame('insteadof', $methods[2]->getName());
+        static::assertSame('trait', $methods[0]->getImage());
+        static::assertSame('callable', $methods[1]->getImage());
+        static::assertSame('insteadof', $methods[2]->getImage());
     }
 
     public function testKeywordsAsConstants(): void

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -130,7 +130,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $reference = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTClassReference::class, $reference);
-        static::assertEquals('Foo', $reference->getType()->getName());
+        static::assertEquals('Foo', $reference->getType()->getImage());
     }
 
     /**
@@ -143,7 +143,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $self = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTSelfReference::class, $self);
-        static::assertEquals(__FUNCTION__, $self->getType()->getName());
+        static::assertEquals(__FUNCTION__, $self->getType()->getImage());
     }
 
     /**
@@ -156,7 +156,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $parent = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTParentReference::class, $parent);
-        static::assertEquals(__FUNCTION__ . 'Parent', $parent->getType()->getName());
+        static::assertEquals(__FUNCTION__ . 'Parent', $parent->getType()->getImage());
     }
 
     /**
@@ -169,7 +169,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $reference = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTClassReference::class, $reference);
-        static::assertEquals('Bar', $reference->getType()->getName());
+        static::assertEquals('Bar', $reference->getType()->getImage());
     }
 
     /**
@@ -182,7 +182,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $reference = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTClassReference::class, $reference);
-        static::assertEquals('Bar', $reference->getType()->getName());
+        static::assertEquals('Bar', $reference->getType()->getImage());
     }
 
     /**
@@ -195,7 +195,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $reference = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTClassReference::class, $reference);
-        static::assertEquals('Foo', $reference->getType()->getName());
+        static::assertEquals('Foo', $reference->getType()->getImage());
     }
 
     /**
@@ -238,7 +238,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
         $reference = $allocation->getChild(0);
 
         static::assertInstanceOf(ASTStaticReference::class, $reference);
-        static::assertEquals(__FUNCTION__, $reference->getType()->getName());
+        static::assertEquals(__FUNCTION__, $reference->getType()->getImage());
     }
 
     /**

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -328,18 +328,18 @@ class CommandTest extends AbstractTestCase
                 'exceptions' => [],
             ];
             foreach ($namespace->getFunctions() as $function) {
-                $statistics['functions'][] = $function->getName();
+                $statistics['functions'][] = $function->getImage();
                 foreach ($function->getExceptionClasses() as $exception) {
-                    $statistics['exceptions'][] = $exception->getName();
+                    $statistics['exceptions'][] = $exception->getImage();
                 }
             }
 
             foreach ($namespace->getClasses() as $class) {
-                $statistics['classes'][] = $class->getName();
+                $statistics['classes'][] = $class->getImage();
             }
 
             foreach ($namespace->getInterfaces() as $interface) {
-                $statistics['interfaces'][] = $interface->getName();
+                $statistics['interfaces'][] = $interface->getImage();
             }
 
             sort($statistics['functions']);
@@ -347,7 +347,7 @@ class CommandTest extends AbstractTestCase
             sort($statistics['interfaces']);
             sort($statistics['exceptions']);
 
-            $actual[$namespace->getName()] = $statistics;
+            $actual[$namespace->getImage()] = $statistics;
         }
         ksort($actual);
 

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -338,18 +338,18 @@ class RunnerTest extends AbstractTestCase
                 'exceptions' => [],
             ];
             foreach ($namespace->getFunctions() as $function) {
-                $statistics['functions'][] = $function->getName();
+                $statistics['functions'][] = $function->getImage();
                 foreach ($function->getExceptionClasses() as $exception) {
-                    $statistics['exceptions'][] = $exception->getName();
+                    $statistics['exceptions'][] = $exception->getImage();
                 }
             }
 
             foreach ($namespace->getClasses() as $class) {
-                $statistics['classes'][] = $class->getName();
+                $statistics['classes'][] = $class->getImage();
             }
 
             foreach ($namespace->getInterfaces() as $interface) {
-                $statistics['interfaces'][] = $interface->getName();
+                $statistics['interfaces'][] = $interface->getImage();
             }
 
             sort($statistics['functions']);
@@ -357,7 +357,7 @@ class RunnerTest extends AbstractTestCase
             sort($statistics['interfaces']);
             sort($statistics['exceptions']);
 
-            $actual[$namespace->getName()] = $statistics;
+            $actual[$namespace->getImage()] = $statistics;
         }
         ksort($actual);
 


### PR DESCRIPTION
Type: refactoring
Breaking change: no

This gets rid of the last remaining deprecation.