### PR TITLE
Apply code style to tests

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -97,6 +97,9 @@ return $config
     ])
     ->setFinder(PhpCsFixer\Finder::create()
         ->exclude('vendor')
-        ->in(__DIR__ . '/src/main/php/PDepend')
+        ->in([
+            __DIR__ . '/src/main/php/PDepend',
+            __DIR__ . '/src/test/php',
+        ])
     )
 ;

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -42,6 +42,9 @@
 
 namespace PDepend;
 
+use ArrayIterator;
+use DirectoryIterator;
+use ErrorException;
 use Exception;
 use Imagick;
 use PDepend\Input\ExcludePathFilter;
@@ -63,7 +66,8 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 use PHPUnit\Framework\TestCase;
-use ReflectionProperty;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Abstract test case implementation for the PDepend namespace.
@@ -77,14 +81,13 @@ abstract class AbstractTestCase extends TestCase
      * The current working directory.
      *
      * @var string
+     *
      * @since 0.10.0
      */
     protected $workingDirectory = null;
 
     /**
      * Removes temporary test contents.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -104,8 +107,6 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Resets the global iterator filter.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -127,7 +128,6 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $directory Optional working directory.
      *
-     * @return void
      * @since 0.10.0
      */
     protected function changeWorkingDirectory($directory = null): void
@@ -144,6 +144,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the working directory for the currently executed test.
      *
      * @return string
+     *
      * @since 1.0.0
      */
     protected function getTestWorkingDirectory()
@@ -158,7 +159,6 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Resets a previous changed working directory.
      *
-     * @return void
      * @since 0.10.0
      */
     protected function resetWorkingDirectory(): void
@@ -175,7 +175,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function getFirstNodeOfTypeInFunction($testCase, $nodeType)
     {
@@ -198,7 +198,7 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return Source\AST\ASTClosure
      */
     protected function getFirstClosureForTestCase()
     {
@@ -212,7 +212,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Create a TextUi Runner
      *
-     * @return \PDepend\TextUI\Runner
+     * @return TextUI\Runner
      */
     protected function createTextUiRunner()
     {
@@ -223,7 +223,7 @@ abstract class AbstractTestCase extends TestCase
 
     protected function createTestApplication()
     {
-        $application = new \PDepend\Application();
+        $application = new Application();
         $application->setConfigurationFile(__DIR__ . '/../../resources/pdepend.xml.dist');
 
         return $application;
@@ -234,7 +234,8 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $nodeType The searched node class.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
+     *
      * @since 1.0.0
      */
     protected function getFirstNodeOfTypeInTrait($nodeType)
@@ -249,7 +250,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function getFirstNodeOfTypeInClass($testCase, $nodeType)
     {
@@ -263,7 +264,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function getFirstNodeOfTypeInInterface($testCase, $nodeType)
     {
@@ -275,7 +276,8 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first trait found in a test file associated with the given
      * test case.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
+     *
      * @since 1.0.0
      */
     protected function getFirstTraitForTestCase()
@@ -290,7 +292,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first class found in a test file associated with the given
      * test case.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     protected function getFirstClassForTestCase()
     {
@@ -304,7 +306,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first method that could be found in the source file
      * associated with the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     protected function getFirstClassMethodForTestCase()
     {
@@ -320,7 +322,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first interface that could be found in the source file
      * associated with the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     protected function getFirstInterfaceForTestCase()
     {
@@ -334,7 +336,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first method that could be found in the source file
      * associated with the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     protected function getFirstInterfaceMethodForTestCase()
     {
@@ -350,7 +352,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return Source\AST\AbstractASTClassOrInterface
      */
     protected function getFirstTypeForTestCase()
     {
@@ -364,7 +366,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first method that could be found in the code under test for
      * the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     protected function getFirstMethodForTestCase()
     {
@@ -374,7 +376,7 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return Source\AST\ASTFormalParameter
      */
     protected function getFirstFormalParameterForTestCase()
     {
@@ -387,8 +389,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Collects all children from a given node.
      *
-     * @param \PDepend\Source\AST\ASTNode $node   The current root node.
-     * @param array                   $actual Previous filled list.
+     * @param ASTNode $node   The current root node.
+     * @param array   $actual Previous filled list.
      *
      * @return array<string>
      */
@@ -405,10 +407,7 @@ abstract class AbstractTestCase extends TestCase
      * Tests that the given node and its children represent the expected ast
      * object graph.
      *
-     * @param \PDepend\Source\AST\ASTNode $node
      * @param array<string> $expected
-     *
-     * @return void
      */
     protected static function assertGraphEquals(ASTNode $node, array $expected): void
     {
@@ -418,7 +417,7 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Collects all children from a given node.
      *
-     * @param \PDepend\Source\AST\ASTNode $node The current root node.
+     * @param ASTNode $node The current root node.
      *
      * @return array
      */
@@ -438,10 +437,8 @@ abstract class AbstractTestCase extends TestCase
      * Tests that the given node and its children represent the expected ast
      * object graph.
      *
-     * @param \PDepend\Source\AST\ASTNode $node  The root node.
-     * @param array                   $graph Expected class structure.
-     *
-     * @return void
+     * @param ASTNode $node  The root node.
+     * @param array   $graph Expected class structure.
      */
     protected static function assertGraph(ASTNode $node, $graph): void
     {
@@ -455,6 +452,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $className Name of the class to mock.
      *
      * @return stdClass
+     *
      * @since 0.10.0
      */
     protected function getMockWithoutConstructor($className)
@@ -471,7 +469,6 @@ abstract class AbstractTestCase extends TestCase
      * Clears all temporary resources.
      *
      * @param string $dir
-     * @return void
      */
     private function clearRunResources($dir = null): void
     {
@@ -479,7 +476,7 @@ abstract class AbstractTestCase extends TestCase
             $dir = __DIR__ . '/_run';
         }
 
-        foreach (new \DirectoryIterator($dir) as $file) {
+        foreach (new DirectoryIterator($dir) as $file) {
             if ($file == '.' || $file == '..' || $file == '.svn') {
                 continue;
             }
@@ -496,7 +493,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Creates a test configuration instance.
      *
-     * @return \PDepend\Util\Configuration
+     * @return Util\Configuration
+     *
      * @since 0.10.0
      */
     protected function createConfigurationFixture()
@@ -507,7 +505,7 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     protected function createCacheFixture()
     {
@@ -521,7 +519,8 @@ abstract class AbstractTestCase extends TestCase
      * Creates a PDepend instance configured with the code resource associated
      * with the calling test case.
      *
-     * @return \PDepend\Engine
+     * @return Engine
+     *
      * @since 0.10.0
      */
     protected function createEngineFixture()
@@ -533,14 +532,14 @@ abstract class AbstractTestCase extends TestCase
         $application = $this->createTestApplication();
 
         $configuration = $application->getConfiguration();
-        $cacheFactory = new \PDepend\Util\Cache\CacheFactory($configuration);
+        $cacheFactory = new Util\Cache\CacheFactory($configuration);
         $analyzerFactory = $application->getAnalyzerFactory();
 
         return new Engine($configuration, $cacheFactory, $analyzerFactory);
     }
 
     /**
-     * @param \PDepend\TextUI\Runner $runner
+     * @param TextUI\Runner $runner
      *
      * @return int
      */
@@ -552,7 +551,7 @@ abstract class AbstractTestCase extends TestCase
 
         try {
             $exitCode = $runner->run();
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             $error = $exception;
         }
 
@@ -570,7 +569,8 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $name Optional class name.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
+     *
      * @since 1.0.2
      */
     protected function createClassFixture($name = null)
@@ -592,7 +592,8 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $name Optional interface name.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
+     *
      * @since 1.0.2
      */
     protected function createInterfaceFixture($name = null)
@@ -610,7 +611,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use trait fixture.
      *
      * @param string $name Optional trait name.
-     * @return \PDepend\Source\AST\ASTTrait
+     *
+     * @return ASTTrait
+     *
      * @since 1.0.2
      */
     protected function createTraitFixture($name = null)
@@ -627,7 +630,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use function fixture.
      *
      * @param string $name Optional function name.
-     * @return \PDepend\Source\AST\ASTFunction
+     *
+     * @return ASTFunction
+     *
      * @since 1.0.2
      */
     protected function createFunctionFixture($name = null)
@@ -646,7 +651,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use method fixture.
      *
      * @param string $name Optional method name.
-     * @return \PDepend\Source\AST\ASTMethod
+     *
+     * @return ASTMethod
+     *
      * @since 1.0.2
      */
     protected function createMethodFixture($name = null)
@@ -664,8 +671,10 @@ abstract class AbstractTestCase extends TestCase
      * Creates a temporary resource for the given file name.
      *
      * @param string $fileName
+     *
      * @return string
-     * @throws \ErrorException
+     *
+     * @throws ErrorException
      */
     protected function createRunResourceURI($fileName = null)
     {
@@ -676,15 +685,17 @@ abstract class AbstractTestCase extends TestCase
      * Creates a code uri for the given file name.
      *
      * @param string $fileName The code file name.
+     *
      * @return string
-     * @throws \ErrorException
+     *
+     * @throws ErrorException
      */
     protected static function createCodeResourceURI($fileName)
     {
         $uri = realpath(__DIR__ . '/../../resources/files') . DIRECTORY_SEPARATOR . $fileName;
 
         if (file_exists($uri) === false) {
-            throw new \ErrorException("File '{$fileName}' does not exists.");
+            throw new ErrorException("File '{$fileName}' does not exists.");
         }
         return $uri;
     }
@@ -717,7 +728,7 @@ abstract class AbstractTestCase extends TestCase
         $fileName = substr(implode(DIRECTORY_SEPARATOR, $parts), 0, -4) . DIRECTORY_SEPARATOR . $method;
         try {
             return self::createCodeResourceURI($fileName);
-        } catch (\ErrorException $e) {
+        } catch (ErrorException $e) {
             return self::createCodeResourceURI("{$fileName}.php");
         }
     }
@@ -734,13 +745,11 @@ abstract class AbstractTestCase extends TestCase
                 return "{$frame['class']}::{$frame['function']}";
             }
         }
-        throw new \ErrorException("No calling test case found.");
+        throw new ErrorException("No calling test case found.");
     }
 
     /**
      * Initializes the test environment.
-     *
-     * @return void
      */
     public static function init(): void
     {
@@ -764,7 +773,6 @@ abstract class AbstractTestCase extends TestCase
      * Autoloader for the test cases.
      *
      * @param string $className Name of the missing class.
-     * @return void
      */
     public static function autoload($className): void
     {
@@ -780,7 +788,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Parses the test code associated with the calling test method.
      *
-     * @param boolean $ignoreAnnotations The parser should ignore annotations.
+     * @param bool $ignoreAnnotations The parser should ignore annotations.
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     protected function parseCodeResourceForTest($ignoreAnnotations = false)
@@ -796,7 +805,8 @@ abstract class AbstractTestCase extends TestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param boolean $ignoreAnnotations
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -808,7 +818,7 @@ abstract class AbstractTestCase extends TestCase
 
         try {
             $fileOrDirectory = self::createCodeResourceURI($fileName);
-        } catch (\ErrorException $e) {
+        } catch (ErrorException $e) {
             $fileOrDirectory = self::createCodeResourceURI($fileName . '.php');
         }
 
@@ -819,8 +829,9 @@ abstract class AbstractTestCase extends TestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string  $fileOrDirectory
-     * @param boolean $ignoreAnnotations
+     * @param string $fileOrDirectory
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseSource($fileOrDirectory, $ignoreAnnotations = false)
@@ -831,13 +842,13 @@ abstract class AbstractTestCase extends TestCase
 
         if (is_dir($fileOrDirectory)) {
             $it = new Iterator(
-                new \RecursiveIteratorIterator(
-                    new \RecursiveDirectoryIterator($fileOrDirectory)
+                new RecursiveIteratorIterator(
+                    new RecursiveDirectoryIterator($fileOrDirectory)
                 ),
                 new ExcludePathFilter(['.svn'])
             );
         } else {
-            $it = new \ArrayIterator([$fileOrDirectory]);
+            $it = new ArrayIterator([$fileOrDirectory]);
         }
 
         $files = [];
@@ -868,10 +879,9 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder<mixed> $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     *
+     * @return Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
@@ -889,7 +899,6 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * @param array<int, string> $requiredFormats
-     * @return void
      */
     protected function requireImagick(array $requiredFormats = ['PNG', 'SVG']): void
     {

--- a/src/test/php/PDepend/ApplicationTest.php
+++ b/src/test/php/PDepend/ApplicationTest.php
@@ -42,15 +42,17 @@
 
 namespace PDepend;
 
+use InvalidArgumentException;
 use PDepend\Metrics\Analyzer\CrapIndexAnalyzer;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
+ * @covers \PDepend\Application
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Application
  * @group integration
  */
 class ApplicationTest extends AbstractTestCase
@@ -92,16 +94,14 @@ class ApplicationTest extends AbstractTestCase
         $this->assertMatchesRegularExpression('/<file\s.*name="php:\/\/stdin"/', $xml);
     }
 
-    /**
-     */
     public function testSetConfigurationFileAndThrowInvalidArgumentException(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('(^The configuration file ".*fileThatDoesNotExists\\.txt" doesn\\\'t exist\\.$)');
 
         $filename = __DIR__ . '/fileThatDoesNotExists.txt';
 
-        $application = new \PDepend\Application();
+        $application = new Application();
         $application->setConfigurationFile($filename);
     }
 

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -58,6 +58,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * calling test case.
      *
      * @return string
+     *
      * @since 0.10.0
      */
     protected function createSummaryXmlForCallingTest()
@@ -83,7 +84,8 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Parses the source of a test case file.
      *
      * @param string $testCase
-     * @param boolean $ignoreAnnotations
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -98,6 +100,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Returns the source file for the given test case.
      *
      * @param string $testCase The qualified test case name.
+     *
      * @return string
      */
     protected function getSourceFileForTestCase($testCase)

--- a/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
+++ b/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
  */
 
@@ -48,15 +49,15 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link      http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
+ *
  * @group regressiontest
  */
 class AlternativeSyntaxClosingTagBug163Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesAlternativeSyntaxTerminatedByClosingTag
-     *
-     * @return void
      */
     public function testParserHandlesAlternativeSyntaxTerminatedByClosingTag(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
+++ b/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
@@ -54,8 +54,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 {
     /**
      * testParserAcceptsNullAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsClassName(): void
     {
@@ -64,8 +62,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsNullAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsInterfaceName(): void
     {
@@ -74,8 +70,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsTrueAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsClassName(): void
     {
@@ -84,8 +78,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsTrueAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsInterfaceName(): void
     {
@@ -94,8 +86,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsFalseAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsClassName(): void
     {
@@ -104,8 +94,6 @@ class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsFalseAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsInterfaceName(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
@@ -57,8 +57,6 @@ class ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test extends Abstr
 {
     /**
      * Tests that the parser does not throw an exception.
-     *
-     * @return void
      */
     public function testMagicClassConstantDoesNotResultInExceptionAsArrayDefaultValue(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
@@ -57,8 +57,6 @@ class ClassConstantAsArrayExpressionBug299Test extends AbstractRegressionTestCas
 {
     /**
      * Tests that the parser does not throw an exception.
-     *
-     * @return void
      */
     public function testConstantArrayConcatenation(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
+++ b/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
@@ -55,8 +55,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects an
      * interface without a body.
-     *
-     * @return void
      */
     public function testInterfaceDeclarationWithoutBody(): void
     {
@@ -73,8 +71,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects an
      * interface declaration with extend but without a body.
-     *
-     * @return void
      */
     public function testInterfaceDeclarationWithExtendWithoutBody(): void
     {
@@ -91,8 +87,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects an
      * interface declaration with extend with invalid end of interface list.
-     *
-     * @return void
      */
     public function testInterfaceDeclarationWithInvalidInterfaceList(): void
     {
@@ -105,12 +99,10 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
 
         $this->parseCodeResourceForTest();
     }
-    
+
     /**
      * Tests that the parser does not end in an endless loop when it detects a
      * class declaration without a body.
-     *
-     * @return void
      */
     public function testClassDeclarationWithoutBody(): void
     {
@@ -127,8 +119,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects a
      * class declaration with extend but without a parent class name and a body.
-     *
-     * @return void
      */
     public function testClassDeclarationWithExtendsWithoutClassName(): void
     {
@@ -145,8 +135,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects a
      * class declaration with implements but without a interface name and a body.
-     *
-     * @return void
      */
     public function testClassDeclarationWithExtendsWithoutInterfaceName(): void
     {
@@ -163,8 +151,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects a
      * class declaration with parent interface but without a body.
-     *
-     * @return void
      */
     public function testClassDeclarationWithParentInterfaceWithoutBody(): void
     {
@@ -181,8 +167,6 @@ class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not end in an endless loop when it detects a
      * class declaration with an incomplete parent interface list and without a body.
-     *
-     * @return void
      */
     public function testClassDeclarationWithIncompleteParentInterfaceWithoutBody(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
+++ b/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
  */
 
@@ -52,6 +53,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
  *
  * @group regressiontest
@@ -60,8 +62,6 @@ class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegress
 {
     /**
      * testAnalyzerCountsNumberOfMethodsForClassInterfaceSize
-     *
-     * @return void
      */
     public function testAnalyzerCountsNumberOfMethodsForClassInterfaceSize(): void
     {
@@ -78,7 +78,7 @@ class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegress
         $analyzer->addAnalyzer($ccnAnalyzer);
 
         $analyzer->analyze($namespaces);
-        
+
         $metrics = $analyzer->getNodeMetrics($class);
 
         $this->assertEquals(2, $metrics['cis']);
@@ -86,8 +86,6 @@ class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegress
 
     /**
      * testAnalyzerCountsNumberOfMethodsForClassSize
-     *
-     * @return void
      */
     public function testAnalyzerCountsNumberOfMethodsForClassSize(): void
     {

--- a/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/9936901
  */
 
@@ -52,17 +53,17 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link https://www.pivotaltracker.com/story/show/9936901
  *
  * @ticket 9936901
+ *
  * @group regressiontest
  */
 class ClassLevelAnalyzerBug09936901Test extends AbstractRegressionTestCase
 {
     /**
      * testWmciMetricIsCalculatedForCurrentAndNotParentClass
-     *
-     * @return void
      */
     public function testWmciMetricIsCalculatedForCurrentAndNotParentClass(): void
     {

--- a/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
+++ b/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
@@ -47,6 +47,7 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/182
  *
  * @group regressiontest
@@ -55,8 +56,6 @@ class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTes
 {
     /**
      * testParserAcceptsCloneAsFunctionName
-     *
-     * @return void
      */
     public function testParserAcceptsCloneAsFunctionName(): void
     {
@@ -65,8 +64,6 @@ class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTes
 
     /**
      * testParserAcceptsCloneAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsCloneAsMethodName(): void
     {
@@ -75,8 +72,6 @@ class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTes
 
     /**
      * testParserAcceptsCloneAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsCloneAsClassName(): void
     {
@@ -85,8 +80,6 @@ class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTes
 
     /**
      * testParserAcceptsCloneAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsCloneAsInterfaceName(): void
     {

--- a/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
@@ -54,8 +54,6 @@ class ClosureAsArrayElement126Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesClosureAsArrayElement
-     *
-     * @return void
      */
     public function testParserHandlesClosureAsArrayElement(): void
     {

--- a/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -55,8 +55,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
     /**
      * Tests that the parser does not throw an exception when it detects a
      * lambda function on file level.
-     *
-     * @return void
      */
     public function testParserHandlesLambdaFunctionOnFileLevelBug70(): void
     {
@@ -65,8 +63,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a lambda function with parameters.
-     *
-     * @return void
      */
     public function testParserHandlesLambdaFunctionWithParametersBug70(): void
     {
@@ -75,8 +71,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a closure function with bound variables.
-     *
-     * @return void
      */
     public function testParserHandlesClosureFunctionWithBoundVariableBug70(): void
     {
@@ -85,8 +79,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a closure function with bound variables.
-     *
-     * @return void
      */
     public function testParserHandlesClosureFunctionWithBoundVariableByRefBug70(): void
     {
@@ -95,8 +87,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a closure function with bound variables.
-     *
-     * @return void
      */
     public function testParserThrowsExceptionForInvalidBoundClosureVariableBug70(): void
     {
@@ -107,8 +97,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a nested function within a function.
-     *
-     * @return void
      */
     public function testParserHandlesFunctionDeclarationWithinFunctionDeclarationBug70(): void
     {
@@ -123,8 +111,6 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser handles a nested closure within a function declaration.
-     *
-     * @return void
      */
     public function testParserHandlesClosureWithinFunctionDeclarationBug70(): void
     {

--- a/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
@@ -55,8 +55,6 @@ class ClosureReturnsByReferenceBug094Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesClosureThatReturnsReference
-     *
-     * @return void
      */
     public function testParserHandlesClosureThatReturnsReference(): void
     {

--- a/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -42,9 +42,6 @@
 
 namespace PDepend\Bugs;
 
-use PDepend\Source\AST\ASTLiteral;
-use PDepend\Source\AST\ASTString;
-
 /**
  * Test case for ticket #114.
  *
@@ -57,8 +54,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesStringWithEmbeddedBacktickExpression
-     *
-     * @return void
      */
     public function testParserHandlesStringWithEmbeddedBacktickExpression(): void
     {
@@ -67,8 +62,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesStringWithEmbeddedExpression
-     *
-     * @return void
      */
     public function testParserHandlesStringWithEmbeddedExpression(): void
     {
@@ -77,8 +70,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesBacktickExpressionWithEmbeddedStringExpression
-     *
-     * @return void
      */
     public function testParserHandlesBacktickExpressionWithEmbeddedStringExpression(): void
     {
@@ -87,8 +78,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesStringWithEscapedVariable
-     *
-     * @return void
      */
     public function testParserHandlesStringWithEscapedVariable(): void
     {
@@ -97,8 +86,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesBacktickExpressionWithEscapedVariable
-     *
-     * @return void
      */
     public function testParserHandlesBacktickExpressionWithEscapedVariable(): void
     {
@@ -107,8 +94,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesStringWithVariableAndAssignment
-     *
-     * @return void
      */
     public function testParserHandlesStringWithVariableAndAssignment(): void
     {
@@ -117,8 +102,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesStringWithVariableNotAsFunctionCall
-     *
-     * @return void
      */
     public function testParserHandlesStringWithVariableNotAsFunctionCall(): void
     {
@@ -127,8 +110,6 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesStringWithQuestionMarkNotAsTernaryOperator
-     *
-     * @return void
      */
     public function testParserHandlesStringWithQuestionMarkNotAsTernaryOperator(): void
     {

--- a/src/test/php/PDepend/Bugs/ConflictingImportTest.php
+++ b/src/test/php/PDepend/Bugs/ConflictingImportTest.php
@@ -42,12 +42,14 @@
 
 namespace PDepend\Bugs;
 
+use ReflectionClass;
+
 class ConflictingImportTest extends AbstractRegressionTestCase
 {
     public function testSymfonyExtension(): void
     {
         // force compilation of both conflicting files
-        new \ReflectionClass('PDepend\DependencyInjection\Extension');
-        new \ReflectionClass('PDepend\DependencyInjection\PdependExtension');
+        new ReflectionClass('PDepend\DependencyInjection\Extension');
+        new ReflectionClass('PDepend\DependencyInjection\PdependExtension');
     }
 }

--- a/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
+++ b/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
@@ -56,8 +56,6 @@ class CouplingAnalyzerBug014Test extends AbstractRegressionTestCase
 {
     /**
      * Test case for the execution chain bug 14.
-     *
-     * @return void
      */
     public function testAnalyzerExecutionChain(): void
     {

--- a/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
@@ -55,8 +55,6 @@ class DefaultNamespaceBug106Test extends AbstractRegressionTestCase
 {
     /**
      * testAllocatedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile
-     *
-     * @return void
      */
     public function testAllocatedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile(): void
     {
@@ -66,8 +64,6 @@ class DefaultNamespaceBug106Test extends AbstractRegressionTestCase
 
     /**
      * testExtendedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile
-     *
-     * @return void
      */
     public function testExtendedInternalClassWithLeadingBackslashNotAppearsInSummaryLogFile(): void
     {

--- a/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
@@ -56,8 +56,6 @@ class DefaultPackageContainsBrokenAritfactsBug098Test extends AbstractRegression
 {
     /**
      * Tests that the result does not contain an interface with a broken body.
-     *
-     * @return void
      */
     public function testDefaultPackageDoesNotContainsInterfaceWithBrokenBody(): void
     {

--- a/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -54,8 +54,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 {
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetParentClass
-     *
-     * @return void
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetParentClass(): void
     {
@@ -68,8 +66,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetParentClass2
-     *
-     * @return void
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetParentClass2(): void
     {
@@ -84,8 +80,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetInterfaces
-     *
-     * @return void
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetInterfaces(): void
     {
@@ -98,8 +92,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetInterfaces2
-     *
-     * @return void
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetInterfaces2(): void
     {
@@ -112,8 +104,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testClassNotResultsInEndlessLoopWhileCallingGetInterfaces3
-     *
-     * @return void
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetInterfaces3(): void
     {
@@ -126,8 +116,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testClassDeclarationAndParameterTypeHintAreReferencesToTheSameClass
-     *
-     * @return void
      */
     public function testClassDeclarationAndParameterTypeHintAreReferencesToTheSameClass(): void
     {
@@ -143,8 +131,6 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
 
     /**
      * testParserDoesNotDetectThrownInternalExceptionClassAsPartOfPackage
-     *
-     * @return void
      */
     public function testParserDoesNotDetectThrownInternalExceptionClassAsPartOfPackage(): void
     {

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/18459091
  * @since 1.0.0
  */
@@ -54,18 +55,18 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link https://www.pivotaltracker.com/story/show/18459091
  * @since 1.0.0
  *
  * @ticket 18459091
+ *
  * @group regressiontest
  */
 class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 {
     /**
      * Resets the execution time to -1.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -76,8 +77,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForTwoLevelClassHierarchy
-     *
-     * @return void
      */
     public function testClassLevelAnalyzerNotRunsEndlessForTwoLevelClassHierarchy(): void
     {
@@ -96,8 +95,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForDeepClassHierarchy
-     *
-     * @return void
      */
     public function testClassLevelAnalyzerNotRunsEndlessForDeepClassHierarchy(): void
     {
@@ -116,8 +113,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForTwoLevelInterfaceHierarchy
-     *
-     * @return void
      */
     public function testClassLevelAnalyzerNotRunsEndlessForTwoLevelInterfaceHierarchy(): void
     {
@@ -134,8 +129,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testClassLevelAnalyzerNotRunsEndlessForDeepInterfaceHierarchy
-     *
-     * @return void
      */
     public function testClassLevelAnalyzerNotRunsEndlessForDeepInterfaceHierarchy(): void
     {
@@ -152,8 +145,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testInheritanceAnalyzerNotRunsEndlessForTwoLevelClassHierarchy
-     *
-     * @return void
      */
     public function testInheritanceAnalyzerNotRunsEndlessForTwoLevelClassHierarchy(): void
     {
@@ -167,8 +158,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testInheritanceAnalyzerNotRunsEndlessForDeepClassHierarchy
-     *
-     * @return void
      */
     public function testInheritanceAnalyzerNotRunsEndlessForDeepClassHierarchy(): void
     {
@@ -182,8 +171,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testInheritanceAnalyzerNotRunsEndlessForTwoLevelInterfaceHierarchy
-     *
-     * @return void
      */
     public function testInheritanceAnalyzerNotRunsEndlessForTwoLevelInterfaceHierarchy(): void
     {
@@ -195,8 +182,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testInheritanceAnalyzerNotRunsEndlessForDeepInterfaceHierarchy
-     *
-     * @return void
      */
     public function testInheritanceAnalyzerNotRunsEndlessForDeepInterfaceHierarchy(): void
     {
@@ -208,8 +193,6 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
     /**
      * testFullStackNotRunsEndless
-     *
-     * @return void
      */
     public function testFullStackNotRunsEndless(): void
     {
@@ -219,7 +202,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
             __FILE__,
             '--summary-xml=' . $this->createRunResourceURI('jdepend.xml'),
             '--jdepend-xml=' . $this->createRunResourceURI('summary.xml'),
-            $this->createCodeResourceUriForTest()
+            $this->createCodeResourceUriForTest(),
         ];
 
         ob_start();

--- a/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
+++ b/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
@@ -49,6 +49,7 @@ use PDepend\Input\ExcludePathFilter;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/191
  *
  * @group regressiontest
@@ -57,8 +58,6 @@ class ExcludePathFilterShouldFilterByAbsolutePathBug191Test extends AbstractRegr
 {
     /**
      * testAbsoluteUnixPathAsFilterPattern
-     *
-     * @return void
      */
     public function testAbsoluteUnixPathAsFilterPattern(): void
     {
@@ -68,8 +67,6 @@ class ExcludePathFilterShouldFilterByAbsolutePathBug191Test extends AbstractRegr
 
     /**
      * testAbsoluteWindowsPathAsFilterPattern
-     *
-     * @return void
      */
     public function testAbsoluteWindowsPathAsFilterPattern(): void
     {

--- a/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
+++ b/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
@@ -61,8 +61,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * class Bar extends Foo {}
      * interface Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphClassDeclaredBeforeInterfaceWithPackage(): void
     {
@@ -85,8 +83,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * class Bar extends Foo {}
      * interface Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphClassDeclaredBeforeInterfaceWithoutPackage(): void
     {
@@ -106,8 +102,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * class Bar implements Foo {}
      * class Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphInterfaceDeclaredBeforeClassWithPackage(): void
     {
@@ -132,8 +126,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * class Bar implements Foo {}
      * class Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphInterfaceDeclaredBeforeClassWithoutPackage(): void
     {
@@ -153,8 +145,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * class Bar extends Foo {}
      * class Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphClassDeclaredBeforeClassWithPackage(): void
     {
@@ -178,8 +168,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      * interface Bar extends Foo {}
      * interface Foo {}
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphInterfaceDeclaredBeforeInterfaceWithPackage(): void
     {
@@ -207,8 +195,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      *     interface Foo {}
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphClassDeclaredBeforeInterfaceWithNamespace(): void
     {
@@ -236,8 +222,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
      *     class Foo {}
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserCreatesExpectedObjectGraphInterfaceDeclaredBeforeClassWithNamespace(): void
     {
@@ -256,8 +240,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 
     /**
      * Tests that pdepend does not die with a fatal error.
-     *
-     * @return void
      */
     public function testPHPDependDoesNotDieWithErrorClassDeclaredBeforeInterfaceWithPackage(): void
     {
@@ -266,8 +248,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 
     /**
      * Tests that pdepend does not die with a fatal error.
-     *
-     * @return void
      */
     public function testPHPDependDoesNotDieWithErrorClassDeclaredBeforeInterfaceWithoutPackage(): void
     {
@@ -276,8 +256,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 
     /**
      * Tests that pdepend does not die with a fatal error.
-     *
-     * @return void
      */
     public function testPHPDependDoesNotDieWithErrorInterfaceDeclaredBeforeClassWithPackage(): void
     {
@@ -286,8 +264,6 @@ class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 
     /**
      * Tests that pdepend does not die with a fatal error.
-     *
-     * @return void
      */
     public function testPHPDependDoesNotDieWithErrorInterfaceDeclaredBeforeClassWithoutPackage(): void
     {

--- a/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
+++ b/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
@@ -57,8 +57,6 @@ class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 {
     /**
      * Tests that the parser sets the expected start and end line for a property.
-     *
-     * @return void
      */
     public function testParserSetsExpectedStartAndEndLineForPropertyWithoutDefaultValue(): void
     {
@@ -75,8 +73,6 @@ class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser sets the expected start and end line for a property.
-     *
-     * @return void
      */
     public function testParserSetsExpectedStartAndEndLineForPropertyWithCommentsInDeclaration(): void
     {
@@ -93,8 +89,6 @@ class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser sets the expected start and end line for a property.
-     *
-     * @return void
      */
     public function testParserSetsExpectedStartAndEndLineForPropertyWithArrayDefaultValue(): void
     {
@@ -110,8 +104,6 @@ class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser sets the expected start and end line for a property.
-     *
-     * @return void
      */
     public function testParserSetsExpectedStartAndEndLineForPropertyWithScalarDefaultValueAndComments(): void
     {

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -42,13 +42,16 @@
 
 namespace PDepend\Bugs;
 
+use ArrayIterator;
 use PDepend\Input\Iterator;
+use SplFileInfo;
 
 /**
  * Test case for bug #164.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/164
  *
  * @group regressiontest
@@ -57,8 +60,6 @@ class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegress
 {
     /**
      * testIteratorOnlyPassesLocalPathToFilter
-     *
-     * @return void
      */
     public function testIteratorOnlyPassesLocalPathToFilter(): void
     {
@@ -69,7 +70,7 @@ class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegress
             ->with($this->equalTo(DIRECTORY_SEPARATOR . basename(__FILE__)));
 
         $iterator = new Iterator(
-            new \ArrayIterator([new \SplFileInfo(__FILE__)]),
+            new ArrayIterator([new SplFileInfo(__FILE__)]),
             $filter,
             __DIR__
         );

--- a/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
+++ b/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
@@ -58,8 +58,6 @@ class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegression
     /**
      * Tests that the parser handles an interface within an instanceof operator
      * correct.
-     *
-     * @return void
      */
     public function testParserTreatsTypeInInstanceOfOperatorGenericWithInterface(): void
     {
@@ -85,8 +83,6 @@ class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegression
     /**
      * Tests that the parser handles an interface within an instanceof operator
      * correct.
-     *
-     * @return void
      */
     public function testParserTreatsTypeInInstanceOfOperatorGenericWithClass(): void
     {

--- a/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
@@ -54,8 +54,6 @@ class InvalidNowdocSubstitutionBug150Test extends AbstractRegressionTestCase
 {
     /**
      * testTokenizerDoesNotDetectNowdocSyntaxInString
-     *
-     * @return void
      */
     public function testTokenizerDoesNotDetectNowdocSyntaxInString(): void
     {

--- a/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
@@ -55,8 +55,6 @@ class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegr
     /**
      * Tests that the parser handles function with reference return values
      * correct.
-     *
-     * @return void
      */
     public function testParserCreatesInvalidFunctionWhenReturnsByReference(): void
     {
@@ -71,8 +69,6 @@ class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegr
     /**
      * Tests that the parser handles function with reference return values
      * correct.
-     *
-     * @return void
      */
     public function testParserCreatesInvalidMethodWhenReturnsByReference(): void
     {

--- a/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
@@ -54,8 +54,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 {
     /**
      * testParserHandlesObjectPropertyAsForeachLoopKey
-     *
-     * @return void
      */
     public function testParserHandlesObjectPropertyAsForeachLoopKey(): void
     {
@@ -64,8 +62,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 
     /**
      * testParserHandlesObjectPropertyAsForeachLoopValue
-     *
-     * @return void
      */
     public function testParserHandlesObjectPropertyAsForeachLoopValue(): void
     {
@@ -74,8 +70,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 
     /**
      * testParserHandlesObjectPropertyAsForeachLoopKeyAndValue
-     *
-     * @return void
      */
     public function testParserHandlesObjectPropertyAsForeachLoopKeyAndValue(): void
     {
@@ -84,8 +78,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 
     /**
      * testParserHandlesClassPropertyAsForeachLoopKey
-     *
-     * @return void
      */
     public function testParserHandlesClassPropertyAsForeachLoopKey(): void
     {
@@ -94,8 +86,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 
     /**
      * testParserHandlesClassPropertyAsForeachLoopValue
-     *
-     * @return void
      */
     public function testParserHandlesClassPropertyAsForeachLoopValue(): void
     {
@@ -104,8 +94,6 @@ class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressi
 
     /**
      * testParserHandlesClassPropertyAsForeachLoopKeyAndValue
-     *
-     * @return void
      */
     public function testParserHandlesClassPropertyAsForeachLoopKeyAndValue(): void
     {

--- a/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
+++ b/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
@@ -54,8 +54,6 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 {
     /**
      * testParserNotThrowsAnExceptionForKeywordUse
-     *
-     * @return void
      */
     public function testParserNotThrowsAnExceptionForKeywordUse(): void
     {
@@ -64,8 +62,6 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 
     /**
      * testParserNotThrowsAnExceptionForKeywordGoto
-     *
-     * @return void
      */
     public function testParserNotThrowsAnExceptionForKeywordGoto(): void
     {
@@ -74,8 +70,6 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 
     /**
      * testParserNotThrowsAnExceptionForKeywordNamespace
-     *
-     * @return void
      */
     public function testParserNotThrowsAnExceptionForKeywordNamespace(): void
     {
@@ -84,8 +78,6 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 
     /**
      * testParserNotThrowsAnExceptionForMagicNamespaceConstant
-     *
-     * @return void
      */
     public function testParserNotThrowsAnExceptionForMagicNamespaceConstant(): void
     {
@@ -94,8 +86,6 @@ class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegression
 
     /**
      * testParserNotThrowsAnExceptionForKeywordParent
-     *
-     * @return void
      */
     public function testParserNotThrowsAnExceptionForKeywordParent(): void
     {

--- a/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
+++ b/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
@@ -56,8 +56,6 @@ class MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test extends AbstractR
 {
     /**
      * testAnalyzerNotCountsImplementedAbstractMethodsAsOverwritten
-     *
-     * @return void
      */
     public function testAnalyzerNotCountsImplementedAbstractMethodsAsOverwritten(): void
     {
@@ -73,8 +71,6 @@ class MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test extends AbstractR
 
     /**
      * testAnalyzerNotCountsImplementedInterfaceMethodsAsOverwritten
-     *
-     * @return void
      */
     public function testAnalyzerNotCountsImplementedInterfaceMethodsAsOverwritten(): void
     {

--- a/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
+++ b/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
@@ -60,8 +60,6 @@ class NPathComplexityIsBrokenInVersion096Bug095Test extends AbstractRegressionTe
     /**
      * Tests that the parser handles an interface within an instanceof operator
      * correct.
-     *
-     * @return void
      */
     public function testAnalyzerReturnsExpectedNPathValue(): void
     {

--- a/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
@@ -60,8 +60,6 @@ class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends Abstr
 {
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresObjectAllocation(): void
     {
@@ -76,8 +74,6 @@ class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends Abstr
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsIdenticalFunctionCalls(): void
     {
@@ -92,8 +88,6 @@ class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends Abstr
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsDifferentFunctionCalls(): void
     {
@@ -108,8 +102,6 @@ class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends Abstr
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsIdenticalMethodCalls(): void
     {
@@ -124,8 +116,6 @@ class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends Abstr
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsDifferentMethodCalls(): void
     {

--- a/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
@@ -57,8 +57,6 @@ class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTe
 {
     /**
      * testParserHandlesNamespaceKeywordInFunctionParameterTypeHint
-     *
-     * @return void
      */
     public function testParserHandlesNamespaceKeywordInFunctionParameterTypeHint(): void
     {
@@ -70,8 +68,6 @@ class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTe
 
     /**
      * testParserHandlesNamespaceKeywordInMethodParameterTypeHint
-     *
-     * @return void
      */
     public function testParserHandlesNamespaceKeywordInMethodParameterTypeHint(): void
     {

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2016 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link    https://github.com/pdepend/pdepend/issues/247
  */
 
@@ -46,23 +47,24 @@ namespace PDepend\Bugs;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit_Framework_MockObject_MockObject;
 
 /**
  * Test case for bug #247.
  *
  * @copyright 2008-2016 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link    https://github.com/pdepend/pdepend/issues/247
  *
  * @ticket 247
+ *
  * @group regressiontest
  */
 class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTestCase
 {
     /**
      * testUseConst
-     *
-     * @return void
      */
     public function testUseConst(): void
     {
@@ -85,8 +87,6 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
 
     /**
      * testUseFunction
-     *
-     * @return void
      */
     public function testUseFunction(): void
     {
@@ -108,10 +108,9 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
      * @param \PDepend\Source\Builder\Builder<mixed> $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     *
+     * @return PHPUnit_Framework_MockObject_MockObject
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -38,22 +38,22 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/13405179
  */
 
 namespace PDepend\Bugs;
-
-use PDepend\Engine;
-use PDepend\Util\Configuration\ConfigurationFactory;
 
 /**
  * Test case for bug #13405179.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link https://www.pivotaltracker.com/story/show/13405179
  *
  * @ticket 13405179
+ *
  * @group regressiontest
  */
 class PHPDependBug13405179Test extends AbstractRegressionTestCase
@@ -64,7 +64,6 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
      * @param string $className Class name of a logger implementation.
      * @param string $extension Log file extension.
      *
-     * @return void
      * @dataProvider getLoggerClassNames
      */
     public function testLogFileIsCreatedForUnstructuredCode($className, $extension): void

--- a/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
+++ b/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
@@ -58,8 +58,6 @@ class ParameterStringDefaultValueBug103Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesStringDefaultValueWithEmbeddedExpression
-     *
-     * @return void
      */
     public function testParserHandlesStringDefaultValueWithEmbeddedExpression(): void
     {

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -56,8 +56,6 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
 {
     /**
      * Tests that the parser handles the parent type hint as expected.
-     *
-     * @return void
      */
     public function testParserSetsExpectedParentTypeHintReference(): void
     {
@@ -75,8 +73,6 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
     /**
      * Tests that the parser throws an exception when the parent keyword is used
      * within a function signature.
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForParentTypeHintInFunction(): void
     {
@@ -93,8 +89,6 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
 
     /**
      * testParserThrowsExpectedExceptionForParentTypeHintWithRootClass
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForParentTypeHintWithRootClass(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug001Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug001Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 1
+ *
  * @group regressiontest
  */
 class ParserBug001Test extends AbstractRegressionTestCase
@@ -56,8 +57,6 @@ class ParserBug001Test extends AbstractRegressionTestCase
     /**
      * Test case for parser bug 01 that doesn't add dependencies for static
      * method calls.
-     *
-     * @return void
      */
     public function testParserStaticCall(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug006Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug006Test.php
@@ -49,14 +49,13 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 006
+ *
  * @group regressiontest
  */
 class ParserBug006Test extends AbstractRegressionTestCase
 {
     /**
      * testParserNotSetsReferenceForVariableObjectInstantiation
-     *
-     * @return void
      */
     public function testParserNotSetsReferenceForVariableObjectInstantiation(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug007Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug007Test.php
@@ -49,14 +49,13 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 7
+ *
  * @group regressiontest
  */
 class ParserBug007Test extends AbstractRegressionTestCase
 {
     /**
      * testParserCurlyBrace
-     *
-     * @return void
      */
     public function testParserCurlyBrace(): void
     {
@@ -68,7 +67,7 @@ class ParserBug007Test extends AbstractRegressionTestCase
         $actual   = [
             'classes'   => $classes->count(),
             'functions' => $functions->count(),
-            'methods'   => $classes->current()->getMethods()->count()
+            'methods'   => $classes->current()->getMethods()->count(),
         ];
 
         $this->assertEquals($expected, $actual);

--- a/src/test/php/PDepend/Bugs/ParserBug008Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug008Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 8
+ *
  * @group regressiontest
  */
 class ParserBug008Test extends AbstractRegressionTestCase
@@ -57,8 +58,6 @@ class ParserBug008Test extends AbstractRegressionTestCase
      * Tests that the parser handles curly braces in strings correct.
      *
      * http://bugs.xplib.de/index.php?do=details&task_id=12&project=3
-     *
-     * @return void
      */
     public function testParserCurlyBrace(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug015Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug015Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 15
+ *
  * @group regressiontest
  */
 class ParserBug015Test extends AbstractRegressionTestCase
@@ -57,8 +58,6 @@ class ParserBug015Test extends AbstractRegressionTestCase
      * Tests that the parser ignores backtick expressions.
      *
      * http://bugs.xplib.de/index.php?do=details&task_id=15&project=3
-     *
-     * @return void
      */
     public function testParserBacktickExpression(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug016Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug016Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 16
+ *
  * @group regressiontest
  */
 class ParserBug016Test extends AbstractRegressionTestCase
@@ -63,8 +64,6 @@ class ParserBug016Test extends AbstractRegressionTestCase
      * </code>
      *
      * http://bugs.pdepend.org/index.php?do=details&task_id=16
-     *
-     * @return void
      */
     public function testParserDetectsTypeWithinInstanceOfOperator(): void
     {
@@ -87,7 +86,6 @@ class ParserBug016Test extends AbstractRegressionTestCase
      *
      * http://bugs.pdepend.org/index.php?do=details&task_id=16
      *
-     * @return void
      * @todo TODO: It would be a cool feature if PDepend would replace such
      *             combinations (T_VARIABLE = T_CONSTANT_ENCAPSED_STRING with
      *             T_INSTANCEOF + T_VARIABLE).

--- a/src/test/php/PDepend/Bugs/ParserBug017Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug017Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 17
+ *
  * @group regressiontest
  */
 class ParserBug017Test extends AbstractRegressionTestCase
@@ -63,8 +64,6 @@ class ParserBug017Test extends AbstractRegressionTestCase
      * </code>
      *
      * http://bugs.pdepend.org/index.php?do=details&task_id=17
-     *
-     * @return void
      */
     public function testDetectsTypeWithinCatchBlock(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug030Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug030Test.php
@@ -51,6 +51,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 30
+ *
  * @group regressiontest
  */
 class ParserBug030Test extends AbstractRegressionTestCase
@@ -59,8 +60,6 @@ class ParserBug030Test extends AbstractRegressionTestCase
      * Tests that the parser sets the correct type tokens.
      *
      * http://bugs.xplib.de/index.php?do=details&task_id=30&project=3
-     *
-     * @return void
      */
     public function testCorrectClassTokensAreSet(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug033Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug033Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 33
+ *
  * @group regressiontest
  */
 class ParserBug033Test extends AbstractRegressionTestCase
@@ -58,8 +59,6 @@ class ParserBug033Test extends AbstractRegressionTestCase
      * value for a function parameter.
      *
      * http://bugs.pdepend.org/index.php?do=details&task_id=33&project=3
-     *
-     * @return void
      */
     public function testParserDetectsOnlyTypeHintsWithinTheFunctionSignature(): void
     {
@@ -76,8 +75,6 @@ class ParserBug033Test extends AbstractRegressionTestCase
      * value for a method parameter.
      *
      * http://bugs.pdepend.org/index.php?do=details&task_id=33&project=3
-     *
-     * @return void
      */
     public function testParserDetectsOnlyTypeHintsWithinTheMethodSignature(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug059Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug059Test.php
@@ -49,15 +49,13 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 59
+ *
  * @group regressiontest
  */
 class ParserBug059Test extends AbstractRegressionTestCase
 {
-
     /**
      * Tests that the parser sets the source file of an interface method.
-     *
-     * @return void
      */
     public function testParserSetsSourceFileForInterfaceMethod(): void
     {
@@ -77,8 +75,6 @@ class ParserBug059Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser sets the source file of a class method.
-     *
-     * @return void
      */
     public function testParserSetsSourceFileForClassMethod(): void
     {
@@ -98,8 +94,6 @@ class ParserBug059Test extends AbstractRegressionTestCase
 
     /**
      * Tests that the parser sets the source file of a class property.
-     *
-     * @return void
      */
     public function testParserSetsSourceFileForClassProperty(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug069Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug069Test.php
@@ -49,6 +49,7 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 69
+ *
  * @group regressiontest
  */
 class ParserBug069Test extends AbstractRegressionTestCase
@@ -59,8 +60,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
      * <code>
      * PDepend\Parser::call();
      * </code>
-     *
-     * @return void
      */
     public function testStaticMethodCallInFunctionBody(): void
     {
@@ -78,8 +77,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
      * <code>
      * \PDepend\Parser::call();
      * </code>
-     *
-     * @return void
      */
     public function testStaticMethodLeadingBackslashCallInFunctionBody(): void
     {
@@ -97,8 +94,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
      * <code>
      * \PDepend\Parser\call();
      * </code>
-     *
-     * @return void
      */
     public function testNotHandlesQualifiedFunctionCallAsDependencyInFunctionBody(): void
     {
@@ -116,8 +111,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
      * <code>
      * \PDepend\Parser::$prop;
      * </code>
-     *
-     * @return void
      */
     public function testQualifiedPropertyAccessAsDependencyInFunctionBody(): void
     {
@@ -135,8 +128,6 @@ class ParserBug069Test extends AbstractRegressionTestCase
      * <code>
      * \PDepend\Parser::CONSTANT;
      * </code>
-     *
-     * @return void
      */
     public function testQualifiedConstantAccessAsDependencyInFunctionBody(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug124Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug124Test.php
@@ -51,6 +51,7 @@ use PDepend\Source\Tokenizer\Tokens;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @ticket 124
+ *
  * @group regressiontest
  */
 class ParserBug124Test extends AbstractRegressionTestCase
@@ -61,8 +62,6 @@ class ParserBug124Test extends AbstractRegressionTestCase
      * <code>
      * $className = stdClass::class;
      * </code>
-     *
-     * @return void
      */
     public function testClassNameScalarKeyword(): void
     {
@@ -81,7 +80,7 @@ class ParserBug124Test extends AbstractRegressionTestCase
             Tokens::T_STRING,
             Tokens::T_DOUBLE_COLON,
             Tokens::T_CLASS_FQN,
-            Tokens::T_SEMICOLON
+            Tokens::T_SEMICOLON,
         ];
 
         $this->assertEquals($tokenTypes, $actual);

--- a/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/17264279
  */
 
@@ -48,17 +49,17 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/17264279
  *
  * @ticket 17264279
+ *
  * @group regressiontest
  */
 class ParserBug17264279Test extends AbstractRegressionTestCase
 {
     /**
      * testParserAcceptsUseAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsUseAsClassName(): void
     {
@@ -67,8 +68,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsNullAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsClassName(): void
     {
@@ -77,8 +76,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsTrueAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsClassName(): void
     {
@@ -87,8 +84,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsCloneAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsCloneAsClassName(): void
     {
@@ -97,8 +92,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsFalseAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsClassName(): void
     {
@@ -107,8 +100,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsStringAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsStringAsClassName(): void
     {
@@ -117,8 +108,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsObjectAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsObjectAsClassName(): void
     {
@@ -127,8 +116,6 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
 
     /**
      * testParserAcceptsNamespaceAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsNamespaceAsClassName(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/21500611
  * @since 1.0.0
  */
@@ -51,18 +52,18 @@ use PDepend\Source\AST\ASTHeredoc;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link https://www.pivotaltracker.com/story/show/21500611
  * @since 1.0.0
  *
  * @ticket 21500611
+ *
  * @group regressiontest
  */
 class ParserBug21500611Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesNowdocInPropertyDeclaration
-     *
-     * @return void
      */
     public function testParserHandlesNowdocInPropertyDeclaration(): void
     {
@@ -71,8 +72,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesNowdocInStaticVariableDeclaration
-     *
-     * @return void
      */
     public function testParserHandlesNowdocInStaticVariableDeclaration(): void
     {
@@ -81,8 +80,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesNowdocForMultipleStaticVariableDeclarations
-     *
-     * @return void
      */
     public function testParserHandlesNowdocForMultipleStaticVariableDeclarations(): void
     {
@@ -91,8 +88,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesNowdocInParameterDefaultValue
-     *
-     * @return void
      */
     public function testParserHandlesNowdocInParameterDefaultValue(): void
     {
@@ -101,8 +96,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesNowdocForMultipleParametersDefaultValue
-     *
-     * @return void
      */
     public function testParserHandlesNowdocForMultipleParametersDefaultValue(): void
     {
@@ -112,7 +105,7 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
     /**
      * Returns the first heredoc found in a class.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      */
     protected function getFirstHeredocInClass()
     {

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/23905939
  * @since 0.10.8
  */
@@ -49,18 +50,18 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/23905939
  * @since 0.10.8
  *
  * @ticket 23905939
+ *
  * @group regressiontest
  */
 class ParserBug23905939Test extends AbstractRegressionTestCase
 {
     /**
      * testParserExtractsCorrectClassPackage
-     *
-     * @return void
      */
     public function testParserExtractsCorrectClassPackage(): void
     {
@@ -76,8 +77,6 @@ class ParserBug23905939Test extends AbstractRegressionTestCase
 
     /**
      * testParserExtractsCorrectInterfacePackage
-     *
-     * @return void
      */
     public function testParserExtractsCorrectInterfacePackage(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -38,32 +38,30 @@
  *
  * @copyright 2008-2011 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/23951621
  * @since 0.10.9
  */
 
 namespace PDepend\Bugs;
 
-use PDepend\Source\AST\ASTClass;
-use PDepend\Source\AST\ASTInterface;
-
 /**
  * Test case for bug #23951621.
  *
  * @copyright 2008-2011 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @link https://www.pivotaltracker.com/story/show/23951621
  * @since 0.10.9
  *
  * @ticket 23951621
+ *
  * @group regressiontest
  */
 class ParserBug23951621Test extends AbstractRegressionTestCase
 {
     /**
      * testParserHandlesHeredocAsPropertyDefaultValue
-     *
-     * @return void
      */
     public function testParserHandlesHeredocAsPropertyDefaultValue(): void
     {
@@ -73,8 +71,6 @@ class ParserBug23951621Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesHeredocAsParameterDefaultValue
-     *
-     * @return void
      */
     public function testParserHandlesHeredocAsParameterDefaultValue(): void
     {
@@ -84,8 +80,6 @@ class ParserBug23951621Test extends AbstractRegressionTestCase
 
     /**
      * testParserHandlesHeredocAsClassConstantValue
-     *
-     * @return void
      */
     public function testParserHandlesHeredocAsClassConstantValue(): void
     {

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/8927377
  */
 
@@ -50,17 +51,17 @@ use PDepend\Source\AST\ASTPropertyPostfix;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://www.pivotaltracker.com/story/show/8927377
  *
  * @ticket 8927377
+ *
  * @group regressiontest
  */
 class ParserBug8927377Test extends AbstractRegressionTestCase
 {
     /**
      * testPropertyPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedStartLine(): void
     {
@@ -70,8 +71,6 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
 
     /**
      * testPropertyPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedEndLine(): void
     {
@@ -81,8 +80,6 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
 
     /**
      * testPropertyPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedStartColumn(): void
     {
@@ -92,8 +89,6 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
 
     /**
      * testPropertyPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedEndColumn(): void
     {
@@ -104,7 +99,7 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
     /**
      * Returns the property postfix found in a class.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      */
     protected function getFirstPropertyPostfixInClass()
     {

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -58,10 +58,9 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
      * This method tests that the parser handles reserved keywords in type
      * constant names correct.
      *
-     * @param string         $sourceFile   Name of the test file.
-     * @param array<integer> $constantName Name of the expected constant
+     * @param string     $sourceFile   Name of the test file.
+     * @param array<int> $constantName Name of the expected constant
      *
-     * @return void
      * @dataProvider dataProviderReservedKeywordAsTypeConstantName
      */
     public function testReservedKeywordAsTypeConstantName($sourceFile, $constantName): void
@@ -86,43 +85,43 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
         return [
             [
                 'bugs/076-022-tokenizer-keyword-substitution.php',
-                'null'
+                'null',
             ],
             [
                 'bugs/076-023-tokenizer-keyword-substitution.php',
-                'use'
+                'use',
             ],
             [
                 'bugs/076-024-tokenizer-keyword-substitution.php',
-                'goto'
+                'goto',
             ],
             [
                 'bugs/076-025-tokenizer-keyword-substitution.php',
-                'self'
+                'self',
             ],
             [
                 'bugs/076-026-tokenizer-keyword-substitution.php',
-                'true'
+                'true',
             ],
             [
                 'bugs/076-027-tokenizer-keyword-substitution.php',
-                'false'
+                'false',
             ],
             [
                 'bugs/076-028-tokenizer-keyword-substitution.php',
-                'parent'
+                'parent',
             ],
             [
                 'bugs/076-029-tokenizer-keyword-substitution.php',
-                'namespace'
+                'namespace',
             ],
             [
                 'bugs/076-030-tokenizer-keyword-substitution.php',
-                '__dir__'
+                '__dir__',
             ],
             [
                 'bugs/076-031-tokenizer-keyword-substitution.php',
-                '__NaMeSpAcE__'
+                '__NaMeSpAcE__',
             ],
         ];
     }

--- a/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
+++ b/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
@@ -55,8 +55,6 @@ class ParserSetsIncorrectStartLineBug101Test extends AbstractRegressionTestCase
 {
     /**
      * testParserSetsExpectedStartLineNumber
-     *
-     * @return void
      */
     public function testParserSetsExpectedStartLineNumber(): void
     {
@@ -70,8 +68,6 @@ class ParserSetsIncorrectStartLineBug101Test extends AbstractRegressionTestCase
 
     /**
      * testParserSetsExpectedEndLineNumber
-     *
-     * @return void
      */
     public function testParserSetsExpectedEndLineNumber(): void
     {

--- a/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
+++ b/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\Bugs\Phpmd;
 
-
 use PDepend\Bugs\AbstractRegressionTestCase;
 use PDepend\Source\AST\ASTFunction;
 
@@ -57,7 +56,7 @@ class FunctionDocBlockBugPhpmd914Test extends AbstractRegressionTestCase
         $function = $this->getFirstFunctionForTestCase();
 
         $lines = array_map(
-            static fn (string $line) => trim($line, " \t\n\r\0\x0B/*"),
+            static fn(string $line) => trim($line, " \t\n\r\0\x0B/*"),
             explode("\n", trim($function->getComment(), " \t\n\r\0\x0B/*")),
         );
 
@@ -73,7 +72,7 @@ class FunctionDocBlockBugPhpmd914Test extends AbstractRegressionTestCase
         $function = $this->getFirstClassMethodForTestCase();
 
         $lines = array_map(
-            static fn ($line) => trim($line, " \t\n\r\0\x0B/*"),
+            static fn($line) => trim($line, " \t\n\r\0\x0B/*"),
             explode("\n", trim($function->getComment(), " \t\n\r\0\x0B/*")),
         );
 

--- a/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
+++ b/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
@@ -54,8 +54,6 @@ class ReconfigureXdebugMaxNestingLevelBug133Test extends AbstractRegressionTestC
 {
     /**
      * testParserResetsReconfiguredXdebugMaxNestingLevel
-     *
-     * @return void
      */
     public function testParserResetsReconfiguredXdebugMaxNestingLevel(): void
     {
@@ -66,11 +64,9 @@ class ReconfigureXdebugMaxNestingLevelBug133Test extends AbstractRegressionTestC
 
         $this->assertEquals($level, ini_get('xdebug.max_nesting_level'));
     }
-    
+
     /**
      * testParserReconfiguresXdebugMaxNestingLevel
-     *
-     * @return void
      */
     public function testParserReconfiguresXdebugMaxNestingLevel(): void
     {

--- a/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
+++ b/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://github.com/pdepend/pdepend/issues/95
  * @link       https://github.com/pdepend/pdepend/issues/104
  * @since 1.1.1
@@ -50,20 +51,20 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://github.com/pdepend/pdepend/issues/95
  * @link       https://github.com/pdepend/pdepend/issues/104
  * @since 1.1.1
  *
  * @ticket 104
  * @ticket 95
+ *
  * @group regressiontest
  */
 class ShortArraySyntaxInitializerBug00000104Test extends AbstractRegressionTestCase
 {
     /**
      * testPropertyDefaultValue
-     *
-     * @return void
      */
     public function testPropertyDefaultValue(): void
     {
@@ -72,8 +73,6 @@ class ShortArraySyntaxInitializerBug00000104Test extends AbstractRegressionTestC
 
     /**
      * testPropertyDefaultValue
-     *
-     * @return void
      */
     public function testParameterDefaultValue(): void
     {

--- a/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
+++ b/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
@@ -54,8 +54,6 @@ class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionT
 {
     /**
      * Tests that the parser handles a parameter with a signed default value.
-     *
-     * @return void
      */
     public function testParserHandlesSimpleSignedDefaultValue(): void
     {
@@ -69,8 +67,6 @@ class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionT
 
     /**
      * Tests that the parser handles a parameter with a signed default value.
-     *
-     * @return void
      */
     public function testParserHandlesMultipleSignedDefaultValue(): void
     {
@@ -84,8 +80,6 @@ class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionT
 
     /**
      * Tests that the parser handles a parameter with a signed default value.
-     *
-     * @return void
      */
     public function testParserHandlesComplexSignedDefaultValue(): void
     {

--- a/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
+++ b/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
@@ -54,8 +54,6 @@ class StringWithDollarStringLiteralBug162Test extends AbstractRegressionTestCase
 {
     /**
      * testParserDoesNotHandleDollarStringLiteralInDoubleQuoteString
-     *
-     * @return void
      */
     public function testParserDoesNotHandleDollarStringLiteralInDoubleQuoteString(): void
     {

--- a/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
+++ b/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
@@ -54,8 +54,6 @@ class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRe
 {
     /**
      * testSummaryReportFiltersClassesNotFlaggedUserDefined
-     *
-     * @return void
      */
     public function testSummaryReportFiltersClassesNotFlaggedUserDefined(): void
     {
@@ -65,8 +63,6 @@ class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRe
 
     /**
      * testSummaryReportFiltersInternalClasses
-     *
-     * @return void
      */
     public function testSummaryReportFiltersInternalClasses(): void
     {
@@ -76,8 +72,6 @@ class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRe
 
     /**
      * testSummaryReportDoesNotContainEmptyPackages
-     *
-     * @return void
      */
     public function testSummaryReportDoesNotContainEmptyPackages(): void
     {

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
@@ -57,8 +57,6 @@ class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegress
 {
     /**
      * Tests that the parser handles a comma separated constant definition.
-     *
-     * @return void
      */
     public function testParserHandlesSimpleCommaSeparatedConstantDefinition(): void
     {
@@ -74,8 +72,6 @@ class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegress
     /**
      * Tests that the parser handles a comma separated constant definition with
      * inline comments.
-     *
-     * @return void
      */
     public function testParserHandlesCommaSeparatedConstantDefinitionWithInlineComments(): void
     {
@@ -91,8 +87,6 @@ class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegress
     /**
      * Tests that the parser handles multiple comma separated constant
      * definitions as expected.
-     *
-     * @return void
      */
     public function testParserHandlesMultipleCommaSeparatedConstantDefinitions(): void
     {

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
@@ -57,8 +57,6 @@ class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegres
 {
     /**
      * Tests that the parser handles a comma separated property declaration.
-     *
-     * @return void
      */
     public function testParserHandlesSimpleCommaSeparatedPropertyDeclaration(): void
     {
@@ -73,8 +71,6 @@ class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegres
 
     /**
      * Tests that the parser handles a comma separated property declaration.
-     *
-     * @return void
      */
     public function testParserSetsSameVisibilityForAllPropertyDeclarations(): void
     {
@@ -88,7 +84,7 @@ class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegres
         foreach ($properties as $property) {
             $actual[] = [
                 'private'  =>  $property->isPrivate(),
-                'public'   =>  $property->isPublic()
+                'public'   =>  $property->isPublic(),
             ];
         }
 
@@ -105,8 +101,6 @@ class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegres
 
     /**
      * Tests that the parser handles a comma separated property declaration.
-     *
-     * @return void
      */
     public function testParserSetsExpectedStaticModifierForAllPropertyDeclarations(): void
     {

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -61,10 +61,9 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
      * This method tests that the parser does not substitute keyword tokens in
      * a class or object operator chain.
      *
-     * @param string         $sourceFile Name of the text file.
-     * @param array<integer> $tokenTypes List of all expected token types.
+     * @param string     $sourceFile Name of the text file.
+     * @param array<int> $tokenTypes List of all expected token types.
      *
-     * @return void
      * @dataProvider dataProviderTokenizerKeywordSubstitutionInOperatorChain
      */
     public function testTokenizerKeywordSubstitutionInOperatorChain($sourceFile, array $tokenTypes): void
@@ -97,8 +96,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-002-tokenizer-keyword-substitution.php',
@@ -108,8 +107,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-003-tokenizer-keyword-substitution.php',
@@ -119,8 +118,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-004-tokenizer-keyword-substitution.php',
@@ -130,8 +129,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-005-tokenizer-keyword-substitution.php',
@@ -141,8 +140,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-006-tokenizer-keyword-substitution.php',
@@ -152,8 +151,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-007-tokenizer-keyword-substitution.php',
@@ -163,8 +162,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-008-tokenizer-keyword-substitution.php',
@@ -174,8 +173,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-009-tokenizer-keyword-substitution.php',
@@ -185,8 +184,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-010-tokenizer-keyword-substitution.php',
@@ -196,8 +195,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-011-tokenizer-keyword-substitution.php',
@@ -207,8 +206,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_VARIABLE,
                     Tokens::T_OBJECT_OPERATOR,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-012-tokenizer-keyword-substitution.php',
@@ -218,8 +217,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-013-tokenizer-keyword-substitution.php',
@@ -229,8 +228,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-014-tokenizer-keyword-substitution.php',
@@ -240,8 +239,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-015-tokenizer-keyword-substitution.php',
@@ -251,8 +250,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-016-tokenizer-keyword-substitution.php',
@@ -262,8 +261,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-017-tokenizer-keyword-substitution.php',
@@ -273,8 +272,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-018-tokenizer-keyword-substitution.php',
@@ -284,8 +283,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-019-tokenizer-keyword-substitution.php',
@@ -295,8 +294,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-020-tokenizer-keyword-substitution.php',
@@ -306,8 +305,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
             [
                 'bugs/076-021-tokenizer-keyword-substitution.php',
@@ -317,8 +316,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
                     Tokens::T_STRING,
                     Tokens::T_DOUBLE_COLON,
                     Tokens::T_STRING,
-                    Tokens::T_SEMICOLON
-                ]
+                    Tokens::T_SEMICOLON,
+                ],
             ],
         ];
     }

--- a/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
+++ b/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://github.com/pdepend/pdepend/issues/100
  */
 
@@ -48,6 +49,7 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       https://github.com/pdepend/pdepend/issues/100
  *
  * @group regressiontest
@@ -56,8 +58,6 @@ class TraitsNotHandledCorrrectBug00000100Test extends AbstractRegressionTestCase
 {
     /**
      * testHandlingOfSelfReferenceInTrait
-     *
-     * @return void
      */
     public function testHandlingOfSelfReferenceInTrait(): void
     {

--- a/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -54,8 +54,6 @@ class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTes
 {
     /**
      * testTrueKeywordInNamespace
-     *
-     * @return void
      */
     public function testTrueKeywordInNamespace(): void
     {
@@ -64,8 +62,6 @@ class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTes
 
     /**
      * testFalseKeywordInNamespace
-     *
-     * @return void
      */
     public function testFalseKeywordInNamespace(): void
     {

--- a/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
+++ b/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
  */
@@ -52,6 +53,7 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
  *
@@ -61,8 +63,6 @@ class UnexpectedTokenAsciiChar39Bug181Test extends AbstractRegressionTestCase
 {
     /**
      * testUnexpectedTokenDoesNotQuitPDepend
-     *
-     * @return void
      */
     public function testUnexpectedTokenDoesNotQuitPDepend(): void
     {

--- a/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
+++ b/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
@@ -56,8 +56,6 @@ class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTe
 {
     /**
      * testParserHandlesVariableVariableAsForeachValue
-     *
-     * @return void
      */
     public function testParserHandlesVariableVariableAsForeachValue(): void
     {
@@ -66,8 +64,6 @@ class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTe
 
     /**
      * testParserHandlesVariableVariableAsForeachKey
-     *
-     * @return void
      */
     public function testParserHandlesVariableVariableAsForeachKey(): void
     {
@@ -76,8 +72,6 @@ class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTe
 
     /**
      * testParserHandlesVariableVariableAsForeachKeyAndValue
-     *
-     * @return void
      */
     public function testParserHandlesVariableVariableAsForeachKeyAndValue(): void
     {

--- a/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
+++ b/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
@@ -59,8 +59,6 @@ class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTestC
 {
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsIdenticalMethodCallWithFunctionComment(): void
     {
@@ -75,8 +73,6 @@ class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTestC
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsFunctionCallWithCommentBetweenParenthesisAndIdentifier(): void
     {
@@ -91,8 +87,6 @@ class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTestC
 
     /**
      * Tests that the analyzer calculates the expected result.
-     *
-     * @return void
      */
     public function testAnalyzerDetectsObjectAllocation(): void
     {

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -42,7 +42,6 @@
 
 namespace PDepend\DependencyInjection;
 
-use Exception;
 use PDepend\AbstractTestCase;
 use PDepend\TestExtension;
 use ReflectionMethod;
@@ -50,11 +49,12 @@ use ReflectionMethod;
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
+ * @covers \PDepend\DependencyInjection\TreeBuilderFactory
+ * @covers \PDepend\DependencyInjection\TreeBuilder
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\DependencyInjection\TreeBuilderFactory
- * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
 class ConfigurationTest extends AbstractTestCase

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -49,12 +49,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\DependencyInjection\ExtensionManager
  * @covers \PDepend\DependencyInjection\Extension
  * @covers \PDepend\DependencyInjection\TreeBuilder
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ExtensionManagerTest extends AbstractTestCase

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -47,10 +47,11 @@ use PDepend\AbstractTestCase;
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
+ * @covers \PDepend\DependencyInjection\TreeBuilder
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\DependencyInjection\TreeBuilder
  * @group unittest
  */
 class TreeBuilderTest extends AbstractTestCase

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -42,15 +42,17 @@
 
 namespace PDepend;
 
+use InvalidArgumentException;
 use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for \PDepend\Engine facade.
  *
+ * @covers \PDepend\Engine
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Engine
  * @group unittest
  */
 class EngineTest extends AbstractTestCase
@@ -58,8 +60,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::addDirectory()} method
      * fails with an exception for an invalid directory.
-     *
-     * @return void
      */
     public function testAddInvalidDirectoryFail(): void
     {
@@ -75,8 +75,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::addDirectory()} method
      * with an existing directory.
-     *
-     * @return void
      */
     public function testAddDirectory(): void
     {
@@ -86,8 +84,6 @@ class EngineTest extends AbstractTestCase
 
     /**
      * testAnalyzeMethodReturnsAnIterator
-     *
-     * @return void
      */
     public function testAnalyzeMethodReturnsAnIterator(): void
     {
@@ -101,8 +97,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests the {@link \PDepend\Engine::analyze()} method and the return
      * value.
-     *
-     * @return void
      */
     public function testAnalyze(): void
     {
@@ -115,7 +109,7 @@ class EngineTest extends AbstractTestCase
         $expected = [
             'package1'  =>  true,
             'package2'  =>  true,
-            'package3'  =>  true
+            'package3'  =>  true,
         ];
 
         foreach ($metrics as $metric) {
@@ -128,8 +122,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Engine::analyze()} throws an exception
      * if no source directory was set.
-     *
-     * @return void
      */
     public function testAnalyzeThrowsAnExceptionForNoSourceDirectory(): void
     {
@@ -141,8 +133,6 @@ class EngineTest extends AbstractTestCase
 
     /**
      * testAnalyzeReturnsEmptyIteratorWhenNoPackageExists
-     *
-     * @return void
      */
     public function testAnalyzeReturnsEmptyIteratorWhenNoPackageExists(): void
     {
@@ -156,8 +146,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Engine::analyze()} configures the
      * ignore annotations option correct.
-     *
-     * @return void
      */
     public function testAnalyzeSetsWithoutAnnotations(): void
     {
@@ -180,8 +168,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::countClasses()} method
      * returns the expected number of classes.
-     *
-     * @return void
      */
     public function testCountClasses(): void
     {
@@ -196,8 +182,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::countClasses()} method fails
      * with an exception if the code was not analyzed before.
-     *
-     * @return void
      */
     public function testCountClassesWithoutAnalyzeFail(): void
     {
@@ -216,8 +200,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::countNamespaces()} method
      * returns the expected number of namespaces.
-     *
-     * @return void
      */
     public function testCountNamespaces(): void
     {
@@ -231,8 +213,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::countNamespaces()} method
      * fails with an exception if the code was not analyzed before.
-     *
-     * @return void
      */
     public function testCountNamespacesWithoutAnalyzeFail(): void
     {
@@ -251,8 +231,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method
      * returns the expected {@link \PDepend\Source\AST\ASTNamespace} objects.
-     *
-     * @return void
      */
     public function testGetNamespace(): void
     {
@@ -263,7 +241,7 @@ class EngineTest extends AbstractTestCase
         $namespaces = [
             'package1',
             'package2',
-            'package3'
+            'package3',
         ];
 
         $className = '\\PDepend\\Source\\AST\\ASTNamespace';
@@ -276,8 +254,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method fails
      * with an exception if the code was not analyzed before.
-     *
-     * @return void
      */
     public function testGetNamespaceWithoutAnalyzeFail(): void
     {
@@ -296,8 +272,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::getNamespace()} method fails
      * with an exception if you request an invalid package.
-     *
-     * @return void
      */
     public function testGetNamespacesWithUnknownPackageFail(): void
     {
@@ -318,8 +292,6 @@ class EngineTest extends AbstractTestCase
      * Tests that the {@link \PDepend\Engine::getNamespaces()} method
      * returns the expected {@link \PDepend\Source\AST\ASTNamespace} objects
      * and reuses the result of {@link \PDepend\Engine::analyze()}.
-     *
-     * @return void
      */
     public function testGetNamespaces(): void
     {
@@ -337,8 +309,6 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Engine::getNamespaces()} method
      * fails with an exception if the code was not analyzed before.
-     *
-     * @return void
      */
     public function testGetNamespacesWithoutAnalyzeFail(): void
     {
@@ -357,7 +327,7 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests the newly added support for single file handling.
      *
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function testSupportForSingleFileIssue90()
     {
@@ -372,8 +342,6 @@ class EngineTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testSupportForSingleFileIssue90
      */
     public function testSupportForSingleFileIssue90ExpectedNumberOfClasses(ASTNamespace $namespace): void
@@ -382,8 +350,6 @@ class EngineTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testSupportForSingleFileIssue90
      */
     public function testSupportForSingleFileIssue90ExpectedNumberOfInterfaces(ASTNamespace $namespace): void
@@ -394,12 +360,10 @@ class EngineTest extends AbstractTestCase
     /**
      * Tests that the addFile() method throws the expected exception when an
      * added file does not exist.
-     *
-     * @return void
      */
     public function testAddFileMethodThrowsExpectedExceptionForFileThatNotExists(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $filePath = $this->createRunResourceURI('pdepend_');
         unlink($filePath);
 

--- a/src/test/php/PDepend/Input/CompositeFilterTest.php
+++ b/src/test/php/PDepend/Input/CompositeFilterTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the composite filter.
  *
+ * @covers \PDepend\Input\CompositeFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Input\CompositeFilter
  * @group unittest
  */
 class CompositeFilterTest extends AbstractTestCase
 {
     /**
      * testCompositeInvokesFirstAcceptInFilterChain
-     *
-     * @return void
      */
     public function testCompositeInvokesFirstAcceptInFilterChain(): void
     {
@@ -74,8 +73,6 @@ class CompositeFilterTest extends AbstractTestCase
 
     /**
      * testCompositeInvokesNextAcceptIfPreviousAcceptReturnsTrue
-     *
-     * @return void
      */
     public function testCompositeInvokesNextAcceptIfPreviousAcceptReturnsTrue(): void
     {
@@ -93,8 +90,6 @@ class CompositeFilterTest extends AbstractTestCase
 
     /**
      * testCompositeNotInvokesNextAcceptIfPreviousAcceptReturnsTrue
-     *
-     * @return void
      */
     public function testCompositeNotInvokesNextAcceptIfPreviousAcceptReturnsTrue(): void
     {

--- a/src/test/php/PDepend/Input/DummyFilter.php
+++ b/src/test/php/PDepend/Input/DummyFilter.php
@@ -53,21 +53,21 @@ class DummyFilter implements Filter
     /**
      * The return value for this filter.
      *
-     * @var boolean
+     * @var bool
      */
     public $returnValue = false;
 
     /**
      * Was this filter invoked?
      *
-     * @var boolean
+     * @var bool
      */
     public $invoked = false;
 
     /**
      * Constructs a new dummy filter
      *
-     * @param boolean $returnValue The pre defined return value for this filter.
+     * @param bool $returnValue The pre defined return value for this filter.
      */
     public function __construct($returnValue)
     {

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -43,22 +43,23 @@
 namespace PDepend\Input;
 
 use PDepend\AbstractTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Test case for the exclude path filter.
  *
+ * @covers \PDepend\Input\ExcludePathFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Input\ExcludePathFilter
  * @group unittest
  */
 class ExcludePathFilterTest extends AbstractTestCase
 {
     /**
      * testAbsoluteUnixPathAsFilterPatternMatches
-     *
-     * @return void
      */
     public function testAbsoluteUnixPathAsFilterPatternMatches(): void
     {
@@ -68,8 +69,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testAbsoluteUnixPathAsFilterPatternNotMatches
-     *
-     * @return void
      */
     public function testAbsoluteUnixPathAsFilterPatternNotMatches(): void
     {
@@ -77,9 +76,6 @@ class ExcludePathFilterTest extends AbstractTestCase
         $this->assertTrue($filter->accept('/foo/baz/bar', '/foo/baz/bar'));
     }
 
-    /**
-     * @return void
-     */
     public function testRelativePathMatchOrNot(): void
     {
         $filter = new ExcludePathFilter(['link-to/bar']);
@@ -92,8 +88,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testUnixPathAsFilterPatternNotMatchesPartial
-     *
-     * @return void
      */
     public function testUnixPathAsFilterPatternNotMatchesPartial(): void
     {
@@ -107,8 +101,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testAbsoluteWindowsPathAsFilterPatternMatches
-     *
-     * @return void
      */
     public function testAbsoluteWindowsPathAsFilterPatternMatches(): void
     {
@@ -118,8 +110,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testAbsoluteWindowsPathAsFilterPatternNotMatches
-     *
-     * @return void
      */
     public function testAbsoluteWindowsPathAsFilterPatternNotMatches(): void
     {
@@ -129,8 +119,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testWindowsPathAsFilterPatternNotMatchesPartial
-     *
-     * @return void
      */
     public function testWindowsPathAsFilterPatternNotMatchesPartial(): void
     {
@@ -144,8 +132,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testExcludePathFilterRejectsFile
-     *
-     * @return void
      */
     public function testExcludePathFilterRejectsFile(): void
     {
@@ -157,8 +143,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testExcludePathFilterRejectsFiles
-     *
-     * @return void
      */
     public function testExcludePathFilterRejectsFiles(): void
     {
@@ -170,8 +154,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testExcludePathFilterRejectsDirectory
-     *
-     * @return void
      */
     public function testExcludePathFilterRejectsDirectory(): void
     {
@@ -183,8 +165,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testExcludePathFilterRejectsDirectories
-     *
-     * @return void
      */
     public function testExcludePathFilterRejectsDirectories(): void
     {
@@ -196,8 +176,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testExcludePathFilterRejectsFilesAndDirectories
-     *
-     * @return void
      */
     public function testExcludePathFilterRejectsFilesAndDirectories(): void
     {
@@ -221,8 +199,8 @@ class ExcludePathFilterTest extends AbstractTestCase
     {
         $filter = new ExcludePathFilter($excludes);
 
-        $files = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
                 $this->createCodeResourceUriForTest()
             )
         );

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -43,22 +43,23 @@
 namespace PDepend\Input;
 
 use PDepend\AbstractTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 
 /**
  * Test case for the file extension filter.
  *
+ * @covers \PDepend\Input\ExtensionFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Input\ExtensionFilter
  * @group unittest
  */
 class ExtensionFilterTest extends AbstractTestCase
 {
     /**
      * testExtensionFilterAcceptsOneFileExtension
-     *
-     * @return void
      */
     public function testExtensionFilterAcceptsOneFileExtension(): void
     {
@@ -70,8 +71,6 @@ class ExtensionFilterTest extends AbstractTestCase
 
     /**
      * testExtensionFilterAcceptsMultipleFileExtensions
-     *
-     * @return void
      */
     public function testExtensionFilterAcceptsMultipleFileExtensions(): void
     {
@@ -81,9 +80,6 @@ class ExtensionFilterTest extends AbstractTestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @return void
-     */
     public function testExtensionFilterAcceptsPhpProtocol(): void
     {
         $filter = new ExtensionFilter(['abc']);
@@ -103,8 +99,8 @@ class ExtensionFilterTest extends AbstractTestCase
     {
         $filter = new ExtensionFilter($includes);
 
-        $files = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator(
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
                 $this->createCodeResourceUriForTest()
             )
         );

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -42,23 +42,27 @@
 
 namespace PDepend\Input;
 
+use ArrayIterator;
+use DirectoryIterator;
 use PDepend\AbstractTestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
 
 /**
  * Test case for the php file filter iterator.
  *
+ * @covers \PDepend\Input\Iterator
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Input\Iterator
  * @group unittest
  */
 class IteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorWithOneFileExtension
-     *
-     * @return void
      */
     public function testIteratorWithOneFileExtension(): void
     {
@@ -70,8 +74,6 @@ class IteratorTest extends AbstractTestCase
 
     /**
      * testIteratorWithMultipleFileExtensions
-     *
-     * @return void
      */
     public function testIteratorWithMultipleFileExtensions(): void
     {
@@ -83,16 +85,14 @@ class IteratorTest extends AbstractTestCase
 
     /**
      * Tests that iterator returns only files.
-     *
-     * @return void
      */
     public function testIteratorReturnsOnlyFiles(): void
     {
-        $directory=$this->createCodeResourceUriForTest();
+        $directory = $this->createCodeResourceUriForTest();
         $pattern = $directory . DIRECTORY_SEPARATOR . 'Ignored';
 
         $files  = new Iterator(
-            new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($directory)),
+            new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory)),
             new ExcludePathFilter([$pattern])
         );
 
@@ -103,14 +103,12 @@ class IteratorTest extends AbstractTestCase
         sort($actual);
 
         $expected = ['file.php', 'file_process.php'];
-        
+
         $this->assertEquals($expected, $actual);
     }
-    
+
     /**
      * testIteratorPassesLocalPathToFilterWhenRootIsPresent
-     *
-     * @return void
      */
     public function testIteratorPassesLocalPathToFilterWhenRootIsPresent(): void
     {
@@ -119,9 +117,9 @@ class IteratorTest extends AbstractTestCase
         $filter->expects($this->once())
             ->method('accept')
             ->with($this->equalTo(DIRECTORY_SEPARATOR . basename(__FILE__)));
-        
+
         $iterator = new Iterator(
-            new \ArrayIterator([new \SplFileInfo(__FILE__)]),
+            new ArrayIterator([new SplFileInfo(__FILE__)]),
             $filter,
             __DIR__
         );
@@ -130,12 +128,10 @@ class IteratorTest extends AbstractTestCase
 
     /**
      * testIteratorPassesAbsolutePathToFilterWhenNoRootIsPresent
-     *
-     * @return void
      */
     public function testIteratorPassesAbsolutePathToFilterWhenNoRootIsPresent(): void
     {
-        $files = new \ArrayIterator([new \SplFileInfo(__FILE__)]);
+        $files = new ArrayIterator([new SplFileInfo(__FILE__)]);
 
         $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
             ->getMock();
@@ -149,12 +145,10 @@ class IteratorTest extends AbstractTestCase
 
     /**
      * testIteratorPassesAbsolutePathToFilterWhenRootNotMatches
-     *
-     * @return void
      */
     public function testIteratorPassesAbsolutePathToFilterWhenRootNotMatches(): void
     {
-        $files = new \ArrayIterator([new \SplFileInfo(__FILE__)]);
+        $files = new ArrayIterator([new SplFileInfo(__FILE__)]);
 
         $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
             ->getMock();
@@ -176,7 +170,7 @@ class IteratorTest extends AbstractTestCase
     protected function createFilteredFileList(array $extensions)
     {
         $files  = new Iterator(
-            new \DirectoryIterator($this->createCodeResourceUriForTest()),
+            new DirectoryIterator($this->createCodeResourceUriForTest()),
             new ExtensionFilter($extensions)
         );
 

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -81,8 +81,6 @@ class BuilderParserCacheTest extends AbstractTestCase
 
     /**
      * Creates temporary test resources.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -96,8 +94,6 @@ class BuilderParserCacheTest extends AbstractTestCase
 
     /**
      * testUnchangedSourceFileGetsRestored
-     *
-     * @return void
      */
     public function testUnchangedSourceFileGetsRestored(): void
     {
@@ -112,8 +108,6 @@ class BuilderParserCacheTest extends AbstractTestCase
 
     /**
      * testChangedSourceFileGetsProcessed
-     *
-     * @return void
      */
     public function testChangedSourceFileGetsProcessed(): void
     {
@@ -130,6 +124,7 @@ class BuilderParserCacheTest extends AbstractTestCase
      * Parses the given test file and then returns the builder instance.
      *
      * @param string $file Relative path to a test file for the calling test.
+     *
      * @return \PDepend\Source\Builder\Builder
      */
     protected function parseSourceAndReturnBuilder($file)

--- a/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -55,11 +55,8 @@ use PDepend\AbstractTestCase;
  */
 class DependExcludePathFilterTest extends AbstractTestCase
 {
-
     /**
      * testPDependFiltersSingleFileWithPattern
-     *
-     * @return void
      */
     public function testPDependFiltersSingleFileWithPattern(): void
     {
@@ -69,7 +66,7 @@ class DependExcludePathFilterTest extends AbstractTestCase
         $pattern   = '*' . DIRECTORY_SEPARATOR . 'Integration' . DIRECTORY_SEPARATOR . '*';
 
         $pdepend = $this->createEngineFixture();
-        $pdepend->addFile($this->createCodeResourceUriForTest().'/Integration/FilteredClass.php');
+        $pdepend->addFile($this->createCodeResourceUriForTest() . '/Integration/FilteredClass.php');
         $pdepend->addFileFilter(
             new \PDepend\Input\ExcludePathFilter([$pattern])
         );
@@ -80,8 +77,6 @@ class DependExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testPDependFiltersByRelativePath
-     *
-     * @return void
      */
     public function testPDependFiltersByRelativePath(): void
     {
@@ -101,8 +96,6 @@ class DependExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testPDependFiltersByAbsolutePath
-     *
-     * @return void
      */
     public function testPDependFiltersByAbsolutePath(): void
     {
@@ -134,8 +127,6 @@ class DependExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testPDependNotFiltersByOverlappingPathMatch
-     *
-     * @return void
      */
     public function testPDependNotFiltersByOverlappingPathMatch(): void
     {

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Issues;
 
+use ErrorException;
 use PDepend\AbstractTestCase;
 
 /**
@@ -67,6 +68,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * Parses the source for the calling test case.
      *
      * @param string $testCase
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     protected function parseTestCase($testCase = null)
@@ -82,14 +84,15 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param boolean $ignoreAnnotations
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
         if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0) {
-            throw new \ErrorException('Unexpected class name format');
+            throw new ErrorException('Unexpected class name format');
         }
         return $this->parseSource('issues/' . $match[1] . '/' . $method . '.php');
     }
@@ -107,6 +110,6 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
                 return $frame['class'] . '::' . $frame['function'];
             }
         }
-        throw new \ErrorException('Cannot locate test case method.');
+        throw new ErrorException('Cannot locate test case method.');
     }
 }

--- a/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -49,18 +49,17 @@ use PDepend\Source\Tokenizer\Tokens;
 /**
  * Test case for issue #638, php 8.2 readonly allows double class modifiers.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that a class can have a readonly modifier
-     *
-     * @return void
      */
     public function testReadonlyClass(): void
     {
@@ -81,8 +80,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have an abstract modifier
-     *
-     * @return void
      */
     public function testAbstractClass(): void
     {
@@ -103,8 +100,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have a final modifier
-     *
-     * @return void
      */
     public function testFinalClass(): void
     {
@@ -125,8 +120,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have an abstract and readonly modifier
-     *
-     * @return void
      */
     public function testAbstractReadonlyClass(): void
     {
@@ -152,8 +145,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have a readonly and abstract modifier
-     *
-     * @return void
      */
     public function testReadonlyAbstractClass(): void
     {
@@ -179,8 +170,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have a final and readonly modifier
-     *
-     * @return void
      */
     public function testFinalReadonlyClass(): void
     {
@@ -206,8 +195,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have a readonly and final modifier
-     *
-     * @return void
      */
     public function testReadonlyFinalClass(): void
     {
@@ -233,8 +220,6 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 
     /**
      * Tests that a class can have a readonly and final modifier
-     *
-     * @return void
      */
     public function testAbstractFinalReadonlyClass(): void
     {

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -45,10 +45,11 @@ namespace PDepend\Issues;
 /**
  * Test case for issue #87. Handling of dependencies declared in inline comments.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatureTestCase
@@ -59,12 +60,11 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
      *
      * <code>
      * function foo() {
-     *     /* @var $bar Bar * /
+     *
+     *     /* @var Bar $bar * /
      *     $bar = bar();
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsDependencyDefinedInInlineCommentWithWhitespace(): void
     {
@@ -80,12 +80,11 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
      *
      * <code>
      * function foo() {
-     *     /*@var $bar Bar* /
+     *
+     *     /*@var Bar* $bar /
      *     $bar = bar();
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsDependencyDefinedInInlineCommentWithoutWhitespace(): void
     {
@@ -103,13 +102,11 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
      * <code>
      * function foo() {
      *     /*
-     *      * @var $bar Bar
+     *      * @var Bar $bar
      *      * /
      *     $bar = bar();
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserIgnoresDependencyDefinedInMultilineComment(): void
     {
@@ -126,12 +123,11 @@ class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatu
      *
      * <code>
      * function foo() {
-     *     // A comment line... /* @var $bar Bar * /
+     *
+     *     // A comment line... /* @var Bar $bar * /
      *     $bar = bar();
      * }
      * </code>
-     *
-     * @return void
      */
     public function testParserIgnoresDependencyDefinedWithinAnotherComment(): void
     {

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -42,17 +42,15 @@
 
 namespace PDepend\Issues;
 
-use PDepend\Source\AST\ASTFieldDeclaration;
-use PDepend\Source\AST\ASTType;
-
 /**
  * Test case for issue #84, where the object model should keep information about
  * primitive property and parameter types.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCase
@@ -63,7 +61,6 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
      * @param string $actual   The actual used type identifier.
      * @param string $expected The expected primitive type image.
      *
-     * @return void
      * @dataProvider dataProviderParserSetsExpectedPrimitivePropertyType
      */
     public function testParserSetsExpectedPrimitivePropertyType($actual, $expected): void
@@ -80,8 +77,6 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
 
     /**
      * Tests that the parser sets the expected array type information.
-     *
-     * @return void
      */
     public function testParserSetsExpectedArrayPropertyType(): void
     {
@@ -94,8 +89,6 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
 
     /**
      * Tests that the parser sets the expected array type information.
-     *
-     * @return void
      */
     public function testParserSetsExpectedArrayWithParenthesisPropertyType(): void
     {

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -45,18 +45,17 @@ namespace PDepend\Issues;
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser handles a simple use statement as expected.
-     *
-     * @return void
      */
     public function testParserHandlesSimpleUseDeclaration(): void
     {
@@ -69,8 +68,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser handles multiple, comma separated use declarations.
-     *
-     * @return void
      */
     public function testParserHandlesMultipleUseDeclarations(): void
     {
@@ -90,8 +87,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that parser handles a use declaration case insensitive.
-     *
-     * @return void
      */
     public function testParserHandlesUseDeclarationCaseInsensitive(): void
     {
@@ -108,8 +103,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that parser throws an expected exception.
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionWhenUseDeclarationContextEndsOnBackslash(): void
     {
@@ -126,8 +119,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser handles a namespace declaration with namespace
      * identifier and curly brace syntax.
-     *
-     * @return void
      */
     public function testParserHandlesNamespaceDeclarationWithIdentifierAndCurlyBraceSyntax(): void
     {
@@ -137,8 +128,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * testParserDoesNotAddEmptyNamespaceToResultSet
-     *
-     * @return void
      */
     public function testParserDoesNotAddEmptyNamespaceToResultSet(): void
     {
@@ -149,8 +138,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser handles a namespace declaration with namespace
      * identifier and semicolon syntax.
-     *
-     * @return void
      */
     public function testParserHandlesNamespaceDeclarationWithIdentifierAndSemicolonSyntax(): void
     {
@@ -161,8 +148,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser handles a namespace declaration without namespace
      * identifier and semicolon syntax.
-     *
-     * @return void
      */
     public function testParserHandlesNamespaceDeclarationWithoutIdentifierAndCurlyBraceSyntax(): void
     {
@@ -174,8 +159,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not accept an empty namespace identifier for
      * the semicolon syntax.
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForNamespaceDeclarationWithoutIdentifierAndSemicolonSyntax(): void
     {
@@ -192,8 +175,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not accept a leading backslash in a namespace
      * identifier.
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForLeadingBackslashInIdentifier(): void
     {
@@ -210,8 +191,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that an existing namespace declaration has a higher priority than
      * a simply package annotation.
-     *
-     * @return void
      */
     public function testNamespaceHasHigherPriorityThanPackageAnnotationSemicolonSyntax(): void
     {
@@ -227,8 +206,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Tests that an existing namespace declaration has a higher priority than
      * a simply package annotation.
-     *
-     * @return void
      */
     public function testNamespaceHasHigherPriorityThanPackageAnnotationCurlyBraceSyntax(): void
     {
@@ -243,8 +220,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser handles multiple namespaces in a single file correct.
-     *
-     * @return void
      */
     public function testParserHandlesFileWithMultipleNamespacesCorrectSemicolonSyntax(): void
     {
@@ -274,8 +249,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser handles multiple namespaces in a single file correct.
-     *
-     * @return void
      */
     public function testParserHandlesFileWithMultipleNamespacesCorrectCurlyBraceSyntax(): void
     {
@@ -305,8 +278,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser adds a function to a declared namespace.
-     *
-     * @return void
      */
     public function testParserAddsFunctionToDeclaredNamespaceSemicolonSyntax(): void
     {
@@ -325,7 +296,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInTypeSignature
      */
     public function testParserResolvesQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
@@ -347,7 +317,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInFunction
      */
     public function testParserResolvesQualifiedTypeNameInFunction($fileName, $namespaceName): void
@@ -374,7 +343,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInTypeSignature
      */
     public function testParserKeepsQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
@@ -396,7 +364,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInFunction
      */
     public function testParserKeepsQualifiedTypeNameInFunction($fileName, $namespaceName): void
@@ -418,7 +385,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax
      */
     public function testParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax($fileName, $namespaceName): void
@@ -440,7 +406,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax
      */
     public function testParserResolvesNamespaceKeywordInFunctionSemicolonSyntax($fileName, $namespaceName): void
@@ -462,7 +427,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax
      */
     public function testParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax($fileName, $namespaceName): void
@@ -484,7 +448,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $fileName      Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
      *
-     * @return void
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax
      */
     public function testParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax($fileName, $namespaceName): void

--- a/src/test/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/src/test/php/PDepend/Issues/NewClassInstanceTest.php
@@ -42,24 +42,22 @@
 
 namespace PDepend\Issues;
 
-use PDepend\Source\AST\ASTAllocationExpression;
 use PDepend\Source\AST\ASTStatement;
 
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class NewClassInstanceTest extends AbstractFeatureTestCase
 {
     /**
      * Tests that a new keyword can be followed by variable or parentheses expression.
-     *
-     * @return void
      */
     public function testNewKeyword(): void
     {

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -47,10 +47,11 @@ use PDepend\Input\ExtensionFilter;
 /**
  * Test case for the catch error ticket #61.
  *
+ * @covers \PDepend\Engine
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Engine
  * @group unittest
  */
 class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
@@ -58,8 +59,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * Tests that the {@link \PDepend\Engine::getExceptions()} returns a
      * list with the expected exceptions.
-     *
-     * @return void
      */
     public function testPHPDependReturnsExpectedExceptionInstances(): void
     {
@@ -80,7 +79,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      * Tests that the {@link \PDepend\TextUI\Runner::hasErrors()} method will
      * return <b>false</b> when not parsing error occurred.
      *
-     * @return void
      * @covers \PDepend\TextUI\Runner
      */
     public function testRunnerReturnsFalseWhenNoErrorOccurredDuringTheParsingProcess(): void
@@ -97,7 +95,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      * Tests that the {@link \PDepend\TextUI\Runner::hasErrors()} method will
      * return <b>true</b> when a parsing error occurred.
      *
-     * @return void
      * @covers \PDepend\TextUI\Runner
      */
     public function testRunnerReturnsTrueWhenAnErrorOccurredDuringTheParsingProcess(): void
@@ -115,7 +112,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      * Tests that the output does not contain the error hint when the parsing
      * process was successful.
      *
-     * @return void
      * @covers \PDepend\TextUI\Command
      */
     public function testCommandDoesNotPrintErrorOutputOnSuccessfulParsingProcess(): void
@@ -123,7 +119,7 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
         $this->prepareArgv(
             [
                 '--dummy-logger=' . $this->createRunResourceURI('pdepend.log'),
-                $this->createCodeResourceUriForTest()
+                $this->createCodeResourceUriForTest(),
             ]
         );
 
@@ -135,7 +131,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * testCommandPrintsExceptionMessageWhenAnErrorOccurredDuringTheParsingProcess
      *
-     * @return void
      * @covers \PDepend\TextUI\Command
      */
     public function testCommandPrintsExceptionMessageWhenAnErrorOccurredDuringTheParsingProcess(): void
@@ -144,7 +139,7 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
             [
                 '--dummy-logger=' . $this->createRunResourceURI('pdepend.log'),
                 '--configuration=' . __DIR__ . '/../../../resources/pdepend.xml.dist',
-                $this->createCodeResourceUriForTest()
+                $this->createCodeResourceUriForTest(),
             ]
         );
         [$exitCode, $output] = $this->runTextUICommand();
@@ -156,8 +151,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      * Sets a command line argument vector.
      *
      * @param array<string> $argv The temporary command line argument vector
-     *
-     * @return void
      */
     protected function prepareArgv($argv): void
     {

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -45,18 +45,17 @@ namespace PDepend\Issues;
 /**
  * Test case for parameter related ticker #32.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 {
     /**
      * testParserSetsExpectedNumberOfFunctionParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedNumberOfFunctionParameters(): void
     {
@@ -66,8 +65,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsExpectedPositionOfFunctionParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedPositionOfFunctionParameters(): void
     {
@@ -80,8 +77,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsFunctionParametersInExpectedOrder
-     *
-     * @return void
      */
     public function testParserSetsFunctionParametersInExpectedOrder(): void
     {
@@ -94,8 +89,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsExpectedTypeHintsForFunctionParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedTypeHintsForFunctionParameters(): void
     {
@@ -108,8 +101,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsExpectedNumberOfMethodParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedNumberOfMethodParameters(): void
     {
@@ -119,8 +110,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsExpectedPositionOfMethodParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedPositionOfMethodParameters(): void
     {
@@ -133,8 +122,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsMethodParametersInExpectedOrder
-     *
-     * @return void
      */
     public function testParserSetsMethodParametersInExpectedOrder(): void
     {
@@ -147,8 +134,6 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 
     /**
      * testParserSetsExpectedTypeHintsForMethodParameters
-     *
-     * @return void
      */
     public function testParserSetsExpectedTypeHintsForMethodParameters(): void
     {

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -47,19 +47,18 @@ use PDepend\Source\AST\ASTNode;
 /**
  * Test case for the Reflection API compatibility ticket #67.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTParameter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTParameter
  * @group unittest
  */
 class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parser sets the parameter flag by reference.
-     *
-     * @return void
      */
     public function testParserSetsFunctionParameterByReference(): void
     {
@@ -69,8 +68,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser sets the parameter flag by reference.
-     *
-     * @return void
      */
     public function testParserSetsMultipleFunctionParameterByReference(): void
     {
@@ -86,8 +83,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser sets the parameter flag by reference.
-     *
-     * @return void
      */
     public function testParserSetsFunctionParameterByReferenceWithTypeHint(): void
     {
@@ -99,8 +94,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser sets the parameter flag by reference.
-     *
-     * @return void
      */
     public function testParserSetsMultipleFunctionParameterByReferenceWithTypeHint(): void
     {
@@ -115,8 +108,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser sets the is array flag when the parameter contains
      * the array type hint.
-     *
-     * @return void
      */
     public function testParserSetsParameterArrayFlag(): void
     {
@@ -127,8 +118,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not set the array flag when the parameter is
      * scalar without type hint.
-     *
-     * @return void
      */
     public function testParserDoesNotSetParameterArrayFlagForScalar(): void
     {
@@ -139,8 +128,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not set the array flag when the parameter has
      * a class type hint.
-     *
-     * @return void
      */
     public function testParserDoesNotSetParameterArrayFlagForType(): void
     {
@@ -150,8 +137,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the boolean flag has default value is <b>false</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterWithoutDefaultValue(): void
     {
@@ -162,8 +147,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is <b>null</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueNull(): void
     {
@@ -173,8 +156,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForNullDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForNullDefaultValue(): void
     {
@@ -185,8 +166,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is <b>false</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueBooleanFalse(): void
     {
@@ -196,8 +175,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForFalseDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForFalseDefaultValue(): void
     {
@@ -208,8 +185,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is also <b>true</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueBooleanTrue(): void
     {
@@ -219,8 +194,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForTrueDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForTrueDefaultValue(): void
     {
@@ -231,8 +204,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is a <b>float</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueFloat(): void
     {
@@ -242,8 +213,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForFloatDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForFloatDefaultValue(): void
     {
@@ -254,8 +223,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is an <b>integer</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueInteger(): void
     {
@@ -265,8 +232,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForIntegerDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForIntegerDefaultValue(): void
     {
@@ -277,8 +242,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is a <b>string</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueString(): void
     {
@@ -288,8 +251,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForStringDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForStringDefaultValue(): void
     {
@@ -300,8 +261,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is an <b>array</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueArray(): void
     {
@@ -311,8 +270,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForArrayDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForArrayDefaultValue(): void
     {
@@ -323,8 +280,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is an <b>array</b>.
-     *
-     * @return void
      */
     public function testParserHandlesDefaultParameterValueNestedArray(): void
     {
@@ -334,8 +289,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForArrayDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForNestedArrayDefaultValue(): void
     {
@@ -346,8 +299,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is <b>null</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueConstant(): void
     {
@@ -357,8 +308,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForConstantDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForConstantDefaultValue(): void
     {
@@ -369,8 +318,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag has default value is <b>true</b> and the
      * default value is <b>null</b>.
-     *
-     * @return void
      */
     public function testParserHandlesParameterDefaultValueClassConstant(): void
     {
@@ -381,15 +328,13 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
         $node = $parameters[0]->getDefaultValue()->getChild(0);
         $image = implode(
             $node->getImage(),
-            array_map(static fn (ASTNode $node) => $node->getImage(), $node->getChildren()),
+            array_map(static fn(ASTNode $node) => $node->getImage(), $node->getChildren()),
         );
         $this->assertSame('\\PDepend\\Code::CONSTANT', $image);
     }
 
     /**
      * testIsDefaultValueAvailableReturnsTrueForClassConstantDefaultValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsTrueForClassConstantDefaultValue(): void
     {
@@ -400,8 +345,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parameter returns the expected result for a parameter
      * without default value.
-     *
-     * @return void
      */
     public function testParserHandlesParameterWithoutDefaultValueReturnsNull(): void
     {
@@ -411,8 +354,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsFalseWhenNoDefaultValueExists
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsFalseWhenNoDefaultValueExists(): void
     {
@@ -423,8 +364,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag for optional parameters is set to <b>false</b>
      * for all parameters.
-     *
-     * @return void
      */
     public function testParserHandlesParameterOptionalIsFalseForAllParameters(): void
     {
@@ -439,8 +378,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag for optional parameters is set to <b>false</b>
      * for all parameters.
-     *
-     * @return void
      */
     public function testParserHandlesParameterOptionalIsFalseForAllParametersEvenADefaultValueExists(): void
     {
@@ -455,8 +392,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag for optional parameters is set to <b>false</b>
      * for the first two parameters.
-     *
-     * @return void
      */
     public function testParserHandlesParameterOptionalIsFalseForFirstTwoParameters(): void
     {
@@ -471,8 +406,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the boolean flag for optional parameters is set to <b>true</b>
      * for all parameters.
-     *
-     * @return void
      */
     public function testParserHandlesParameterOptionalIsTrueForAllParameters(): void
     {
@@ -486,8 +419,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser sets the user-defined flag for an analyzed class.
-     *
-     * @return void
      */
     public function testParserSetsUserDefinedFlagForClass(): void
     {
@@ -498,8 +429,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not set the user-defined flag for an unknown
      * class.
-     *
-     * @return void
      */
     public function testParserNotSetsUserDefinedFlagForUnknownClass(): void
     {
@@ -511,8 +440,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser sets the user-defined flag for an analyzed interface.
-     *
-     * @return void
      */
     public function testParserSetsUserDefinedFlagForInterface(): void
     {
@@ -522,8 +449,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not sets the user-defined flag for an unknown
      * interface.
-     *
-     * @return void
      */
     public function testParserNotSetsUserDefinedFlagForUnknownInterface(): void
     {
@@ -534,8 +459,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser flag a function with returns reference when its
      * declaraction contains an amphersand.
-     *
-     * @return void
      */
     public function testParserFlagsFunctionWithReturnsReference(): void
     {
@@ -545,8 +468,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not set the returns reference flag when the
      * function declaration does not contain an amphersand.
-     *
-     * @return void
      */
     public function testParserDoesNotFlagFunctionWithReturnsReference(): void
     {
@@ -556,8 +477,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser sets the returns reference flag when a method
      * declaration contains an amphersand.
-     *
-     * @return void
      */
     public function testParserFlagsClassMethodWithReturnsReferences(): void
     {
@@ -568,8 +487,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser does not set the returns reference flag when a
      * method declaration does not contain an amphersand.
-     *
-     * @return void
      */
     public function testParserDoesNotFlagClassMethodWithReturnsReferences(): void
     {
@@ -580,8 +497,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the <b>getStaticVariables()</b> method returns the expected
      * result.
-     *
-     * @return void
      */
     public function testParserSetsFunctionStaticVariableSingleUninitialized(): void
     {
@@ -594,8 +509,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the <b>getStaticVariables()</b> method returns the expected
      * result.
-     *
-     * @return void
      */
     public function testParserSetsFunctionStaticVariableSingleInitialized(): void
     {
@@ -608,8 +521,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the <b>getStaticVariables()</b> method returns the expected
      * result.
-     *
-     * @return void
      */
     public function testParserSetsFunctionStaticVariablesInSingleDeclaration(): void
     {
@@ -622,8 +533,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the <b>getStaticVariables()</b> method returns the expected
      * result.
-     *
-     * @return void
      */
     public function testParserSetsFunctionStaticVariablesInMultipleDeclarations(): void
     {
@@ -635,8 +544,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser handles a static invoke as expected.
-     *
-     * @return void
      */
     public function testParserStaticVariablesDoNotConflictWithStaticInvoke(): void
     {
@@ -648,8 +555,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser handles a static object allocation as expected.
-     *
-     * @return void
      */
     public function testParserStaticVariablesDoNotConflictWithStaticAllocation(): void
     {
@@ -663,7 +568,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
      * Tests that the parser throws the expected exception when no default value
      * was defined.
      *
-     * @return void
      * @covers \PDepend\Source\Parser\MissingValueException
      */
     public function testParserThrowsExpectedExceptionForMissingDefaultValue(): void
@@ -677,7 +581,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
      * Tests that the parser throws the expected exception when it reaches the
      * end of file while it parses a parameter default value.
      *
-     * @return void
      * @covers \PDepend\Source\Parser\TokenStreamEndException
      */
     public function testParserThrowsExpectedExceptionWhenReachesEofWhileParsingDefaultValue(): void

--- a/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
+++ b/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
@@ -51,10 +51,11 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * http://tracker.pdepend.org/pdepend/issue_tracker/issue/79
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
@@ -62,7 +63,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parameter contains the start line of the first token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTParameter
      */
     public function testParameterContainsStartLineOfFirstToken(): void
@@ -79,7 +79,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parameter contains the end line of the last token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTParameter
      */
     public function testParameterContainsEndLineOfLastToken(): void
@@ -96,7 +95,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected function tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testParserStoresExpectedFunctionTokens(): void
@@ -124,7 +122,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected function tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testParserStoresExpectedFunctionTokensWithParameters(): void
@@ -161,7 +158,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the function uses the start line of the first token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testFunctionContainsStartLineOfFirstToken(): void
@@ -180,7 +176,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the function uses the end line of the last token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testFunctionContainsEndLineOfLastToken(): void
@@ -199,7 +194,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected method tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokens(): void
@@ -230,7 +224,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected method tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokensWithStaticModifier(): void
@@ -262,7 +255,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected method tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokensWithStaticAndFinalModifiers(): void
@@ -295,7 +287,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the method uses the start line of the first token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testMethodContainsStartLineOfFirstToken(): void
@@ -316,7 +307,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the method uses the end line of the last token.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testMethodContainsEndLineOfLastToken(): void
@@ -337,7 +327,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected class tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokens(): void
@@ -367,7 +356,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected class tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokensWithFinalModifier(): void
@@ -398,7 +386,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected class tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokensWithAbstractModifier(): void
@@ -429,7 +416,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser stores the expected interface tokens.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTInterface
      */
     public function testParserStoresExpectedInterfaceTokens(): void

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Metrics;
 
+use Exception;
 use PDepend\AbstractTestCase;
 
 /**
@@ -56,8 +57,9 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string  $testCase
-     * @param boolean $ignoreAnnotations
+     * @param string $testCase
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -76,9 +78,9 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
                 ),
                 $ignoreAnnotations
             );
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
         }
-        
+
         return parent::parseSource(
             sprintf(
                 'Metrics/%s/%s/%s',

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -47,10 +47,11 @@ use PDepend\Metrics\AbstractMetricsTestCase;
 /**
  * Tests the for the package metrics visitor.
  *
+ * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
  * @group unittest
  */
 class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
@@ -71,7 +72,7 @@ class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
         'AbstractBase' => [
             'efferent' => [],
             'afferent' => [
-                'BaseClass'
+                'BaseClass',
             ],
         ],
         'SomeInterface' => [
@@ -106,8 +107,6 @@ class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the generated package metrics.
-     *
-     * @return void
      */
     public function testGenerateMetrics(): void
     {
@@ -120,11 +119,11 @@ class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getTypes() as $type) {
                 $actual[$type->getName()]['efferent'] = array_map(
-                    static fn ($type) => $type->getName(),
+                    static fn($type) => $type->getName(),
                     $visitor->getEfferents($type)
                 );
                 $actual[$type->getName()]['afferent'] = array_map(
-                    static fn ($type) => $type->getName(),
+                    static fn($type) => $type->getName(),
                     $visitor->getAfferents($type)
                 );
             }

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -42,18 +42,21 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use InvalidArgumentException;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use RuntimeException;
 
 /**
  * Test case for the class level analyzer.
  *
+ * @covers \PDepend\Metrics\Analyzer\ClassLevelAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\ClassLevelAnalyzer
  * @group unittest
  */
 class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
@@ -61,12 +64,10 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the {@link \PDepend\Metrics\Analyzer\ClassLevelAnalyzer::analyzer()}
      * method fails with an exception if no cc analyzer was set.
-     *
-     * @return void
      */
     public function testAnalyzerFailsWithoutCCAnalyzerFail(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $namespace = new ASTNamespace('package1');
         $namespaces = new ASTArtifactList([$namespace]);
@@ -78,12 +79,10 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that {@link \PDepend\Metrics\Analyzer\ClassLevelAnalyzer::addAnalyzer()}
      * fails for an invalid child analyzer.
-     *
-     * @return void
      */
     public function testAddAnalyzerFailsForAnInvalidAnalyzerTypeFail(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $analyzer = new ClassLevelAnalyzer();
         $analyzer->addAnalyzer(new CodeRankAnalyzer());
@@ -91,8 +90,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetRequiredAnalyzersReturnsExpectedClassNames
-     *
-     * @return void
      */
     public function testGetRequiredAnalyzersReturnsExpectedClassNames(): void
     {
@@ -105,8 +102,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsArrayWithExpectedSetOfMetrics
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsArrayWithExpectedSetOfMetrics(): void
     {
@@ -118,8 +113,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct IMPL values.
-     *
-     * @return void
      */
     public function testCalculateIMPLMetric(): void
     {
@@ -128,8 +121,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct IMPL values.
-     *
-     * @return void
      */
     public function testCalculateIMPLMetric1(): void
     {
@@ -138,8 +129,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct IMPL values.
-     *
-     * @return void
      */
     public function testCalculateIMPLMetric2(): void
     {
@@ -148,8 +137,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateIMPLMetricContainsUnknownImplementedInterface
-     *
-     * @return void
      */
     public function testCalculateIMPLMetricContainsUnknownImplementedInterface(): void
     {
@@ -158,8 +145,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateIMPLMetricContainsUnknownIndirectImplementedInterface
-     *
-     * @return void
      */
     public function testCalculateIMPLMetricContainsUnknownIndirectImplementedInterface(): void
     {
@@ -168,8 +153,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateIMPLMetricContainsInternalImplementedInterface
-     *
-     * @return void
      */
     public function testCalculateIMPLMetricContainsInternalImplementedInterface(): void
     {
@@ -178,8 +161,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the calculated Class Interface Size(CSI) is correct.
-     *
-     * @return void
      */
     public function testCalculateCISMetricZeroInheritance(): void
     {
@@ -188,8 +169,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the calculated Class Interface Size(CSI) is correct.
-     *
-     * @return void
      */
     public function testCalculateCISMetricOneLevelInheritance(): void
     {
@@ -198,8 +177,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the calculated Class Interface Size(CSI) is correct.
-     *
-     * @return void
      */
     public function testCalculateCISMetricTwoLevelInheritance(): void
     {
@@ -208,8 +185,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateCISMetricOnlyCountsMethodsAndNotSumsComplexity
-     *
-     * @return void
      */
     public function testCalculateCISMetricOnlyCountsMethodsAndNotSumsComplexity(): void
     {
@@ -218,8 +193,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the calculated Class SiZe(CSZ) metric is correct.
-     *
-     * @return void
      */
     public function testCalculateCSZMetricZeroInheritance(): void
     {
@@ -228,8 +201,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the calculated Class SiZe(CSZ) metric is correct.
-     *
-     * @return void
      */
     public function testCalculateCSZMetricOneLevelInheritance(): void
     {
@@ -238,8 +209,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateCSZMetricOnlyCountsMethodsAndNotSumsComplexity
-     *
-     * @return void
      */
     public function testCalculateCSZMetricOnlyCountsMethodsAndNotSumsComplexity(): void
     {
@@ -248,8 +217,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForEmptyClass
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForEmptyClass(): void
     {
@@ -258,8 +225,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithPublicMethod
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithPublicMethod(): void
     {
@@ -268,8 +233,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithPublicMethods
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithPublicMethods(): void
     {
@@ -278,8 +241,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithPublicStaticMethod
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithPublicStaticMethod(): void
     {
@@ -288,8 +249,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithProtectedMethod
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithProtectedMethod(): void
     {
@@ -298,8 +257,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithPrivateMethod
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithPrivateMethod(): void
     {
@@ -308,8 +265,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateNpmMetricForClassWithAllVisibilityMethods
-     *
-     * @return void
      */
     public function testCalculateNpmMetricForClassWithAllVisibilityMethods(): void
     {
@@ -318,8 +273,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARS metric
-     *
-     * @return void
      */
     public function testCalculateVARSMetricZeroInheritance(): void
     {
@@ -328,8 +281,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARS metric
-     *
-     * @return void
      */
     public function testCalculateVARSMetricOneLevelInheritance(): void
     {
@@ -338,8 +289,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARSi metric
-     *
-     * @return void
      */
     public function testCalculateVARSiMetric(): void
     {
@@ -348,8 +297,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARSi metric
-     *
-     * @return void
      */
     public function testCalculateVARSiMetricWithInheritance(): void
     {
@@ -358,8 +305,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARSnp metric
-     *
-     * @return void
      */
     public function testCalculateVARSnpMetric(): void
     {
@@ -368,8 +313,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct VARSnp metric
-     *
-     * @return void
      */
     public function testCalculateVARSnpMetricWithInheritance(): void
     {
@@ -378,8 +321,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMC metric.
-     *
-     * @return void
      */
     public function testCalculateWMCMetric(): void
     {
@@ -388,8 +329,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMC metric.
-     *
-     * @return void
      */
     public function testCalculateWMCMetricOneLevelInheritance(): void
     {
@@ -398,8 +337,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMC metric.
-     *
-     * @return void
      */
     public function testCalculateWMCMetricTwoLevelInheritance(): void
     {
@@ -408,8 +345,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCi metric.
-     *
-     * @return void
      */
     public function testCalculateWMCiMetric(): void
     {
@@ -418,8 +353,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCi metric.
-     *
-     * @return void
      */
     public function testCalculateWMCiMetricOneLevelInheritance(): void
     {
@@ -428,8 +361,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCi metric.
-     *
-     * @return void
      */
     public function testCalculateWMCiMetricTwoLevelInheritance(): void
     {
@@ -438,8 +369,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCnp metric.
-     *
-     * @return void
      */
     public function testCalculateWMCnpMetric(): void
     {
@@ -448,8 +377,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCnp metric.
-     *
-     * @return void
      */
     public function testCalculateWMCnpMetricOneLevelInheritance(): void
     {
@@ -458,8 +385,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct WMCnp metric.
-     *
-     * @return void
      */
     public function testCalculateWMCnpMetricTwoLevelInheritance(): void
     {
@@ -502,6 +427,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTrait
      *
      * @return array
+     *
      * @since 1.0.6
      */
     public function testGetNodeMetricsForTrait()
@@ -518,8 +444,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testGetNodeMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
@@ -535,8 +461,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateIMPLMetricForTrait(array $metrics): void
@@ -549,8 +475,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateCISMetricForTrait(array $metrics): void
@@ -563,8 +489,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateCSZMetricForTrait(array $metrics): void
@@ -577,8 +503,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateNpmMetricForTrait(array $metrics): void
@@ -591,8 +517,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateVARSMetricForTrait(array $metrics): void
@@ -605,8 +531,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateVARSiMetricForTrait(array $metrics): void
@@ -619,8 +545,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateVARSnpMetricForTrait(array $metrics): void
@@ -633,8 +559,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateWMCMetricForTrait(array $metrics): void
@@ -647,8 +573,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateWMCiMetricForTrait(array $metrics): void
@@ -661,8 +587,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated class metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateWMCnpMetricForTrait(array $metrics): void
@@ -675,6 +601,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * returns all measured metrics.
      *
      * @return array<string, mixed>
+     *
      * @since 1.0.6
      */
     private function calculateTraitMetrics()

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -43,28 +43,26 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
-use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
 
 /**
  * Test case for the method strategy.
  *
+ * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
  * @group unittest
  */
 class MethodStrategyTest extends AbstractTestCase
 {
     /**
      * testStrategyCountsCorrectTypes
-     *
-     * @return void
      */
     public function testStrategyCountsCorrectTypes(): void
     {
         $namespaces = $this->parseCodeResourceForTest();
-        
+
         $idMap = [
             'PDepend::CodeRankA'       =>  null,
             'PDepend::CodeRankB'       =>  null,
@@ -72,7 +70,7 @@ class MethodStrategyTest extends AbstractTestCase
             'PDepend_CodeRank_ClassB'  =>  null,
             'PDepend_CodeRank_ClassC'  =>  null,
         ];
-        
+
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getClasses() as $class) {
                 $this->assertArrayHasKey($class->getName(), $idMap);
@@ -87,48 +85,48 @@ class MethodStrategyTest extends AbstractTestCase
             $idMap['PDepend_CodeRank_ClassA']  =>  [
                 'in'  =>  [
                     $idMap['PDepend_CodeRank_ClassB'],
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'out'  =>  [
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassA',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend_CodeRank_ClassB']  =>  [
                 'in'  =>  [
                     $idMap['PDepend_CodeRank_ClassC'],
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'out'  =>  [
-                    $idMap['PDepend_CodeRank_ClassA']
+                    $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassB',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend_CodeRank_ClassC']  =>  [
                 'in'  =>  [
-                    $idMap['PDepend_CodeRank_ClassA']
+                    $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'out'  =>  [
                     $idMap['PDepend_CodeRank_ClassA'],
                     $idMap['PDepend_CodeRank_ClassB'],
-                    $idMap['PDepend_CodeRank_ClassB']
+                    $idMap['PDepend_CodeRank_ClassB'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassC',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend::CodeRankA']  =>  [
                 'in'  =>  [
                     $idMap['PDepend::CodeRankB'],
                     $idMap['PDepend::CodeRankB'],
-                    $idMap['PDepend::CodeRankB']
+                    $idMap['PDepend::CodeRankB'],
                 ],
                 'out'  =>  [
                     $idMap['PDepend::CodeRankB'],
                 ],
                 'name'  =>  'PDepend::CodeRankA',
-                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace'
+                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace',
             ],
             $idMap['PDepend::CodeRankB']  =>  [
                 'in'  =>  [
@@ -137,20 +135,20 @@ class MethodStrategyTest extends AbstractTestCase
                 'out'  =>  [
                     $idMap['PDepend::CodeRankA'],
                     $idMap['PDepend::CodeRankA'],
-                    $idMap['PDepend::CodeRankA']
+                    $idMap['PDepend::CodeRankA'],
                 ],
                 'name'  =>  'PDepend::CodeRankB',
-                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace'
+                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace',
             ],
         ];
-    
+
         $strategy = new MethodStrategy();
         foreach ($namespaces as $namespace) {
             $namespace->accept($strategy);
         }
 
         $actual = $strategy->getCollectedNodes();
-        
+
         $this->assertEquals($expected, $actual);
     }
 }

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -43,28 +43,26 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
-use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
 
 /**
  * Test case for the code rank property strategy.
  *
+ * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
-   * @group unittest
+ * @group unittest
  */
 class PropertyStrategyTest extends AbstractTestCase
 {
     /**
      * testStrategyCountsCorrectTypes
-     *
-     * @return void
      */
     public function testStrategyCountsCorrectTypes(): void
     {
         $namespaces = $this->parseCodeResourceForTest();
-        
+
         $idMap = [
             'PDepend::CodeRankA'       =>  null,
             'PDepend::CodeRankB'       =>  null,
@@ -72,7 +70,7 @@ class PropertyStrategyTest extends AbstractTestCase
             'PDepend_CodeRank_ClassB'  =>  null,
             'PDepend_CodeRank_ClassC'  =>  null,
         ];
-        
+
         foreach ($namespaces as $namespace) {
             foreach ($namespace->getClasses() as $class) {
                 $this->assertArrayHasKey($class->getName(), $idMap);
@@ -87,48 +85,48 @@ class PropertyStrategyTest extends AbstractTestCase
             $idMap['PDepend_CodeRank_ClassA']  =>  [
                 'in'  =>  [
                     $idMap['PDepend_CodeRank_ClassB'],
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'out'  =>  [
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassA',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend_CodeRank_ClassB']  =>  [
                 'in'  =>  [
                     $idMap['PDepend_CodeRank_ClassC'],
-                    $idMap['PDepend_CodeRank_ClassC']
+                    $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'out'  =>  [
-                    $idMap['PDepend_CodeRank_ClassA']
+                    $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassB',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend_CodeRank_ClassC']  =>  [
                 'in'  =>  [
-                    $idMap['PDepend_CodeRank_ClassA']
+                    $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'out'  =>  [
                     $idMap['PDepend_CodeRank_ClassA'],
                     $idMap['PDepend_CodeRank_ClassB'],
-                    $idMap['PDepend_CodeRank_ClassB']
+                    $idMap['PDepend_CodeRank_ClassB'],
                 ],
                 'name'  =>  'PDepend_CodeRank_ClassC',
-                'type'  =>  'PDepend\\Source\\AST\\ASTClass'
+                'type'  =>  'PDepend\\Source\\AST\\ASTClass',
             ],
             $idMap['PDepend::CodeRankA']  =>  [
                 'in'  =>  [
                     $idMap['PDepend::CodeRankB'],
                     $idMap['PDepend::CodeRankB'],
-                    $idMap['PDepend::CodeRankB']
+                    $idMap['PDepend::CodeRankB'],
                 ],
                 'out'  =>  [
                     $idMap['PDepend::CodeRankB'],
                 ],
                 'name'  =>  'PDepend::CodeRankA',
-                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace'
+                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace',
             ],
             $idMap['PDepend::CodeRankB']  =>  [
                 'in'  =>  [
@@ -137,20 +135,20 @@ class PropertyStrategyTest extends AbstractTestCase
                 'out'  =>  [
                     $idMap['PDepend::CodeRankA'],
                     $idMap['PDepend::CodeRankA'],
-                    $idMap['PDepend::CodeRankA']
+                    $idMap['PDepend::CodeRankA'],
                 ],
                 'name'  =>  'PDepend::CodeRankB',
-                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace'
+                'type'  =>  'PDepend\\Source\\AST\\ASTNamespace',
             ],
         ];
-    
+
         $strategy = new PropertyStrategy();
         foreach ($namespaces as $namespace) {
             $namespace->accept($strategy);
         }
 
         $actual = $strategy->getCollectedNodes();
-        
+
         $this->assertEquals($expected, $actual);
     }
 }

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
@@ -43,15 +43,15 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
-use PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory;
 
 /**
  * Test case for the code rank property strategy.
  *
+ * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory
  * @group unittest
  */
 class StrategyFactoryTest extends AbstractTestCase
@@ -59,8 +59,6 @@ class StrategyFactoryTest extends AbstractTestCase
     /**
      * Tests that the factory throws the expected exception for an invalid
      * strategy identifier.
-     *
-     * @return void
      */
     public function testFactoryMethodThrowsExceptionForInvalidStrategyIdentifier(): void
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -48,10 +48,11 @@ use PDepend\Source\AST\ASTClass;
 /**
  * Test case for the code metric analyzer class.
  *
+ * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer
  * @group unittest
  */
 class CodeRankAnalyzerTest extends AbstractMetricsTestCase
@@ -82,14 +83,13 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * The code rank analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\CodeRankAnalyzer
+     * @var CodeRankAnalyzer
      */
     private $analyzer = null;
 
     /**
      * testCodeRankOfSimpleInheritanceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testCodeRankOfSimpleInheritanceExample(): void
@@ -107,7 +107,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfSimpleInheritanceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testReverseCodeRankOfSimpleInheritanceExample(): void
@@ -125,7 +124,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfNamespacedSameNameInheritanceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testCodeRankOfNamespacedSameNameInheritanceExample(): void
@@ -137,7 +135,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfNamespacedSameNamePropertyExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testCodeRankOfNamespacedSameNamePropertyExample(): void
@@ -151,7 +148,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfNamespacedSameNamePropertyExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNamePropertyExample(): void
@@ -165,7 +161,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfNamespacedSameNameMethodParamExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodParamExample(): void
@@ -179,7 +174,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodParamExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodParamExample(): void
@@ -193,7 +187,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfNamespacedSameNameMethodReturnExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodReturnExample(): void
@@ -207,7 +200,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodReturnExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodReturnExample(): void
@@ -221,7 +213,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfNamespacedSameNameMethodExceptionExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodExceptionExample(): void
@@ -235,7 +226,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodExceptionExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodExceptionExample(): void
@@ -249,7 +239,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfNamespacedSameNameInheritanceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameInheritanceExample(): void
@@ -261,7 +250,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfOrderExampleWithInheritanceAndMethodStrategy
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
@@ -284,7 +272,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfOrderExampleWithInheritanceAndMethodStrategy
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
@@ -307,7 +294,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
@@ -330,7 +316,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
@@ -353,7 +338,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testCodeRankOfInternalInterfaceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
@@ -376,7 +360,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testReverseCodeRankOfInternalInterfaceExample
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
@@ -399,7 +382,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
      * Tests the result of the class rank calculation against previous computed
      * values.
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
@@ -437,7 +419,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
      * Tests that {@link \PDepend\Metrics\Analyzer\CodeRankAnalyzer::getNodeMetrics()}
      * returns an empty <b>array</b> for an unknown identifier.
      *
-     * @return void
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -43,23 +43,21 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
-use PDepend\Metrics\Analyzer\CouplingAnalyzer;
 
 /**
  * Test case for the coupling analyzer.
  *
+ * @covers \PDepend\Metrics\Analyzer\CouplingAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CouplingAnalyzer
  * @group unittest
  */
 class CouplingAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testGetNodeMetricsReturnsAnEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsAnEmptyArrayByDefault(): void
     {
@@ -75,8 +73,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsArrayWithExpectedSetOfMetrics
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsArrayWithExpectedSetOfMetrics(): void
     {
@@ -95,8 +91,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithoutDependencies
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithoutDependencies(): void
     {
@@ -105,8 +99,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithObjectInstantiation
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithObjectInstantiation(): void
     {
@@ -115,8 +107,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithStaticReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithStaticReference(): void
     {
@@ -125,8 +115,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithReturnReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithReturnReference(): void
     {
@@ -135,8 +123,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithExceptionReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithExceptionReference(): void
     {
@@ -145,8 +131,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithPropertyReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithPropertyReference(): void
     {
@@ -155,8 +139,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaWithoutDuplicateCount
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaWithoutDuplicateCount(): void
     {
@@ -165,8 +147,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForParameterTypes
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForParameterTypes(): void
     {
@@ -175,8 +155,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForParentTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForParentTypeReference(): void
     {
@@ -185,8 +163,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForChildTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForChildTypeReference(): void
     {
@@ -195,8 +171,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctionReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionReference(): void
     {
@@ -205,8 +179,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctionException
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionException(): void
     {
@@ -215,8 +187,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctionReturnType
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionReturnType(): void
     {
@@ -225,8 +195,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctionParameter
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionParameter(): void
     {
@@ -235,8 +203,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctions
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctions(): void
     {
@@ -245,8 +211,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCaForFunctionCountsTypeOnce
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCaForFunctionCountsTypeOnce(): void
     {
@@ -255,8 +219,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithoutDependencies
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithoutDependencies(): void
     {
@@ -265,8 +227,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithObjectInstantiation
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithObjectInstantiation(): void
     {
@@ -275,8 +235,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithStaticReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithStaticReference(): void
     {
@@ -285,8 +243,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithReturnReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithReturnReference(): void
     {
@@ -295,8 +251,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithExceptionReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithExceptionReference(): void
     {
@@ -305,8 +259,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithPropertyReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithPropertyReference(): void
     {
@@ -315,8 +267,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboWithoutDuplicateCount
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboWithoutDuplicateCount(): void
     {
@@ -325,8 +275,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboForParameterTypes
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboForParameterTypes(): void
     {
@@ -335,8 +283,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboForParentTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboForParentTypeReference(): void
     {
@@ -345,8 +291,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboForChildTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboForChildTypeReference(): void
     {
@@ -355,8 +299,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboForUseInSameNamespace
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboForUseInSameNamespace(): void
     {
@@ -365,8 +307,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCboForUseInPartialSameNamespace
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCboForUseInPartialSameNamespace(): void
     {
@@ -375,8 +315,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithoutDependencies
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithoutDependencies(): void
     {
@@ -385,8 +323,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithObjectInstantiation
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithObjectInstantiation(): void
     {
@@ -395,8 +331,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithStaticReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithStaticReference(): void
     {
@@ -405,8 +339,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithReturnReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithReturnReference(): void
     {
@@ -415,8 +347,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithExceptionReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithExceptionReference(): void
     {
@@ -425,8 +355,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithPropertyReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithPropertyReference(): void
     {
@@ -435,8 +363,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeWithoutDuplicateCount
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeWithoutDuplicateCount(): void
     {
@@ -445,8 +371,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeForParameterTypes
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeForParameterTypes(): void
     {
@@ -455,8 +379,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeForParentTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeForParentTypeReference(): void
     {
@@ -465,8 +387,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeForChildTypeReference
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeForChildTypeReference(): void
     {
@@ -475,8 +395,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeForUseInSameNamespace
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeForUseInSameNamespace(): void
     {
@@ -485,8 +403,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsExpectedCeForUseInPartialSameNamespace
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsExpectedCeForUseInPartialSameNamespace(): void
     {
@@ -513,8 +429,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerGetProjectMetricsReturnsArrayWithExpectedKeys
-     *
-     * @return void
      */
     public function testAnalyzerGetProjectMetricsReturnsArrayWithExpectedKeys(): void
     {
@@ -527,8 +441,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates correct fanout and call metrics for
      * functions.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectFunctionCoupling(): void
     {
@@ -541,8 +453,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates correct fanout and call metrics for
      * methods.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectMethodCoupling(): void
     {
@@ -555,8 +465,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates correct fanout and call metrics for
      * properties.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectPropertyCoupling(): void
     {
@@ -569,8 +477,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates correct fanout and call metrics for
      * properties.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectClassCoupling(): void
     {
@@ -583,8 +489,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates correct fanout and call metrics for
      * complete source.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectCoupling(): void
     {
@@ -598,6 +502,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTrait
      *
      * @return array
+     *
      * @since 1.0.6
      */
     public function testGetNodeMetricsForTrait()
@@ -613,8 +518,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testGetNodeMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
@@ -627,8 +532,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateCEMetricForTrait(array $metrics): void
@@ -641,8 +546,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateCBOMetricForTrait(array $metrics): void
@@ -655,8 +560,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetNodeMetricsForTrait
      */
     public function testCalculateCAMetricForTrait(array $metrics): void
@@ -668,6 +573,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetProjectMetricsForTrait
      *
      * @return array
+     *
      * @since 1.0.6
      */
     public function testGetProjectMetricsForTrait()
@@ -686,8 +592,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetProjectMetricsForTrait
      */
     public function testGetProjectMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
@@ -700,8 +606,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetProjectMetricsForTrait
      */
     public function testCalculateCallsMetricForTrait(array $metrics): void
@@ -714,8 +620,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array $metrics Calculated coupling metrics.
      *
-     * @return void
      * @since 1.0.6
+     *
      * @depends testGetProjectMetricsForTrait
      */
     public function testCalculateFanoutMetricForTrait(array $metrics): void
@@ -728,6 +634,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * returns all measured metrics.
      *
      * @return array<string, mixed>
+     *
      * @since 1.0.6
      */
     private function calculateTraitMetrics()
@@ -743,9 +650,9 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the expected call count.
      *
-     * @param string  $testCase File with test source.
-     * @param integer $calls    Number of expected calls.
-     * @param integer $fanout   Expected fanout value.
+     * @param string $testCase File with test source.
+     * @param int    $calls    Number of expected calls.
+     * @param int    $fanout   Expected fanout value.
      *
      * @dataProvider dataProviderAnalyzerCalculatesExpectedCallCount
      */
@@ -767,6 +674,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @param string $testCase Optional name of the calling test case.
      *
      * @return array<string, mixed>
+     *
      * @since 0.10.2
      */
     private function calculateProjectMetrics($testCase = null)

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -47,18 +47,17 @@ use PDepend\Metrics\AbstractMetricsTestCase;
 /**
  * Test cases for the {@link  \PDepend\Metrics\Analyzer\CrapIndexAnalyzer} class.
  *
+ * @covers \PDepend\Metrics\Analyzer\CrapIndexAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\CrapIndexAnalyzer
  * @group unittest
  */
 class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testAnalyzerReturnsExpectedDependencies
-     *
-     * @return void
      */
     public function testAnalyzerReturnsExpectedDependencies(): void
     {
@@ -71,8 +70,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIsEnabledReturnsFalseWhenNoCoverageReportFileWasSupplied
-     *
-     * @return void
      */
     public function testAnalyzerIsEnabledReturnsFalseWhenNoCoverageReportFileWasSupplied(): void
     {
@@ -83,8 +80,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIsEnabledReturnsTrueWhenCoverageReportFileWasSupplied
-     *
-     * @return void
      */
     public function testAnalyzerIsEnabledReturnsTrueWhenCoverageReportFileWasSupplied(): void
     {
@@ -96,8 +91,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIgnoresAbstractMethods
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresAbstractMethods(): void
     {
@@ -107,8 +100,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIgnoresInterfaceMethods
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresInterfaceMethods(): void
     {
@@ -118,8 +109,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerReturnsExpectedResultForMethodWithoutCoverage
-     *
-     * @return void
      */
     public function testAnalyzerReturnsExpectedResultForMethodWithoutCoverage(): void
     {
@@ -128,8 +117,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerReturnsExpectedResultForMethodWith100PercentCoverage
-     *
-     * @return void
      */
     public function testAnalyzerReturnsExpectedResultForMethodWith100PercentCoverage(): void
     {
@@ -138,8 +125,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerReturnsExpectedResultForMethodWith50PercentCoverage
-     *
-     * @return void
      */
     public function testAnalyzerReturnsExpectedResultForMethodWith50PercentCoverage(): void
     {
@@ -148,8 +133,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyterReturnsExpectedResultForMethodWithoutCoverageData
-     *
-     * @return void
      */
     public function testAnalyterReturnsExpectedResultForMethodWithoutCoverageData(): void
     {
@@ -158,8 +141,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyterReturnsExpectedResultForFunctionWithoutCoverageData
-     *
-     * @return void
      */
     public function testAnalyterReturnsExpectedResultForFunctionWithoutCoverageData(): void
     {
@@ -169,11 +150,9 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the crap index algorithm implementation.
      *
-     * @param string  $testCase  Name of the calling test case.
-     * @param integer $ccn       The entire cyclomatic complexity number.
-     * @param integer $crapIndex The expected crap index.
-     *
-     * @return void
+     * @param string $testCase  Name of the calling test case.
+     * @param int    $ccn       The entire cyclomatic complexity number.
+     * @param int    $crapIndex The expected crap index.
      */
     private function doTestCrapIndexCalculation($testCase, $ccn, $crapIndex): void
     {
@@ -184,8 +163,8 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Calculates the crap index.
      *
-     * @param string  $testCase Name of the calling test case.
-     * @param integer $ccn      The entire cyclomatic complexity number.
+     * @param string $testCase Name of the calling test case.
+     * @param int    $ccn      The entire cyclomatic complexity number.
      *
      * @return array
      */
@@ -236,8 +215,9 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a mocked instance of the cyclomatic complexity analyzer.
      *
-     * @param integer $ccn
-     * @return \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+     * @param int $ccn
+     *
+     * @return CyclomaticComplexityAnalyzer
      */
     private function createCyclomaticComplexityAnalyzerMock($ccn = 42)
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -48,25 +48,25 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the cyclomatic analyzer.
  *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
  * @group unittest
  */
 class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 1.0.0
      */
     private $cache;
 
     /**
      * Initializes a in memory cache.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -77,8 +77,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetCCNReturnsZeroForUnknownNode
-     *
-     * @return void
      */
     public function testGetCCNReturnsZeroForUnknownNode(): void
     {
@@ -90,8 +88,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetCCN2ReturnsZeroForUnknownNode
-     *
-     * @return void
      */
     public function testGetCCN2ReturnsZeroForUnknownNode(): void
     {
@@ -103,8 +99,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct function cc numbers.
-     *
-     * @return void
      */
     public function testCalculateFunctionCCNAndCNN2(): void
     {
@@ -116,7 +110,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
         $actual   = [];
         $expected = [
             'pdepend1' => ['ccn' => 5, 'ccn2' => 6],
-            'pdepend2' => ['ccn' => 7, 'ccn2' => 10]
+            'pdepend2' => ['ccn' => 7, 'ccn2' => 10],
         ];
 
         foreach ($namespaces[0]->getFunctions() as $function) {
@@ -131,8 +125,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateFunctionCCNAndCNN2ProjectMetrics
-     *
-     * @return void
      */
     public function testCalculateFunctionCCNAndCNN2ProjectMetrics(): void
     {
@@ -147,8 +139,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct method cc numbers.
-     *
-     * @return void
      */
     public function testCalculateMethodCCNAndCNN2(): void
     {
@@ -163,7 +153,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
         $actual   = [];
         $expected = [
             'pdepend1' => ['ccn' => 5, 'ccn2' => 6],
-            'pdepend2' => ['ccn' => 7, 'ccn2' => 10]
+            'pdepend2' => ['ccn' => 7, 'ccn2' => 10],
         ];
 
         foreach ($methods as $method) {
@@ -179,8 +169,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer also detects a conditional expression nested in a
      * compound expression.
-     *
-     * @return void
      */
     public function testCalculateCCNWithConditionalExprInCompoundExpr(): void
     {
@@ -195,8 +183,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateExpectedCCNForDoWhileStatement
-     *
-     * @return void
      */
     public function testCalculateExpectedCCNForDoWhileStatement(): void
     {
@@ -211,8 +197,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateExpectedCCN2ForDoWhileStatement
-     *
-     * @return void
      */
     public function testCalculateExpectedCCN2ForDoWhileStatement(): void
     {
@@ -227,8 +211,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer ignores the default label in a switch statement.
-     *
-     * @return void
      */
     public function testCalculateCCNIgnoresDefaultLabelInSwitchStatement(): void
     {
@@ -243,8 +225,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer counts all case labels in a switch statement.
-     *
-     * @return void
      */
     public function testCalculateCCNCountsAllCaseLabelsInSwitchStatement(): void
     {
@@ -259,8 +239,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer detects expressions in a for loop.
-     *
-     * @return void
      */
     public function testCalculateCCNDetectsExpressionsInAForLoop(): void
     {
@@ -275,8 +253,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer detects expressions in a while loop.
-     *
-     * @return void
      */
     public function testCalculateCCNDetectsExpressionsInAWhileLoop(): void
     {
@@ -291,8 +267,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer aggregates the correct project metrics.
-     *
-     * @return void
      */
     public function testCalculateProjectMetrics(): void
     {
@@ -307,8 +281,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerAlsoCalculatesCCNAndCCN2OfClosureInMethod
-     *
-     * @return void
      */
     public function testAnalyzerAlsoCalculatesCCNAndCCN2OfClosureInMethod(): void
     {
@@ -324,7 +296,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFunctionMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFunctionMetricsFromCache(): void
@@ -348,7 +319,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedMethodMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedMethodMetricsFromCache(): void
@@ -373,7 +343,8 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
+     * @return CyclomaticComplexityAnalyzer
+     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -47,10 +47,11 @@ use PDepend\Metrics\AbstractMetricsTestCase;
 /**
  * Tests the for the package metrics visitor.
  *
+ * @covers \PDepend\Metrics\Analyzer\DependencyAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\DependencyAnalyzer
  * @group unittest
  */
 class DependencyAnalyzerTest extends AbstractMetricsTestCase
@@ -76,7 +77,7 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
             'ce'  =>  0,
             'a'   =>  0,
             'i'   =>  0,
-            'd'   =>  1
+            'd'   =>  1,
         ],
         'pkg1'  =>  [
             'tc'  =>  1,
@@ -86,7 +87,7 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
             'ce'  =>  2,
             'a'   =>  0,
             'i'   =>  1,
-            'd'   =>  0
+            'd'   =>  0,
         ],
         'pkg2'  =>  [
             'tc'  =>  1,
@@ -96,7 +97,7 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
             'ce'  =>  0,
             'a'   =>  1,
             'i'   =>  0,
-            'd'   =>  0
+            'd'   =>  0,
         ],
         'pkg3'  =>  [
             'tc'  =>  1,
@@ -112,8 +113,6 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the generated package metrics.
-     *
-     * @return void
      */
     public function testGenerateMetrics(): void
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -48,25 +48,25 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the cyclomatic analyzer.
  *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
+ *
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
  * @group unittest
  */
 class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 1.0.0
      */
     private $cache;
 
     /**
      * Initializes a in memory cache.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -77,8 +77,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsNothingForUnknownNode
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsNothingForUnknownNode(): void
     {
@@ -91,8 +89,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct function Halstead n1, n2,
      * N1 & N2.
-     *
-     * @return void
      */
     public function testCalculateFunctionBaseMeasures(): void
     {
@@ -120,8 +116,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct function Halstead n1, n2,
      * N1 & N2.
-     *
-     * @return void
      */
     public function testCalculateFunctionMeasures(): void
     {
@@ -170,8 +164,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct method Halstead n1, n2,
      * N1 & N2.
-     *
-     * @return void
      */
     public function testCalculateMethodBaseMeasures(): void
     {
@@ -202,8 +194,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct method Halstead n1, n2,
      * N1 & N2.
-     *
-     * @return void
      */
     public function testCalculateMethodMeasures(): void
     {
@@ -254,7 +244,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFunctionMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFunctionMetricsFromCache(): void
@@ -278,7 +267,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedMethodMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedMethodMetricsFromCache(): void
@@ -303,7 +291,8 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return \PDepend\Metrics\Analyzer\HalsteadAnalyzer
+     * @return HalsteadAnalyzer
+     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -48,18 +48,17 @@ use PDepend\Source\AST\ASTClass;
 /**
  * Test case for the hierarchy analyzer.
  *
+ * @covers \PDepend\Metrics\Analyzer\HierarchyAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\HierarchyAnalyzer
-   * @group unittest
+ * @group unittest
  */
 class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testCalculatesExpectedNumberOfLeafClasses
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfLeafClasses(): void
     {
@@ -72,8 +71,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNumberOfAbstractClasses
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfAbstractClasses(): void
     {
@@ -86,8 +83,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNumberOfConcreteClasses
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfConcreteClasses(): void
     {
@@ -100,8 +95,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNumberOfRootClasses
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfRootClasses(): void
     {
@@ -114,8 +107,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatedLeafsMetricDoesNotContainNotUserDefinedClasses
-     *
-     * @return void
      */
     public function testCalculatedLeafsMetricDoesNotContainNotUserDefinedClasses(): void
     {
@@ -128,8 +119,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIgnoresClassesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresClassesThatAreNotUserDefined(): void
     {
@@ -145,8 +134,6 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that {@link \PDepend\Metrics\Analyzer\HierarchyAnalyzer::getNodeMetrics()}
      * returns an empty <b>array</b> for an unknown node id.
-     *
-     * @return void
      */
     public function testGetNodeMetricsForUnknownId(): void
     {
@@ -157,7 +144,7 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
     }
 
     /**
-     * @return \PDepend\Metrics\Analyzer\HierarchyAnalyzer
+     * @return HierarchyAnalyzer
      */
     private function createAnalyzer()
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -50,10 +50,11 @@ use PDepend\Source\AST\ASTClass;
 /**
  * Test case for the inheritance analyzer.
  *
+ * @covers \PDepend\Metrics\Analyzer\InheritanceAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\InheritanceAnalyzer
  * @group unittest
  */
 class InheritanceAnalyzerTest extends AbstractMetricsTestCase
@@ -61,8 +62,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct average number of derived
      * classes.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectANDCValue(): void
     {
@@ -80,8 +79,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct average hierarchy height.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectAHHValue(): void
     {
@@ -99,8 +96,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoccMetricForClassWithoutChildren
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoccMetricForClassWithoutChildren(): void
     {
@@ -109,8 +104,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoccMetricForClassWithDirectChildren
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoccMetricForClassWithDirectChildren(): void
     {
@@ -119,8 +112,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoccMetricForClassWithDirectAndIndirectChildren
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoccMetricForClassWithDirectAndIndirectChildren(): void
     {
@@ -129,8 +120,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct DIT values.
-     *
-     * @return void
      */
     public function testCalculateDITMetricNoInheritance(): void
     {
@@ -139,8 +128,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct DIT values.
-     *
-     * @return void
      */
     public function testCalculateDITMetricOneLevelInheritance(): void
     {
@@ -149,8 +136,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct DIT values.
-     *
-     * @return void
      */
     public function testCalculateDITMetricTwoLevelNoInheritance(): void
     {
@@ -159,8 +144,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct DIT values.
-     *
-     * @return void
      */
     public function testCalculateDITMetricThreeLevelNoInheritance(): void
     {
@@ -169,8 +152,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct DIT values.
-     *
-     * @return void
      */
     public function testCalculateDITMetricFourLevelNoInheritance(): void
     {
@@ -179,8 +160,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateDITMetricForUnknownParentIncrementsMetricWithTwo
-     *
-     * @return void
      */
     public function testCalculateDITMetricForUnknownParentIncrementsMetricWithTwo(): void
     {
@@ -189,8 +168,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculateDITMetricForInternalParentIncrementsMetricWithTwo
-     *
-     * @return void
      */
     public function testCalculateDITMetricForInternalParentIncrementsMetricWithTwo(): void
     {
@@ -200,8 +177,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that {@link \PDepend\Metrics\Analyzer\InheritanceAnalyzer::analyze()}
      * calculates the expected DIT values.
-     *
-     * @return void
      */
     public function testCalculateDepthOfInheritanceForSeveralClasses(): void
     {
@@ -231,8 +206,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedMaxDepthOfInheritanceTreeMetric
-     *
-     * @return void
      */
     public function testCalculatesExpectedMaxDepthOfInheritanceTreeMetric(): void
     {
@@ -245,8 +218,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoamMetricForClassWithoutParent
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoamMetricForClassWithoutParent(): void
     {
@@ -255,8 +226,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoamMetricForClassWithDirectParent
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoamMetricForClassWithDirectParent(): void
     {
@@ -265,8 +234,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoamMetricForClassWithIndirectParent
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoamMetricForClassWithIndirectParent(): void
     {
@@ -275,8 +242,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoomMetricForClassWithoutParent
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoomMetricForClassWithoutParent(): void
     {
@@ -285,8 +250,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoomMetricForClassWithParent
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoomMetricForClassWithParent(): void
     {
@@ -295,8 +258,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNoomMetricForClassWithParentPrivateMethods
-     *
-     * @return void
      */
     public function testCalculatesExpectedNoomMetricForClassWithParentPrivateMethods(): void
     {
@@ -305,8 +266,6 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIgnoresClassesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresClassesThatAreNotUserDefined(): void
     {
@@ -339,7 +298,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
     }
 
     /**
-     * @return \PDepend\Metrics\Analyzer\InheritanceAnalyzer
+     * @return InheritanceAnalyzer
      */
     private function createAnalyzer()
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -48,25 +48,25 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the cyclomatic analyzer.
  *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
+ *
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
  * @group unittest
  */
 class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 1.0.0
      */
     private $cache;
 
     /**
      * Initializes a in memory cache.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -77,8 +77,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testGetNodeMetricsReturnsNothingForUnknownNode
-     *
-     * @return void
      */
     public function testGetNodeMetricsReturnsNothingForUnknownNode(): void
     {
@@ -91,8 +89,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct function maintainability
      * index.
-     *
-     * @return void
      */
     public function testCalculateFunctionMaintainabilityIndex(): void
     {
@@ -120,8 +116,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct method maintainability
      * index.
-     *
-     * @return void
      */
     public function testCalculateMethodMaintainabilityIndex(): void
     {
@@ -153,7 +147,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFunctionMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFunctionMetricsFromCache(): void
@@ -177,7 +170,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedMethodMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedMethodMetricsFromCache(): void
@@ -202,7 +194,8 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
+     * @return MaintainabilityIndexAnalyzer
+     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -49,25 +49,25 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the NPath complexity analyzer.
  *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
  * @group unittest
  */
 class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 1.0.0
      */
     private $cache;
 
     /**
      * Initializes a in memory cache.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -79,7 +79,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFunctionMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFunctionMetricsFromCache(): void
@@ -105,7 +104,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedMethodMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedMethodMetricsFromCache(): void
@@ -133,7 +131,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForNestedIfStatementsWithScope
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForNestedIfStatementsWithScope(): void
@@ -144,7 +141,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForNestedIfStatementsWithoutScope
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForNestedIfStatementsWithoutScope(): void
@@ -155,7 +151,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForSiblingConditionalExpressions
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForSiblingConditionalExpressions(): void
@@ -166,8 +161,8 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForSiblingExpressions
      *
-     * @return void
      * @since 0.9.12
+     *
      * @todo What happens with boolean/logical expressions within the body of
      *       any other statement/expression?
      */
@@ -179,7 +174,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForTwoSiblingIfStatetements
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForTwoSiblingIfStatetements(): void
@@ -190,7 +184,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForForeachStatementWithNestedIfStatetements
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForForeachStatementWithNestedIfStatetements(): void
@@ -201,7 +194,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForSiblingIfStatementsAndForeachStatement
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForSiblingIfStatementsAndForeachStatement(): void
@@ -212,7 +204,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForComplexFunction
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForComplexFunction(): void
@@ -223,7 +214,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForConditionalsInArrayDeclaration
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForComplexNestedControlStatements(): void
@@ -234,7 +224,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testNPathComplexityForConditionalsInArrayDeclaration
      *
-     * @return void
      * @since 0.9.12
      */
     public function testNPathComplexityForConditionalsInArrayDeclaration(): void
@@ -244,8 +233,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testNPathComplexityIsZeroForEmptyMethod
-     *
-     * @return void
      */
     public function testNPathComplexityIsZeroForEmptyMethod(): void
     {
@@ -254,8 +241,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests a method body with a simple if statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForMethodWithSimpleIfStatement(): void
     {
@@ -264,8 +249,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests a method body with a simple if statement with dynamic identifier.
-     *
-     * @return void
      */
     public function testNPathComplexityForIfStatementWithNestedDynamicIdentifier(): void
     {
@@ -274,8 +257,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer implementation against consecutive if-statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForConsecutiveIfStatements(): void
     {
@@ -284,8 +265,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer implementation against multiple if-else-if statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForConsecutiveIfElseIfStatements(): void
     {
@@ -294,8 +273,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer implementation against multiple if-elseif statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForConsecutiveIfElsifStatements(): void
     {
@@ -304,8 +281,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer implementation against an empty while statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForEmptyWhileStatement(): void
     {
@@ -314,8 +289,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the anaylzer with nested while statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForNestedWhileStatements(): void
     {
@@ -324,8 +297,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the npath algorithm with a simple do-while statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleDoWhileStatement(): void
     {
@@ -334,8 +305,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer with a simple for statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleForStatement(): void
     {
@@ -344,8 +313,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer with a complex for statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForComplexForStatement(): void
     {
@@ -354,8 +321,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the analyzer implementation with a simple foreach statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleForeachStatement(): void
     {
@@ -364,8 +329,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a simple return statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleReturnStatement(): void
     {
@@ -374,8 +337,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a return statement that contains boolean expressions.
-     *
-     * @return void
      */
     public function testNPathComplexityForReturnStatementWithBooleanExpressions(): void
     {
@@ -384,8 +345,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a return statement that contains a conditional.
-     *
-     * @return void
      */
     public function testNPathComplexityForReturnStatementWithConditionalStatement(): void
     {
@@ -395,8 +354,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the algorithm with a simple switch statement that contains one case
      * child.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleSwitchStatement(): void
     {
@@ -406,8 +363,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the algorithm with a switch statement that contains multiple case
      * statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForSwitchStatementWithMultipleCaseStatements(): void
     {
@@ -417,8 +372,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the algorithm with a switch statement that contains complex case
      * statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForSwitchStatementWithComplexCaseStatements(): void
     {
@@ -427,8 +380,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a simple try statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleTryCatchStatement(): void
     {
@@ -437,8 +388,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a try statement with multiple catch statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForTryStatementWithMutlipleCatchStatements(): void
     {
@@ -447,8 +396,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a try statement with nested if statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForTryCatchStatementWithNestedIfStatements(): void
     {
@@ -457,8 +404,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with a conditional statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForSimpleConditionalStatement(): void
     {
@@ -467,8 +412,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with nested conditional statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForTwoNestedConditionalStatements(): void
     {
@@ -477,8 +420,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests the algorithm with nested conditional statements.
-     *
-     * @return void
      */
     public function testNPathComplexityForThreeNestedConditionalStatements(): void
     {
@@ -488,8 +429,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the algorithm with a conditional statement with boolean/logical
      * expressions.
-     *
-     * @return void
      */
     public function testNPathComplexityForConditionalStatementWithLogicalExpressions(): void
     {
@@ -499,8 +438,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the algorithm implementation against an existing bug in the
      * combination of return, conditional and if statement.
-     *
-     * @return void
      */
     public function testNPathComplexityForReturnStatementWithConditional(): void
     {
@@ -512,7 +449,8 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Returns the NPath Complexity of the first function found in source file
      * associated with the calling test case.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.9.12
      */
     private function calculateFunctionMetric()
@@ -527,6 +465,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * the first function found in the test case source file.
      *
      * @return \PDepend\Source\AST\ASTFunction
+     *
      * @since 0.9.12
      */
     private function getFirstFunctionForTestCaseInternal()
@@ -541,7 +480,8 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Returns the NPath Complexity of the first method found in source file
      * associated with the calling test case.
      *
-     * @return integer
+     * @return int
+     *
      * @since 0.9.12
      */
     private function calculateMethodMetric()
@@ -556,6 +496,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * the first method found in the test case source file.
      *
      * @return \PDepend\Source\AST\ASTMethod
+     *
      * @since 0.9.12
      */
     private function getFirstMethodForTestCaseInternal()
@@ -571,8 +512,8 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Calculates the NPath complexity for the given callable instance.
      *
-     * @param \PDepend\Source\AST\AbstractASTCallable $callable
      * @return string
+     *
      * @since 0.9.12
      */
     private function calculateNPathComplexity(AbstractASTCallable $callable)
@@ -587,7 +528,8 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a ready to use npath complexity analyzer.
      *
-     * @return \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
+     * @return NPathComplexityAnalyzer
+     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -49,18 +49,17 @@ use PDepend\Source\AST\ASTNamespace;
 /**
  * Test case for the node count analyzer.
  *
+ * @covers \PDepend\Metrics\Analyzer\NodeCountAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Metrics\Analyzer\NodeCountAnalyzer
  * @group unittest
  */
 class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * testVisitClassIgnoresClassesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testVisitClassIgnoresClassesThatAreNotUserDefined(): void
     {
@@ -78,8 +77,6 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testVisitClassCountsClassesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testVisitClassCountsClassesThatAreNotUserDefined(): void
     {
@@ -98,8 +95,6 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testVisitClassIgnoresInterfacesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testVisitClassIgnoresInterfacesThatAreNotUserDefined(): void
     {
@@ -117,8 +112,6 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testVisitClassCountsInterfacesThatAreNotUserDefined
-     *
-     * @return void
      */
     public function testVisitClassCountsInterfacesThatAreNotUserDefined(): void
     {
@@ -137,38 +130,32 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct number of packages value.
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfPackages(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
         $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
-        
+
         $metrics = $analyzer->getProjectMetrics();
         $this->assertEquals(3, $metrics['nop']);
     }
-    
+
     /**
      * testCalculatesExpectedNumberOfClassesInProject
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfClassesInProject(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
         $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
-        
+
         $metrics = $analyzer->getProjectMetrics();
         $this->assertEquals(6, $metrics['noc']);
     }
 
     /**
      * testCalculatesExpectedNumberOfClassesInPackages
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfClassesInPackages(): void
     {
@@ -190,26 +177,22 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
             $metrics
         );
     }
-    
+
     /**
      * testCalculatesExpectedNumberOfInterfacesInProject
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfInterfacesInProject(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
         $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
-        
+
         $metrics = $analyzer->getProjectMetrics();
         $this->assertEquals(9, $metrics['noi']);
     }
 
     /**
      * testCalculatesExpectedNumberOfInterfacesInPackages
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfInterfacesInPackages(): void
     {
@@ -231,26 +214,22 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
             $metrics
         );
     }
-    
+
     /**
      * testCalculatesExpectedNumberOfMethodsInProject
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfMethodsInProject(): void
     {
         $namespaces = $this->parseTestCaseSource(__METHOD__);
         $analyzer = $this->createAnalyzer();
         $analyzer->analyze($namespaces);
-        
+
         $metrics = $analyzer->getProjectMetrics();
         $this->assertEquals(9, $metrics['nom']);
     }
 
     /**
      * testCalculatesExpectedNumberOfMethodsInPackages
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfMethodsInPackages(): void
     {
@@ -275,8 +254,6 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNumberOfFunctionsInProject
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfFunctionsInProject(): void
     {
@@ -290,8 +267,6 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedNumberOfFunctionsInPackages
-     *
-     * @return void
      */
     public function testCalculatesExpectedNumberOfFunctionsInPackages(): void
     {
@@ -315,7 +290,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
     }
 
     /**
-     * @return \PDepend\Metrics\Analyzer\NodeCountAnalyzer
+     * @return NodeCountAnalyzer
      */
     private function createAnalyzer()
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -49,25 +49,25 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the node lines of code analyzer.
  *
+ * @covers \PDepend\Metrics\AbstractCachingAnalyzer
+ * @covers \PDepend\Metrics\Analyzer\NodeLocAnalyzer
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\NodeLocAnalyzer
  * @group unittest
  */
 class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
+     *
      * @since 1.0.0
      */
     private $cache;
 
     /**
      * Initializes a in memory cache.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -78,8 +78,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesCorrectFunctionMetrics
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectFunctionMetrics(): void
     {
@@ -96,7 +94,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
                 'cloc'   =>  3,
                 'eloc'   =>  2,
                 'lloc'   =>  0,
-                'ncloc'  =>  3
+                'ncloc'  =>  3,
             ],
             'func_without_comment'  =>  [
                 'loc'    =>  7,
@@ -134,8 +132,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesCorrectFunctionFileMetrics
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectFunctionFileMetrics(): void
     {
@@ -154,7 +150,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  15,
             'eloc'   =>  13,
             'lloc'   =>  4,
-            'ncloc'  =>  16
+            'ncloc'  =>  16,
         ];
         $this->assertEquals($expected, $actual);
     }
@@ -162,8 +158,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that the analyzer calculates the correct class, method and file
      * loc values.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesClassMethodsIntoNcloc(): void
     {
@@ -181,8 +175,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesClassPropertiesIntoNcloc
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesClassPropertiesIntoNcloc(): void
     {
@@ -200,8 +192,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerNotCalculatesClassPropertiesIntoEloc
-     *
-     * @return void
      */
     public function testAnalyzerNotCalculatesClassPropertiesIntoEloc(): void
     {
@@ -219,8 +209,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Tests that the analyzer calculates the correct class file metrics.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectClassFileMetrics(): void
     {
@@ -239,15 +227,13 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  10,
             'eloc'   =>  8,
             'lloc'   =>  4,
-            'ncloc'  =>  11
+            'ncloc'  =>  11,
         ];
         $this->assertEquals($expected, $actual);
     }
 
     /**
      * testAnalyzerCalculatesCorrectClassMetrics
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectClassMetrics(): void
     {
@@ -265,15 +251,13 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  7,
             'eloc'   =>  3,
             'lloc'   =>  1,
-            'ncloc'  =>  15
+            'ncloc'  =>  15,
         ];
         $this->assertEquals($expected, $actual);
     }
 
     /**
      * Tests that the analyzer calculates the correct interface file value.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectInterfaceFileLoc(): void
     {
@@ -292,15 +276,13 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  10,
             'eloc'   =>  8,
             'lloc'   =>  4,
-            'ncloc'  =>  11
+            'ncloc'  =>  11,
         ];
         $this->assertEquals($expected, $actual);
     }
 
     /**
      * testAnalyzerCalculatesCorrectInterfaceLoc
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectInterfaceLoc(): void
     {
@@ -318,15 +300,13 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  7,
             'eloc'   =>  0,
             'lloc'   =>  0,
-            'ncloc'  =>  10
+            'ncloc'  =>  10,
         ];
         $this->assertEquals($expected, $actual);
     }
 
     /**
      * Tests that the analyzer aggregates the expected project values.
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesCorrectProjectMetrics(): void
     {
@@ -341,7 +321,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
             'cloc'   =>  144,
             'eloc'   =>  89,
             'lloc'   =>  40,
-            'ncloc'  =>  117
+            'ncloc'  =>  117,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -349,8 +329,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesElocOfZeroForAbstractMethod
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesElocOfZeroForAbstractMethod(): void
     {
@@ -370,8 +348,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesElocOfZeroForInterfaceMethod
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesElocOfZeroForInterfaceMethod(): void
     {
@@ -391,8 +367,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerCalculatesClassConstantsIntoNcloc
-     *
-     * @return void
      */
     public function testAnalyzerCalculatesClassConstantsIntoNcloc(): void
     {
@@ -410,8 +384,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerNotCalculatesClassConstantsIntoEloc
-     *
-     * @return void
      */
     public function testAnalyzerNotCalculatesClassConstantsIntoEloc(): void
     {
@@ -429,8 +401,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedProjectLLocForFileWithInterfaces
-     *
-     * @return void
      */
     public function testCalculatesExpectedProjectLLocForFileWithInterfaces(): void
     {
@@ -444,7 +414,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFileMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFileMetricsFromCache(): void
@@ -471,7 +440,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedClassMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedClassMetricsFromCache(): void
@@ -497,7 +465,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedInterfaceMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedInterfaceMetricsFromCache(): void
@@ -523,7 +490,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedMethodMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedMethodMetricsFromCache(): void
@@ -551,7 +517,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedFunctionMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedFunctionMetricsFromCache(): void
@@ -577,7 +542,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testAnalyzerRestoresExpectedProjectMetricsFromCache
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAnalyzerRestoresExpectedProjectMetricsFromCache(): void
@@ -599,8 +563,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForReturnStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForReturnStatement(): void
     {
@@ -609,8 +571,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForIfAndElseIfStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForIfAndElseIfStatement(): void
     {
@@ -619,8 +579,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForForStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForForStatement(): void
     {
@@ -629,8 +587,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForSwitchStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForSwitchStatement(): void
     {
@@ -639,8 +595,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForTryCatchStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForTryCatchStatement(): void
     {
@@ -649,8 +603,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForForeachStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForForeachStatement(): void
     {
@@ -659,8 +611,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForWhileStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForWhileStatement(): void
     {
@@ -669,8 +619,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCalculatesExpectedLLocForDoWhileStatement
-     *
-     * @return void
      */
     public function testCalculatesExpectedLLocForDoWhileStatement(): void
     {
@@ -679,8 +627,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testAnalyzerIgnoresFilesWithoutFileName
-     *
-     * @return void
      */
     public function testAnalyzerIgnoresFilesWithoutFileName(): void
     {
@@ -719,7 +665,8 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a ready to use node loc analyzer.
      *
-     * @return \PDepend\Metrics\Analyzer\NodeLocAnalyzer
+     * @return NodeLocAnalyzer
+     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -48,18 +48,17 @@ use PDepend\Report\DummyAnalyzer;
 /**
  * Test case for the {@link \PDepend\Metrics\AnalyzerIterator} class.
  *
+ * @covers \PDepend\Metrics\AnalyzerIterator
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Metrics\AnalyzerIterator
  * @group unittest
  */
 class AnalyzerIteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorReturnsEnabledAnalyzerInstances
-     *
-     * @return void
      */
     public function testIteratorReturnsEnabledAnalyzerInstances(): void
     {
@@ -75,8 +74,6 @@ class AnalyzerIteratorTest extends AbstractTestCase
 
     /**
      * testIteratorDoesNotReturnDisabledAnalyzerInstances
-     *
-     * @return void
      */
     public function testIteratorDoesNotReturnDisabledAnalyzerInstances(): void
     {

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend;
 
+use DirectoryIterator;
+
 /**
  * Test case that parses several files where we have found errors in PDepend's
  * parser implementation.
@@ -58,7 +60,6 @@ class ParserRegressionTest extends AbstractTestCase
      *
      * @param string $pathName Name of the file to parse.
      *
-     * @return void
      * @dataProvider dataProviderSourceFiles
      */
     public function testParserHandlesSourceFileWithoutException($pathName): void
@@ -74,7 +75,7 @@ class ParserRegressionTest extends AbstractTestCase
     public static function dataProviderSourceFiles()
     {
         $files = [];
-        foreach (new \DirectoryIterator(self::createCodeResourceURI('parser_regression')) as $file) {
+        foreach (new DirectoryIterator(self::createCodeResourceURI('parser_regression')) as $file) {
             if ($file->isFile()) {
                 $files[] = [realpath($file->getPathname())];
             }

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -43,10 +43,6 @@
 namespace PDepend;
 
 use PDepend\Source\AST\ASTArtifactList;
-use PDepend\Source\AST\ASTForeachStatement;
-use PDepend\Source\AST\ASTLiteral;
-use PDepend\Source\AST\ASTString;
-use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\State;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
@@ -58,18 +54,17 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case implementation for the PDepend code parser.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class ParserTest extends AbstractTestCase
 {
     /**
      * testParserHandlesMaxNestingLevel
-     *
-     * @return void
      */
     public function testParserHandlesMaxNestingLevel(): void
     {
@@ -88,8 +83,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests the main parse method.
-     *
-     * @return void
      */
     public function testParseMixedCode(): void
     {
@@ -97,7 +90,7 @@ class ParserTest extends AbstractTestCase
             'pkg1'                               =>  true,
             'pkg2'                               =>  true,
             'pkg3'                               =>  true,
-            \PDepend\Source\Builder\Builder::DEFAULT_NAMESPACE  =>  true
+            Source\Builder\Builder::DEFAULT_NAMESPACE  =>  true,
         ];
 
         $tmp = $this->parseCodeResourceForTest();
@@ -134,8 +127,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception if it reaches the end of the
      * stream but not all class curly braces are closed.
-     *
-     * @return void
      */
     public function testParserWithUnclosedClassFail(): void
     {
@@ -153,8 +144,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception if it reaches the end of the
      * stream but not all function curly braces are closed.
-     *
-     * @return void
      */
     public function testParserWithUnclosedFunctionFail(): void
     {
@@ -171,8 +160,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception if it finds an invalid
      * function signature.
-     *
-     * @return void
      */
     public function testParserWithInvalidFunction1Fail(): void
     {
@@ -189,8 +176,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception if it finds an invalid
      * function signature.
-     *
-     * @return void
      */
     public function testParserWithInvalidFunction2Fail(): void
     {
@@ -206,8 +191,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct line number for a function.
-     *
-     * @return void
      */
     public function testParserSetsCorrectFunctionLineNumber(): void
     {
@@ -219,8 +202,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct tokens for a function.
-     *
-     * @return void
      */
     public function testParserSetsCorrectFunctionTokens(): void
     {
@@ -261,8 +242,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets a detected file comment.
-     *
-     * @return void
      */
     public function testParserSetsCorrectFileComment(): void
     {
@@ -291,8 +270,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser doesn't reuse a type comment as file comment.
-     *
-     * @return void
      */
     public function testParserDoesntReuseTypeComment(): void
     {
@@ -311,8 +288,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser doesn't reuse a function comment as file comment.
-     *
-     * @return void
      */
     public function testParserDoesntReuseFunctionComment(): void
     {
@@ -331,8 +306,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct start line number for a class.
-     *
-     * @return void
      */
     public function testParserSetsCorrectClassStartLineNumber(): void
     {
@@ -341,8 +314,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct end line number for a class.
-     *
-     * @return void
      */
     public function testParserSetsCorrectClassEndLineNumber(): void
     {
@@ -351,8 +322,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct start line number for class methods.
-     *
-     * @return void
      */
     public function testParserSetsCorrectClassMethodStartLineNumber(): void
     {
@@ -365,8 +334,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct end line number for class methods.
-     *
-     * @return void
      */
     public function testParserSetsCorrectClassMethodEndLineNumber(): void
     {
@@ -379,8 +346,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct start line number for an interface.
-     *
-     * @return void
      */
     public function testParserSetsCorrectInterfaceStartLineNumber(): void
     {
@@ -389,8 +354,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct end line number for an interface.
-     *
-     * @return void
      */
     public function testParserSetsCorrectInterfaceEndLineNumber(): void
     {
@@ -400,8 +363,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser sets the correct start line number for interface
      * methods.
-     *
-     * @return void
      */
     public function testParserSetsCorrectInterfaceMethodStartLineNumbers(): void
     {
@@ -411,8 +372,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct end line number for interface methods.
-     *
-     * @return void
      */
     public function testParserSetsCorrectInterfaceMethodEndLineNumbers(): void
     {
@@ -422,8 +381,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser marks all interface methods as abstract.
-     *
-     * @return void
      */
     public function testParserSetsAllInterfaceMethodsAbstract(): void
     {
@@ -433,8 +390,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesClassWithMultipleImplementedInterfaces
-     *
-     * @return void
      */
     public function testParserHandlesClassWithMultipleImplementedInterfaces(): void
     {
@@ -448,8 +403,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesInterfaceWithMultipleParentInterfaces
-     *
-     * @return void
      */
     public function testParserHandlesInterfaceWithMultipleParentInterfaces(): void
     {
@@ -463,8 +416,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct line number for methods.
-     *
-     * @return void
      */
     public function testParserSetsCorrectMethodLineNumber(): void
     {
@@ -481,8 +432,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser doesn't mark a non abstract method as abstract.
-     *
-     * @return void
      */
     public function testParserDoesNotMarkNonAbstractMethodAsAbstract(): void
     {
@@ -495,8 +444,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser marks an abstract method as abstract.
-     *
-     * @return void
      */
     public function testParserMarksAbstractMethodAsAbstract(): void
     {
@@ -510,8 +457,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser handles PHP 5.3 object namespace + class chaining.
-     *
-     * @return void
      */
     public function testParserParseNewInstancePHP53(): void
     {
@@ -528,8 +473,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that doc comment blocks are added to a function.
-     *
-     * @return void
      */
     public function testParserSetsCorrectFunctionDocComment(): void
     {
@@ -556,7 +499,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
-     * @return void
+     *
      * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsFunctionReturnTypeToNull($functions): void
@@ -564,18 +507,18 @@ class ParserTest extends AbstractTestCase
         $this->assertSame(
             [
                 'function' => 'func1',
-                'returnClass' => null
+                'returnClass' => null,
             ],
             [
                 'function' => $functions[0]->getName(),
-                'returnClass' => $functions[0]->getReturnClass()
+                'returnClass' => $functions[0]->getReturnClass(),
             ]
         );
     }
 
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
-     * @return void
+     *
      * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionTwo($functions): void
@@ -583,18 +526,18 @@ class ParserTest extends AbstractTestCase
         $this->assertSame(
             [
                 'function' => 'func2',
-                'returnClass' => 'SplObjectStore'
+                'returnClass' => 'SplObjectStore',
             ],
             [
                 'function' => $functions[1]->getName(),
-                'returnClass' => $functions[1]->getReturnClass()->getName()
+                'returnClass' => $functions[1]->getReturnClass()->getName(),
             ]
         );
     }
 
     /**
      * @param \PDepend\Source\AST\ASTFunction[] $functions
-     * @return void
+     *
      * @depends testParserSetsCorrectFunctionReturnType
      */
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionThree($functions): void
@@ -602,19 +545,17 @@ class ParserTest extends AbstractTestCase
         $this->assertSame(
             [
                 'function' => 'func3',
-                'returnClass' => 'SplObjectStore'
+                'returnClass' => 'SplObjectStore',
             ],
             [
                 'function' => $functions[2]->getName(),
-                'returnClass' => $functions[2]->getReturnClass()->getName()
+                'returnClass' => $functions[2]->getReturnClass()->getName(),
             ]
         );
     }
 
     /**
      * Tests that the parser sets the correct method exception types.
-     *
-     * @return void
      */
     public function testParserSetsCorrectFunctionExceptionTypes(): void
     {
@@ -641,8 +582,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser doesn't handle annotations if this is set to true.
-     *
-     * @return void
      */
     public function testParserHandlesIgnoreAnnotationsCorrectForFunctions(): void
     {
@@ -661,8 +600,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that doc comment blocks are added to a method.
-     *
-     * @return void
      */
     public function testParserSetsCorrectMethodDocComment(): void
     {
@@ -677,8 +614,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct method return type.
-     *
-     * @return void
      */
     public function testParserSetsCorrectMethodReturnType(): void
     {
@@ -702,8 +637,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct method exception types.
-     *
-     * @return void
      */
     public function testParserSetsCorrectMethodExceptionTypes(): void
     {
@@ -728,7 +661,7 @@ class ParserTest extends AbstractTestCase
                 'method1',
                 'OutOfRangeException',
                 'OutOfBoundsException',
-                'method2'
+                'method2',
             ],
             $actual
         );
@@ -736,8 +669,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser doesn't handle annotations if this is set to true.
-     *
-     * @return void
      */
     public function testParserHandlesIgnoreAnnotationsCorrectForMethods(): void
     {
@@ -758,8 +689,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct doc comment blocks for properties.
-     *
-     * @return void
      */
     public function testParserSetsCorrectPropertyDocComment(): void
     {
@@ -774,8 +703,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets the correct visibility for properties.
-     *
-     * @return void
      */
     public function testParserSetsCorrectPropertyVisibility(): void
     {
@@ -807,8 +734,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets property types for non scalar properties.
-     *
-     * @return void
      */
     public function testParserSetsCorrectPropertyTypes(): void
     {
@@ -846,8 +771,6 @@ class ParserTest extends AbstractTestCase
      * // Results in
      * Runtime
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsExpectedPropertyTypeForChainedComment(): void
     {
@@ -871,8 +794,6 @@ class ParserTest extends AbstractTestCase
      * // Results in
      * Session
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsExpectedPropertyTypeForChainedCommentInArray(): void
     {
@@ -896,8 +817,6 @@ class ParserTest extends AbstractTestCase
      * // Results in
      * Runtime
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsExpectedReturnTypeForChainedComment(): void
     {
@@ -921,8 +840,6 @@ class ParserTest extends AbstractTestCase
      * // Results in
      * Session
      * </code>
-     *
-     * @return void
      */
     public function testParserSetsExpectedReturnTypeForChainedCommentInArray(): void
     {
@@ -939,8 +856,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser sets property types for non scalar properties.
-     *
-     * @return void
      */
     public function testHandlesIgnoreAnnotationsCorrectForProperties(): void
     {
@@ -961,8 +876,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that parser sets the correct doc comment blocks for classes and
      * interfaces.
-     *
-     * @return void
      */
     public function testParserSetsCorrectClassOrInterfaceDocComment(): void
     {
@@ -984,8 +897,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser supports sub packages.
-     *
-     * @return void
      */
     public function testParserSubpackageSupport(): void
     {
@@ -1009,7 +920,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
-     * @return void
+     *
      * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInFirstNamespace($namespaces): void
@@ -1020,7 +931,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
-     * @return void
+     *
      * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInSecondNamespace($namespaces): void
@@ -1031,7 +942,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
-     * @return void
+     *
      * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForFirstFunctionInFirstNamespace($namespaces): void
@@ -1043,7 +954,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
-     * @return void
+     *
      * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForSecondFunctionInFirstNamespace($namespaces): void
@@ -1055,7 +966,7 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
-     * @return void
+     *
      * @depends testParserSetsFileLevelFunctionPackage
      */
     public function testParserSetsFileExpectedPackageForFirstFunctionInSecondNamespace($namespaces): void
@@ -1067,8 +978,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserSetsAbstractPropertyOnClass
-     *
-     * @return void
      */
     public function testParserSetsAbstractPropertyOnClass(): void
     {
@@ -1082,8 +991,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserSetsAbstractModifierOnClass
-     *
-     * @return void
      */
     public function testParserSetsAbstractModifierOnClass(): void
     {
@@ -1100,8 +1007,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserSetsFinalPropertyOnClass
-     *
-     * @return void
      */
     public function testParserSetsFinalPropertyOnClass(): void
     {
@@ -1115,8 +1020,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserSetsFinalModifierOnClass
-     *
-     * @return void
      */
     public function testParserSetsFinalModifierOnClass(): void
     {
@@ -1131,8 +1034,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser handles nested array structures as parameter
      * default value correct.
-     *
-     * @return void
      */
     public function testParserHandlesNestedArraysAsParameterDefaultValue(): void
     {
@@ -1142,8 +1043,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserStripsCommentsInParseExpressionUntilCorrect
-     *
-     * @return void
      */
     public function testParserStripsCommentsInParseExpressionUntilCorrect(): void
     {
@@ -1161,8 +1060,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception for an unclosed array
      * declaration within the default value of a parameter.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForBrokenParameterArrayDefaultValue(): void
     {
@@ -1179,8 +1076,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception when it detects an invalid
      * token within the parameter declaration of a function or method.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInParameterDefaultValue(): void
     {
@@ -1197,8 +1092,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception when it detects an invalid
      * token in a class body.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInClassBody(): void
     {
@@ -1215,8 +1108,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser throws an exception when it detects an invalid
      * token in a method or property declaration.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInMethodDeclaration(): void
     {
@@ -1233,8 +1124,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser handles the <b>parent</b> keyword within the default
      * value of a function.
-     *
-     * @return void
      */
     public function testParserHandlesParentKeywordInFunctionParameterDefaultValue(): void
     {
@@ -1248,8 +1137,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser handles the <b>parent</b> keyword within the default
      * value of a method.
-     *
-     * @return void
      */
     public function testParserHandlesParentKeywordInMethodParameterDefaultValue(): void
     {
@@ -1259,8 +1146,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Tests that the parser handles the self keyword as parameter type hint.
-     *
-     * @return void
      */
     public function testParserHandlesSelfKeywordAsParameterTypeHint(): void
     {
@@ -1270,8 +1155,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserSetsBestMatchForParameterTypeHintEvenWhenNameEquals
-     *
-     * @return void
      */
     public function testParserSetsBestMatchForParameterTypeHintEvenWhenNameEquals(): void
     {
@@ -1287,8 +1170,6 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser translates the self keyword into the same instance,
      * even when a similar class exists.
-     *
-     * @return void
      */
     public function testParserSetsTheReallySameParameterHintInstanceForKeywordSelf(): void
     {
@@ -1301,8 +1182,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserStripsLeadingSlashFromNamespacedClassName
-     *
-     * @return void
      */
     public function testParserStripsLeadingSlashFromNamespacedClassName(): void
     {
@@ -1312,8 +1191,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserStripsLeadingSlashFromNamespacedClassName
-     *
-     * @return void
      */
     public function testParserStripsLeadingSlashFromNamespaceAliasedClassName(): void
     {
@@ -1326,8 +1203,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserStripsLeadingSlashFromInheritNamespacedClassName
-     *
-     * @return void
      */
     public function testParserStripsLeadingSlashFromInheritNamespacedClassName(): void
     {
@@ -1340,20 +1215,16 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionWhenDefaultStaticDefaultValueNotExists
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionWhenDefaultStaticDefaultValueNotExists(): void
     {
-        $this->expectException(\PDepend\Source\Parser\MissingValueException::class);
+        $this->expectException(Source\Parser\MissingValueException::class);
 
         $this->parseCodeResourceForTest();
     }
 
     /**
      * testParserHandlesDoubleQuoteStringAsConstantDefaultValue
-     *
-     * @return void
      */
     public function testParserHandlesDoubleQuoteStringAsConstantDefaultValue(): void
     {
@@ -1362,8 +1233,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesDoubleQuoteStringWithEscapedVariable
-     *
-     * @return void
      */
     public function testParserHandlesDoubleQuoteStringWithEscapedVariable(): void
     {
@@ -1380,8 +1249,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesDoubleQuoteStringWithEscapedDoubleQuote
-     *
-     * @return void
      */
     public function testParserHandlesDoubleQuoteStringWithEscapedDoubleQuote(): void
     {
@@ -1398,8 +1265,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserNotHandlesDoubleQuoteStringWithVariableAndParenthesisAsFunctionCall
-     *
-     * @return void
      */
     public function testParserNotHandlesDoubleQuoteStringWithVariableAndParenthesisAsFunctionCall(): void
     {
@@ -1416,8 +1281,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserNotHandlesDoubleQuoteStringWithVariableAndEqualAsAssignment
-     *
-     * @return void
      */
     public function testParserNotHandlesDoubleQuoteStringWithVariableAndEqualAsAssignment(): void
     {
@@ -1434,8 +1297,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesStringWithQuestionMarkNotAsTernaryOperator
-     *
-     * @return void
      */
     public function testParserHandlesStringWithQuestionMarkNotAsTernaryOperator(): void
     {
@@ -1452,8 +1313,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserStopsProcessingWhenCacheContainsValidResult
-     *
-     * @return void
      */
     public function testParserStopsProcessingWhenCacheContainsValidResult(): void
     {
@@ -1480,8 +1339,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParseClosureAsFunctionArgument
-     *
-     * @return void
      */
     public function testParseClosureAsFunctionArgument(): void
     {
@@ -1490,8 +1347,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParseNowdocInMethodBody
-     *
-     * @return void
      */
     public function testParseNowdocInMethodBody(): void
     {
@@ -1500,8 +1355,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParseDoWhileStatement
-     *
-     * @return void
      */
     public function testParseDoWhileStatement(): void
     {
@@ -1510,8 +1363,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesCompoundExpressionInArrayBrackets
-     *
-     * @return void
      */
     public function testParserHandlesCompoundExpressionInArrayBrackets(): void
     {
@@ -1520,8 +1371,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesEmptyNonePhpCodeInMethodBody
-     *
-     * @return void
      */
     public function testParserHandlesEmptyNonePhpCodeInMethodBody(): void
     {
@@ -1530,8 +1379,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesPhpCloseTagInMethodBody
-     *
-     * @return void
      */
     public function testParserHandlesPhpCloseTagInMethodBody(): void
     {
@@ -1540,8 +1387,6 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParserHandlesMultiplePhpCloseTagsInMethodBody
-     *
-     * @return void
      */
     public function testParserHandlesMultiplePhpCloseTagsInMethodBody(): void
     {
@@ -1550,20 +1395,16 @@ class ParserTest extends AbstractTestCase
 
     /**
      * testParseExpressionUntilThrowsExceptionForUnclosedStatement
-     *
-     * @return void
      */
     public function testParseExpressionUntilThrowsExceptionForUnclosedStatement(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(Source\Parser\UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }
 
     /**
      * Tests to ensure function docblock comments are parsed correctly
-     *
-     * @return void
      */
     public function testFunctionDocBlockIsCorrectlyParsed(): void
     {
@@ -1581,7 +1422,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns an interface instance from the mixed code test file.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return Source\AST\ASTInterface
      */
     protected function getInterfaceForTest()
     {
@@ -1608,7 +1449,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns a class instance from the mixed code test file.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return Source\AST\ASTClass
      */
     protected function getClassForTest()
     {
@@ -1630,9 +1471,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Generic comment test method.
      *
-     * @param \PDepend\Source\AST\ASTArtifactList $nodes
-     * @param integer $indent
-     * @return void
+     * @param int $indent
      */
     protected function doTestParserSetsCorrectDocComment(ASTArtifactList $nodes, $indent = 1): void
     {

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -43,15 +43,15 @@
 namespace PDepend\Report\Dependencies;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * Test case for the xml summary log.
  *
+ * @covers \PDepend\Report\Dependencies\Xml
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Report\Dependencies\Xml
  * @group unittest
  */
 class XmlTest extends AbstractTestCase
@@ -72,8 +72,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Creates the package structure from a test source file.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -84,8 +82,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Removes the temporary log files.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -96,8 +92,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Tests that the logger returns the expected set of analyzers.
-     *
-     * @return void
      */
     public function testReturnsExceptedAnalyzers(): void
     {
@@ -113,8 +107,6 @@ class XmlTest extends AbstractTestCase
     /**
      * Tests that the logger throws an exception if the log target wasn't
      * configured.
-     *
-     * @return void
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -131,8 +123,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testLogMethodReturnsFalseForWrongAnalyzer
-     *
-     * @return void
      */
     public function testLogMethodReturnsFalseForWrongAnalyzer(): void
     {
@@ -147,8 +137,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testLogMethodReturnsTrueForAnalyzerOfTypeClassDepenendecyAnalyzer
-     *
-     * @return void
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeClassDepenendecyAnalyzer(): void
     {
@@ -165,8 +153,6 @@ class XmlTest extends AbstractTestCase
      * Tests that {@link \PDepend\Report\Dependencies\Xml::write()} generates the
      * expected document structure for the source, but without any applied
      * metrics.
-     *
-     * @return void
      */
     public function testXmlLogWithoutMetrics(): void
     {
@@ -187,8 +173,6 @@ class XmlTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Report\Dependencies\Xml::write()} generates the
      * expected document structure for the source, with applied metrics.
-     *
-     * @return void
      */
     public function testXmlLogWithMetrics(): void
     {

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -68,7 +68,7 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      */
     private $input = [
         'code'       =>  null,
-        'analyzers'  =>  []
+        'analyzers'  =>  [],
     ];
 
     /**
@@ -82,8 +82,6 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      * Sets the output log file.
      *
      * @param string $logFile The output log file.
-     *
-     * @return void
      */
     public function setLogFile($logFile): void
     {
@@ -115,9 +113,6 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
 
     /**
      * Sets the context code nodes.
-     *
-     * @param \PDepend\Source\AST\ASTArtifactList $artifacts
-     * @return void
      */
     public function setArtifacts(ASTArtifactList $artifacts): void
     {
@@ -129,7 +124,8 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     * @return boolean
+     *
+     * @return bool
      */
     public function log(\PDepend\Metrics\Analyzer $analyzer)
     {
@@ -139,8 +135,6 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
 
     /**
      * Closes the logger process and writes the output file.
-     *
-     * @return void
      */
     public function close(): void
     {

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -46,7 +46,6 @@ use PDepend\Metrics\AnalyzerListener;
 use PDepend\Metrics\AnalyzerNodeAware;
 use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Source\AST\ASTArtifact;
-use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * Simple dummy analyzer.
@@ -93,7 +92,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
     /**
      * Returns the node metrics.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -107,8 +105,7 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
     /**
      * Adds a listener to this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function addAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -117,8 +114,7 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
     /**
      * Removes the listener from this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function removeAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -126,8 +122,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
-     *
-     * @return void
      */
     public function analyze($namespaces): void
     {
@@ -137,7 +131,8 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      * By default all analyzers are enabled. Overwrite this method to provide
      * state based disabling/enabling.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -149,6 +144,7 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      * Set global options
      *
      * @param array<string, mixed> $options
+     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Report\Jdepend;
 
+use DOMDocument;
+use DOMXPath;
 use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
@@ -51,10 +53,11 @@ use PDepend\Source\AST\ASTArtifactList;
 /**
  * Test case for the jdepend chart logger.
  *
+ * @covers \PDepend\Report\Jdepend\Chart
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Report\Jdepend\Chart
  * @group unittest
  */
 class ChartTest extends AbstractTestCase
@@ -68,8 +71,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * setUp()
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -83,8 +84,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * tearDown()
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -97,8 +96,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * Tests that the logger returns the expected set of analyzers.
-     *
-     * @return void
      */
     public function testReturnsExceptedAnalyzers(): void
     {
@@ -109,8 +106,6 @@ class ChartTest extends AbstractTestCase
     /**
      * Tests that the logger throws an exception if the log target wasn't
      * configured.
-     *
-     * @return void
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -122,8 +117,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * testChartLogAcceptsValidAnalyzer
-     *
-     * @return void
      */
     public function testChartLogAcceptsValidAnalyzer(): void
     {
@@ -133,8 +126,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * testChartLogRejectsInvalidAnalyzer
-     *
-     * @return void
      */
     public function testChartLogRejectsInvalidAnalyzer(): void
     {
@@ -144,8 +135,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * Tests that the logger generates an image file.
-     *
-     * @return void
      */
     public function testGeneratesCorrectSVGImageFile(): void
     {
@@ -165,8 +154,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * testGeneratedSvgImageContainsExpectedPackages
-     *
-     * @return void
      */
     public function testGeneratedSvgImageContainsExpectedPackages(): void
     {
@@ -181,10 +168,10 @@ class ChartTest extends AbstractTestCase
         $logger->log($analyzer);
         $logger->close();
 
-        $svg = new \DOMDocument();
+        $svg = new DOMDocument();
         $svg->load($this->outputFile, LIBXML_NOWARNING);
 
-        $xpath = new \DOMXPath($svg);
+        $xpath = new DOMXPath($svg);
         $xpath->registerNamespace('s', 'http://www.w3.org/2000/svg');
 
         $this->assertEquals(1, $xpath->query("//s:ellipse[@title='package0']")->length);
@@ -193,8 +180,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * testGeneratesSVGImageDoesNotContainNoneUserDefinedPackages
-     *
-     * @return void
      */
     public function testGeneratesSVGImageDoesNotContainNoneUserDefinedPackages(): void
     {
@@ -209,10 +194,10 @@ class ChartTest extends AbstractTestCase
         $logger->log($analyzer);
         $logger->close();
 
-        $svg = new \DOMDocument();
+        $svg = new DOMDocument();
         $svg->load($this->outputFile, LIBXML_NOWARNING);
 
-        $xpath = new \DOMXPath($svg);
+        $xpath = new DOMXPath($svg);
         $xpath->registerNamespace('s', 'http://www.w3.org/2000/svg');
 
         $this->assertEquals(0, $xpath->query("//s:ellipse[@title='package1']")->length);
@@ -220,8 +205,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * testCalculateCorrectEllipseSize
-     *
-     * @return void
      */
     public function testCalculateCorrectEllipseSize(): void
     {
@@ -240,14 +223,14 @@ class ChartTest extends AbstractTestCase
                                 'i'   =>  0,
                                 'd'   =>  0,
                                 'cc'  =>  250,
-                                'ac'  =>  250
+                                'ac'  =>  250,
                             ],
                             $nodes[1]->getId()  =>  [
                                 'a'   =>  0,
                                 'i'   =>  0,
                                 'd'   =>  0,
                                 'cc'  =>  50,
-                                'ac'  =>  50
+                                'ac'  =>  50,
                             ],
                         ];
 
@@ -268,10 +251,10 @@ class ChartTest extends AbstractTestCase
 
         $logger->close();
 
-        $svg = new \DOMDocument();
+        $svg = new DOMDocument();
         $svg->load($this->outputFile, LIBXML_NOWARNING);
 
-        $xpath = new \DOMXPath($svg);
+        $xpath = new DOMXPath($svg);
         $xpath->registerNamespace('s', 'http://www.w3.org/2000/svg');
 
         $ellipseA = $xpath->query("//s:ellipse[@title='package0']")->item(0);
@@ -289,8 +272,6 @@ class ChartTest extends AbstractTestCase
 
     /**
      * Tests that the logger generates an image file.
-     *
-     * @return void
      */
     public function testGeneratesImageFile(): void
     {
@@ -339,8 +320,9 @@ class ChartTest extends AbstractTestCase
     }
 
     /**
-     * @param boolean $userDefined
+     * @param bool   $userDefined
      * @param string $packageName
+     *
      * @return \PDepend\Source\AST\ASTNamespace
      */
     private function createPackage($userDefined, $packageName)

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -49,10 +49,11 @@ use PDepend\Report\DummyAnalyzer;
 /**
  * Test case for the jdepend xml logger.
  *
+ * @covers \PDepend\Report\Jdepend\Xml
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Report\Jdepend\Xml
  * @group unittest
  */
 class XmlTest extends AbstractTestCase
@@ -67,7 +68,7 @@ class XmlTest extends AbstractTestCase
     /**
      * Test dependency analyzer.
      *
-     * @var \PDepend\Metrics\Analyzer\DependencyAnalyzer
+     * @var DependencyAnalyzer
      */
     protected $analyzer = null;
 
@@ -80,8 +81,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Creates the package structure from a test source file.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -92,8 +91,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Removes the temporary log files.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -104,8 +101,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Tests that the logger returns the expected set of analyzers.
-     *
-     * @return void
      */
     public function testReturnsExceptedAnalyzers(): void
     {
@@ -119,8 +114,6 @@ class XmlTest extends AbstractTestCase
     /**
      * Tests that the logger throws an exception if the log target wasn't
      * configured.
-     *
-     * @return void
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -137,8 +130,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testXmlLogAcceptsOnlyTheCorrectAnalyzer
-     *
-     * @return void
      */
     public function testXmlLogAcceptsOnlyTheCorrectAnalyzer(): void
     {
@@ -152,6 +143,7 @@ class XmlTest extends AbstractTestCase
      * Normalizes the file references within the expected result document.
      *
      * @param string $fileName File name of the expected result document.
+     *
      * @return string The prepared xml document
      */
     protected function getNormalizedPathXml($fileName)

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -42,24 +42,24 @@
 
 namespace PDepend\Report\Overview;
 
+use DOMDocument;
 use PDepend\AbstractTestCase;
 use PDepend\Report\DummyAnalyzer;
 
 /**
  * Test case for the overview pyramid logger.
  *
+ * @covers \PDepend\Report\Overview\Pyramid
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Report\Overview\Pyramid
  * @group unittest
  */
 class PyramidTest extends AbstractTestCase
 {
     /**
      * Tests that the logger returns the expected set of analyzers.
-     *
-     * @return void
      */
     public function testReturnsExceptedAnalyzers(): void
     {
@@ -81,8 +81,6 @@ class PyramidTest extends AbstractTestCase
      * configured.
      *
      * @covers \PDepend\Report\NoLogOutputException
-     *
-     * @return void
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -99,8 +97,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the log method returns <b>false</b> for an invalid logger.
-     *
-     * @return void
      */
     public function testPyramidDoesntAcceptInvalidAnalyzer(): void
     {
@@ -110,8 +106,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the logger checks for the required analyzer.
-     *
-     * @return void
      */
     public function testCloseThrowsAnExceptionIfNoCouplingAnalyzerWasSet(): void
     {
@@ -133,8 +127,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the logger checks for the required analyzer.
-     *
-     * @return void
      */
     public function testCloseThrowsAnExceptionIfNoCyclomaticComplexityAnalyzerWasSet(): void
     {
@@ -156,8 +148,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the logger checks for the required analyzer.
-     *
-     * @return void
      */
     public function testCloseThrowsAnExceptionIfNoInheritanceAnalyzerWasSet(): void
     {
@@ -179,8 +169,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the logger checks for the required analyzer.
-     *
-     * @return void
      */
     public function testCloseThrowsAnExceptionIfNoNodeCountAnalyzerWasSet(): void
     {
@@ -202,8 +190,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * Tests that the logger checks for the required analyzer.
-     *
-     * @return void
      */
     public function testCloseThrowsAnExceptionIfNoNodeLOCAnalyzerWasSet(): void
     {
@@ -225,8 +211,6 @@ class PyramidTest extends AbstractTestCase
 
     /**
      * testCollectedAndComputedValuesInOutputSVG
-     *
-     * @return void
      */
     public function testCollectedAndComputedValuesInOutputSVG(): void
     {
@@ -261,10 +245,10 @@ class PyramidTest extends AbstractTestCase
             'nom-noc'       =>  9.42,
             'noc-nop'       =>  20.21,
             'fanout-calls'  =>  0.56,
-            'calls-nom'     =>  4.18
+            'calls-nom'     =>  4.18,
         ];
 
-        $svg = new \DOMDocument();
+        $svg = new DOMDocument();
         $svg->load($output, LIBXML_NOWARNING);
 
         // TODO: Replace this loop assertion
@@ -286,7 +270,7 @@ class PyramidTest extends AbstractTestCase
             ->will($this->returnValue(
                 [
                     'fanout'  =>  8590,
-                    'calls'   =>  15128
+                    'calls'   =>  15128,
                 ]
             ));
 
@@ -301,7 +285,7 @@ class PyramidTest extends AbstractTestCase
             ->method('getProjectMetrics')
             ->will($this->returnValue(
                 [
-                    'ccn2'  =>  5579
+                    'ccn2'  =>  5579,
                 ]
             ));
 
@@ -317,7 +301,7 @@ class PyramidTest extends AbstractTestCase
             ->will($this->returnValue(
                 [
                     'andc'  =>  0.31,
-                    'ahh'   =>  0.12
+                    'ahh'   =>  0.12,
                 ]
             ));
 
@@ -335,7 +319,7 @@ class PyramidTest extends AbstractTestCase
                     'nop'  =>  19,
                     'noc'  =>  384,
                     'nom'  =>  2018,
-                    'nof'  =>  1600
+                    'nof'  =>  1600,
                 ]
             ));
 
@@ -350,7 +334,7 @@ class PyramidTest extends AbstractTestCase
             ->method('getProjectMetrics')
             ->will($this->returnValue(
                 [
-                    'eloc'  =>  35175
+                    'eloc'  =>  35175,
                 ]
             ));
 

--- a/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
+++ b/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
@@ -62,8 +62,6 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Report\ReportGeneratorFactory::createGenerator()}
      * returns the expected instance for a valid identifier.
-     *
-     * @return void
      */
     public function testCreateGeneratorWithValidIdentifier(): void
     {
@@ -76,8 +74,6 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
     /**
      * Tests the singleton behaviour of the logger factory method
      * {@link \PDepend\Report\ReportGeneratorFactory::createGenerator()}.
-     *
-     * @return void
      */
     public function testCreateGeneratorSingletonBehaviour(): void
     {
@@ -92,8 +88,6 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Report\ReportGeneratorFactory::createGenerator()}
      * fails with an exception for an invalid logger identifier.
-     *
-     * @return void
      */
     public function testCreateGeneratorWithInvalidIdentifierFail(): void
     {

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -85,7 +85,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * Adds a listener to this analyzer.
      *
      * @param AnalyzerListener $listener The listener instance.
-     * @return void
      */
     public function addAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -94,8 +93,7 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
     /**
      * Removes the listener from this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function removeAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -103,8 +101,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
-     *
-     * @return void
      */
     public function analyze($namespaces): void
     {
@@ -114,7 +110,8 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * By default all analyzers are enabled. Overwrite this method to provide
      * state based disabling/enabling.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -135,7 +132,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
     /**
      * Returns an array with metrics for the requested node.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -147,6 +143,7 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * Set global options
      *
      * @param array<string, mixed> $options
+     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -74,8 +74,7 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
     /**
      * Adds a listener to this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function addAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -84,8 +83,7 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
     /**
      * Removes the listener from this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function removeAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -93,8 +91,6 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
-     *
-     * @return void
      */
     public function analyze($namespaces): void
     {
@@ -104,7 +100,8 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * By default all analyzers are enabled. Overwrite this method to provide
      * state based disabling/enabling.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -115,7 +112,6 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
     /**
      * Returns an array with metrics for the requested node.
      *
-     * @param \PDepend\Source\AST\ASTArtifact $artifact
      * @return array<string, mixed>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
@@ -130,6 +126,7 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * Set global options
      *
      * @param array<string, mixed> $options
+     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -73,8 +73,7 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
     /**
      * Adds a listener to this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function addAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -83,8 +82,7 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
     /**
      * Removes the listener from this analyzer.
      *
-     * @param \PDepend\Metrics\AnalyzerListener $listener The listener instance.
-     * @return void
+     * @param AnalyzerListener $listener The listener instance.
      */
     public function removeAnalyzeListener(AnalyzerListener $listener): void
     {
@@ -92,8 +90,6 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
 
     /**
      * Processes all {@link \PDepend\Source\AST\ASTNamespace} code nodes.
-     *
-     * @return void
      */
     public function analyze($namespaces): void
     {
@@ -103,7 +99,8 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
      * By default all analyzers are enabled. Overwrite this method to provide
      * state based disabling/enabling.
      *
-     * @return boolean
+     * @return bool
+     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -125,6 +122,7 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
      * Set global options
      *
      * @param array<string, mixed> $options
+     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -48,10 +48,11 @@ use PDepend\Source\AST\ASTArtifactList;
 /**
  * Test case for the xml summary log.
  *
+ * @covers \PDepend\Report\Summary\Xml
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Report\Summary\Xml
  * @group unittest
  */
 class XmlTest extends AbstractTestCase
@@ -72,8 +73,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Creates the package structure from a test source file.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -84,8 +83,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Removes the temporary log files.
-     *
-     * @return void
      */
     protected function tearDown(): void
     {
@@ -96,8 +93,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * Tests that the logger returns the expected set of analyzers.
-     *
-     * @return void
      */
     public function testReturnsExceptedAnalyzers(): void
     {
@@ -125,8 +120,6 @@ class XmlTest extends AbstractTestCase
     /**
      * Tests that the logger throws an exception if the log target wasn't
      * configured.
-     *
-     * @return void
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -143,8 +136,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testLogMethodReturnsTrueForAnalyzerOfTypeProjectAware
-     *
-     * @return void
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeProjectAware(): void
     {
@@ -159,8 +150,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware
-     *
-     * @return void
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware(): void
     {
@@ -177,8 +166,6 @@ class XmlTest extends AbstractTestCase
      * Tests that {@link \PDepend\Report\Summary\Xml::write()} generates the
      * expected document structure for the source, but without any applied
      * metrics.
-     *
-     * @return void
      */
     public function testXmlLogWithoutMetrics(): void
     {
@@ -199,8 +186,6 @@ class XmlTest extends AbstractTestCase
     /**
      * Tests that the xml logger generates the expected xml document for an
      * empty source code structure.
-     *
-     * @return void
      */
     public function testProjectAwareAnalyzerWithoutCode(): void
     {
@@ -227,8 +212,6 @@ class XmlTest extends AbstractTestCase
 
     /**
      * testAnalyzersThatImplementProjectAndNodeAwareAsExpected
-     *
-     * @return void
      */
     public function testAnalyzersThatImplementProjectAndNodeAwareAsExpected(): void
     {
@@ -256,7 +239,7 @@ class XmlTest extends AbstractTestCase
     /**
      * @param string $fixture
      * @param string $expectation
-     * @return void
+     *
      * @dataProvider dataProviderNodeAware
      */
     public function testNodeAwareAnalyzer($fixture, $expectation): void

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTAllocationExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTAllocationExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTAllocationExpression
  * @group unittest
  */
 class ASTAllocationExpressionTest extends ASTNodeTestCase
 {
     /**
      * Tests the implementation with an allocation expression without arguments.
-     *
-     * @return void
      */
     public function testAllocationExpressionWithoutArguments(): void
     {
@@ -69,8 +68,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the implementation with an allocation expression with arguments.
-     *
-     * @return void
      */
     public function testAllocationExpressionWithArguments(): void
     {
@@ -83,8 +80,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
     /**
      * Tests the implementation with an allocation expression with nested
      * expressions that have arguments.
-     *
-     * @return void
      */
     public function testAllocationExpressionWithNestedArguments(): void
     {
@@ -96,8 +91,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line of an allocation expression.
-     *
-     * @return void
      */
     public function testAllocationExpressionHasExpectedStartLine(): void
     {
@@ -107,8 +100,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column of an allocation expression.
-     *
-     * @return void
      */
     public function testAllocationExpressionHasExpectedStartColumn(): void
     {
@@ -118,8 +109,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line of an allocation expression.
-     *
-     * @return void
      */
     public function testAllocationExpressionHasExpectedEndLine(): void
     {
@@ -129,8 +118,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column of an allocation expression.
-     *
-     * @return void
      */
     public function testAllocationExpressionHasExpectedEndColumn(): void
     {
@@ -143,7 +130,7 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase The calling test case.
      *
-     * @return \PDepend\Source\AST\ASTAllocationExpression
+     * @return ASTAllocationExpression
      */
     private function getFirstAllocationExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -47,46 +47,35 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCatchStatement} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
  * @covers \PDepend\Source\AST\ASTAnonymousClass
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTAnonymousClassTest extends ASTNodeTestCase
 {
-    /**
-     * @return void
-     */
     public function testAnonymousClassHasExpectedStartLine(): void
     {
         $expr = $this->getFirstAnonymousClassInFunction(__METHOD__);
         $this->assertEquals(4, $expr->getStartLine());
     }
 
-    /**
-     * @return void
-     */
     public function testAnonymousClassHasExpectedStartColumn(): void
     {
         $expr = $this->getFirstAnonymousClassInFunction(__METHOD__);
         $this->assertEquals(16, $expr->getStartColumn());
     }
 
-    /**
-     * @return void
-     */
     public function testAnonymousClassHasExpectedEndLine(): void
     {
         $expr = $this->getFirstAnonymousClassInFunction(__METHOD__);
         $this->assertEquals(9, $expr->getEndLine());
     }
 
-    /**
-     * @return void
-     */
     public function testAnonymousClassHasExpectedEndColumn(): void
     {
         $expr = $this->getFirstAnonymousClassInFunction(__METHOD__);
@@ -95,8 +84,6 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames(): void
     {
@@ -119,14 +106,14 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
                 'namespaceName',
                 'startLine',
                 'userDefined',
-                'id'
+                'id',
             ],
             $class->__sleep()
         );
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTAnonymousClass
+     * @return ASTAnonymousClass
      */
     private function getFirstAnonymousClassInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArguments} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTArguments
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTArguments
  * @group unittest
  */
 class ASTArgumentsTest extends ASTNodeTestCase
@@ -57,7 +58,6 @@ class ASTArgumentsTest extends ASTNodeTestCase
     /**
      * testArgumentsGraphWithMagicClassConstant
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArgumentsGraphWithMagicClassConstant(): void
@@ -66,19 +66,17 @@ class ASTArgumentsTest extends ASTNodeTestCase
         $this->assertGraph(
             $arguments,
             [
-                'PDepend\\Source\\AST\\ASTConstant'         . ' (__CLASS__)',
-                'PDepend\\Source\\AST\\ASTLiteral'          . ' ("run")',
-                'PDepend\\Source\\AST\\ASTArray'            . ' ()', [
+                'PDepend\\Source\\AST\\ASTConstant' . ' (__CLASS__)',
+                'PDepend\\Source\\AST\\ASTLiteral' . ' ("run")',
+                'PDepend\\Source\\AST\\ASTArray' . ' ()', [
                     'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTVariable' . ' ($count)']]
+                        'PDepend\\Source\\AST\\ASTVariable' . ' ($count)']],
             ]
         );
     }
 
     /**
      * Tests the start line value of an arguments instance.
-     *
-     * @return void
      */
     public function testArgumentsHasExpectedStartLine(): void
     {
@@ -88,8 +86,6 @@ class ASTArgumentsTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value of an arguments instance.
-     *
-     * @return void
      */
     public function testArgumentsHasExpectedStartColumn(): void
     {
@@ -99,8 +95,6 @@ class ASTArgumentsTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value of an arguments instance.
-     *
-     * @return void
      */
     public function testArgumentsHasExpectedEndLine(): void
     {
@@ -110,8 +104,6 @@ class ASTArgumentsTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value of an arguments instance.
-     *
-     * @return void
      */
     public function testArgumentsHasExpectedEndColumn(): void
     {
@@ -121,8 +113,6 @@ class ASTArgumentsTest extends ASTNodeTestCase
 
     /**
      * Tests the accessors for variadic placeholder
-     *
-     * @return void
      */
     public function testArgumentsIsVariadicPlaceholder(): void
     {
@@ -136,7 +126,7 @@ class ASTArgumentsTest extends ASTNodeTestCase
     /**
      * Returns an arguments instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      */
     private function getFirstArgumentsOfFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,12 +47,14 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArrayElement} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTArrayElement
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTArrayElementTest extends ASTNodeTestCase
@@ -70,15 +73,13 @@ class ASTArrayElementTest extends ASTNodeTestCase
      *   - ASTArrayElement
      *     - ASTVariable    ->  $foo
      * </code>
-     *
-     * @return void
      */
     public function testArrayElementGraphSimpleValue(): void
     {
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)'
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)',
             ]
         );
     }
@@ -97,15 +98,13 @@ class ASTArrayElementTest extends ASTNodeTestCase
      *   - ASTArrayElement
      *     - ASTVariable    ->  $foo
      * </code>
-     *
-     * @return void
      */
     public function testArrayElementGraphSimpleValueByReference(): void
     {
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)'
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)',
             ]
         );
     }
@@ -125,8 +124,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
      *     - ASTVariable    ->  $key
      *     - ASTVariable    ->  $value
      * </code>
-     *
-     * @return void
      */
     public function testArrayElementGraphKeyValue(): void
     {
@@ -134,7 +131,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
             $this->getFirstArrayElementInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)'
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)',
             ]
         );
     }
@@ -154,8 +151,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
      *     - ASTVariable    ->  $key
      *     - ASTVariable    ->  $value
      * </code>
-     *
-     * @return void
      */
     public function testArrayElementGraphKeyValueByReference(): void
     {
@@ -163,7 +158,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
             $this->getFirstArrayElementInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)'
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)',
             ]
         );
     }
@@ -202,38 +197,34 @@ class ASTArrayElementTest extends ASTNodeTestCase
      *             - ASTAllocationExpression  ->  new
      *               - ASTClassReference      ->  Object
      * </code>
-     *
-     * @return void
      */
     public function testArrayElementGraphWithTwoDimensions(): void
     {
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTLiteral'                              . ' ("bar")',
-                'PDepend\\Source\\AST\\ASTArray'                                . ' ()', [
-                    'PDepend\\Source\\AST\\ASTArrayElement'                     . ' ()', [
-                        'PDepend\\Source\\AST\\ASTAllocationExpression'         . ' (new)', [
-                            'PDepend\\Source\\AST\\ASTClassReference'           . ' (Object)']],
-                    'PDepend\\Source\\AST\\ASTArrayElement'                     . ' ()', [
-                        'PDepend\\Source\\AST\\ASTLiteral'                      . ' (23)',
-                        'PDepend\\Source\\AST\\ASTAllocationExpression'         . ' (new)', [
-                            'PDepend\\Source\\AST\\ASTClassReference'           . ' (Object)']],
-                    'PDepend\\Source\\AST\\ASTArrayElement'                     . ' ()', [
-                        'PDepend\\Source\\AST\\ASTArray'                        . ' ()', [
-                            'PDepend\\Source\\AST\\ASTArrayElement'             . ' ()', [
-                                'PDepend\\Source\\AST\\ASTLiteral'              . ' ("foo")',
+                'PDepend\\Source\\AST\\ASTLiteral' . ' ("bar")',
+                'PDepend\\Source\\AST\\ASTArray' . ' ()', [
+                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
+                        'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
+                            'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']],
+                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
+                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)',
+                        'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
+                            'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']],
+                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
+                        'PDepend\\Source\\AST\\ASTArray' . ' ()', [
+                            'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
+                                'PDepend\\Source\\AST\\ASTLiteral' . ' ("foo")',
                                 'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                                    'PDepend\\Source\\AST\\ASTClassReference'   . ' (Object)']]]]
-            ]
+                                    'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']]]],
+                ],
             ]
         );
     }
 
     /**
      * testArrayElementByReferenceReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testArrayElementByReferenceReturnsFalseByDefault(): void
     {
@@ -243,8 +234,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * testArrayElementByReferenceReturnsTrueForValue
-     *
-     * @return void
      */
     public function testArrayElementByReferenceReturnsTrueForValue(): void
     {
@@ -254,8 +243,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * testArrayElementByReferenceReturnsFalseForKeyValue
-     *
-     * @return void
      */
     public function testArrayElementByReferenceReturnsFalseForKeyValue(): void
     {
@@ -265,8 +252,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * testArrayElementByReferenceReturnsTrueForKeyValue
-     *
-     * @return void
      */
     public function testArrayElementByReferenceReturnsTrueForKeyValue(): void
     {
@@ -276,8 +261,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value of an array element.
-     *
-     * @return void
      */
     public function testArrayElementHasExpectedStartLine(): void
     {
@@ -287,8 +270,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value of an array element.
-     *
-     * @return void
      */
     public function testArrayElementHasExpectedStartColumn(): void
     {
@@ -298,8 +279,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value of an array element.
-     *
-     * @return void
      */
     public function testArrayElementHasExpectedEndLine(): void
     {
@@ -309,8 +288,6 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value of an array element.
-     *
-     * @return void
      */
     public function testArrayElementHasExpectedEndColumn(): void
     {
@@ -321,7 +298,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
     /**
      * Returns an array element for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArrayElement
+     * @return ASTArrayElement
      */
     private function getFirstArrayElementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -45,12 +45,13 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArrayIndexExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIndexExpression
  * @covers \PDepend\Source\AST\ASTArrayIndexExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTArrayIndexExpressionTest extends ASTNodeTestCase
@@ -72,7 +73,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromFunctionCall(): void
@@ -83,7 +83,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -105,7 +105,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromVariableFunctionCall(): void
@@ -116,7 +115,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -140,7 +139,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromMethodCall(): void
@@ -153,7 +151,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -177,7 +175,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromVariableMethodCall(): void
@@ -190,7 +187,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -214,7 +211,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromStaticMethodCall(): void
@@ -227,7 +223,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -251,7 +247,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      *   - ASTLiteral
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayIndexGraphDereferencedFromVariableStaticMethodCall(): void
@@ -264,7 +259,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -275,8 +270,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      * <code>
      * $array[42];
      * </code>
-     *
-     * @return void
      */
     public function testArrayIndexExpressionGraphForVariable(): void
     {
@@ -284,7 +277,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
             $this->getFirstArrayIndexExpressionInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -295,8 +288,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      * <code>
      * $object->foo[42];
      * </code>
-     *
-     * @return void
      */
     public function testArrayIndexExpressionGraphForProperty(): void
     {
@@ -304,7 +295,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
             $this->getFirstArrayIndexExpressionInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -315,8 +306,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
      * <code>
      * $array[0][0][0];
      * </code>
-     *
-     * @return void
      */
     public function testArrayIndexExpressionGraphForChainedArrayAccess(): void
     {
@@ -328,15 +317,13 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTLiteral',
                 'PDepend\\Source\\AST\\ASTLiteral',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
 
     /**
      * testArrayIndexExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testArrayIndexExpressionHasExpectedStartLine(): void
     {
@@ -346,8 +333,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testArrayIndexExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testArrayIndexExpressionHasExpectedStartColumn(): void
     {
@@ -357,8 +342,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testArrayIndexExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testArrayIndexExpressionHasExpectedEndLine(): void
     {
@@ -368,8 +351,6 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testArrayIndexExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testArrayIndexExpressionHasExpectedEndColumn(): void
     {
@@ -380,7 +361,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArrayIndexExpression
+     * @return ASTArrayIndexExpression
      */
     private function getFirstArrayIndexExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,12 +47,14 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArray} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTArray
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTArrayTest extends ASTNodeTestCase
@@ -68,8 +71,6 @@ class ASTArrayTest extends ASTNodeTestCase
      * <code>
      * - ASTArray
      * </code>
-     *
-     * @return void
      */
     public function testArrayGraphForEmptyArrayDefinition(): void
     {
@@ -91,8 +92,6 @@ class ASTArrayTest extends ASTNodeTestCase
      * <code>
      * - ASTArray
      * </code>
-     *
-     * @return void
      */
     public function testArrayGraphForEmptyShortArrayDefinition(): void
     {
@@ -104,8 +103,6 @@ class ASTArrayTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value of an array instance.
-     *
-     * @return void
      */
     public function testArrayHasExpectedStartLine(): void
     {
@@ -115,8 +112,6 @@ class ASTArrayTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value of an array instance.
-     *
-     * @return void
      */
     public function testArrayHasExpectedStartColumn(): void
     {
@@ -126,8 +121,6 @@ class ASTArrayTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value of an array instance.
-     *
-     * @return void
      */
     public function testArrayHasExpectedEndLine(): void
     {
@@ -137,8 +130,6 @@ class ASTArrayTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value of an array instance.
-     *
-     * @return void
      */
     public function testArrayHasExpectedEndColumn(): void
     {
@@ -149,7 +140,7 @@ class ASTArrayTest extends ASTNodeTestCase
     /**
      * Returns an array instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArray
+     * @return ASTArray
      */
     private function getFirstArrayInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -42,15 +42,18 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
+use OutOfBoundsException;
 use PDepend\AbstractTestCase;
 
 /**
  * Test case the node iterator.
  *
+ * @covers \PDepend\Source\AST\ASTArtifactList
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTArtifactList
  * @group unittest
  */
 class ASTArtifactListTest extends AbstractTestCase
@@ -58,8 +61,6 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * Tests the ctor with an valid input array of {@link \PDepend\Source\AST\AbstractASTArtifact}
      * objects.
-     *
-     * @return void
      */
     public function testCreateIteratorWidthValidInput(): void
     {
@@ -69,16 +70,14 @@ class ASTArtifactListTest extends AbstractTestCase
             new ASTMethod('method', 0),
             new ASTFunction('func', 0),
         ];
-        
+
         $it = new ASTArtifactList($nodes);
-        
+
         $this->assertEquals(4, $it->count());
     }
-    
+
     /**
      * testNodeIteratorReturnsObjectsInUnmodifiedOrder
-     *
-     * @return void
      */
     public function testNodeIteratorReturnsObjectsInUnmodifiedOrder(): void
     {
@@ -88,7 +87,7 @@ class ASTArtifactListTest extends AbstractTestCase
             new ASTMethod('method', 0),
             new ASTNamespace('pkg'),
         ];
-        
+
         $iterator = new ASTArtifactList($expected);
 
         $actual = [];
@@ -101,8 +100,6 @@ class ASTArtifactListTest extends AbstractTestCase
 
     /**
      * testNodeIteratorReturnsObjectsUnique
-     *
-     * @return void
      */
     public function testNodeIteratorReturnsObjectsUnique(): void
     {
@@ -113,7 +110,7 @@ class ASTArtifactListTest extends AbstractTestCase
                 $object3 = new ASTClass('o3', 0, 'o3.php'),
                 $object1,
                 $object2,
-                $object3
+                $object3,
             ]
         );
 
@@ -128,8 +125,6 @@ class ASTArtifactListTest extends AbstractTestCase
 
     /**
      * testIteratorUsesNodeNameAsItsIterationKey
-     *
-     * @return void
      */
     public function testIteratorUsesNodeNameAsItsIterationKey(): void
     {
@@ -153,12 +148,10 @@ class ASTArtifactListTest extends AbstractTestCase
 
     /**
      * testCurrentReturnsFalseWhenNoMoreElementExists
-     *
-     * @return void
      */
     public function testCurrentThrowsOutOfBoundsExceptionWhenNoMoreElementExists(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $iterator = new ASTArtifactList([]);
         $this->assertFalse($iterator->valid());
@@ -168,7 +161,6 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetExistsReturnsFalse
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetExistsReturnsFalse(): void
@@ -180,7 +172,6 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetExistsReturnsTrue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetExistsReturnsTrue(): void
@@ -189,7 +180,7 @@ class ASTArtifactListTest extends AbstractTestCase
             [
                 new ASTClass('Class'),
                 new ASTInterface('Interface'),
-                new ASTTrait('Trait')
+                new ASTTrait('Trait'),
             ]
         );
         $this->assertTrue(isset($iterator[1]));
@@ -198,7 +189,6 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetGetReturnsExpectedNode
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetGetReturnsExpectedNode(): void
@@ -207,7 +197,7 @@ class ASTArtifactListTest extends AbstractTestCase
             [
                 $class     = new ASTClass('Class'),
                 $interface = new ASTInterface('Interface'),
-                $trait     = new ASTTrait('Trait')
+                $trait     = new ASTTrait('Trait'),
             ]
         );
         $this->assertSame($interface, $iterator[1]);
@@ -216,12 +206,11 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetGetThrowsExpectedOutOfBoundsException
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetGetThrowsExpectedOutOfBoundsException(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $iterator = new ASTArtifactList([]);
         $iterator[0]->getName();
@@ -230,12 +219,11 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetSetThrowsExpectedBadMethodCallException
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetSetThrowsExpectedBadMethodCallException(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         $iterator    = new ASTArtifactList([]);
         $iterator[0] = new ASTClass('Class');
@@ -244,12 +232,11 @@ class ASTArtifactListTest extends AbstractTestCase
     /**
      * testArrayBehaviorOffsetUnsetThrowsExpectedBadMethodCallException
      *
-     * @return void
      * @since 1.0.0
      */
     public function testArrayBehaviorOffsetUnsetThrowsExpectedBadMethodCallException(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         $iterator = new ASTArtifactList([]);
         unset($iterator[0]);

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -47,25 +47,24 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\AST\AbstractASTArtifact} class.
  *
+ * @covers \PDepend\Source\AST\AbstractASTArtifact
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @group unittest
  */
 class ASTArtifactTest extends AbstractTestCase
 {
     /**
      * testGetNameReturnsValueOfFirstConstructorArgument
-     *
-     * @return void
      */
     public function testGetNameReturnsValueOfFirstConstructorArgument(): void
     {
         $item = $this->getItemMock();
         $this->assertEquals(__CLASS__, $item->getName());
     }
-    
+
     /**
      * testSetNameOverridesPreviousItemName
      *
@@ -75,14 +74,12 @@ class ASTArtifactTest extends AbstractTestCase
     {
         $item = $this->getItemMock();
         $item->setName(__FUNCTION__);
-        
+
         $this->assertEquals(__FUNCTION__, $item->getName());
     }
 
     /**
      * testGetIdReturnsMd5HashByDefault
-     *
-     * @return void
      */
     public function testGetIdReturnsMd5HashByDefault(): void
     {
@@ -92,8 +89,6 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * testGetIdReturnsInjectedIdValue
-     *
-     * @return void
      */
     public function testGetIdReturnsInjectedIdValue(): void
     {
@@ -105,8 +100,6 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * testGetSourceFileReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetSourceFileReturnsNullByDefault(): void
     {
@@ -116,8 +109,6 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * testGetSourceFileReturnsInjectedFileInstance
-     *
-     * @return void
      */
     public function testGetSourceFileReturnsInjectedFileInstance(): void
     {
@@ -131,8 +122,6 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsNullByDefault(): void
     {
@@ -142,8 +131,6 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsInjectedDocCommentValue
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsInjectedDocCommentValue(): void
     {
@@ -156,7 +143,7 @@ class ASTArtifactTest extends AbstractTestCase
     /**
      * Returns a mocked item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     protected function getItemMock()
     {

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTAssignmentExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTAssignmentExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTAssignmentExpression
  * @group unittest
  */
 class ASTAssignmentExpressionTest extends ASTNodeTestCase
 {
     /**
      * testAssignmentExpressionFromMethodInvocation
-     *
-     * @return void
      */
     public function testAssignmentExpressionFromMethodInvocation(): void
     {
@@ -69,15 +68,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * testAssignmentExpressionFromPropertyAccess
-     *
-     * @return void
      */
     public function testAssignmentExpressionFromPropertyAccess(): void
     {
@@ -88,15 +85,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
 
     /**
      * testAssignmentExpressionFromFunctionReturnValue
-     *
-     * @return void
      */
     public function testAssignmentExpressionFromFunctionReturnValue(): void
     {
@@ -109,15 +104,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
 
     /**
      * Tests the resulting object graph.
-     *
-     * @return void
      */
     public function testAssignmentExpressionGraphForIntegerLiteral(): void
     {
@@ -125,15 +118,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
             $this->getFirstAssignmentExpressionInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
 
     /**
      * Tests the resulting object graph.
-     *
-     * @return void
      */
     public function testAssignmentExpressionGraphForFloatLiteral(): void
     {
@@ -141,7 +132,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
             $this->getFirstAssignmentExpressionInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -149,7 +140,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithEqual(): void
@@ -161,7 +151,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithAndEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithAndEqual(): void
@@ -173,7 +162,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithConcatEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithConcatEqual(): void
@@ -185,7 +173,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithDivEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithDivEqual(): void
@@ -197,7 +184,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithMinusEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithMinusEqual(): void
@@ -209,7 +195,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithModEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithModEqual(): void
@@ -221,7 +206,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithMulEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithMulEqual(): void
@@ -233,7 +217,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithOrEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithOrEqual(): void
@@ -245,7 +228,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithPlusEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithPlusEqual(): void
@@ -257,7 +239,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithXorEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithXorEqual(): void
@@ -269,7 +250,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithShiftLeftEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithShiftLeftEqual(): void
@@ -281,7 +261,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testAssignmentExpressionWithShiftRightEqual
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAssignmentExpressionWithShiftRightEqual(): void
@@ -293,7 +272,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testVariableAssignmentExpression
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
+     *
      * @since 1.0.1
      */
     public function testVariableAssignmentExpression()
@@ -307,9 +287,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testVariableAssignmentExpression
      */
     public function testVariableAssignmentExpressionHasExpectedStartLine($expr): void
@@ -320,9 +299,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testVariableAssignmentExpression
      */
     public function testVariableAssignmentExpressionHasExpectedStartColumn($expr): void
@@ -333,9 +311,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testVariableAssignmentExpression
      */
     public function testVariableAssignmentExpressionHasExpectedEndLine($expr): void
@@ -346,9 +323,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testVariableAssignmentExpression
      */
     public function testVariableAssignmentExpressionHasExpectedEndColumn($expr): void
@@ -359,7 +335,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testStaticPropertyAssignmentExpression
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
+     *
      * @since 1.0.1
      */
     public function testStaticPropertyAssignmentExpression()
@@ -373,9 +350,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testStaticPropertyAssignmentExpression
      */
     public function testStaticPropertyAssignmentExpressionHasExpectedStartLine($expr): void
@@ -386,9 +362,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testStaticPropertyAssignmentExpression
      */
     public function testStaticPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
@@ -399,9 +374,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testStaticPropertyAssignmentExpression
      */
     public function testStaticPropertyAssignmentExpressionHasExpectedEndLine($expr): void
@@ -412,9 +386,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testStaticPropertyAssignmentExpression
      */
     public function testStaticPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
@@ -425,7 +398,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testObjectPropertyAssignmentExpression
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
+     *
      * @since 1.0.1
      */
     public function testObjectPropertyAssignmentExpression()
@@ -439,9 +413,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testObjectPropertyAssignmentExpression
      */
     public function testObjectPropertyAssignmentExpressionHasExpectedStartLine($expr): void
@@ -452,9 +425,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testObjectPropertyAssignmentExpression
      */
     public function testObjectPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
@@ -465,9 +437,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testObjectPropertyAssignmentExpression
      */
     public function testObjectPropertyAssignmentExpressionHasExpectedEndLine($expr): void
@@ -478,9 +449,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testObjectPropertyAssignmentExpression
      */
     public function testObjectPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
@@ -491,7 +461,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testChainedPropertyAssignmentExpression
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
+     *
      * @since 1.0.1
      */
     public function testChainedPropertyAssignmentExpression()
@@ -505,9 +476,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testChainedPropertyAssignmentExpression
      */
     public function testChainedPropertyAssignmentExpressionHasExpectedStartLine($expr): void
@@ -518,9 +488,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testChainedPropertyAssignmentExpression
      */
     public function testChainedPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
@@ -531,9 +500,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testChainedPropertyAssignmentExpression
      */
     public function testChainedPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
@@ -544,9 +512,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param \PDepend\Source\AST\ASTAssignmentExpression $expr
+     * @param ASTAssignmentExpression $expr
      *
-     * @return void
      * @depends testChainedPropertyAssignmentExpression
      */
     public function testChainedPropertyAssignmentExpressionHasExpectedEndLine($expr): void
@@ -557,7 +524,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Returns a test assignment-expression.
      *
-     * @return \PDepend\Source\AST\ASTAssignmentExpression
+     * @return ASTAssignmentExpression
      */
     private function getFirstAssignmentExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBooleanAndExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTBooleanAndExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTBooleanAndExpression
  * @group unittest
  */
 class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 {
     /**
      * testBooleanAndExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testBooleanAndExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanAndExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testBooleanAndExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanAndExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testBooleanAndExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanAndExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testBooleanAndExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTBooleanAndExpression
+     * @return ASTBooleanAndExpression
      */
     private function getFirstBooleanAndExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBooleanOrExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTBooleanOrExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTBooleanOrExpression
  * @group unittest
  */
 class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 {
     /**
      * testBooleanOrExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testBooleanOrExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanOrExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testBooleanOrExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanOrExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testBooleanOrExpressionHasExpectedEndLine(): void
     {
@@ -89,21 +84,19 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testBooleanOrExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testBooleanOrExpressionHasExpectedEndColumn(): void
     {
         $expr = $this->getFirstBooleanOrExpressionInFunction(__METHOD__);
         $this->assertEquals(19, $expr->getEndColumn());
     }
-    
+
     /**
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTBooleanOrExpression
+     * @return ASTBooleanOrExpression
      */
     private function getFirstBooleanOrExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBreakStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTBreakStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTBreakStatement
  * @group unittest
  */
 class ASTBreakStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testBreakStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTBreakStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testBreakStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTBreakStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testBreakStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTBreakStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testBreakStatementHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTBreakStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTBreakStatement
+     * @return ASTBreakStatement
      */
     private function getFirstBreakStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -48,18 +48,17 @@ use PDepend\Source\Tokenizer\Token;
 /**
  * Test case for the {@link \PDepend\Source\AST\AbstractASTCallable} class.
  *
+ * @covers \PDepend\Source\AST\AbstractASTCallable
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\AbstractASTCallable
  * @group unittest
  */
 class ASTCallableTest extends AbstractTestCase
 {
     /**
      * testGetParametersReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetParametersReturnsEmptyArrayByDefault(): void
     {
@@ -69,8 +68,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersReturnsArrayWithOneElement
-     *
-     * @return void
      */
     public function testGetParametersReturnsArrayWithOneElement(): void
     {
@@ -80,8 +77,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersReturnsArrayWithThreeElements
-     *
-     * @return void
      */
     public function testGetParametersReturnsArrayWithThreeElements(): void
     {
@@ -91,8 +86,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersReturnsArrayWithObjectsOfTypeParameter
-     *
-     * @return void
      */
     public function testGetParametersReturnsArrayWithObjectsOfTypeParameter(): void
     {
@@ -102,8 +95,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersNotSetsOptionalOnParameterWithoutDefaultValue
-     *
-     * @return void
      */
     public function testGetParametersNotSetsOptionalOnParameterWithoutDefaultValue(): void
     {
@@ -113,8 +104,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersNotSetsOptionalOnParameterWithFollowingParameterWithoutDefaultValue
-     *
-     * @return void
      */
     public function testGetParametersNotSetsOptionalOnParameterWithFollowingParameterWithoutDefaultValue(): void
     {
@@ -124,8 +113,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersSetsOptionalOnParameterWithDefaultValue
-     *
-     * @return void
      */
     public function testGetParametersSetsOptionalOnParameterWithDefaultValue(): void
     {
@@ -135,8 +122,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetParametersSetsOptionalOnLastParameterWithDefaultValue
-     *
-     * @return void
      */
     public function testGetParametersSetsOptionalOnLastParameterWithDefaultValue(): void
     {
@@ -147,7 +132,6 @@ class ASTCallableTest extends AbstractTestCase
     /**
      * testGetChildrenReturnsExpectedNumberOfNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetChildrenReturnsExpectedNumberOfNodes(): void
@@ -160,8 +144,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetTokensDelegatesCallToCacheRestore
-     *
-     * @return void
      */
     public function testGetTokensDelegatesCallToCacheRestore(): void
     {
@@ -180,8 +162,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testSetTokensDelegatesCallToCacheStore
-     *
-     * @return void
      */
     public function testSetTokensDelegatesCallToCacheStore(): void
     {
@@ -202,8 +182,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetStartLineReturnsZeroByDefault(): void
     {
@@ -213,14 +191,12 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsStartLineOfFirstToken
-     *
-     * @return void
      */
     public function testGetStartLineReturnsStartLineOfFirstToken(): void
     {
         $tokens = [
             new Token(1, 'a', 13, 17, 0, 0),
-            new Token(2, 'b', 23, 42, 0, 0)
+            new Token(2, 'b', 23, 42, 0, 0),
         ];
 
         $cache = $this->createCacheFixture();
@@ -237,8 +213,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetEndLineReturnsZeroByDefault(): void
     {
@@ -248,14 +222,12 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsEndLineOfLastToken
-     *
-     * @return void
      */
     public function testGetEndLineReturnsEndLineOfLastToken(): void
     {
         $tokens = [
             new Token(1, 'a', 13, 17, 0, 0),
-            new Token(2, 'b', 23, 42, 0, 0)
+            new Token(2, 'b', 23, 42, 0, 0),
         ];
 
         $cache = $this->createCacheFixture();
@@ -272,8 +244,6 @@ class ASTCallableTest extends AbstractTestCase
 
     /**
      * testGetReturnClassReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetReturnClassReturnsNullByDefault(): void
     {
@@ -285,7 +255,8 @@ class ASTCallableTest extends AbstractTestCase
      * Returns the first callable found in the test file for the calling test
      * method.
      *
-     * @return \PDepend\Source\AST\AbstractASTCallable
+     * @return AbstractASTCallable
+     *
      * @since 0.10.0
      */
     protected function getFirstCallableForTest()
@@ -296,7 +267,7 @@ class ASTCallableTest extends AbstractTestCase
     /**
      * Returns a mocked instance of the callable class.
      *
-     * @return \PDepend\Source\AST\AbstractASTCallable
+     * @return AbstractASTCallable
      */
     protected function getCallableMock()
     {

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -45,239 +45,198 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCastExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTCastExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTCastExpression
  * @group unittest
  */
 class ASTCastExpressionTest extends ASTNodeTestCase
 {
     /**
      * testNormalizesWhitespacesInCastExpression
-     *
-     * @return void
      */
     public function testNormalizesWhitespacesInCastExpression(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression("\n( float )\t\r");
+        $expr = new ASTCastExpression("\n( float )\t\r");
         $this->assertEquals('(float)', $expr->getImage());
     }
 
     /**
      * testNormalizesCaseInCastExpressionImage
-     *
-     * @return void
      */
     public function testNormalizesCaseInCastExpressionImage(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression("(DouBlE)");
+        $expr = new ASTCastExpression("(DouBlE)");
         $this->assertEquals('(double)', $expr->getImage());
     }
 
     /**
      * testIsBooleanReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsBooleanReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('');
+        $expr = new ASTCastExpression('');
         $this->assertFalse($expr->isBoolean());
     }
 
     /**
      * testIsBooleanReturnsTrueForShortExpression
-     *
-     * @return void
      */
     public function testIsBooleanReturnsTrueForShortExpression(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(bool)');
+        $expr = new ASTCastExpression('(bool)');
         $this->assertTrue($expr->isBoolean());
     }
 
     /**
      * testIsBooleanReturnsTrueForLongExpression
-     *
-     * @return void
      */
     public function testIsBooleanReturnsTrueForLongExpression(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(boolean)');
+        $expr = new ASTCastExpression('(boolean)');
         $this->assertTrue($expr->isBoolean());
     }
 
     /**
      * testIsIntegerReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsIntegerReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('');
+        $expr = new ASTCastExpression('');
         $this->assertFalse($expr->isInteger());
     }
 
     /**
      * testIsIntegerReturnsTrueForShortNotation
-     *
-     * @return void
      */
     public function testIsIntegerReturnsTrueForShortNotation(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(int)');
+        $expr = new ASTCastExpression('(int)');
         $this->assertTrue($expr->isInteger());
     }
 
     /**
      * testIsIntegerReturnsTrueForLongNotation
-     *
-     * @return void
      */
     public function testIsIntegerReturnsTrueForLongNotation(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(integer)');
+        $expr = new ASTCastExpression('(integer)');
         $this->assertTrue($expr->isInteger());
     }
 
     /**
      * testIsArrayReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsArrayReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('');
+        $expr = new ASTCastExpression('');
         $this->assertFalse($expr->isArray());
     }
 
     /**
      * testIsArrayReturnsTrueForArrayCast
-     *
-     * @return void
      */
     public function testIsArrayReturnsTrueForArrayCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(array)');
+        $expr = new ASTCastExpression('(array)');
         $this->assertTrue($expr->isArray());
     }
 
     /**
      * testIsFloatReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsFloatReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('');
+        $expr = new ASTCastExpression('');
         $this->assertFalse($expr->isFloat());
     }
 
     /**
      * testIsFloatReturnsTrueForRealCast
-     *
-     * @return void
      */
     public function testIsFloatReturnsTrueForRealCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(real)');
+        $expr = new ASTCastExpression('(real)');
         $this->assertTrue($expr->isFloat());
     }
 
     /**
      * testIsFloatReturnsTrueForFloatCast
-     *
-     * @return void
      */
     public function testIsFloatReturnsTrueForFloatCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(float)');
+        $expr = new ASTCastExpression('(float)');
         $this->assertTrue($expr->isFloat());
     }
 
     /**
      * testIsFloatReturnsTrueForDoubleCast
-     *
-     * @return void
      */
     public function testIsFloatReturnsTrueForDoubleCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(double)');
+        $expr = new ASTCastExpression('(double)');
         $this->assertTrue($expr->isFloat());
     }
 
     /**
      * testIsStringReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsStringReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('( )');
+        $expr = new ASTCastExpression('( )');
         $this->assertFalse($expr->isString());
     }
 
     /**
      * testIsStringReturnsTrueForStringCast
-     *
-     * @return void
      */
     public function testIsStringReturnsTrueForStringCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(string)');
+        $expr = new ASTCastExpression('(string)');
         $this->assertTrue($expr->isString());
     }
 
     /**
      * testIsObjectReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsObjectReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('( obj )');
+        $expr = new ASTCastExpression('( obj )');
         $this->assertFalse($expr->isObject());
     }
 
     /**
      * testIsObjectReturnsTrueForObjectCast
-     *
-     * @return void
      */
     public function testIsObjectReturnsTrueForObjectCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(object)');
+        $expr = new ASTCastExpression('(object)');
         $this->assertTrue($expr->isObject());
     }
 
     /**
      * testIsUnsetReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsUnsetReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(nu)');
+        $expr = new ASTCastExpression('(nu)');
         $this->assertFalse($expr->isUnset());
     }
 
     /**
      * testIsUnsetReturnsTrueForUnsetCast
-     *
-     * @return void
      */
     public function testIsUnsetReturnsTrueForUnsetCast(): void
     {
-        $expr = new \PDepend\Source\AST\ASTCastExpression('(unset)');
+        $expr = new ASTCastExpression('(unset)');
         $this->assertTrue($expr->isUnset());
     }
 
     /**
      * testParserHandlesNestedCastExpressions
-     *
-     * @return void
      */
     public function testParserHandlesNestedCastExpressions(): void
     {
@@ -288,15 +247,13 @@ class ASTCastExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTCastExpression',
                 'PDepend\\Source\\AST\\ASTCastExpression',
                 'PDepend\\Source\\AST\\ASTCastExpression',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testCastExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testCastExpressionHasExpectedStartLine(): void
     {
@@ -306,8 +263,6 @@ class ASTCastExpressionTest extends ASTNodeTestCase
 
     /**
      * testCastExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testCastExpressionHasExpectedStartColumn(): void
     {
@@ -317,8 +272,6 @@ class ASTCastExpressionTest extends ASTNodeTestCase
 
     /**
      * testCastExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testCastExpressionHasExpectedEndLine(): void
     {
@@ -328,8 +281,6 @@ class ASTCastExpressionTest extends ASTNodeTestCase
 
     /**
      * testCastExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testCastExpressionHasExpectedEndColumn(): void
     {
@@ -342,7 +293,7 @@ class ASTCastExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTCastExpression
+     * @return ASTCastExpression
      */
     private function getFirstCastExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCatchStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTCatchStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTCatchStatement
  * @group unittest
  */
 class ASTCatchStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testCatchStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testCatchStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testCatchStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testCatchStatementHasExpectedEndColumn(): void
     {
@@ -100,8 +93,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * testCatchStatementVariableHasExpectedStartLine
-     *
-     * @return void
      */
     public function testCatchStatementVariableHasExpectedStartLine(): void
     {
@@ -112,8 +103,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * testCatchStatementVariableHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testCatchStatementVariableHasExpectedStartColumn(): void
     {
@@ -124,8 +113,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * testCatchStatementVariableHasExpectedEndLine
-     *
-     * @return void
      */
     public function testCatchStatementVariableHasExpectedEndLine(): void
     {
@@ -136,8 +123,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * testCatchStatementVariableHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testCatchStatementVariableHasExpectedEndColumn(): void
     {
@@ -148,8 +133,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfCatchStatementIsScopeStatement
-     *
-     * @return void
      */
     public function testThirdChildOfCatchStatementIsScopeStatement(): void
     {
@@ -162,7 +145,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTCatchStatement
+     * @return ASTCatchStatement
      */
     private function getFirstCatchStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -45,23 +45,22 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPropertyPostfix} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\AST\ASTClassFqnPostfix
+ *
  * @group unittest
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClassFqnPostfix
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 class ASTClassFqnPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImage
-     *
-     * @return void
      */
     public function testGetImage(): void
     {
@@ -71,8 +70,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixStructureWithStatic
-     *
-     * @return void
      */
     public function testClassFqnPostfixStructureWithStatic(): void
     {
@@ -80,15 +77,13 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
                 'PDepend\\Source\\AST\\ASTStaticReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix'
+                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
             ]
         );
     }
 
     /**
      * testGetImageWorksCaseInsensitive
-     *
-     * @return void
      */
     public function testGetImageWorksCaseInsensitive(): void
     {
@@ -98,8 +93,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixStructureWithSelf
-     *
-     * @return void
      */
     public function testClassFqnPostfixStructureWithSelf(): void
     {
@@ -107,15 +100,13 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
                 'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix'
+                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
             ]
         );
     }
 
     /**
      * testClassFqnPostfixStructureWithParent
-     *
-     * @return void
      */
     public function testClassFqnPostfixStructureWithParent(): void
     {
@@ -123,15 +114,13 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
                 'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix'
+                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
             ]
         );
     }
 
     /**
      * testClassFqnPostfixStructureWithClassName
-     *
-     * @return void
      */
     public function testClassFqnPostfixStructureWithClassName(): void
     {
@@ -139,7 +128,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix'
+                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
             ]
         );
     }
@@ -150,25 +139,23 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
      * <code>
      * protected $foo = \Iterator::class;
      * </code>
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsPropertyInitializer(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTFieldDeclaration $fieldDeclaration */
+        /** @var ASTFieldDeclaration $fieldDeclaration */
         $fieldDeclaration = $this->getFirstClassForTestCase(__METHOD__)->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFieldDeclaration', $fieldDeclaration);
 
-        /** @var \PDepend\Source\AST\ASTVariableDeclarator $variableDeclarator */
+        /** @var ASTVariableDeclarator $variableDeclarator */
         $variableDeclarator = $fieldDeclaration->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
         $this->assertTrue($variableDeclarator->getValue()->isValueAvailable());
 
-        /** @var \PDepend\Source\AST\ASTClassOrInterfaceReference $classReference */
+        /** @var ASTClassOrInterfaceReference $classReference */
         $classReference = $variableDeclarator->getValue()->getValue();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $classReference);
 
@@ -181,25 +168,23 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
      * <code>
      * protected $foo = self::class;
      * </code>
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsPropertyInitializerWithSelf(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTFieldDeclaration $fieldDeclaration */
+        /** @var ASTFieldDeclaration $fieldDeclaration */
         $fieldDeclaration = $this->getFirstClassForTestCase(__METHOD__)->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFieldDeclaration', $fieldDeclaration);
 
-        /** @var \PDepend\Source\AST\ASTVariableDeclarator $variableDeclarator */
+        /** @var ASTVariableDeclarator $variableDeclarator */
         $variableDeclarator = $fieldDeclaration->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
         $this->assertTrue($variableDeclarator->getValue()->isValueAvailable());
 
-        /** @var \PDepend\Source\AST\ASTSelfReference $classReference */
+        /** @var ASTSelfReference $classReference */
         $classReference = $variableDeclarator->getValue()->getValue();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $classReference);
 
@@ -208,8 +193,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixAsParameterInitializer
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsParameterInitializer(): void
     {
@@ -226,8 +209,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixAsParameterInitializerWithSelf
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsParameterInitializerWithSelf(): void
     {
@@ -244,19 +225,17 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixAsConstantInitializer
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsConstantInitializer(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTConstantDefinition $constantDefinition */
+        /** @var ASTConstantDefinition $constantDefinition */
         $constantDefinition = $this->getFirstClassForTestCase()->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constantDefinition);
 
-        /** @var \PDepend\Source\AST\ASTConstantDeclarator $constantDefinition */
+        /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $constantDeclarator);
@@ -264,19 +243,17 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixAsConstantInitializerWithSelf
-     *
-     * @return void
      */
     public function testClassFqnPostfixAsConstantInitializerWithSelf(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTConstantDefinition $constantDefinition */
+        /** @var ASTConstantDefinition $constantDefinition */
         $constantDefinition = $this->getFirstClassForTestCase()->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constantDefinition);
 
-        /** @var \PDepend\Source\AST\ASTConstantDeclarator $constantDefinition */
+        /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $constantDeclarator);
@@ -284,8 +261,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testClassFqnPostfixHasExpectedStartLine(): void
     {
@@ -295,8 +270,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testClassFqnPostfixHasExpectedStartColumn(): void
     {
@@ -306,8 +279,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testClassFqnPostfixHasExpectedEndLine(): void
     {
@@ -317,8 +288,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassFqnPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testClassFqnPostfixHasExpectedEndColumn(): void
     {
@@ -329,7 +298,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     /**
      * Creates a field declaration node.
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      */
     protected function createNodeInstance()
     {
@@ -339,7 +308,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTClassFqnPostfix
+     * @return ASTClassFqnPostfix
      */
     private function getFirstClassFqnPostfixInClass()
     {
@@ -353,7 +322,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -47,19 +47,18 @@ use PDepend\Source\Builder\BuilderContext;
 /**
  * description
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTClassOrInterfaceReference
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTClassOrInterfaceReference
  * @group unittest
  */
 class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 {
     /**
      * testReturnValueOfMagicSleepContainsContextProperty
-     *
-     * @return void
      */
     public function testReturnValueOfMagicSleepContainsContextProperty(): void
     {
@@ -73,7 +72,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
                 'context',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $reference->__sleep()
         );
@@ -81,8 +80,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testGetTypeDelegatesToBuilderContextGetClassOrInterface
-     *
-     * @return void
      */
     public function testGetTypeDelegatesToBuilderContextGetClassOrInterface(): void
     {
@@ -102,8 +99,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testGetTypeCachesReturnValueOfBuilderContextGetClassOrInterface
-     *
-     * @return void
      */
     public function testGetTypeCachesReturnValueOfBuilderContextGetClassOrInterface(): void
     {
@@ -123,8 +118,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testReferenceHasExpectedStartLine
-     *
-     * @return void
      */
     public function testReferenceHasExpectedStartLine(): void
     {
@@ -134,8 +127,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testReferenceHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testReferenceHasExpectedStartColumn(): void
     {
@@ -145,8 +136,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testReferenceHasExpectedEndLine
-     *
-     * @return void
      */
     public function testReferenceHasExpectedEndLine(): void
     {
@@ -156,8 +145,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * testReferenceHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testReferenceHasExpectedEndColumn(): void
     {
@@ -168,7 +155,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInInterfaceExtendsHasExpectedStartLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInInterfaceExtendsHasExpectedStartLine(): void
@@ -180,7 +166,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInInterfaceExtendsHasExpectedStartColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInInterfaceExtendsHasExpectedStartColumn(): void
@@ -192,7 +177,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInInterfaceExtendsHasExpectedEndLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInInterfaceExtendsHasExpectedEndLine(): void
@@ -204,7 +188,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInInterfaceExtendsHasExpectedEndColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInInterfaceExtendsHasExpectedEndColumn(): void
@@ -216,7 +199,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassImplementsHasExpectedStartLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassImplementsHasExpectedStartLine(): void
@@ -228,7 +210,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassImplementsHasExpectedStartColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassImplementsHasExpectedStartColumn(): void
@@ -240,7 +221,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassImplementsHasExpectedEndLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassImplementsHasExpectedEndLine(): void
@@ -252,7 +232,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassImplementsHasExpectedEndColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassImplementsHasExpectedEndColumn(): void
@@ -266,7 +245,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      */
     private function getFirstReferenceInFunction($testCase)
     {
@@ -279,7 +258,8 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
+     *
      * @since 0.10.5
      */
     private function getFirstReferenceInClass()
@@ -293,7 +273,8 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
+     *
      * @since 0.10.5
      */
     private function getFirstReferenceInInterface()
@@ -307,7 +288,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function createNodeInstance()
     {
@@ -320,7 +301,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Returns a mocked builder context instance.
      *
-     * @return \PDepend\Source\Builder\BuilderContext
+     * @return BuilderContext
      */
     protected function getBuilderContextMock()
     {

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -47,19 +47,18 @@ use PDepend\Source\Builder\BuilderContext;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClassReference} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTClassReference
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTClassReference
  * @group unittest
  */
 class ASTClassReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeDelegatesToBuilderContextGetClass
-     *
-     * @return void
      */
     public function testGetTypeDelegatesToBuilderContextGetClass(): void
     {
@@ -69,14 +68,12 @@ class ASTClassReferenceTest extends ASTNodeTestCase
             ->with($this->equalTo(__CLASS__))
             ->will($this->returnValue($this));
 
-        $reference = new \PDepend\Source\AST\ASTClassReference($context, __CLASS__);
+        $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();
     }
 
     /**
      * testGetTypeCachesReturnValueOfBuilderContextGetClass
-     *
-     * @return void
      */
     public function testGetTypeCachesReturnValueOfBuilderContextGetClass(): void
     {
@@ -86,14 +83,12 @@ class ASTClassReferenceTest extends ASTNodeTestCase
             ->with($this->equalTo(__CLASS__))
             ->will($this->returnValue($this));
 
-        $reference = new \PDepend\Source\AST\ASTClassReference($context, __CLASS__);
+        $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();
     }
 
     /**
      * testReturnValueOfMagicSleepContainsContextProperty
-     *
-     * @return void
      */
     public function testReturnValueOfMagicSleepContainsContextProperty(): void
     {
@@ -102,7 +97,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
                 'context',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $this->createNodeInstance()->__sleep()
         );
@@ -110,8 +105,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
 
     /**
      * testClassReferenceHasExpectedStartLine
-     *
-     * @return void
      */
     public function testClassReferenceHasExpectedStartLine(): void
     {
@@ -121,8 +114,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
 
     /**
      * testClassReferenceHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testClassReferenceHasExpectedStartColumn(): void
     {
@@ -132,8 +123,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
 
     /**
      * testClassReferenceHasExpectedEndLine
-     *
-     * @return void
      */
     public function testClassReferenceHasExpectedEndLine(): void
     {
@@ -143,8 +132,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
 
     /**
      * testClassReferenceHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testClassReferenceHasExpectedEndColumn(): void
     {
@@ -155,7 +142,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassExtendsHasExpectedStartLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassExtendsHasExpectedStartLine(): void
@@ -167,7 +153,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassExtendsHasExpectedStartColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassExtendsHasExpectedStartColumn(): void
@@ -179,7 +164,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassExtendsHasExpectedEndLine
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassExtendsHasExpectedEndLine(): void
@@ -191,7 +175,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * testReferenceInClassExtendsHasExpectedEndColumn
      *
-     * @return void
      * @since 0.10.5
      */
     public function testReferenceInClassExtendsHasExpectedEndColumn(): void
@@ -205,7 +188,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTClassReference
+     * @return ASTClassReference
      */
     private function getFirstReferenceInFunction($testCase)
     {
@@ -218,7 +201,8 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTClassReference
+     * @return ASTClassReference
+     *
      * @since 0.10.5
      */
     private function getFirstReferenceInClass()
@@ -232,11 +216,11 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTClassReference(
+        return new ASTClassReference(
             $this->getBuilderContextMock(),
             __CLASS__
         );
@@ -245,13 +229,13 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * Returns a mocked builder context instance.
      *
-     * @return \PDepend\Source\Builder\BuilderContext
+     * @return BuilderContext
      */
     protected function getBuilderContextMock()
     {
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
-        
+
         return $context;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -42,30 +42,30 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
+use InvalidArgumentException;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
-use PDepend\Source\Builder\BuilderContext;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTClass class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\AST\AbstractASTClassOrInterface
  * @covers \PDepend\Source\AST\AbstractASTType
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTClassTest extends AbstractASTArtifactTestCase
 {
     /**
      * testGetAllMethodsContainsMethodsOfImplementedInterface
-     *
-     * @return void
      */
     public function testGetAllMethodsContainsMethodsOfImplementedInterface(): void
     {
@@ -78,8 +78,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsContainsMethodsOfImplementedInterfaces
-     *
-     * @return void
      */
     public function testGetAllMethodsContainsMethodsOfImplementedInterfaces(): void
     {
@@ -92,8 +90,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsContainsMethodsOfIndirectImplementedInterfaces
-     *
-     * @return void
      */
     public function testGetAllMethodsContainsMethodsOfIndirectImplementedInterfaces(): void
     {
@@ -106,8 +102,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsContainsMethodsOfParentClass
-     *
-     * @return void
      */
     public function testGetAllMethodsContainsMethodsOfParentClass(): void
     {
@@ -120,8 +114,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsContainsMethodsOfParentClasses
-     *
-     * @return void
      */
     public function testGetAllMethodsContainsMethodsOfParentClasses(): void
     {
@@ -135,7 +127,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsOnClassWithParentReturnsTraitMethod
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnClassWithParentReturnsTraitMethod(): void
@@ -152,7 +143,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsOnClassWhereTraitExcludesParentMethod
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnClassWhereTraitExcludesParentMethod(): void
@@ -169,7 +159,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsOnClassWithParentAndPrecedenceReturnsParentMethod
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnClassWithParentAndPrecedenceReturnsParentMethod(): void
@@ -186,7 +175,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult(): void
@@ -201,7 +189,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithRedeclaredMethodReturnsExpectedInstance
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithRedeclaredMethodReturnsExpectedInstance(): void
@@ -215,7 +202,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithAliasedMethodCollision
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithAliasedMethodCollision(): void
@@ -230,7 +216,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithAliasedMethodTwice
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithAliasedMethodTwice(): void
@@ -245,7 +230,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithVisibilityChangedToPublic
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithVisibilityChangedToPublic(): void
@@ -262,7 +246,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithVisibilityChangedToProtected
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithVisibilityChangedToProtected(): void
@@ -279,7 +262,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithVisibilityChangedToPrivate
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithVisibilityChangedToPrivate(): void
@@ -296,7 +278,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier(): void
@@ -313,7 +294,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsStaticModifier
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsStaticModifier(): void
@@ -330,7 +310,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsHandlesTraitMethodPrecedence
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsHandlesTraitMethodPrecedence(): void
@@ -347,7 +326,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsExcludeTraitMethodWithPrecedence
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsExcludeTraitMethodWithPrecedence(): void
@@ -359,15 +337,15 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithMethodCollisionThrowsExpectedException
      *
-     * @return void
-     * @since 1.0.0
      * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
+     *
+     * @since 1.0.0
      *
      * @group issue-154
      */
     public function testGetAllMethodsWithMethodCollisionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTTraitMethodCollisionException::class);
+        $this->expectException(ASTTraitMethodCollisionException::class);
 
         $class = $this->getFirstClassForTestCase();
         $class->getAllMethods();
@@ -376,7 +354,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsAnEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsAnEmptyArrayByDefault(): void
@@ -388,7 +365,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
@@ -399,8 +375,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantsReturnsAnEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetConstantsReturnsAnEmptyArrayByDefault(): void
     {
@@ -410,8 +384,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantsReturnsExpectedConstant
-     *
-     * @return void
      */
     public function testGetConstantsReturnsExpectedConstant(): void
     {
@@ -421,8 +393,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantsReturnsExpectedConstants
-     *
-     * @return void
      */
     public function testGetConstantsReturnsExpectedConstants(): void
     {
@@ -432,8 +402,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantsReturnsExpectedParentConstants
-     *
-     * @return void
      */
     public function testGetConstantsReturnsExpectedParentConstants(): void
     {
@@ -443,8 +411,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantsReturnsExpectedMergedParentAndChildConstants
-     *
-     * @return void
      */
     public function testGetConstantsReturnsExpectedMergedParentAndChildConstants(): void
     {
@@ -455,7 +421,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetConstantsReturnsExpectedInterfaceConstants
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetConstantsReturnsExpectedInterfaceConstants(): void
@@ -466,8 +431,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantReturnsFalseForNotExistentConstant
-     *
-     * @return void
      */
     public function testGetConstantReturnsFalseForNotExistentConstant(): void
     {
@@ -477,8 +440,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantReturnsExpectedValueForExistentConstant
-     *
-     * @return void
      */
     public function testGetConstantReturnsExpectedValueForExistentConstant(): void
     {
@@ -488,8 +449,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetConstantReturnsExpectedValueNullForExistentConstant
-     *
-     * @return void
      */
     public function testGetConstantReturnsExpectedValueNullForExistentConstant(): void
     {
@@ -499,8 +458,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testHasConstantReturnsFalseForNotExistentConstant
-     *
-     * @return void
      */
     public function testHasConstantReturnsFalseForNotExistentConstant(): void
     {
@@ -510,8 +467,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testHasConstantReturnsTrueForExistentConstant
-     *
-     * @return void
      */
     public function testHasConstantReturnsTrueForExistentConstant(): void
     {
@@ -521,8 +476,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testHasConstantReturnsTrueForExistentNullConstant
-     *
-     * @return void
      */
     public function testHasConstantReturnsTrueForExistentNullConstant(): void
     {
@@ -533,7 +486,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesReturnsEmptyResultByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesReturnsEmptyResultByDefault(): void
@@ -545,7 +497,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsImplementedInterface
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsImplementedInterface(): void
@@ -557,7 +508,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsImplementedInterfaces
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsImplementedInterfaces(): void
@@ -569,7 +519,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsParentClass
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsParentClass(): void
@@ -581,7 +530,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsParentClassAndInterfaces
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsParentClassAndInterfaces(): void
@@ -592,8 +540,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
@@ -621,8 +567,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
@@ -656,8 +600,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
@@ -688,8 +630,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration(): void
     {
@@ -703,8 +643,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeFindsASTNodeInMethodDeclarations(): void
     {
@@ -718,8 +656,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testFindChildrenOfTypeFindsASTNodesFromVariousCodeItems
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeFindsASTNodesFromVariousCodeItems(): void
     {
@@ -733,8 +669,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassStillIsParentOfChildMethods
-     *
-     * @return void
      */
     public function testUnserializedClassStillIsParentOfChildMethods(): void
     {
@@ -746,8 +680,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassAndChildMethodsStillReferenceTheSameFile
-     *
-     * @return void
      */
     public function testUnserializedClassAndChildMethodsStillReferenceTheSameFile(): void
     {
@@ -762,8 +694,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassStillReferencesSameParentClass
-     *
-     * @return void
      */
     public function testUnserializedClassStillReferencesSameParentClass(): void
     {
@@ -778,8 +708,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassStillReferencesSameParentInterface
-     *
-     * @return void
      */
     public function testUnserializedClassStillReferencesSameParentInterface(): void
     {
@@ -794,8 +722,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassIsReturnedByMethodAsReturnClass
-     *
-     * @return void
      */
     public function testUnserializedClassIsReturnedByMethodAsReturnClass(): void
     {
@@ -812,8 +738,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassStillReferencesSamePackage
-     *
-     * @return void
      */
     public function testUnserializedClassStillReferencesSamePackage(): void
     {
@@ -828,8 +752,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassRegistersToPackage
-     *
-     * @return void
      */
     public function testUnserializedClassRegistersToPackage(): void
     {
@@ -841,8 +763,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedClassNotAddsDublicateClassToPackage
-     *
-     * @return void
      */
     public function testUnserializedClassNotAddsDublicateClassToPackage(): void
     {
@@ -854,8 +774,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the ctor and the {@link \PDepend\Source\AST\ASTClass::getName()}.
-     *
-     * @return void
      */
     public function testCreateNewClassInstance(): void
     {
@@ -865,8 +783,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsAbstractReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsAbstractReturnsFalseByDefault(): void
     {
@@ -876,8 +792,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testMarkClassInstanceAsAbstract
-     *
-     * @return void
      */
     public function testMarkClassInstanceAsAbstract(): void
     {
@@ -889,8 +803,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsFinalReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsFinalReturnsFalseByDefault(): void
     {
@@ -900,8 +812,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testMarkClassInstanceAsFinal
-     *
-     * @return void
      */
     public function testMarkClassInstanceAsFinal(): void
     {
@@ -914,12 +824,10 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTClass::setModifiers()}
      * when it is called with an invalid modifier.
-     *
-     * @return void
      */
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifier(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $class = new ASTClass(__CLASS__);
         $class->setModifiers(
@@ -931,8 +839,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Tests that a new {@link \PDepend\Source\AST\ASTClass} object returns
      * an empty {@link \PDepend\Source\AST\ASTArtifactList} instance for methods.
-     *
-     * @return void
      */
     public function testGetMethodsNodeIteratorIsEmptyByDefault(): void
     {
@@ -946,8 +852,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      * Tests that the {@link \PDepend\Source\AST\ASTClass::addMethod()}
      * method adds a method to the internal list and sets the context class as
      * parent.
-     *
-     * @return void
      */
     public function testAddMethodStoresNewlyAddedMethodInCollection(): void
     {
@@ -960,8 +864,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testAddMethodSetsParentOfNewlyAddedMethod
-     *
-     * @return void
      */
     public function testAddMethodSetsParentOfNewlyAddedMethod(): void
     {
@@ -975,8 +877,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetNamespaceReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetNamespaceReturnsNullByDefault(): void
     {
@@ -988,8 +888,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      * Tests that the {@link \PDepend\Source\AST\ASTClass::getNamespace()}
      * returns as default value <b>null</b> and that the namespace could be set
      * and unset.
-     *
-     * @return void
      */
     public function testGetSetNamespace(): void
     {
@@ -1002,8 +900,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnsetNamespaceResetsNamespaceReference
-     *
-     * @return void
      */
     public function testUnsetNamespaceResetsNamespaceReference(): void
     {
@@ -1018,7 +914,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testUnsetNamespaceResetsNamespaceNameProperty
      *
-     * @return void
      * @since 0.10.2
      */
     public function testUnsetNamespaceResetsNamespaceNameProperty(): void
@@ -1034,8 +929,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Tests that {@link \PDepend\Source\AST\ASTClass::getInterfaces()}
      * returns the expected result.
-     *
-     * @return void
      */
     public function testGetInterfaces(): void
     {
@@ -1053,8 +946,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Tests that {@link \PDepend\Source\AST\ASTClass::getInterfaces()}
      * returns the expected result.
-     *
-     * @return void
      */
     public function testGetInterfacesByInheritance(): void
     {
@@ -1077,8 +968,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Tests that {@link \PDepend\Source\AST\ASTClass::getInterfaces()}
      * returns the expected result.
-     *
-     * @return void
      */
     public function testGetInterfacesByClassInheritence(): void
     {
@@ -1095,8 +984,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTClass::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeInInheritanceHierarchy(): void
     {
@@ -1118,7 +1005,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             'C' => false,
             'D' => true,
             'E' => true,
-            'F' => false
+            'F' => false,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -1126,8 +1013,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTClass::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeInClassInheritanceHierarchy(): void
     {
@@ -1149,7 +1034,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             'C' => false,
             'D' => true,
             'E' => true,
-            'F' => false
+            'F' => false,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -1157,8 +1042,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTClass::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeInClassAndInterfaceInheritanceHierarchy(): void
     {
@@ -1180,7 +1063,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             'C' => true,
             'D' => true,
             'E' => true,
-            'F' => true
+            'F' => true,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -1188,8 +1071,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetPropertiesReturnsExpectedNumberOfProperties
-     *
-     * @return void
      */
     public function testGetPropertiesReturnsExpectedNumberOfProperties(): void
     {
@@ -1199,12 +1080,10 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests that it is not possible to overwrite previously set class modifiers.
-     *
-     * @return void
      */
     public function testSetModifiersThrowsExpectedExceptionOnOverwrite(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         $class = new ASTClass(__CLASS__);
         $class->setModifiers(State::IS_FINAL);
@@ -1213,8 +1092,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetModifiersReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetModifiersReturnsZeroByDefault(): void
     {
@@ -1224,8 +1101,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetModifiersReturnsInjectedModifierValue
-     *
-     * @return void
      */
     public function testGetModifiersReturnsInjectedModifierValue(): void
     {
@@ -1237,8 +1112,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the visitor accept method.
-     *
-     * @return void
      */
     public function testVisitorAccept(): void
     {
@@ -1251,8 +1124,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetTokensDelegatesCallToCacheRestore
-     *
-     * @return void
      */
     public function testGetTokensDelegatesCallToCacheRestore(): void
     {
@@ -1271,8 +1142,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testSetTokensDelegatesCallToCacheStore
-     *
-     * @return void
      */
     public function testSetTokensDelegatesCallToCacheStore(): void
     {
@@ -1294,8 +1163,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStartLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetStartLineReturnsZeroByDefault(): void
     {
@@ -1305,8 +1172,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStartLineReturnsStartLineOfFirstToken
-     *
-     * @return void
      */
     public function testGetStartLineReturnsStartLineOfFirstToken(): void
     {
@@ -1329,8 +1194,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetEndLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetEndLineReturnsZeroByDefault(): void
     {
@@ -1340,8 +1203,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetEndLineReturnsEndLineOfLastToken
-     *
-     * @return void
      */
     public function testGetEndLineReturnsEndLineOfLastToken(): void
     {
@@ -1364,8 +1225,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassReferenceReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetParentClassReferenceReturnsNullByDefault(): void
     {
@@ -1375,8 +1234,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassReturnsExpectedClassInstance
-     *
-     * @return void
      */
     public function testGetParentClassReturnsExpectedClassInstance(): void
     {
@@ -1392,12 +1249,11 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetParentClassThrowsExpectedExceptionWhenBothAreTheSame
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function testGetParentClassThrowsExpectedExceptionWhenBothAreTheSame(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         $this->parseCodeResourceForTest()
             ->current()
@@ -1408,8 +1264,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetParentClassesReturnsEmptyArrayByDefault(): void
     {
@@ -1419,8 +1273,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassesReturnsExpectedListClasses
-     *
-     * @return void
      */
     public function testGetParentClassesReturnsExpectedListClasses(): void
     {
@@ -1438,7 +1290,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             [
                 'testGetParentClassesReturnsExpectedListClasses_parentA',
                 'testGetParentClassesReturnsExpectedListClasses_parentB',
-                'testGetParentClassesReturnsExpectedListClasses_parentC'
+                'testGetParentClassesReturnsExpectedListClasses_parentC',
             ],
             $classes
         );
@@ -1447,7 +1299,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetParentReturnsNullWhenParentIsFiltered
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetParentReturnsNullWhenParentIsFiltered(): void
@@ -1463,12 +1314,11 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetParentClassesThrowsExpectedExceptionForRecursiveInheritanceHierarchy
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function testGetParentClassesThrowsExpectedExceptionForRecursiveInheritanceHierarchy(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         $this->parseCodeResourceForTest()
             ->current()
@@ -1479,8 +1329,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetInterfaceReferencesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetInterfaceReferencesReturnsEmptyArrayByDefault(): void
     {
@@ -1490,8 +1338,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetInterfaceReferencesReturnsExpectedNumberOfInterfaces
-     *
-     * @return void
      */
     public function testGetInterfaceReferencesReturnsExpectedNumberOfInterfaces(): void
     {
@@ -1501,8 +1347,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsUserDefinedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsFalseByDefault(): void
     {
@@ -1512,8 +1356,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsUserDefinedReturnsTrueAfterSetUserDefinedCall
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsTrueAfterSetUserDefinedCall(): void
     {
@@ -1525,8 +1367,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseByDefault(): void
     {
@@ -1536,8 +1376,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseWhenObjectGetsSerialized
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseWhenObjectGetsSerialized(): void
     {
@@ -1547,18 +1385,12 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $this->assertFalse($class->isCached());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedName(): void
     {
         $class = new ASTClass('MyClass');
         $this->assertSame('MyClass', $class->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithNamespaceDeclaration(): void
     {
         $class = new ASTClass('MyClass');
@@ -1567,9 +1399,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $this->assertSame('My\\Namespace\\MyClass', $class->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithPackageAnnotation(): void
     {
         $namespace = new ASTNamespace('My\\Namespace');
@@ -1583,8 +1412,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames(): void
     {
@@ -1607,7 +1434,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
                 'namespaceName',
                 'startLine',
                 'userDefined',
-                'id'
+                'id',
             ],
             $class->__sleep()
         );
@@ -1615,8 +1442,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicWakeupSetsSourceFileOnChildMethods
-     *
-     * @return void
      */
     public function testMagicWakeupSetsSourceFileOnChildMethods(): void
     {
@@ -1625,7 +1450,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         $method = new ASTMethod(__FUNCTION__);
         $class->addMethod($method);
-        
+
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
         $class->setContext($context);
@@ -1639,8 +1464,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicWakeupCallsRegisterClassOnBuilderContext
-     *
-     * @return void
      */
     public function testMagicWakeupCallsRegisterClassOnBuilderContext(): void
     {
@@ -1658,14 +1481,14 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * Creates an abstract item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     protected function createItem()
     {
         $class = new ASTClass(__CLASS__);
         $class->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $class->setCache(new MemoryCacheDriver());
-        
+
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
         $class->setContext($context);

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCloneExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTCloneExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTCloneExpression
  * @group unittest
  */
 class ASTCloneExpressionTest extends ASTNodeTestCase
 {
     /**
      * testCloneExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testCloneExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
 
     /**
      * testCloneExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testCloneExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
 
     /**
      * testCloneExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testCloneExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
 
     /**
      * testCloneExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testCloneExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTCloneExpression
+     * @return ASTCloneExpression
      */
     private function getFirstCloneExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClosure} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTClosure
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTClosure
  * @group unittest
  */
 class ASTClosureTest extends ASTNodeTestCase
 {
     /**
      * testReturnsByReferenceReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testReturnsByReferenceReturnsFalseByDefault(): void
     {
@@ -67,8 +66,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testReturnsByReferenceReturnsFalseByDefaultForStaticClosure
-     *
-     * @return void
      */
     public function testReturnsByReferenceReturnsFalseByDefaultForStaticClosure(): void
     {
@@ -78,8 +75,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testReturnsByReferenceReturnsTrueForClosure
-     *
-     * @return void
      */
     public function testReturnsByReferenceReturnsTrueForClosure(): void
     {
@@ -89,8 +84,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testReturnsByReferenceReturnsTrueForStaticClosure
-     *
-     * @return void
      */
     public function testReturnsByReferenceReturnsTrueForStaticClosure(): void
     {
@@ -100,8 +93,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testReturnsByReferenceReturnsTrueForAssignedClosure
-     *
-     * @return void
      */
     public function testReturnsByReferenceReturnsTrueForAssignedClosure(): void
     {
@@ -112,7 +103,6 @@ class ASTClosureTest extends ASTNodeTestCase
     /**
      * testParserHandlesPureClosureStatementWithoutAssignment
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesPureClosureStatementWithoutAssignment(): void
@@ -123,36 +113,30 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testIsStaticReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsStaticReturnsFalseByDefault(): void
     {
-        $closure = new \PDepend\Source\AST\ASTClosure();
+        $closure = new ASTClosure();
         $this->assertFalse($closure->isStatic());
     }
 
     /**
      * testIsStaticReturnsTrueWhenSetToTrue
-     *
-     * @return void
      */
     public function testIsStaticReturnsTrueWhenSetToTrue(): void
     {
-        $closure = new \PDepend\Source\AST\ASTClosure();
+        $closure = new ASTClosure();
         $closure->setStatic(true);
-        
+
         $this->assertTrue($closure->isStatic());
     }
 
     /**
      * testIsStaticReturnsFalseWhenSetToFalse
-     *
-     * @return void
      */
     public function testIsStaticReturnsFalseWhenSetToFalse(): void
     {
-        $closure = new \PDepend\Source\AST\ASTClosure();
+        $closure = new ASTClosure();
         $closure->setStatic(false);
 
         $this->assertFalse($closure->isStatic());
@@ -167,8 +151,6 @@ class ASTClosureTest extends ASTNodeTestCase
      *     return pow($x, $y);
      * }
      * </code>
-     *
-     * @return void
      */
     public function testIsStaticReturnsFalseForNonStaticClosure(): void
     {
@@ -185,8 +167,6 @@ class ASTClosureTest extends ASTNodeTestCase
      *     return pow($x, $y);
      * }
      * </code>
-     *
-     * @return void
      */
     public function testIsStaticReturnsTrueForStaticClosure(): void
     {
@@ -196,8 +176,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testClosureContainsExpectedNumberChildNodes
-     *
-     * @return void
      */
     public function testClosureContainsExpectedNumberChildNodes(): void
     {
@@ -207,8 +185,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testClosureHasExpectedStartLine(): void
     {
@@ -218,8 +194,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testClosureHasExpectedStartColumn(): void
     {
@@ -229,8 +203,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testClosureHasExpectedEndLine(): void
     {
@@ -240,8 +212,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testClosureHasExpectedEndColumn(): void
     {
@@ -251,8 +221,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testStaticClosureHasExpectedStartLine
-     *
-     * @return void
      */
     public function testStaticClosureHasExpectedStartLine(): void
     {
@@ -262,8 +230,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testStaticClosureHasExpectedEndLine
-     *
-     * @return void
      */
     public function testStaticClosureHasExpectedEndLine(): void
     {
@@ -273,8 +239,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testStaticClosureHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testStaticClosureHasExpectedStartColumn(): void
     {
@@ -284,8 +248,6 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * testStaticClosureHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testStaticClosureHasExpectedEndColumn(): void
     {
@@ -296,7 +258,7 @@ class ASTClosureTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTClosure
+     * @return ASTClosure
      */
     private function getFirstClosureInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTComment} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTComment
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTComment
  * @group unittest
  */
 class ASTCommentTest extends ASTNodeTestCase
 {
     /**
      * testSingleLineCommentHasExpectedStartLine
-     *
-     * @return void
      */
     public function testSingleLineCommentHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testSingleLineCommentHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testSingleLineCommentHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testSingleLineCommentHasExpectedEndLine
-     *
-     * @return void
      */
     public function testSingleLineCommentHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testSingleLineCommentHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testSingleLineCommentHasExpectedEndColumn(): void
     {
@@ -100,8 +93,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testMultiLineCommentHasExpectedStartLine
-     *
-     * @return void
      */
     public function testMultiLineCommentHasExpectedStartLine(): void
     {
@@ -111,8 +102,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testMultiLineCommentHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testMultiLineCommentHasExpectedStartColumn(): void
     {
@@ -122,8 +111,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testMultiLineCommentHasExpectedEndLine
-     *
-     * @return void
      */
     public function testMultiLineCommentHasExpectedEndLine(): void
     {
@@ -133,8 +120,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testMultiLineCommentHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testMultiLineCommentHasExpectedEndColumn(): void
     {
@@ -144,8 +129,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testDocCommentHasExpectedStartLine
-     *
-     * @return void
      */
     public function testDocCommentHasExpectedStartLine(): void
     {
@@ -155,8 +138,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testDocCommentHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testDocCommentHasExpectedStartColumn(): void
     {
@@ -166,8 +147,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testDocCommentHasExpectedEndLine
-     *
-     * @return void
      */
     public function testDocCommentHasExpectedEndLine(): void
     {
@@ -177,8 +156,6 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * testDocCommentHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testDocCommentHasExpectedEndColumn(): void
     {
@@ -191,7 +168,7 @@ class ASTCommentTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTComment
+     * @return ASTComment
      */
     private function getFirstCommentInClass($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the code file class.
  *
+ * @covers \PDepend\Source\AST\ASTCompilationUnit
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTCompilationUnit
  * @group unittest
  */
 class ASTCompilationUnitTest extends AbstractTestCase
 {
     /**
      * testGetNameReturnsTheFileName
-     *
-     * @return void
      */
     public function testGetNameReturnsTheFileName(): void
     {
@@ -68,8 +67,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetFileNameReturnsTheFileName
-     *
-     * @return void
      */
     public function testGetFileNameReturnsTheFileName(): void
     {
@@ -79,8 +76,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetIdReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetIdReturnsNullByDefault(): void
     {
@@ -90,8 +85,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetIdReturnsInjectedIdValue
-     *
-     * @return void
      */
     public function testGetIdReturnsInjectedIdValue(): void
     {
@@ -103,8 +96,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsNullByDefault(): void
     {
@@ -114,8 +105,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsInjectedDocCommentValue
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsInjectedDocCommentValue(): void
     {
@@ -127,8 +116,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetTokensDelegatesCallToCacheRestoreWithFileId
-     *
-     * @return void
      */
     public function testGetTokensDelegatesCallToCacheRestoreWithFileId(): void
     {
@@ -150,8 +137,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testSetTokensDelegatesCallToCacheStoreWithFileId
-     *
-     * @return void
      */
     public function testSetTokensDelegatesCallToCacheStoreWithFileId(): void
     {
@@ -173,8 +158,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testAcceptInvokesVisitFileOnGivenVisitor
-     *
-     * @return void
      */
     public function testAcceptInvokesVisitFileOnGivenVisitor(): void
     {
@@ -190,8 +173,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testMagicStringMethodReturnsEmptyStringWhenFileNameIsNull
-     *
-     * @return void
      */
     public function testMagicStringMethodReturnsEmptyStringWhenFileNameIsNull(): void
     {
@@ -201,8 +182,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testMagicStringMethodReturnInjectedFileNameValue
-     *
-     * @return void
      */
     public function testMagicStringMethodReturnInjectedFileNameValue(): void
     {
@@ -212,8 +191,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames(): void
     {
@@ -226,7 +203,7 @@ class ASTCompilationUnitTest extends AbstractTestCase
                 'endLine',
                 'fileName',
                 'startLine',
-                'id'
+                'id',
             ],
             $file->__sleep()
         );
@@ -234,8 +211,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testMagicWakeupMethodInvokesSetSourceFileOnChildNodes
-     *
-     * @return void
      */
     public function testMagicWakeupMethodInvokesSetSourceFileOnChildNodes(): void
     {
@@ -254,8 +229,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testIsCachedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseByDefault(): void
     {
@@ -265,8 +238,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testIsCachedReturnsFalseWhenObjectGetsSerialized
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseWhenObjectGetsSerialized(): void
     {
@@ -278,8 +249,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testIsCachedReturnsTrueAfterCallToWakeup
-     *
-     * @return void
      */
     public function testIsCachedReturnsTrueAfterCallToWakeup(): void
     {
@@ -291,8 +260,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsZeroWhenSourceFileNotExists
-     *
-     * @return void
      */
     public function testGetStartLineReturnsZeroWhenSourceFileNotExists(): void
     {
@@ -302,8 +269,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsOneWhenSourceFileExists
-     *
-     * @return void
      */
     public function testGetStartLineReturnsOneWhenSourceFileExists(): void
     {
@@ -313,8 +278,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsZeroWhenSourceFileNotExists
-     *
-     * @return void
      */
     public function testGetEndLineReturnsZeroWhenSourceFileNotExists(): void
     {
@@ -324,8 +287,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsOneWhenSourceFileExists
-     *
-     * @return void
      */
     public function testGetEndLineReturnsOneWhenSourceFileExists(): void
     {
@@ -335,8 +296,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * testGetSourceReturnsNullWhenSourceFileNotExists
-     *
-     * @return void
      */
     public function testGetSourceReturnsNullWhenSourceFileNotExists(): void
     {
@@ -346,8 +305,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
 
     /**
      * Tests the {@link \PDepend\Source\AST\ASTCompilationUnit#getSource()} method.
-     *
-     * @return void
      */
     public function testGetSourceReturnsOriginalFileContents(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCompoundExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTCompoundExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTCompoundExpression
  * @group unittest
  */
 class ASTCompoundExpressionTest extends ASTNodeTestCase
 {
     /**
      * testExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTCompoundExpression
+     * @return ASTCompoundExpression
      */
     private function getFirstExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCompoundVariable} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTCompoundVariable
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTCompoundVariable
  * @group unittest
  */
 class ASTCompoundVariableTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed compound variable has the expected object graph.
-     *
-     * @return void
      */
     public function testCompoundVariableGraphWithInlineLiteral(): void
     {
@@ -69,8 +68,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed compound variable has the expected object graph.
-     *
-     * @return void
      */
     public function testCompoundVariableGraphWithInlineConstantEscapedLiteral(): void
     {
@@ -82,8 +79,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed compound variable has the expected object graph.
-     *
-     * @return void
      */
     public function testCompoundVariableGraphWithInlineBacktickLiteral(): void
     {
@@ -95,8 +90,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed compound variable has the expected object graph.
-     *
-     * @return void
      */
     public function testCompoundVariableGraphWithMemberPrimaryPrefix(): void
     {
@@ -106,7 +99,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($variable, $expected);
@@ -114,8 +107,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests that an invalid compound variable results in the expected exception.
-     *
-     * @return void
      */
     public function testUnclosedCompoundVariableThrowsExpectedException(): void
     {
@@ -123,11 +114,9 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
         $this->parseCodeResourceForTest();
     }
-    
+
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testCompoundVariableHasExpectedStartLine(): void
     {
@@ -137,8 +126,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testCompoundVariableHasExpectedStartColumn(): void
     {
@@ -148,8 +135,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testCompoundVariableHasExpectedEndLine(): void
     {
@@ -159,8 +144,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testCompoundVariableHasExpectedEndColumn(): void
     {
@@ -173,7 +156,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTCompoundVariable
+     * @return ASTCompoundVariable
      */
     private function getFirstVariableInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConditionalExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTConditionalExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTConditionalExpression
  * @group unittest
  */
 class ASTConditionalExpressionTest extends ASTNodeTestCase
 {
     /**
      * testConditionalExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testConditionalExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
 
     /**
      * testConditionalExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testConditionalExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
 
     /**
      * testConditionalExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testConditionalExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
 
     /**
      * testConditionalExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testConditionalExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTConditionalExpression
+     * @return ASTConditionalExpression
      */
     private function getFirstConditionalExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -45,29 +45,28 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantDeclarator} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTConstantDeclarator
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTConstantDeclarator
  * @group unittest
  */
 class ASTConstantDeclaratorTest extends ASTNodeTestCase
 {
     /**
      * testReturnValueOfMagicSleepContainsValueProperty
-     *
-     * @return void
      */
     public function testReturnValueOfMagicSleepContainsValueProperty(): void
     {
-        $node = new \PDepend\Source\AST\ASTConstantDeclarator();
+        $node = new ASTConstantDeclarator();
         $this->assertEquals(
             [
                 'value',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $node->__sleep()
         );
@@ -75,8 +74,6 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testParserInjectsValueObjectIntoConstantDeclarator
-     *
-     * @return void
      */
     public function testParserInjectsValueObjectIntoConstantDeclarator(): void
     {
@@ -86,8 +83,6 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testParserInjectsExpectedScalarValueIntoConstantDeclarator
-     *
-     * @return void
      */
     public function testParserInjectsExpectedScalarValueIntoConstantDeclarator(): void
     {
@@ -98,7 +93,6 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testParserInjectsExpectedHeredocValueIntoConstantDeclarator
      *
-     * @return void
      * @since 0.10.9
      */
     public function testParserInjectsExpectedHeredocValueIntoConstantDeclarator(): void
@@ -110,7 +104,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclarator
      *
-     * @return \PDepend\Source\AST\ASTConstantDeclarator
+     * @return ASTConstantDeclarator
+     *
      * @since 1.0.2
      */
     public function testConstantDeclarator()
@@ -124,9 +119,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDeclarator $declarator
+     * @param ASTConstantDeclarator $declarator
      *
-     * @return void
      * @depends testConstantDeclarator
      */
     public function testConstantDeclaratorHasExpectedStartLine($declarator): void
@@ -137,9 +131,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDeclarator $declarator
+     * @param ASTConstantDeclarator $declarator
      *
-     * @return void
      * @depends testConstantDeclarator
      */
     public function testConstantDeclaratorHasExpectedStartColumn($declarator): void
@@ -150,9 +143,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDeclarator $declarator
+     * @param ASTConstantDeclarator $declarator
      *
-     * @return void
      * @depends testConstantDeclarator
      */
     public function testConstantDeclaratorHasExpectedEndLine($declarator): void
@@ -163,9 +155,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDeclarator $declarator
+     * @param ASTConstantDeclarator $declarator
      *
-     * @return void
      * @depends testConstantDeclarator
      */
     public function testConstantDeclaratorHasExpectedEndColumn($declarator): void
@@ -176,7 +167,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTConstantDeclarator
+     * @return ASTConstantDeclarator
      */
     private function getFirstConstantDeclaratorInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantDefinition} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTConstantDefinition
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTConstantDefinition
  * @group unittest
  */
 class ASTConstantDefinitionTest extends ASTNodeTestCase
@@ -58,8 +59,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * Tests that the field declaration <b>setModifiers()</b> method accepts all
      * valid combinations of modifiers.
      *
-     * @param integer $modifiers Combinations of valid modifiers.
-     * @return void
+     * @param int $modifiers Combinations of valid modifiers.
+     *
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
     public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
@@ -74,9 +75,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * Tests that the <b>setModifiers()</b> method throws an exception when an
      * invalid modifier or modifier combination was set.
      *
-     * @param integer $modifiers Combinations of invalid modifiers.
+     * @param int $modifiers Combinations of invalid modifiers.
      *
-     * @return void
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void
@@ -96,8 +96,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsPublicReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPublicReturnsFalseByDefault(): void
     {
@@ -107,8 +105,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsPublicReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsPublicReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -120,8 +116,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsProtectedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsProtectedReturnsFalseByDefault(): void
     {
@@ -132,8 +126,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsProtectedReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsProtectedReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -145,8 +137,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsPrivateReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPrivateReturnsFalseByDefault(): void
     {
@@ -156,8 +146,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testIsPrivateReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsPrivateReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -169,8 +157,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * Tests that the constant definition has the expected doc comment block.
-     *
-     * @return void
      */
     public function testConstantDefinitionHasExpectedDocComment(): void
     {
@@ -185,8 +171,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * Tests that the constant definition has the expected doc comment block.
-     *
-     * @return void
      */
     public function testConstantDefinitionHasExpectedDocCommentWithInlineCommentBetween(): void
     {
@@ -202,7 +186,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinition
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
+     *
      * @since 1.0.2
      */
     public function testConstantDefinition()
@@ -216,9 +201,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @depends testConstantDefinition
      */
     public function testConstantDefinitionHasExpectedStartLine($constant): void
@@ -229,9 +213,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @depends testConstantDefinition
      */
     public function testConstantDefinitionHasExpectedStartColumn($constant): void
@@ -242,9 +225,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @depends testConstantDefinition
      */
     public function testConstantDefinitionHasExpectedEndLine($constant): void
@@ -255,9 +237,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @depends testConstantDefinition
      */
     public function testConstantDefinitionHasExpectedEndColumn($constant): void
@@ -268,7 +249,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclarators
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
+     *
      * @since 1.0.2
      */
     public function testConstantDefinitionWithDeclarators()
@@ -282,52 +264,52 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testConstantDefinitionWithDeclarators
      */
     public function testConstantDefinitionWithDeclaratorsHasExpectedStartLine($constant): void
     {
         $this->assertEquals(4, $constant->getStartLine());
     }
-    
+
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testConstantDefinitionWithDeclarators
      */
     public function testConstantDefinitionWithDeclaratorsHasExpectedStartColumn($constant): void
     {
         $this->assertEquals(5, $constant->getStartColumn());
     }
-    
+
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testConstantDefinitionWithDeclarators
      */
     public function testConstantDefinitionWithDeclaratorsHasExpectedEndLine($constant): void
     {
         $this->assertEquals(6, $constant->getEndLine());
     }
-    
+
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTConstantDefinition $constant
+     * @param ASTConstantDefinition $constant
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testConstantDefinitionWithDeclarators
      */
     public function testConstantDefinitionWithDeclaratorsHasExpectedEndColumn($constant): void
@@ -338,7 +320,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionInGlobalScope
      *
-     * @return void
      * @since 1.0.2
      */
     public function testConstantDefinitionInGlobalScope(): void
@@ -349,7 +330,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionInNamespaceScope
      *
-     * @return void
      * @since 1.0.2
      */
     public function testConstantDefinitionInNamespaceScope(): void
@@ -360,7 +340,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTConstantDefinition
+     * @return ASTConstantDefinition
      */
     private function getFirstConstantDefinitionInClass()
     {
@@ -396,23 +376,23 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
             [State::IS_STATIC],
             [
                 State::IS_PRIVATE |
-                State::IS_ABSTRACT
+                State::IS_ABSTRACT,
             ],
             [
                 State::IS_PROTECTED |
-                State::IS_ABSTRACT
+                State::IS_ABSTRACT,
             ],
             [
                 State::IS_PUBLIC |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
             [
                 State::IS_PROTECTED |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
             [
                 State::IS_PRIVATE |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
         ];
     }

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantPostfix} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTConstantPostfix
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTConstantPostfix
  * @group unittest
  */
 class ASTConstantPostfixTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed constant postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testConstantPostfixStructureForSimpleStaticAccess(): void
     {
@@ -67,8 +66,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testConstantPostfixStructureForStaticAccessOnVariable(): void
     {
@@ -78,8 +75,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * testConstantPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testConstantPostfixHasExpectedStartLine(): void
     {
@@ -89,8 +84,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * testConstantPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testConstantPostfixHasExpectedStartColumn(): void
     {
@@ -100,8 +93,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * testConstantPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testConstantPostfixHasExpectedEndLine(): void
     {
@@ -111,8 +102,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * testConstantPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testConstantPostfixHasExpectedEndColumn(): void
     {
@@ -125,7 +114,7 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTConstantPostfix
+     * @return ASTConstantPostfix
      */
     private function getFirstConstantPostfixInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstant} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTConstant
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTConstant
  * @group unittest
  */
 class ASTConstantTest extends ASTNodeTestCase
 {
     /**
      * Tests that a parsed constant has the expected object graph.
-     *
-     * @return void
      */
     public function testConstantGraphSimple(): void
     {
@@ -67,8 +66,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed constant has the expected object graph.
-     *
-     * @return void
      */
     public function testConstantGraphKeywordSelf(): void
     {
@@ -78,8 +75,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed constant has the expected object graph.
-     *
-     * @return void
      */
     public function testConstantGraphKeywordParent(): void
     {
@@ -89,8 +84,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * testConstantHasExpectedStartLine
-     *
-     * @return void
      */
     public function testConstantHasExpectedStartLine(): void
     {
@@ -100,8 +93,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * testConstantHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testConstantHasExpectedStartColumn(): void
     {
@@ -111,8 +102,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * testConstantHasExpectedEndLine
-     *
-     * @return void
      */
     public function testConstantHasExpectedEndLine(): void
     {
@@ -122,8 +111,6 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * testConstantHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testConstantHasExpectedEndColumn(): void
     {
@@ -136,7 +123,7 @@ class ASTConstantTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTConstant
+     * @return ASTConstant
      */
     private function getFirstConstantInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTContinueStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTContinueStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTContinueStatement
  * @group unittest
  */
 class ASTContinueStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testContinueStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTContinueStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testContinueStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTContinueStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testContinueStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTContinueStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testContinueStatementHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTContinueStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTContinueStatement
+     * @return ASTContinueStatement
      */
     private function getFirstContinueStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTDeclareStatement} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.10.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTDeclareStatement
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.10.0
+ *
  * @group unittest
  */
 class ASTDeclareStatementTest extends ASTNodeTestCase
 {
     /**
      * testDeclareStatementWithSingleParameter
-     *
-     * @return void
      */
     public function testDeclareStatementWithSingleParameter(): void
     {
@@ -69,8 +70,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithMultipleParameter
-     *
-     * @return void
      */
     public function testDeclareStatementWithMultipleParameter(): void
     {
@@ -80,8 +79,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -91,7 +88,7 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
                 'values',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $stmt->__sleep()
         );
@@ -99,8 +96,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testDeclareStatementHasExpectedStartLine(): void
     {
@@ -110,8 +105,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testDeclareStatementHasExpectedStartColumn(): void
     {
@@ -121,8 +114,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementHasExpectedEndLine
-     *
-     * @return void
      */
     public function testDeclareStatementHasExpectedEndLine(): void
     {
@@ -132,8 +123,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testDeclareStatementHasExpectedEndColumn(): void
     {
@@ -143,8 +132,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testDeclareStatementWithScopeHasExpectedStartLine(): void
     {
@@ -154,8 +141,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testDeclareStatementWithScopeHasExpectedStartColumn(): void
     {
@@ -165,8 +150,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testDeclareStatementWithScopeHasExpectedEndLine(): void
     {
@@ -176,8 +159,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testDeclareStatementWithScopeHasExpectedEndColumn(): void
     {
@@ -187,8 +168,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedStartLine(): void
     {
@@ -198,8 +177,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -209,8 +186,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedEndLine(): void
     {
@@ -220,8 +195,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * testDeclareStatementWithAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testDeclareStatementWithAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -234,7 +207,7 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTDeclareStatement
+     * @return ASTDeclareStatement
      */
     private function getFirstDeclareStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -45,41 +45,36 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTDoWhileStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTDoWhileStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTDoWhileStatement
  * @group unittest
  */
 class ASTDoWhileStatementTest extends ASTNodeTestCase
 {
     /**
      * testDoWhileStatementHasExpectedNumberOfChildNodes
-     *
-     * @return void
      */
     public function testDoWhileStatementHasExpectedNumberOfChildNodes(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertCount(2, $stmt->getChildren());
     }
-    
+
     /**
      * testFirstChildOfDoWhileStatementIsInstanceOfScopeStatement
-     *
-     * @return void
      */
     public function testFirstChildOfDoWhileStatementIsInstanceOfScopeStatement(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
     }
-    
+
     /**
      * testSecondChildOfDoWhileStatementIsInstanceOfExpression
-     *
-     * @return void
      */
     public function testSecondChildOfDoWhileStatementIsInstanceOfExpression(): void
     {
@@ -89,8 +84,6 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testDoWhileStatementHasExpectedStartLine(): void
     {
@@ -100,8 +93,6 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testDoWhileStatementHasExpectedStartColumn(): void
     {
@@ -111,8 +102,6 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testDoWhileStatementHasExpectedEndLine(): void
     {
@@ -122,19 +111,15 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testDoWhileStatementHasExpectedEndColumn(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
         $this->assertEquals(31, $stmt->getEndColumn());
     }
-    
+
     /**
      * testDoWhileStatementWithoutScopeStatementChild
-     *
-     * @return void
      */
     public function testDoWhileStatementWithoutScopeStatementChild(): void
     {
@@ -147,7 +132,7 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTDoWhileStatement
+     * @return ASTDoWhileStatement
      */
     private function getFirstDoWhileStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTEchoStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTEchoStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTEchoStatement
  * @group unittest
  */
 class ASTEchoStatementTest extends ASTNodeTestCase
 {
     /**
      * testEchoStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testEchoStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTEchoStatementTest extends ASTNodeTestCase
 
     /**
      * testEchoStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testEchoStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTEchoStatementTest extends ASTNodeTestCase
 
     /**
      * testEchoStatementHasExpectedEndLine
-     *
-     * @return void
      */
     public function testEchoStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTEchoStatementTest extends ASTNodeTestCase
 
     /**
      * testEchoStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testEchoStatementHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTEchoStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTEchoStatement
+     * @return ASTEchoStatement
      */
     private function getFirstEchoStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTElseIfStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTElseIfStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTElseIfStatement
  * @group unittest
  */
 class ASTElseIfStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasElseMethodReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsFalseByDefault(): void
     {
@@ -67,8 +66,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseIfBranchExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseIfBranchExists(): void
     {
@@ -78,8 +75,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseBranchWithIfExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchWithIfExists(): void
     {
@@ -89,8 +84,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseBranchExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchExists(): void
     {
@@ -100,30 +93,24 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the generated object graph of an elseif statement.
-     *
-     * @return void
      */
     public function testElseIfStatementGraphWithBooleanExpressions(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertCount(2, $stmt->getChildren());
     }
-    
+
     /**
      * testFirstChildOfElseIfStatementIsInstanceOfExpression
-     *
-     * @return void
      */
     public function testFirstChildOfElseIfStatementIsInstanceOfExpression(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
     }
-    
+
     /**
      * testSecondChildOfElseIfStatementIsInstanceOfScopeStatement
-     *
-     * @return void
      */
     public function testSecondChildOfElseIfStatementIsInstanceOfScopeStatement(): void
     {
@@ -133,8 +120,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testElseIfStatementHasExpectedStartLine(): void
     {
@@ -144,8 +129,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testElseIfStatementHasExpectedStartColumn(): void
     {
@@ -155,8 +138,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testElseIfStatementHasExpectedEndLine(): void
     {
@@ -166,19 +147,15 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testElseIfStatementHasExpectedEndColumn(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
         $this->assertEquals(5, $stmt->getEndColumn());
     }
-    
+
     /**
      * testElseIfStatementWithoutScopeStatementBody
-     *
-     * @return void
      */
     public function testElseIfStatementWithoutScopeStatementBody(): void
     {
@@ -188,8 +165,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseIfStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testElseIfStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -199,8 +174,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseIfStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testElseIfStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -210,8 +183,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseIfStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testElseIfStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -221,8 +192,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseIfStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testElseIfStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -235,7 +204,7 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTElseIfStatement
+     * @return ASTElseIfStatement
      */
     private function getFirstElseIfStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
 use PDepend\Source\Language\PHP\PHPBuilder;
@@ -50,19 +51,18 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForInit} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForInit
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForInit
  * @group unittest
  */
 class ASTEnumTest extends AbstractASTArtifactTestCase
 {
     /**
      * testForInitHasExpectedStartLine
-     *
-     * @return void
      */
     public function testSerialization(): void
     {
@@ -107,11 +107,9 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
         ], $nodes);
     }
 
-    /**
-     */
     public function testSetTokensWithEmptyArray(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('An AST node should contain at least one token');
 
         $enum = new ASTEnum('FooBar');

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTEvalExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTEvalExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTEvalExpression
  * @group unittest
  */
 class ASTEvalExpressionTest extends ASTNodeTestCase
 {
     /**
      * testEvalExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testEvalExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
 
     /**
      * testEvalExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testEvalExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
 
     /**
      * testEvalExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testEvalExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
 
     /**
      * testEvalExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testEvalExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTEvalExpression
+     * @return ASTEvalExpression
      */
     private function getFirstEvalExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTExitExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTExitExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTExitExpression
  * @group unittest
  */
 class ASTExitExpressionTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCode
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
+     *
      * @since 1.0.1
      */
     public function testExitExpressionWithExitCode()
@@ -71,10 +73,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithExitCode
      */
     public function testExitExpressionWithExitCodeHasExpectedStartLine($expr): void
@@ -85,10 +87,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithExitCode
      */
     public function testExitExpressionWithExitCodeHasExpectedEndLine($expr): void
@@ -99,10 +101,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithExitCode
      */
     public function testExitExpressionWithExitCodeHasExpectedStartColumn($expr): void
@@ -113,10 +115,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithExitCode
      */
     public function testExitExpressionWithExitCodeHasExpectedEndColumn($expr): void
@@ -127,7 +129,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgs
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
+     *
      * @since 1.0.1
      */
     public function testExitExpressionWithEmptyArgs()
@@ -141,10 +144,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithEmptyArgs
      */
     public function testExitExpressionWithEmptyArgsHasExpectedStartLine($expr): void
@@ -155,10 +158,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithEmptyArgs
      */
     public function testExitExpressionWithEmptyArgsHasExpectedEndLine($expr): void
@@ -169,10 +172,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithEmptyArgs
      */
     public function testExitExpressionWithEmptyArgsHasExpectedStartColumn($expr): void
@@ -183,10 +186,10 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @since 1.0.1
+     *
      * @depends testExitExpressionWithEmptyArgs
      */
     public function testExitExpressionWithEmptyArgsHasExpectedEndColumn($expr): void
@@ -197,7 +200,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgs
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
+     *
      * @since 1.0.1
      */
     public function testExitExpressionWithoutArgs()
@@ -211,9 +215,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgsHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @depends testExitExpressionWithoutArgs
      */
     public function testExitExpressionWithoutArgsHasExpectedStartLine($expr): void
@@ -224,9 +227,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgsHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @depends testExitExpressionWithoutArgs
      */
     public function testExitExpressionWithoutArgsHasExpectedStartColumn($expr): void
@@ -237,9 +239,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionHasExpectedEndLineWithoutArgs
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @depends testExitExpressionWithoutArgs
      */
     public function testExitExpressionWithoutArgsHasExpectedEndLine($expr): void
@@ -250,9 +251,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionHasExpectedEndColumnWithoutArgs
      *
-     * @param \PDepend\Source\AST\ASTExitExpression $expr
+     * @param ASTExitExpression $expr
      *
-     * @return void
      * @depends testExitExpressionWithoutArgs
      */
     public function testExitExpressionWithoutArgsHasExpectedEndColumn($expr): void
@@ -263,7 +263,7 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTExitExpression
+     * @return ASTExitExpression
      */
     private function getFirstExitExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTExpression
  * @group unittest
  */
 class ASTExpressionTest extends ASTNodeTestCase
 {
     /**
      * testExpressionHasExpectedNumberOfChildNodes
-     *
-     * @return void
      */
     public function testExpressionHasExpectedNumberOfChildNodes(): void
     {
@@ -67,8 +66,6 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the generated object graph of an expression node.
-     *
-     * @return void
      */
     public function testExpressionGraphWithBooleanExpressions(): void
     {
@@ -87,8 +84,6 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testExpressionHasExpectedStartLine(): void
     {
@@ -98,8 +93,6 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testExpressionHasExpectedStartColumn(): void
     {
@@ -109,8 +102,6 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testExpressionHasExpectedEndLine(): void
     {
@@ -120,8 +111,6 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * testExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testExpressionHasExpectedEndColumn(): void
     {
@@ -134,7 +123,7 @@ class ASTExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      */
     private function getFirstExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -42,25 +42,21 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\AST\AbstractASTClassOrInterface;
-use PDepend\Source\AST\ASTFieldDeclaration;
-
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFieldDeclaration} class.
+ *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTFieldDeclaration
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTFieldDeclaration
  * @group unittest
  */
 class ASTFieldDeclarationTest extends ASTNodeTestCase
 {
     /**
      * Tests that a field declaration contains the expected class reference.
-     *
-     * @return void
      */
     public function testFieldDeclarationContainsClassReferenceWithAnnotationsEnabled(): void
     {
@@ -72,8 +68,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * Tests that a field declaration does not contain a class reference.
-     *
-     * @return void
      */
     public function testFieldDeclarationNotContainsClassReferenceWithAnnotationsDisabled(): void
     {
@@ -113,8 +107,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * @depends testClassReferenceForJavaStyleArrayNotation
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
-     * @return void
      */
     public function testNamespaceForJavaStyleArrayNotation(AbstractASTClassOrInterface $type): void
     {
@@ -125,8 +117,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * Tests that the field declaration <b>setModifiers()</b> method accepts all
      * valid combinations of modifiers.
      *
-     * @param integer $modifiers Combinations of valid modifiers.
-     * @return void
+     * @param int $modifiers Combinations of valid modifiers.
+     *
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
     public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
@@ -140,9 +132,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * Tests that the <b>setModifiers()</b> method throws an exception when an
      * invalid modifier or modifier combination was set.
      *
-     * @param integer $modifiers Combinations of invalid modifiers.
+     * @param int $modifiers Combinations of invalid modifiers.
      *
-     * @return void
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void
@@ -162,8 +153,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsPublicReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPublicReturnsFalseByDefault(): void
     {
@@ -173,8 +162,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsPublicReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsPublicReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -186,8 +173,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsProtectedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsProtectedReturnsFalseByDefault(): void
     {
@@ -197,8 +182,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsProtectedReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsProtectedReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -210,8 +193,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsPrivateReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPrivateReturnsFalseByDefault(): void
     {
@@ -221,8 +202,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsPrivateReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsPrivateReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -234,8 +213,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsStaticReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsStaticReturnsFalseByDefault(): void
     {
@@ -245,8 +222,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testIsStaticReturnsTrueWhenCorrespondingModifierWasSet
-     *
-     * @return void
      */
     public function testIsStaticReturnsTrueWhenCorrespondingModifierWasSet(): void
     {
@@ -258,8 +233,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -268,7 +241,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
             [
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $declaration->__sleep()
         );
@@ -276,8 +249,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testFieldDeclarationHasExpectedStartLine
-     *
-     * @return void
      */
     public function testFieldDeclarationHasExpectedStartLine(): void
     {
@@ -287,8 +258,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testFieldDeclarationHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testFieldDeclarationHasExpectedStartColumn(): void
     {
@@ -298,8 +267,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testFieldDeclarationHasExpectedEndLine
-     *
-     * @return void
      */
     public function testFieldDeclarationHasExpectedEndLine(): void
     {
@@ -309,8 +276,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testFieldDeclarationHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testFieldDeclarationHasExpectedEndColumn(): void
     {
@@ -344,15 +309,15 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
             [State::IS_PUBLIC],
             [
                 State::IS_PRIVATE |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
             [
                 State::IS_PROTECTED |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
             [
                 State::IS_PUBLIC |
-                State::IS_STATIC
+                State::IS_STATIC,
             ],
         ];
     }
@@ -369,20 +334,20 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
             [State::IS_FINAL],
             [
                 State::IS_PRIVATE |
-                State::IS_ABSTRACT
+                State::IS_ABSTRACT,
             ],
             [
                 State::IS_PROTECTED |
-                State::IS_ABSTRACT
+                State::IS_ABSTRACT,
             ],
             [
                 State::IS_PUBLIC |
-                State::IS_FINAL
+                State::IS_FINAL,
             ],
             [
                 State::IS_PUBLIC |
                 State::IS_STATIC |
-                State::IS_FINAL
+                State::IS_FINAL,
             ],
         ];
     }

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFinallyStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTFinallyStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTFinallyStatement
  * @group unittest
  */
 class ASTFinallyStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testFinallyStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testFinallyStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testFinallyStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testFinallyStatementHasExpectedEndColumn(): void
     {
@@ -100,8 +93,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * testOnlyFinallyStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testOnlyFinallyStatementHasExpectedStartLine(): void
     {
@@ -111,8 +102,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * testOnlyFinallyStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testOnlyFinallyStatementHasExpectedStartColumn(): void
     {
@@ -122,8 +111,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * testOnlyFinallyStatementHasExpectedEndLine
-     *
-     * @return void
      */
     public function testOnlyFinallyStatementHasExpectedEndLine(): void
     {
@@ -133,8 +120,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * testOnlyFinallyStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testOnlyFinallyStatementHasExpectedEndColumn(): void
     {
@@ -144,8 +129,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfFinallyStatementIsScopeStatement
-     *
-     * @return void
      */
     public function testChildOfFinallyStatementIsScopeStatement(): void
     {
@@ -158,7 +141,7 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTFinallyStatement
+     * @return ASTFinallyStatement
      */
     private function getFirstFinallyStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForInit} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForInit
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForInit
  * @group unittest
  */
 class ASTForInitTest extends ASTNodeTestCase
 {
     /**
      * testForInitHasExpectedStartLine
-     *
-     * @return void
      */
     public function testForInitHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTForInitTest extends ASTNodeTestCase
 
     /**
      * testForInitHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testForInitHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTForInitTest extends ASTNodeTestCase
 
     /**
      * testForInitHasExpectedEndLine
-     *
-     * @return void
      */
     public function testForInitHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTForInitTest extends ASTNodeTestCase
 
     /**
      * testForInitHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testForInitHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTForInitTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTForInit
+     * @return ASTForInit
      */
     private function getFirstForInitInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForStatement
  * @group unittest
  */
 class ASTForStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testForStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testForStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testForStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testForStatementHasExpectedEndColumn(): void
     {
@@ -100,8 +93,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testForExpressionHasExpectedStartLine(): void
     {
@@ -111,8 +102,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testForExpressionHasExpectedStartColumn(): void
     {
@@ -122,8 +111,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testForExpressionHasExpectedEndLine(): void
     {
@@ -133,8 +120,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testForExpressionHasExpectedEndColumn(): void
     {
@@ -144,8 +129,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testFirstChildOfForStatementIsInstanceOfForInit
-     *
-     * @return void
      */
     public function testFirstChildOfForStatementIsInstanceOfForInit(): void
     {
@@ -155,8 +138,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testFirstChildOfForStatementCanBeLeftBlank
-     *
-     * @return void
      */
     public function testFirstChildOfForStatementCanBeLeftBlank(): void
     {
@@ -167,8 +148,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesBooleanLiteralInForInit
-     *
-     * @return void
      */
     public function testParserHandlesBooleanLiteralInForInit(): void
     {
@@ -177,8 +156,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testSecondChildOfForStatementIsInstanceOfExpression
-     *
-     * @return void
      */
     public function testSecondChildOfForStatementIsInstanceOfExpression(): void
     {
@@ -188,8 +165,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testSecondChildOfForStatementCanBeLeftBlank
-     *
-     * @return void
      */
     public function testSecondChildOfForStatementCanBeLeftBlank(): void
     {
@@ -199,8 +174,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfForStatementIsInstanceOfForUpdate
-     *
-     * @return void
      */
     public function testThirdChildOfForStatementIsInstanceOfForUpdate(): void
     {
@@ -210,8 +183,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfForStatementCanBeLeftBlank
-     *
-     * @return void
      */
     public function testThirdChildOfForStatementCanBeLeftBlank(): void
     {
@@ -221,8 +192,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testFourthChildOfForStatementIsInstanceOfScopeStatement
-     *
-     * @return void
      */
     public function testFourthChildOfForStatementIsInstanceOfScopeStatement(): void
     {
@@ -232,8 +201,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testFourthChildOfForStatementIsInstanceOfStatement
-     *
-     * @return void
      */
     public function testFourthChildOfForStatementIsInstanceOfStatement(): void
     {
@@ -243,8 +210,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserResetsScopeTreeForEmptyForInit
-     *
-     * @return void
      */
     public function testParserResetsScopeTreeForEmptyForInit(): void
     {
@@ -258,8 +223,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserResetsScopeTreeForEmptyForExpression
-     *
-     * @return void
      */
     public function testParserResetsScopeTreeForEmptyForExpression(): void
     {
@@ -273,8 +236,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testForStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -284,8 +245,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testForStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -295,8 +254,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testForStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -306,8 +263,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testForStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -317,8 +272,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testForStatementTerminatedByPhpCloseTag
-     *
-     * @return void
      */
     public function testForStatementTerminatedByPhpCloseTag(): void
     {
@@ -328,8 +281,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesBooleanLiteralInForExpression
-     *
-     * @return void
      */
     public function testParserHandlesBooleanLiteralInForExpression(): void
     {
@@ -338,8 +289,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserResetsScopeTreeForEmptyForUpdate
-     *
-     * @return void
      */
     public function testParserResetsScopeTreeForEmptyForUpdate(): void
     {
@@ -353,8 +302,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesParenthesisExpressionInForUpdate
-     *
-     * @return void
      */
     public function testParserHandlesParenthesisExpressionInForUpdate(): void
     {
@@ -363,8 +310,6 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesBooleanLiteralInForUpdate
-     *
-     * @return void
      */
     public function testParserHandlesBooleanLiteralInForUpdate(): void
     {
@@ -376,7 +321,7 @@ class ASTForStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTForStatement
+     * @return ASTForStatement
      */
     private function getFirstForStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForUpdate} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForUpdate
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForUpdate
  * @group unittest
  */
 class ASTForUpdateTest extends ASTNodeTestCase
 {
     /**
      * testForUpdateHasExpectedStartLine
-     *
-     * @return void
      */
     public function testForUpdateHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTForUpdateTest extends ASTNodeTestCase
 
     /**
      * testForUpdateHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testForUpdateHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTForUpdateTest extends ASTNodeTestCase
 
     /**
      * testForUpdateHasExpectedEndLine
-     *
-     * @return void
      */
     public function testForUpdateHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTForUpdateTest extends ASTNodeTestCase
 
     /**
      * testForUpdateHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testForUpdateHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTForUpdateTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTForUpdate
+     * @return ASTForUpdate
      */
     private function getFirstForUpdateInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForeachStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForeachStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForeachStatement
  * @group unittest
  */
 class ASTForeachStatementTest extends ASTNodeTestCase
 {
     /**
      * testThirdChildOfForeachStatementIsASTScopeStatement
-     *
-     * @return void
      */
     public function testThirdChildOfForeachStatementIsASTScopeStatement(): void
     {
@@ -67,8 +66,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testForeachStatementHasExpectedStartLine(): void
     {
@@ -78,8 +75,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testForeachStatementHasExpectedStartColumn(): void
     {
@@ -89,8 +84,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testForeachStatementHasExpectedEndLine(): void
     {
@@ -100,8 +93,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testForeachStatementHasExpectedEndColumn(): void
     {
@@ -111,8 +102,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementContainsListExpressionAsFirstChild
-     *
-     * @return void
      */
     public function testForeachStatementContainsExpressionAsFirstChild(): void
     {
@@ -122,8 +111,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithoutKeyAndWithValue
-     *
-     * @return void
      */
     public function testForeachStatementWithoutKeyAndWithValue(): void
     {
@@ -133,8 +120,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithoutKeyAndWithValueByReference
-     *
-     * @return void
      */
     public function testForeachStatementWithoutKeyAndWithValueByReference(): void
     {
@@ -144,8 +129,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithKeyAndValue
-     *
-     * @return void
      */
     public function testForeachStatementWithKeyAndValue(): void
     {
@@ -155,8 +138,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithKeyAndValueByReference
-     *
-     * @return void
      */
     public function testForeachStatementWithKeyAndValueByReference(): void
     {
@@ -166,8 +147,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithObjectPropertyByReference
-     *
-     * @return void
      */
     public function testForeachStatementWithObjectPropertyByReference(): void
     {
@@ -177,8 +156,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithKeyAndObjectPropertyByReference
-     *
-     * @return void
      */
     public function testForeachStatementWithKeyAndObjectPropertyByReference(): void
     {
@@ -188,8 +165,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithObjectPropertyAsKey
-     *
-     * @return void
      */
     public function testForeachStatementWithObjectPropertyAsKey(): void
     {
@@ -199,8 +174,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithObjectPropertyAsValue
-     *
-     * @return void
      */
     public function testForeachStatementWithObjectPropertyAsValue(): void
     {
@@ -210,8 +183,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithObjectPropertyAsKeyAndValue
-     *
-     * @return void
      */
     public function testForeachStatementWithObjectPropertyAsKeyAndValue(): void
     {
@@ -221,8 +192,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementThrowsExpectedExceptionForKeyByReference
-     *
-     * @return void
      */
     public function testForeachStatementThrowsExpectedExceptionForKeyByReference(): void
     {
@@ -233,8 +202,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithCommentBeforeClosingParenthesis
-     *
-     * @return void
      */
     public function testForeachStatementWithCommentBeforeClosingParenthesis(): void
     {
@@ -243,8 +210,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testForeachStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -254,8 +219,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testForeachStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -265,8 +228,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testForeachStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -276,8 +237,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testForeachStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -287,8 +246,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementTerminatedByPhpCloseTag
-     *
-     * @return void
      */
     public function testForeachStatementTerminatedByPhpCloseTag(): void
     {
@@ -298,8 +255,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithList
-     *
-     * @return void
      */
     public function testForeachStatementWithList(): void
     {
@@ -309,8 +264,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithKeyAndList
-     *
-     * @return void
      */
     public function testForeachStatementWithKeyAndList(): void
     {
@@ -320,8 +273,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithList
-     *
-     * @return void
      */
     public function testForeachStatementWithShortList(): void
     {
@@ -331,8 +282,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * testForeachStatementWithList
-     *
-     * @return void
      */
     public function testForeachStatementWithKeyAndShortList(): void
     {
@@ -345,7 +294,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTForeachStatement
+     * @return ASTForeachStatement
      */
     private function getFirstForeachStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFormalParameter} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTFormalParameter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTFormalParameter
  * @group unittest
  */
 class ASTFormalParameterTest extends ASTNodeTestCase
 {
     /**
      * testHasTypeReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testHasTypeReturnsFalseByDefault(): void
     {
@@ -69,8 +68,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testHasTypeReturnsTrueWhenSecondChildNodeExists
-     *
-     * @return void
      */
     public function testHasTypeReturnsTrueWhenSecondChildNodeExists(): void
     {
@@ -83,8 +80,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testGetTypeThrowsAnExceptionByDefault
-     *
-     * @return void
      */
     public function testGetTypeThrowsAnExceptionByDefault(): void
     {
@@ -98,8 +93,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testGetTypeReturnsAssociatedTypeInstance
-     *
-     * @return void
      */
     public function testGetTypeReturnsAssociatedTypeInstance(): void
     {
@@ -112,8 +105,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsVariableArgListReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsVariableArgListReturnsFalseByDefault(): void
     {
@@ -123,8 +114,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsVariableArgListReturnsTrue
-     *
-     * @return void
      */
     public function testIsVariableArgListReturnsTrue(): void
     {
@@ -134,8 +123,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsVariableArgListWithArrayTypeHint
-     *
-     * @return void
      */
     public function testIsVariableArgListWithArrayTypeHint(): void
     {
@@ -145,8 +132,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsVariableArgListWithClassTypeHint
-     *
-     * @return void
      */
     public function testIsVariableArgListWithClassTypeHint(): void
     {
@@ -156,8 +141,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsVariableArgListPassedByReference
-     *
-     * @return void
      */
     public function testIsVariableArgListPassedByReference(): void
     {
@@ -167,8 +150,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsPassedByReferenceReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPassedByReferenceReturnsFalseByDefault(): void
     {
@@ -178,12 +159,10 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testIsPassedByReferenceCanBeSetToTrue
-     *
-     * @return void
      */
     public function testIsPassedByReferenceCanBeSetToTrue(): void
     {
-        $param = new \PDepend\Source\AST\ASTFormalParameter();
+        $param = new ASTFormalParameter();
         $param->setPassedByReference();
 
         $this->assertTrue($param->isPassedByReference());
@@ -191,8 +170,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testSimpleParameterIsFlaggedAsPassedByReference
-     *
-     * @return void
      */
     public function testSimpleParameterIsFlaggedAsPassedByReference(): void
     {
@@ -202,8 +179,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testParameterWithTypeHintIsFlaggedAsPassedByReference
-     *
-     * @return void
      */
     public function testParameterWithTypeHintIsFlaggedAsPassedByReference(): void
     {
@@ -213,19 +188,16 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testParameterWithDefaultValueIsFlaggedAsPassedByReference
-     *
-     * @return void
      */
     public function testParameterWithDefaultValueIsFlaggedAsPassedByReference(): void
     {
         $param = $this->getFirstFormalParameterInFunction();
         $this->assertTrue($param->isPassedByReference());
     }
-    
+
     /**
      * testFormalParameterWithArrayTypeHint
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFormalParameterWithArrayTypeHint(): void
@@ -240,8 +212,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -251,7 +221,7 @@ class ASTFormalParameterTest extends ASTNodeTestCase
                 'modifiers',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $param->__sleep()
         );
@@ -259,8 +229,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testFormalParameterHasExpectedStartLine
-     *
-     * @return void
      */
     public function testFormalParameterHasExpectedStartLine(): void
     {
@@ -270,8 +238,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testFormalParameterHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testFormalParameterHasExpectedStartColumn(): void
     {
@@ -281,8 +247,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testFormalParameterHasExpectedEndLine
-     *
-     * @return void
      */
     public function testFormalParameterHasExpectedEndLine(): void
     {
@@ -292,8 +256,6 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * testFormalParameterHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testFormalParameterHasExpectedEndColumn(): void
     {
@@ -304,7 +266,7 @@ class ASTFormalParameterTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      */
     private function getFirstFormalParameterInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFormalParameterss} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.10.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTFormalParameters
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.10.0
+ *
  * @group unittest
  */
 class ASTFormalParametersTest extends ASTNodeTestCase
 {
     /**
      * testFormalParametersHasExpectedStartLine
-     *
-     * @return void
      */
     public function testFormalParametersHasExpectedStartLine(): void
     {
@@ -69,8 +70,6 @@ class ASTFormalParametersTest extends ASTNodeTestCase
 
     /**
      * testFormalParametersHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testFormalParametersHasExpectedStartColumn(): void
     {
@@ -80,8 +79,6 @@ class ASTFormalParametersTest extends ASTNodeTestCase
 
     /**
      * testFormalParametersHasExpectedEndLine
-     *
-     * @return void
      */
     public function testFormalParametersHasExpectedEndLine(): void
     {
@@ -91,8 +88,6 @@ class ASTFormalParametersTest extends ASTNodeTestCase
 
     /**
      * testFormalParametersHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testFormalParametersHasExpectedEndColumn(): void
     {
@@ -105,7 +100,7 @@ class ASTFormalParametersTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameters
+     * @return ASTFormalParameters
      */
     private function getFirstFormalParametersInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -45,12 +45,13 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFunctionPostfix} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTInvocation
  * @covers \PDepend\Source\AST\ASTFunctionPostfix
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTFunctionPostfixTest extends ASTNodeTestCase
@@ -62,7 +63,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
      * $function(23);
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForVariableFunction(): void
@@ -78,7 +78,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
      * $function[42](23);
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForArrayIndexedVariableFunction(): void
@@ -89,8 +88,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed function postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForSimpleInvocation(): void
     {
@@ -98,7 +95,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -106,15 +103,13 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed function postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForVariableInvocation(): void
     {
         $postfix  = $this->getFirstFunctionPostfixInFunction();
         $expected = [
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -122,8 +117,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed function postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForCompoundVariableInvocation(): void
     {
@@ -132,7 +125,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTCompoundVariable',
             'PDepend\\Source\\AST\\ASTConstant',
             'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTConstant'
+            'PDepend\\Source\\AST\\ASTConstant',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -140,8 +133,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixGraphForArrayIndexedVariableInvocation
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForArrayIndexedVariableInvocation(): void
     {
@@ -152,7 +143,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -160,8 +151,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed function postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForInvocationWithMemberPrimaryPrefixMethod(): void
     {
@@ -169,7 +158,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -177,8 +166,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed function postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForInvocationWithMemberPrimaryPrefixProperty(): void
     {
@@ -186,7 +173,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -194,8 +181,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixGraphForObjectProperty
-     *
-     * @return void
      */
     public function testFunctionPostfixGraphForObjectProperty(): void
     {
@@ -207,7 +192,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTIdentifier',
             'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -215,8 +200,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testFunctionPostfixHasExpectedStartLine(): void
     {
@@ -226,8 +209,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testFunctionPostfixHasExpectedStartColumn(): void
     {
@@ -237,8 +218,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testFunctionPostfixHasExpectedEndLine(): void
     {
@@ -248,8 +227,6 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * testFunctionPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testFunctionPostfixHasExpectedEndColumn(): void
     {
@@ -260,17 +237,17 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     /**
      * Creates a field declaration node.
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @return ASTFunctionPostfix
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTFunctionPostfix(__FUNCTION__);
+        return new ASTFunctionPostfix(__FUNCTION__);
     }
 
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTFunctionPostfix
+     * @return ASTFunctionPostfix
      */
     private function getFirstFunctionPostfixInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -42,27 +42,25 @@
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\Builder\BuilderContext;
-use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PDepend\Source\Tokenizer\Token;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTFunction class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\AbstractASTCallable
  * @covers \PDepend\Source\AST\ASTFunction
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTFunctionTest extends AbstractASTArtifactTestCase
 {
     /**
      * testReturnsReferenceReturnsExpectedTrue
-     *
-     * @return void
      */
     public function testReturnsReferenceReturnsExpectedTrue(): void
     {
@@ -72,8 +70,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testReturnsReferenceReturnsExpectedFalse
-     *
-     * @return void
      */
     public function testReturnsReferenceReturnsExpectedFalse(): void
     {
@@ -83,8 +79,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsEmptyArrayByDefault(): void
     {
@@ -94,8 +88,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsFirstSetOfStaticVariables
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsFirstSetOfStaticVariables(): void
     {
@@ -107,8 +99,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsMergeOfAllStaticVariables
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsMergeOfAllStaticVariables(): void
     {
@@ -120,8 +110,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the ctor and the {@link \PDepend\Source\AST\ASTFunction::getName()} method.
-     *
-     * @return void
      */
     public function testCreateNewFunctionInstance(): void
     {
@@ -131,8 +119,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsMergeOfAllStaticVariables
-     *
-     * @return void
      */
     public function testGetNamespaceReturnsNullByDefault(): void
     {
@@ -142,8 +128,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnsetNamespaceWithNullWillResetPreviousPackage
-     *
-     * @return void
      */
     public function testUnsetNamespaceWithNullWillResetPreviousPackage(): void
     {
@@ -158,8 +142,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnsetNamespaceWithNullWillResetNamespaceNameProperty
-     *
-     * @return void
      */
     public function testUnsetNamespaceWithNullWillResetNamespaceNameProperty(): void
     {
@@ -173,7 +155,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     /**
      * testClassReferenceForJavaStyleArrayNotation
      *
-     * @return \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @return ASTClassOrInterfaceReference
      */
     public function testClassReferenceForJavaStyleArrayNotation()
     {
@@ -187,8 +169,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * @depends testClassReferenceForJavaStyleArrayNotation
-     * @param \PDepend\Source\AST\AbstractASTClassOrInterface $type
-     * @return void
      */
     public function testNamespaceForJavaStyleArrayNotation(AbstractASTClassOrInterface $type): void
     {
@@ -197,8 +177,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testSetNamespaceNotEstablishesBackReference
-     *
-     * @return void
      */
     public function testSetNamespaceNotEstablishesBackReference(): void
     {
@@ -215,8 +193,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTFunction::getNamespace()} returns as
      * default value <b>null</b> and that the namespace could be set and unset.
-     *
-     * @return void
      */
     public function testGetSetNamespace(): void
     {
@@ -229,8 +205,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetNamespaceNameReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetNamespaceNameReturnsNullByDefault(): void
     {
@@ -239,8 +213,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetNamespaceNameReturnsNameOfInjectedPackage
-     *
-     * @return void
      */
     public function testGetNamespaceNameReturnsNameOfInjectedPackage(): void
     {
@@ -252,8 +224,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseByDefault(): void
     {
@@ -263,8 +233,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseWhenObjectGetsSerialized
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseWhenObjectGetsSerialized(): void
     {
@@ -276,8 +244,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -295,7 +261,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
                 'comment',
                 'returnsReference',
                 'returnClassReference',
-                'exceptionClassReferences'
+                'exceptionClassReferences',
             ],
             $function->__sleep()
         );
@@ -303,8 +269,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testSetTokensDelegatesToCacheStoreMethod
-     *
-     * @return void
      */
     public function testSetTokensDelegatesToCacheStoreMethod(): void
     {
@@ -325,8 +289,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetTokensDelegatesToCacheRestoreMethod
-     *
-     * @return void
      */
     public function testGetTokensDelegatesToCacheRestoreMethod(): void
     {
@@ -346,8 +308,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetTokensReturnsArrayEvenWhenCacheReturnsNull
-     *
-     * @return void
      */
     public function testGetTokensReturnsArrayEvenWhenCacheReturnsNull(): void
     {
@@ -368,8 +328,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTFunction::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
@@ -397,8 +355,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTFunction::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
@@ -432,8 +388,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTFunction::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
@@ -461,8 +415,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTFunction::findChildrenOfType()}.
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeReturnsExpectedResult(): void
     {
@@ -490,8 +442,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSameDependency
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSameDependency(): void
     {
@@ -506,8 +456,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSameReturnClass
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSameReturnClass(): void
     {
@@ -522,8 +470,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSameParameterClass
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSameParameterClass(): void
     {
@@ -538,8 +484,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSameExceptionClass
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSameExceptionClass(): void
     {
@@ -554,8 +498,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSameDependencyInterface
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSameDependencyInterface(): void
     {
@@ -570,8 +512,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionStillReferencesSamePackage
-     *
-     * @return void
      */
     public function testUnserializedFunctionStillReferencesSamePackage(): void
     {
@@ -583,8 +523,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionIsInSameNamespace
-     *
-     * @return void
      */
     public function testUnserializedFunctionIsInSameNamespace(): void
     {
@@ -599,8 +537,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionNotAddsDublicateToPackage
-     *
-     * @return void
      */
     public function testUnserializedFunctionNotAddsDublicateToPackage(): void
     {
@@ -612,8 +548,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedFunctionIsChildOfParentPackage
-     *
-     * @return void
      */
     public function testUnserializedFunctionIsChildOfParentPackage(): void
     {
@@ -625,8 +559,6 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the visitor accept method.
-     *
-     * @return void
      */
     public function testVisitorAccept(): void
     {
@@ -654,7 +586,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     /**
      * Creates an abstract item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     protected function createItem()
     {

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTGlobalStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTGlobalStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTGlobalStatement
  * @group unittest
  */
 class ASTGlobalStatementTest extends ASTNodeTestCase
 {
     /**
      * testGlobalStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testGlobalStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
 
     /**
      * testGlobalStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testGlobalStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
 
     /**
      * testGlobalStatementHasExpectedEndLine
-     *
-     * @return void
      */
     public function testGlobalStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
 
     /**
      * testGlobalStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testGlobalStatementHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTGlobalStatement
+     * @return ASTGlobalStatement
      */
     private function getFirstGlobalStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTGotoStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTGotoStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTGotoStatement
  * @group unittest
  */
 class ASTGotoStatementTest extends ASTNodeTestCase
 {
     /**
      * testGotoStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testGotoStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTGotoStatementTest extends ASTNodeTestCase
 
     /**
      * testGotoStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testGotoStatementHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTGotoStatementTest extends ASTNodeTestCase
 
     /**
      * testGotoStatementHasExpectedEndLine
-     *
-     * @return void
      */
     public function testGotoStatementHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTGotoStatementTest extends ASTNodeTestCase
 
     /**
      * testGotoStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testGotoStatementHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTGotoStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTGotoStatement
+     * @return ASTGotoStatement
      */
     private function getFirstGotoStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTHeredoc} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTHeredoc
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTHeredoc
  * @group unittest
  */
 class ASTHeredocTest extends ASTNodeTestCase
@@ -57,7 +58,6 @@ class ASTHeredocTest extends ASTNodeTestCase
     /**
      * testHeredocAsArrayInitializeValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testHeredocAsArrayInitializeValue(): void
@@ -70,8 +70,6 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * testHeredocHasExpectedStartLine
-     *
-     * @return void
      */
     public function testHeredocHasExpectedStartLine(): void
     {
@@ -81,8 +79,6 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * testHeredocHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testHeredocHasExpectedStartColumn(): void
     {
@@ -92,8 +88,6 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * testHeredocHasExpectedEndLine
-     *
-     * @return void
      */
     public function testHeredocHasExpectedEndLine(): void
     {
@@ -103,8 +97,6 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * testHeredocHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testHeredocHasExpectedEndColumn(): void
     {
@@ -115,7 +107,7 @@ class ASTHeredocTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      */
     private function getFirstHeredocInFunction()
     {
@@ -128,7 +120,7 @@ class ASTHeredocTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTHeredoc
+     * @return ASTHeredoc
      */
     private function getFirstHeredocInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIdentifier} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTIdentifier
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTIdentifier
  * @group unittest
  */
 class ASTIdentifierTest extends ASTNodeTestCase
 {
     /**
      * testIdentifierHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIdentifierHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTIdentifierTest extends ASTNodeTestCase
 
     /**
      * testIdentifierHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIdentifierHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTIdentifierTest extends ASTNodeTestCase
 
     /**
      * testIdentifierHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIdentifierHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTIdentifierTest extends ASTNodeTestCase
 
     /**
      * testIdentifierHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIdentifierHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTIdentifierTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTIdentifier
+     * @return ASTIdentifier
      */
     private function getFirstIdentifierInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIfStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTIfStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTIfStatement
  * @group unittest
  */
 class ASTIfStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasElseMethodReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsFalseByDefault(): void
     {
@@ -67,8 +66,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseIfBranchExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseIfBranchExists(): void
     {
@@ -78,8 +75,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseBranchWithIfExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchWithIfExists(): void
     {
@@ -89,19 +84,15 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testHasElseMethodReturnsTrueWhenElseBranchExists
-     *
-     * @return void
      */
     public function testHasElseMethodReturnsTrueWhenElseBranchExists(): void
     {
         $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
         $this->assertTrue($stmt->hasElse());
     }
-    
+
     /**
      * Tests the generated object graph of an if statement.
-     *
-     * @return void
      */
     public function testIfStatementGraphWithBooleanExpressions(): void
     {
@@ -111,8 +102,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testFirstChildOfIfStatementIsInstanceOfExpression
-     *
-     * @return void
      */
     public function testFirstChildOfIfStatementIsInstanceOfExpression(): void
     {
@@ -122,8 +111,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testSecondChildOfIfStatementIsInstanceOfScopeStatement
-     *
-     * @return void
      */
     public function testSecondChildOfIfStatementIsInstanceOfScopeStatement(): void
     {
@@ -133,8 +120,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testParserThrowsExpectedExceptionWhenIfStatementHasNoBody
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionWhenIfStatementHasNoBody(): void
     {
@@ -145,8 +130,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @return void
      */
     public function testIfStatementHasExpectedStartLine(): void
     {
@@ -156,8 +139,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @return void
      */
     public function testIfStatementHasExpectedStartColumn(): void
     {
@@ -167,8 +148,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @return void
      */
     public function testIfStatementHasExpectedEndLine(): void
     {
@@ -178,8 +157,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @return void
      */
     public function testIfStatementHasExpectedEndColumn(): void
     {
@@ -189,8 +166,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIfStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -200,8 +175,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIfStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -211,8 +184,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIfStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -222,8 +193,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIfStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -233,8 +202,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfElseStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIfElseStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -244,8 +211,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfElseStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIfElseStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -255,8 +220,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfElseStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIfElseStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -266,8 +229,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfElseStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIfElseStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -277,8 +238,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @return void
      */
     public function testElseStatementAlternativeScopeHasExpectedStartLine(): void
     {
@@ -288,8 +247,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testElseStatementAlternativeScopeHasExpectedStartColumn(): void
     {
@@ -299,8 +256,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @return void
      */
     public function testElseStatementAlternativeScopeHasExpectedEndLine(): void
     {
@@ -310,8 +265,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testElseStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testElseStatementAlternativeScopeHasExpectedEndColumn(): void
     {
@@ -321,8 +274,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementTerminatedByPhpCloseTag
-     *
-     * @return void
      */
     public function testIfStatementTerminatedByPhpCloseTag(): void
     {
@@ -332,8 +283,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testIfStatementWithElseContainsExpectedNumberOfChildNodes
-     *
-     * @return void
      */
     public function testIfStatementWithElseContainsExpectedNumberOfChildNodes(): void
     {
@@ -343,8 +292,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfIfStatementIsInstanceOfScopeStatementForElse
-     *
-     * @return void
      */
     public function testThirdChildOfIfStatementIsInstanceOfScopeStatementForElse(): void
     {
@@ -354,8 +301,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * testThirdChildOfIfStatementIsInstanceOfExpressionForElseIf
-     *
-     * @return void
      */
     public function testThirdChildOfIfStatementIsInstanceOfIfStatementForElseIf(): void
     {
@@ -368,7 +313,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTIfStatement
+     * @return ASTIfStatement
      */
     private function getFirstIfStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -46,31 +47,29 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIncludeExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.12
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIncludeExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.12
+ *
  * @group unittest
  */
 class ASTIncludeExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIsOnceReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsOnceReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTIncludeExpression();
+        $expr = new ASTIncludeExpression();
         $this->assertFalse($expr->isOnce());
     }
 
     /**
      * testIsOnceReturnsTrueForIncludeOnceExpression
-     *
-     * @return void
      */
     public function testIsOnceReturnsTrueForIncludeOnceExpression(): void
     {
@@ -80,18 +79,16 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
-        $expr = new \PDepend\Source\AST\ASTIncludeExpression();
+        $expr = new ASTIncludeExpression();
         $this->assertEquals(
             [
                 'once',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $expr->__sleep()
         );
@@ -99,8 +96,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIncludeExpressionHasExpectedStartLine(): void
     {
@@ -110,8 +105,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIncludeExpressionHasExpectedStartColumn(): void
     {
@@ -121,8 +114,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIncludeExpressionHasExpectedEndLine(): void
     {
@@ -132,8 +123,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIncludeExpressionHasExpectedEndColumn(): void
     {
@@ -143,8 +132,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionWithParenthesisHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIncludeExpressionWithParenthesisHasExpectedStartLine(): void
     {
@@ -154,8 +141,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionWithParenthesisHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIncludeExpressionWithParenthesisHasExpectedStartColumn(): void
     {
@@ -165,8 +150,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionWithParenthesisHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIncludeExpressionWithParenthesisHasExpectedEndLine(): void
     {
@@ -176,8 +159,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncludeExpressionWithParenthesisHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIncludeExpressionWithParenthesisHasExpectedEndColumn(): void
     {
@@ -190,7 +171,7 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTIncludeExpression
+     * @return ASTIncludeExpression
      */
     private function getFirstIncludeExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTInstanceOfExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTInstanceOfExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTInstanceOfExpression
  * @group unittest
  */
 class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 {
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithStringIdentifier(): void
     {
@@ -72,8 +71,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithLocalNamespaceIdentifier(): void
     {
@@ -88,8 +85,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithAbsoluteNamespaceIdentifier(): void
     {
@@ -104,8 +99,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithAliasedNamespaceIdentifier(): void
     {
@@ -120,8 +113,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithStdClass(): void
     {
@@ -136,8 +127,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithPHPIncompleteClass(): void
     {
@@ -152,8 +141,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests that the created instanceof object graph has the expected structure.
-     *
-     * @return void
      */
     public function testInstanceOfExpressionGraphWithStaticProperty(): void
     {
@@ -171,8 +158,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      *
      * @param object $parent The parent ast node.
      * @param string $image  The expected type image.
-     *
-     * @return void
      */
     protected function assertInstanceOfGraphStatic($parent, $image): void
     {
@@ -188,8 +173,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      *
      * @param object $parent The parent ast node.
      * @param string $image  The expected type image.
-     *
-     * @return void
      */
     protected function assertInstanceOfGraphProperty($parent, $image): void
     {
@@ -206,8 +189,6 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * @param object $parent The parent ast node.
      * @param string $image  The expected type image.
      * @param string $type   The expected class or interface type.
-     *
-     * @return void
      */
     protected function assertInstanceOfGraph($parent, $image, $type): void
     {
@@ -223,10 +204,10 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
     /**
      * Creates a arguments node.
      *
-     * @return \PDepend\Source\AST\ASTInstanceOfExpression
+     * @return ASTInstanceOfExpression
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTInstanceOfExpression();
+        return new ASTInstanceOfExpression();
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -42,27 +42,27 @@
 
 namespace PDepend\Source\AST;
 
+use BadMethodCallException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
  * Test case for the code interface class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\AST\AbstractASTClassOrInterface
  * @covers \PDepend\Source\AST\AbstractASTType
  * @covers \PDepend\Source\AST\ASTInterface
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTInterfaceTest extends AbstractASTArtifactTestCase
 {
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
@@ -90,8 +90,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
@@ -125,8 +123,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
@@ -156,8 +152,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the result of the <b>getInterfaces()</b> method.
-     *
-     * @return void
      */
     public function testGetInterfacesZeroInheritance(): void
     {
@@ -171,8 +165,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the result of the <b>getInterfaces()</b> method.
-     *
-     * @return void
      */
     public function testGetInterfacesOneLevelInheritance(): void
     {
@@ -187,8 +179,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the result of the <b>getInterfaces()</b> method.
-     *
-     * @return void
      */
     public function testGetInterfacesTwoLevelInheritance(): void
     {
@@ -201,8 +191,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the result of the <b>getInterfaces()</b> method.
-     *
-     * @return void
      */
     public function testGetInterfacesComplexInheritance(): void
     {
@@ -216,8 +204,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * Tests that {@link \PDepend\Source\AST\ASTInterface::isSubtypeOf()}
      * returns <b>false</b> for an input class.
-     *
-     * @return void
      */
     public function testIsSubtypeOfReturnsFalseForNonParents(): void
     {
@@ -230,8 +216,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * Checks the {@link \PDepend\Source\AST\ASTInterface::isSubtypeOf()}
      * method.
-     *
-     * @return void
      */
     public function testIsSubtypeOnInheritanceHierarchy(): void
     {
@@ -242,15 +226,13 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'C' => false,
                 'D' => false,
                 'E' => false,
-                'F' => true
+                'F' => true,
             ]
         );
     }
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTInterface::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeOnInheritanceHierarchy1(): void
     {
@@ -261,15 +243,13 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'C' => true,
                 'D' => true,
                 'E' => true,
-                'F' => true
+                'F' => true,
             ]
         );
     }
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTInterface::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeOnInheritanceHierarchy2(): void
     {
@@ -280,15 +260,13 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'A' => true,
                 'D' => true,
                 'E' => true,
-                'F' => false
+                'F' => false,
             ]
         );
     }
 
     /**
      * Checks the {@link \PDepend\Source\AST\ASTInterface::isSubtypeOf()} method.
-     *
-     * @return void
      */
     public function testIsSubtypeOnInheritanceHierarchy3(): void
     {
@@ -299,7 +277,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'D' => false,
                 'A' => true,
                 'E' => false,
-                'F' => false
+                'F' => false,
             ]
         );
     }
@@ -307,9 +285,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * _testIsSubtypeOnInheritanceHierarchy
      *
-     * @param array<string, boolean> $expected Expected result.
-     *
-     * @return void
+     * @param array<string, bool> $expected Expected result.
      */
     private function doTestIsSubtypeOnInheritanceHierarchy(array $expected): void
     {
@@ -330,8 +306,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration(): void
     {
@@ -349,8 +323,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetFirstChildOfTypeFindsASTNodeInMethodDeclaration
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeFindsASTNodeInMethodDeclarations(): void
     {
@@ -368,12 +340,10 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the interface implementation overwrites the
      * setParentClassReference() method and throws an exception.
-     *
-     * @return void
      */
     public function testInterfaceThrowsExpectedExceptionOnSetParentClassReference(): void
     {
-        $this->expectException(\BadMethodCallException::class);
+        $this->expectException(BadMethodCallException::class);
 
         $interface = $this->createItem();
 
@@ -385,8 +355,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the returned modifiers of an interface.
-     *
-     * @return void
      */
     public function testInterfaceReturnsExpectedModifiers(): void
     {
@@ -399,8 +367,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceStillIsParentOfChildMethods
-     *
-     * @return void
      */
     public function testUnserializedInterfaceStillIsParentOfChildMethods(): void
     {
@@ -412,8 +378,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceAndChildMethodsStillReferenceTheSameFile
-     *
-     * @return void
      */
     public function testUnserializedInterfaceAndChildMethodsStillReferenceTheSameFile(): void
     {
@@ -428,8 +392,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceStillReferencesSameParentInterface
-     *
-     * @return void
      */
     public function testUnserializedInterfaceStillReferencesSameParentInterface(): void
     {
@@ -444,8 +406,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceIsReturnedByMethodAsReturnClass
-     *
-     * @return void
      */
     public function testUnserializedInterfaceIsReturnedByMethodAsReturnClass(): void
     {
@@ -462,8 +422,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceStillReferencesSamePackage
-     *
-     * @return void
      */
     public function testUnserializedInterfaceStillReferencesSamePackage(): void
     {
@@ -478,8 +436,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceRegistersToPackage
-     *
-     * @return void
      */
     public function testUnserializedInterfaceRegistersToPackage(): void
     {
@@ -491,8 +447,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedInterfaceNotAddsDublicateClassToPackage
-     *
-     * @return void
      */
     public function testUnserializedInterfaceNotAddsDublicateClassToPackage(): void
     {
@@ -504,8 +458,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetTokensDelegatesCallToCacheRestore
-     *
-     * @return void
      */
     public function testGetTokensDelegatesCallToCacheRestore(): void
     {
@@ -524,8 +476,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testSetTokensDelegatesCallToCacheStore
-     *
-     * @return void
      */
     public function testSetTokensDelegatesCallToCacheStore(): void
     {
@@ -547,8 +497,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStartLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetStartLineReturnsZeroByDefault(): void
     {
@@ -558,8 +506,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStartLineReturnsStartLineOfFirstToken
-     *
-     * @return void
      */
     public function testGetStartLineReturnsStartLineOfFirstToken(): void
     {
@@ -582,8 +528,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetEndLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetEndLineReturnsZeroByDefault(): void
     {
@@ -593,8 +537,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassReferenceReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetParentClassReferenceReturnsNullByDefault(): void
     {
@@ -604,8 +546,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetParentClassesReturnsEmptyArrayByDefault(): void
     {
@@ -615,8 +555,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassesReturnsEmptyArray
-     *
-     * @return void
      */
     public function testGetParentClassesReturnsEmptyArray(): void
     {
@@ -630,8 +568,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetInterfaceReferencesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetInterfaceReferencesReturnsEmptyArrayByDefault(): void
     {
@@ -641,8 +577,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetInterfaceReferencesReturnsExpectedNumberOfInterfaces
-     *
-     * @return void
      */
     public function testGetInterfaceReferencesReturnsExpectedNumberOfInterfaces(): void
     {
@@ -653,7 +587,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsAnEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsAnEmptyArrayByDefault(): void
@@ -665,7 +598,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
@@ -677,7 +609,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesReturnsEmptyResultByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesReturnsEmptyResultByDefault(): void
@@ -689,7 +620,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsExtendedInterface
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsExtendedInterface(): void
@@ -701,7 +631,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetDependenciesContainsExtendedInterfaces
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDependenciesContainsExtendedInterfaces(): void
@@ -712,8 +641,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetEndLineReturnsEndLineOfLastToken
-     *
-     * @return void
      */
     public function testGetEndLineReturnsEndLineOfLastToken(): void
     {
@@ -736,8 +663,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsAbstractReturnsAlwaysTrue
-     *
-     * @return void
      */
     public function testIsAbstractReturnsAlwaysTrue(): void
     {
@@ -747,8 +672,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsUserDefinedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsFalseByDefault(): void
     {
@@ -758,8 +681,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsUserDefinedReturnsTrueAfterSetUserDefinedCall
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsTrueAfterSetUserDefinedCall(): void
     {
@@ -772,7 +693,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * testGetConstantsReturnsExpectedInterfaceConstants
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetConstantsReturnsExpectedInterfaceConstants(): void
@@ -783,8 +703,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseByDefault(): void
     {
@@ -794,8 +712,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseWhenObjectGetsSerialized
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseWhenObjectGetsSerialized(): void
     {
@@ -805,18 +721,12 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $this->assertFalse($interface->isCached());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedName(): void
     {
         $interface = new ASTInterface('MyInterface');
         $this->assertSame('MyInterface', $interface->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithNamespaceDeclaration(): void
     {
         $interface = new ASTInterface('MyInterface');
@@ -825,9 +735,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $this->assertSame('My\\Namespace\\MyInterface', $interface->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithPackageAnnotation(): void
     {
         $namespace = new ASTNamespace('My\\Namespace');
@@ -841,8 +748,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames(): void
     {
@@ -864,7 +769,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'namespaceName',
                 'startLine',
                 'userDefined',
-                'id'
+                'id',
             ],
             $interface->__sleep()
         );
@@ -872,8 +777,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicWakeupSetsSourceFileOnChildMethods
-     *
-     * @return void
      */
     public function testMagicWakeupSetsSourceFileOnChildMethods(): void
     {
@@ -888,8 +791,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicWakeupCallsRegisterInterfaceOnBuilderContext
-     *
-     * @return void
      */
     public function testMagicWakeupCallsRegisterInterfaceOnBuilderContext(): void
     {
@@ -906,8 +807,6 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * testAcceptInvokesVisitInterfaceOnGivenVisitor
-     *
-     * @return void
      */
     public function testAcceptInvokesVisitInterfaceOnGivenVisitor(): void
     {
@@ -924,14 +823,14 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     /**
      * Creates an abstract item instance.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     protected function createItem()
     {
         $interface = new ASTInterface(__CLASS__);
         $interface->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $interface->setCache(new MemoryCacheDriver());
-        
+
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
         $interface->setContext($context);

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIssetExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.12
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIssetExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.12
+ *
  * @group unittest
  */
 class ASTIssetExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIssetExpressionGraphWithMultipleVariables
-     *
-     * @return void
      */
     public function testIssetExpressionGraphWithMultipleVariables(): void
     {
@@ -70,8 +71,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionGraphWithStaticProperty
-     *
-     * @return void
      */
     public function testIssetExpressionGraphWithStaticProperty(): void
     {
@@ -82,8 +81,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionGraphWithArrayProperty
-     *
-     * @return void
      */
     public function testIssetExpressionGraphWithArrayProperty(): void
     {
@@ -94,8 +91,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIssetExpressionHasExpectedStartLine(): void
     {
@@ -105,8 +100,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIssetExpressionHasExpectedStartColumn(): void
     {
@@ -116,8 +109,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIssetExpressionHasExpectedEndLine(): void
     {
@@ -127,8 +118,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * testIssetExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIssetExpressionHasExpectedEndColumn(): void
     {
@@ -141,7 +130,7 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTIssetExpression
+     * @return ASTIssetExpression
      */
     private function getFirstIssetExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLabelStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTLabelStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTLabelStatement
  * @group unittest
  */
 class ASTLabelStatementTest extends ASTNodeTestCase
 {
     /**
      * testLabelStatementHasExpectedStartLine
-     *
-     * @return void
      */
     public function testLabelStatementHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTLabelStatementTest extends ASTNodeTestCase
 
     /**
      * testLabelStatementHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testLabelStatementHasExpectedStartColumn(): void
     {
@@ -78,9 +75,6 @@ class ASTLabelStatementTest extends ASTNodeTestCase
 
     /**
      * testLabelStatementHasExpectedEndLine
-     *
-     * @return void
-     *
      */
     public function testLabelStatementHasExpectedEndLine(): void
     {
@@ -90,8 +84,6 @@ class ASTLabelStatementTest extends ASTNodeTestCase
 
     /**
      * testLabelStatementHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testLabelStatementHasExpectedEndColumn(): void
     {
@@ -104,7 +96,7 @@ class ASTLabelStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTLabelStatement
+     * @return ASTLabelStatement
      */
     private function getFirstLabelStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTListExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTListExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTListExpression
  * @group unittest
  */
 class ASTListExpressionTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpression
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
+     *
      * @since 1.0.2
      */
     public function testListExpression()
@@ -71,9 +73,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @depends testListExpression
      */
     public function testListExpressionHasExpectedStartLine($expr): void
@@ -84,9 +85,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @depends testListExpression
      */
     public function testListExpressionHasExpectedStartColumn($expr): void
@@ -97,9 +97,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @depends testListExpression
      */
     public function testListExpressionHasExpectedEndLine($expr): void
@@ -110,9 +109,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @depends testListExpression
      */
     public function testListExpressionHasExpectedEndColumn($expr): void
@@ -123,7 +121,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedList
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
+     *
      * @since 1.0.2
      */
     public function testListExpressionWithNestedList()
@@ -137,52 +136,52 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedListHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testListExpressionWithNestedList
      */
     public function testListExpressionWithNestedListHasExpectedStartLine($expr): void
     {
         $this->assertEquals(4, $expr->getStartLine());
     }
-    
+
     /**
      * testListExpressionWithNestedListHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testListExpressionWithNestedList
      */
     public function testListExpressionWithNestedListHasExpectedStartColumn($expr): void
     {
         $this->assertEquals(5, $expr->getStartColumn());
     }
-    
+
     /**
      * testListExpressionWithNestedListHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testListExpressionWithNestedList
      */
     public function testListExpressionWithNestedListHasExpectedEndLine($expr): void
     {
         $this->assertEquals(4, $expr->getEndLine());
     }
-    
+
     /**
      * testListExpressionWithNestedListHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTListExpression $expr
+     * @param ASTListExpression $expr
      *
-     * @return void
      * @since 1.0.2
+     *
      * @depends testListExpressionWithNestedList
      */
     public function testListExpressionWithNestedListHasExpectedEndColumn($expr): void
@@ -192,8 +191,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the list supports many variables in it
-     *
-     * @return void
      */
     public function testListExpressionSupportsManyVariables(): void
     {
@@ -204,8 +201,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the list supports a single variable
-     *
-     * @return void
      */
     public function testListExpressionSupportsSingleVariable(): void
     {
@@ -216,8 +211,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the list supports commas without variables
-     *
-     * @return void
      */
     public function testListExpressionSupportsExtraCommas(): void
     {
@@ -228,8 +221,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithComments
-     *
-     * @return void
      */
     public function testListExpressionWithComments(): void
     {
@@ -240,8 +231,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithoutChildExpression
-     *
-     * @return void
      */
     public function testListExpressionWithoutChildExpression(): void
     {
@@ -252,8 +241,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithVariableVariable
-     *
-     * @return void
      */
     public function testListExpressionWithVariableVariable(): void
     {
@@ -265,8 +252,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithSquaredBrackets
-     *
-     * @return void
      */
     public function testListExpressionWithSquaredBrackets(): void
     {
@@ -280,8 +265,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithSquaredBracketsAndEmptySlot
-     *
-     * @return void
      */
     public function testListExpressionWithSquaredBracketsAndEmptySlot(): void
     {
@@ -295,8 +278,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithArrayAndEmptySlot
-     *
-     * @return void
      */
     public function testListExpressionWithArrayAndEmptySlot(): void
     {
@@ -312,8 +293,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testSymmetricArrayDestructuringEmptySlot
-     *
-     * @return void
      */
     public function testSymmetricArrayDestructuringEmptySlot(): void
     {
@@ -328,8 +307,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testFunctionVoidReturnType
-     *
-     * @return void
      */
     public function testFunctionVoidReturnType(): void
     {
@@ -344,8 +321,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithCompoundVariable
-     *
-     * @return void
      */
     public function testListExpressionWithCompoundVariable(): void
     {
@@ -357,8 +332,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithArrayElement
-     *
-     * @return void
      */
     public function testListExpressionWithArrayElement(): void
     {
@@ -370,8 +343,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * testListExpressionWithObjectProperty
-     *
-     * @return void
      */
     public function testListExpressionWithObjectProperty(): void
     {
@@ -384,7 +355,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithKeys
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
+     *
      * @since 1.0.2
      */
     public function testListExpressionWithKeys()
@@ -398,7 +370,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithKeysAndNestedList
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
+     *
      * @since 1.0.2
      */
     public function testListExpressionWithKeysAndNestedList()
@@ -412,7 +385,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTListExpression
+     * @return ASTListExpression
      */
     private function getFirstListExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLiteral} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTLiteral
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTLiteral
  * @group unittest
  */
 class ASTLiteralTest extends ASTNodeTestCase
 {
     /**
      * testLiteralWithBooleanTrueExpression
-     *
-     * @return void
      */
     public function testLiteralWithBooleanTrueExpression(): void
     {
@@ -67,8 +66,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithBooleanFalseExpression
-     *
-     * @return void
      */
     public function testLiteralWithBooleanFalseExpression(): void
     {
@@ -78,8 +75,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithIntegerExpression
-     *
-     * @return void
      */
     public function testLiteralWithIntegerExpression(): void
     {
@@ -89,8 +84,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithSignedIntegerExpression
-     *
-     * @return void
      */
     public function testLiteralWithSignedIntegerExpression(): void
     {
@@ -100,8 +93,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithFloatExpression
-     *
-     * @return void
      */
     public function testLiteralWithFloatExpression(): void
     {
@@ -111,8 +102,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithSignedFloatExpression
-     *
-     * @return void
      */
     public function testLiteralWithSignedFloatExpression(): void
     {
@@ -122,8 +111,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * testLiteralWithNullExpression
-     *
-     * @return void
      */
     public function testLiteralWithNullExpression(): void
     {
@@ -134,7 +121,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroIntegerValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithZeroIntegerValue(): void
@@ -146,7 +132,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroOctalIntegerValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithZeroOctalIntegerValue(): void
@@ -158,7 +143,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroHexIntegerValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithZeroHexIntegerValue(): void
@@ -170,9 +154,9 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroBinaryIntegerValue
      *
-     * @return void
-     * @since 1.0.0
      * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
+     *
+     * @since 1.0.0
      */
     public function testLiteralWithZeroBinaryIntegerValue(): void
     {
@@ -183,7 +167,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithNonZeroOctalIntegerValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithNonZeroOctalIntegerValue(): void
@@ -195,7 +178,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithNonZeroHexIntegerValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithNonZeroHexIntegerValue(): void
@@ -207,9 +189,9 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithNonZeroBinaryIntegerValue
      *
-     * @return void
-     * @since 1.0.0
      * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
+     *
+     * @since 1.0.0
      */
     public function testLiteralWithNonZeroBinaryIntegerValue(): void
     {
@@ -220,9 +202,9 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroFloatValue
      *
-     * @return void
-     * @since 2.16.0
      * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+     *
+     * @since 2.16.0
      */
     public function testLiteralWithZeroFloatValue(): void
     {
@@ -237,7 +219,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithCurlyBraceFollowedByCompoundExpression
      *
-     * @return void
      * @since 1.0.0
      */
     public function testLiteralWithCurlyBraceFollowedByCompoundExpression(): void
@@ -248,8 +229,6 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * Tests that an invalid literal results in the expected exception.
-     *
-     * @return void
      */
     public function testUnclosedDoubleQuoteStringResultsInExpectedException(): void
     {
@@ -261,17 +240,17 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * Creates a literal node.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTLiteral("'" . __METHOD__ . "'");
+        return new ASTLiteral("'" . __METHOD__ . "'");
     }
 
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTLiteral
+     * @return ASTLiteral
      */
     private function getFirstLiteralInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalAndExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.8
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLogicalAndExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.8
+ *
  * @group unittest
  */
 class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalAndExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testLogicalAndExpressionHasExpectedStartLine(): void
     {
@@ -69,8 +70,6 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalAndExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testLogicalAndExpressionHasExpectedStartColumn(): void
     {
@@ -80,8 +79,6 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalAndExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testLogicalAndExpressionHasExpectedEndLine(): void
     {
@@ -91,8 +88,6 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalAndExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testLogicalAndExpressionHasExpectedEndColumn(): void
     {
@@ -105,7 +100,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTLogicalAndExpression
+     * @return ASTLogicalAndExpression
      */
     private function getFirstLogicalAndExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.8
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalOrExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.8
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLogicalOrExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.8
+ *
  * @group unittest
  */
 class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalOrExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testLogicalOrExpressionHasExpectedStartLine(): void
     {
@@ -69,8 +70,6 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalOrExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testLogicalOrExpressionHasExpectedStartColumn(): void
     {
@@ -80,8 +79,6 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalOrExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testLogicalOrExpressionHasExpectedEndLine(): void
     {
@@ -91,8 +88,6 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalOrExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testLogicalOrExpressionHasExpectedEndColumn(): void
     {
@@ -105,7 +100,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTLogicalOrExpression
+     * @return ASTLogicalOrExpression
      */
     private function getFirstLogicalOrExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalXorExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTLogicalXorExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTLogicalXorExpression
  * @group unittest
  */
 class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 {
     /**
      * testLogicalXorExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testLogicalXorExpressionHasExpectedStartLine(): void
     {
@@ -67,8 +66,6 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalXorExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testLogicalXorExpressionHasExpectedStartColumn(): void
     {
@@ -78,8 +75,6 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalXorExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testLogicalXorExpressionHasExpectedEndLine(): void
     {
@@ -89,8 +84,6 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 
     /**
      * testLogicalXorExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testLogicalXorExpressionHasExpectedEndColumn(): void
     {
@@ -103,7 +96,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTLogicalXorExpression
+     * @return ASTLogicalXorExpression
      */
     private function getFirstLogicalXorExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTMemberPrimaryPrefix} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTMemberPrimaryPrefix
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTMemberPrimaryPrefix
  * @group unittest
  */
 class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
@@ -57,7 +58,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
     /**
      * testMemberPrimaryPrefixGraphDereferencedFromArray
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphDereferencedFromArray(): void
@@ -90,7 +90,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *         - ASTVariable              ->  $i
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphInIssetExpression(): void
@@ -98,18 +97,18 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable'                          . ' ($object)',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'               . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix'               . ' (plots)', [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression'      . ' ()', [
-                            'PDepend\\Source\\AST\\ASTIdentifier'            . ' (plots)',
-                            'PDepend\\Source\\AST\\ASTLiteral'               . ' (0)']],
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix'               . ' (coords)', [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression'      . ' ()', [
-                            'PDepend\\Source\\AST\\ASTArrayIndexExpression'  . ' ()', [
-                                'PDepend\\Source\\AST\\ASTIdentifier'        . ' (coords)',
-                                'PDepend\\Source\\AST\\ASTLiteral'           . ' (0)'],
-                            'PDepend\\Source\\AST\\ASTVariable'              . ' ($i)']]]
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($object)',
+                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
+                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (plots)', [
+                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (plots)',
+                            'PDepend\\Source\\AST\\ASTLiteral' . ' (0)']],
+                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (coords)', [
+                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
+                            'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
+                                'PDepend\\Source\\AST\\ASTIdentifier' . ' (coords)',
+                                'PDepend\\Source\\AST\\ASTLiteral' . ' (0)'],
+                            'PDepend\\Source\\AST\\ASTVariable' . ' ($i)']]],
             ]
         );
     }
@@ -130,7 +129,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTIdentifier        ->  X
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticConstant(): void
@@ -140,7 +138,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTConstantPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
@@ -161,7 +159,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTVariable          ->  $property
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticProperty(): void
@@ -172,7 +169,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
@@ -195,7 +192,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *       - ASTLiteral         ->  24
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndStaticMethod(): void
@@ -208,7 +204,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -231,7 +227,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *       - ASTLiteral         ->  23
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphWithDynamicClassAndDynamicMethod(): void
@@ -244,7 +239,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral'
+                'PDepend\\Source\\AST\\ASTLiteral',
             ]
         );
     }
@@ -267,8 +262,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTIdentifier          ->  foo
      *     - ASTArguments           ->  ( )
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndMethodInvocation(): void
     {
@@ -277,12 +270,12 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             $prefix,
             [
                 'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference'   . ' (MyClass)',
-                    'PDepend\\Source\\AST\\ASTArguments'        . ' ()'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix'        . ' (foo)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier'       . ' (foo)',
-                    'PDepend\\Source\\AST\\ASTArguments'        . ' ()'
-            ]]
+                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
+                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',
+                ]]
         );
     }
 
@@ -307,8 +300,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *       - ASTIdentifier          ->  bar
      *       - ASTArguments           ->  ( )
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndMethodChain(): void
     {
@@ -317,14 +308,14 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             $prefix,
             [
                 'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference'   . ' (MyClass)'],
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'  . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTMethodPostfix'    . ' (foo)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier'   . ' (foo)',
-                        'PDepend\\Source\\AST\\ASTArguments'    . ' ()'],
-                    'PDepend\\Source\\AST\\ASTMethodPostfix'    . ' (bar)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier'   . ' (bar)',
-                        'PDepend\\Source\\AST\\ASTArguments'    . ' ()']]
+                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)'],
+                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
+                    'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
+                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
+                        'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                    'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
+                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
+                        'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
             ]
         );
     }
@@ -346,8 +337,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *   - ASTPropertyPostfix       ->  ->
      *     - ASTIdentifier          ->  foo
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndPropertyAccess(): void
     {
@@ -356,10 +345,10 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             $prefix,
             [
                 'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference'   . ' (MyClass)',
-                    'PDepend\\Source\\AST\\ASTArguments'        . ' ()'],
-                'PDepend\\Source\\AST\\ASTPropertyPostfix'      . ' (foo)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier'       . ' (foo)']
+                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)', [
+                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
             ]
         );
     }
@@ -383,8 +372,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTPropertyPostfix       ->  ->
      *       - ASTIdentifier          ->  bar
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphStartedWithAllocationAndPropertyChain(): void
     {
@@ -393,12 +380,12 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             $prefix,
             [
                 'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference'   . ' (MyClass)'],
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'  . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix'  . ' (foo)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier'   . ' (foo)'],
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix'  . ' (bar)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier'   . ' (bar)']]
+                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)'],
+                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
+                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)', [
+                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
+                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (bar)', [
+                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)']],
             ]
         );
     }
@@ -409,8 +396,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * $obj->foo = 42;
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphForObjectPropertyAccess(): void
     {
@@ -420,7 +405,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
@@ -441,7 +426,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTVariable          ->  $property
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphForObjectWithVariablePropertyAccess(): void
@@ -452,7 +436,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
@@ -463,8 +447,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * $obj->foo();
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphForObjectMethodAccess(): void
     {
@@ -475,7 +457,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
@@ -499,7 +481,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *       - ASTLiteral         ->  42
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMemberPrimaryPrefixGraphForObjectWithVariableMethodAccess(): void
@@ -508,12 +489,12 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable'        . ' ($object)',
-                'PDepend\\Source\\AST\\ASTMethodPostfix'   . ' ($method)', [
-                    'PDepend\\Source\\AST\\ASTVariable'    . ' ($method)',
-                    'PDepend\\Source\\AST\\ASTArguments'   . ' ()', [
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($object)',
+                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' ($method)', [
+                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()', [
                         'PDepend\\Source\\AST\\ASTLiteral' . ' (23)',
-                        'PDepend\\Source\\AST\\ASTLiteral' . ' (42)']]
+                        'PDepend\\Source\\AST\\ASTLiteral' . ' (42)']],
             ]
         );
     }
@@ -539,7 +520,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      *     - ASTArguments          ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGraphDereferencedArrayFromFunctionCallAndMethodInvocation(): void
@@ -554,7 +534,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTLiteral',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
@@ -566,25 +546,23 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * $obj->foo->bar()->baz();
      * </code>
-     *
-     * @return void
      */
     public function testMemberPrimaryPrefixGraphForChainedObjectMemberAccess(): void
     {
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable'                    . ' ($obj)',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'         . ' (->)',     [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix'         . ' (foo)',  [
-                        'PDepend\\Source\\AST\\ASTIdentifier'          . ' (foo)'],
-                        'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
-                            'PDepend\\Source\\AST\\ASTMethodPostfix'   . ' (bar)', [
-                                'PDepend\\Source\\AST\\ASTIdentifier'  . ' (bar)',
-                                'PDepend\\Source\\AST\\ASTArguments'   . ' ()'],
-                            'PDepend\\Source\\AST\\ASTMethodPostfix'   . ' (baz)', [
-                                'PDepend\\Source\\AST\\ASTIdentifier'  . ' (baz)',
-                                'PDepend\\Source\\AST\\ASTArguments'   . ' ()']]]
+                'PDepend\\Source\\AST\\ASTVariable' . ' ($obj)',
+                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',     [
+                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)',  [
+                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
+                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
+                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
+                            'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
+                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']]],
             ]
         );
     }
@@ -596,29 +574,27 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * foo(23)[42]->bar()[17]->baz()[0]
      * </code>
-     *
-     * @return void
      */
     public function testGraphDereferencedArrayFromFunctionCallAndMultipleMethodInvocations(): void
     {
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression'         . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'      . ' (->)',  [
+                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
+                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
                         'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTFunctionPostfix'  . ' (foo)', [
-                                'PDepend\\Source\\AST\\ASTIdentifier'   . ' (foo)',
-                                'PDepend\\Source\\AST\\ASTArguments'    . ' ()',    [
-                                    'PDepend\\Source\\AST\\ASTLiteral'  . ' (23)']],
-                            'PDepend\\Source\\AST\\ASTLiteral'          . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix'        . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier'       . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments'        . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral'                  . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix'                . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier'               . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments'                . ' ()']
+                            'PDepend\\Source\\AST\\ASTFunctionPostfix' . ' (foo)', [
+                                'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
+                                'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
+                                    'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']],
+                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
+                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
+                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
+                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
+                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
+                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
             ]
         );
     }
@@ -630,31 +606,29 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * Clazz::foo(23)[42]->bar()[17]->baz()[0]
      * </code>
-     *
-     * @return void
      */
     public function testGraphDereferencedArrayFromStaticMethodCallAndMultipleMethodInvocations(): void
     {
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression'                      . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'                   . ' (->)',  [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression'              . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'           . ' (::)', [
+                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
+                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
+                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
+                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (::)', [
                                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference' . ' (Clazz)',
-                                'PDepend\\Source\\AST\\ASTMethodPostfix'             . ' (foo)', [
-                                    'PDepend\\Source\\AST\\ASTIdentifier'            . ' (foo)',
-                                    'PDepend\\Source\\AST\\ASTArguments'             . ' ()',    [
-                                        'PDepend\\Source\\AST\\ASTLiteral'           . ' (23)']]],
-                            'PDepend\\Source\\AST\\ASTLiteral'                       . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix'                     . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier'                    . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments'                     . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral'                               . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix'                             . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier'                            . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments'                             . ' ()']
+                                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
+                                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
+                                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
+                                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']]],
+                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
+                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
+                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
+                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
+                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
+                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
             ]
         );
     }
@@ -666,39 +640,35 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
      * <code>
      * $class::foo(23)[42]->bar()[17]->baz()[0]
      * </code>
-     *
-     * @return void
      */
     public function testGraphDereferencedArrayFromVariableClassStaticMethodCallAndMultipleMethodInvocations(): void
     {
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression'                      . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'                   . ' (->)',  [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression'              . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'           . ' (::)', [
-                                'PDepend\\Source\\AST\\ASTVariable'                  . ' ($class)',
-                                'PDepend\\Source\\AST\\ASTMethodPostfix'             . ' (foo)', [
-                                    'PDepend\\Source\\AST\\ASTIdentifier'            . ' (foo)',
-                                    'PDepend\\Source\\AST\\ASTArguments'             . ' ()',    [
-                                        'PDepend\\Source\\AST\\ASTLiteral'           . ' (23)']]],
-                            'PDepend\\Source\\AST\\ASTLiteral'                       . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix'                     . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier'                    . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments'                     . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral'                               . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix'                             . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier'                            . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments'                             . ' ()']
+                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
+                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
+                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
+                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (::)', [
+                                'PDepend\\Source\\AST\\ASTVariable' . ' ($class)',
+                                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
+                                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
+                                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
+                                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']]],
+                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
+                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
+                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
+                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
+                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
+                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
+                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
+                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
             ]
         );
     }
 
     /**
      * testObjectMemberPrimaryPrefixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testObjectMemberPrimaryPrefixHasExpectedStartLine(): void
     {
@@ -708,8 +678,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testObjectMemberPrimaryPrefixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testObjectMemberPrimaryPrefixHasExpectedStartColumn(): void
     {
@@ -719,8 +687,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testObjectMemberPrimaryPrefixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testObjectMemberPrimaryPrefixHasExpectedEndLine(): void
     {
@@ -730,8 +696,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testObjectMemberPrimaryPrefixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testObjectMemberPrimaryPrefixHasExpectedEndColumn(): void
     {
@@ -741,8 +705,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testObjectPropertyMemberPrimaryPrefixIsStaticReturnsFalse
-     *
-     * @return void
      */
     public function testObjectPropertyMemberPrimaryPrefixIsStaticReturnsFalse(): void
     {
@@ -752,8 +714,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testObjectMethodMemberPrimaryPrefixIsStaticReturnsFalse
-     *
-     * @return void
      */
     public function testObjectMethodMemberPrimaryPrefixIsStaticReturnsFalse(): void
     {
@@ -763,8 +723,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testClassPropertyMemberPrimaryPrefixIsStaticReturnsTrue
-     *
-     * @return void
      */
     public function testClassPropertyMemberPrimaryPrefixIsStaticReturnsTrue(): void
     {
@@ -774,8 +732,6 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * testClassMethodMemberPrimaryPrefixIsStaticReturnsTrue
-     *
-     * @return void
      */
     public function testClassMethodMemberPrimaryPrefixIsStaticReturnsTrue(): void
     {
@@ -786,7 +742,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
     /**
      * Returns a test member primary prefix.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -45,12 +45,13 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTMethodPostfix} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTInvocation
  * @covers \PDepend\Source\AST\ASTMethodPostfix
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTMethodPostfixTest extends ASTNodeTestCase
@@ -62,7 +63,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * $object->$method(23);
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForVariableMethod(): void
@@ -78,7 +78,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * Clazz::$method(23);
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForVariableStaticMethod(): void
@@ -94,7 +93,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * Clazz::$method[42](23);
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForArrayIndexedVariableStaticMethod(): void
@@ -110,7 +108,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * Clazz::$method[42][17][23]();
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageForMultiArrayIndexedVariableStaticMethod(): void
@@ -121,8 +118,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testMethodPostfixGraphForVariable
-     *
-     * @return void
      */
     public function testMethodPostfixGraphForVariable(): void
     {
@@ -131,7 +126,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -139,8 +134,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testMethodPostfixGraphForArrayIndexedVariable
-     *
-     * @return void
      */
     public function testMethodPostfixGraphForArrayIndexedVariable(): void
     {
@@ -151,7 +144,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -173,7 +166,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments           ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMethodPostfixGraphForCompoundExpression(): void
@@ -182,8 +174,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", [
-                'PDepend\\Source\\AST\\ASTLiteral'            . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments'          . " ()"
+                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
+                'PDepend\\Source\\AST\\ASTArguments' . " ()",
             ]
         );
     }
@@ -204,7 +196,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments         ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMethodPostfixGraphForCompoundVariable(): void
@@ -213,8 +204,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", [
-                'PDepend\\Source\\AST\\ASTLiteral'          . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments'        . " ()"
+                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
+                'PDepend\\Source\\AST\\ASTArguments' . " ()",
             ]
         );
     }
@@ -235,7 +226,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments         ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testMethodPostfixGraphForVariableVariable(): void
@@ -244,8 +234,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', [
-                'PDepend\\Source\\AST\\ASTVariable'         . ' ($method)'],
-                'PDepend\\Source\\AST\\ASTArguments'        . ' ()'
+                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)'],
+                'PDepend\\Source\\AST\\ASTArguments' . ' ()',
             ]
         );
     }
@@ -266,7 +256,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments           ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testStaticMethodPostfixGraphForCompoundExpression(): void
@@ -275,8 +264,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", [
-                'PDepend\\Source\\AST\\ASTLiteral'            . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments'          . " ()"
+                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
+                'PDepend\\Source\\AST\\ASTArguments' . " ()",
             ]
         );
     }
@@ -297,7 +286,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments         ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testStaticMethodPostfixGraphForCompoundVariable(): void
@@ -306,8 +294,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", [
-                'PDepend\\Source\\AST\\ASTLiteral'          . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments'        . " ()"
+                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
+                'PDepend\\Source\\AST\\ASTArguments' . " ()",
             ]
         );
     }
@@ -328,7 +316,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *   - ASTArguments         ->  ( )
      * </code>
      *
-     * @return void
      * @since 1.0.0
      */
     public function testStaticMethodPostfixGraphForVariableVariable(): void
@@ -337,16 +324,14 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             $this->getFirstMethodPostfixInFunction(),
             [
                 'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', [
-                'PDepend\\Source\\AST\\ASTVariable'         . ' ($method)'],
-                'PDepend\\Source\\AST\\ASTArguments'        . ' ()'
+                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)'],
+                'PDepend\\Source\\AST\\ASTArguments' . ' ()',
             ]
         );
     }
 
     /**
      * testObjectMethodPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testObjectMethodPostfixHasExpectedStartLine(): void
     {
@@ -356,8 +341,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testObjectMethodPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testObjectMethodPostfixHasExpectedStartColumn(): void
     {
@@ -367,8 +350,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testObjectMethodPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testObjectMethodPostfixHasExpectedEndLine(): void
     {
@@ -378,8 +359,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testObjectMethodPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testObjectMethodPostfixHasExpectedEndColumn(): void
     {
@@ -389,8 +368,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassMethodPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testClassMethodPostfixHasExpectedStartLine(): void
     {
@@ -400,8 +377,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassMethodPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testClassMethodPostfixHasExpectedStartColumn(): void
     {
@@ -411,8 +386,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassMethodPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testClassMethodPostfixHasExpectedEndLine(): void
     {
@@ -422,8 +395,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * testClassMethodPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testClassMethodPostfixHasExpectedEndColumn(): void
     {
@@ -433,8 +404,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForSimpleInvocation(): void
     {
@@ -443,7 +412,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -451,8 +420,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForVariableInvocation(): void
     {
@@ -461,7 +428,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -469,8 +436,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForVariableVariableInvocation(): void
     {
@@ -480,7 +445,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTVariableVariable',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -488,8 +453,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForCompoundVariableInvocation(): void
     {
@@ -499,7 +462,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTCompoundVariable',
             'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -507,8 +470,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForSimpleStaticInvocation(): void
     {
@@ -517,7 +478,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -525,8 +486,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForVariableStaticInvocation(): void
     {
@@ -535,7 +494,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -543,8 +502,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForVariableVariableStaticInvocation(): void
     {
@@ -554,7 +511,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTVariableVariable',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -562,8 +519,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForCompoundVariableStaticInvocation(): void
     {
@@ -581,13 +536,11 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForVariableCompoundVariableStaticInvocation(): void
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
-        
+
         $expected = [
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
@@ -602,8 +555,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForStaticInvocationWithConsecutiveInvocation(): void
     {
@@ -616,7 +567,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTArguments',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -624,8 +575,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForStaticInvocationOnVariable(): void
     {
@@ -634,7 +583,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTMethodPostfix',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments'
+            'PDepend\\Source\\AST\\ASTArguments',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -642,8 +591,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForSelfInvocation(): void
     {
@@ -660,8 +607,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testMethodPostfixStructureForParentInvocation(): void
     {
@@ -678,8 +623,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object graph.
-     *
-     * @return void
      */
     public function testMethodPostfixGraphForStaticReferenceInvocation(): void
     {
@@ -700,8 +643,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * <code>
      * $this->$foo[0]();
      * </code>
-     *
-     * @return void
      */
     public function testMethodPostfixGraphForVariableArrayElementInvocation(): void
     {
@@ -721,7 +662,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTMethodPostfix
+     * @return ASTMethodPostfix
      */
     private function getFirstMethodPostfixInFunction()
     {
@@ -736,7 +677,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInFunction($testCase)
     {
@@ -751,7 +692,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)
     {
@@ -764,10 +705,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     /**
      * Creates a method postfix node.
      *
-     * @return \PDepend\Source\AST\ASTMethodPostfix
+     * @return ASTMethodPostfix
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTMethodPostfix(__FUNCTION__);
+        return new ASTMethodPostfix(__FUNCTION__);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -42,25 +42,25 @@
 
 namespace PDepend\Source\AST;
 
+use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTMethod class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\AbstractASTCallable
  * @covers \PDepend\Source\AST\ASTMethod
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTMethodTest extends AbstractASTArtifactTestCase
 {
     /**
      * testIsCachedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseByDefault(): void
     {
@@ -70,8 +70,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsCachedReturnsFalseWhenObjectGetsSerialized
-     *
-     * @return void
      */
     public function testIsCachedReturnsFalseWhenObjectGetsSerialized(): void
     {
@@ -83,8 +81,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testReturnValueOfMagicSleepContainsContextProperty
-     *
-     * @return void
      */
     public function testReturnValueOfMagicSleepContainsContextProperty(): void
     {
@@ -101,7 +97,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
                 'comment',
                 'returnsReference',
                 'returnClassReference',
-                'exceptionClassReferences'
+                'exceptionClassReferences',
             ],
             $method->__sleep()
         );
@@ -109,8 +105,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testParserSetsAbstractFlagOnMethod
-     *
-     * @return void
      */
     public function testParserNotSetsAbstractFlagOnMethod(): void
     {
@@ -120,8 +114,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testParserSetsAbstractFlagOnMethod
-     *
-     * @return void
      */
     public function testParserSetsAbstractFlagOnMethod(): void
     {
@@ -131,8 +123,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetReturnClassForMethodWithNamespacedRootClass
-     *
-     * @return void
      */
     public function testGetReturnClassForMethodWithNamespacedRootClass(): void
     {
@@ -142,8 +132,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetReturnClassForMethodWithNamespacedClass
-     *
-     * @return void
      */
     public function testGetReturnClassForMethodWithNamespacedClass(): void
     {
@@ -153,8 +141,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetReturnClassForMethodWithNamespacedArrayRootClass
-     *
-     * @return void
      */
     public function testGetReturnClassForMethodWithNamespacedArrayRootClass(): void
     {
@@ -164,8 +150,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetReturnClassForMethodWithNamespacedArrayClass
-     *
-     * @return void
      */
     public function testGetReturnClassForMethodWithNamespacedArrayClass(): void
     {
@@ -175,8 +159,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetExceptionsForMethodWithNamespacedRootClass
-     *
-     * @return void
      */
     public function testGetExceptionsForMethodWithNamespacedRootClass(): void
     {
@@ -189,8 +171,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetExceptionsForMethodWithNamespacedClass
-     *
-     * @return void
      */
     public function testGetExceptionsForMethodWithNamespacedClass(): void
     {
@@ -203,8 +183,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testInlineDependencyForMethodWithNamespacedRootClass
-     *
-     * @return void
      */
     public function testInlineDependencyForMethodWithNamespacedRootClass(): void
     {
@@ -217,8 +195,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testInlineDependencyForMethodWithNamespacedClass
-     *
-     * @return void
      */
     public function testInlineDependencyForMethodWithNamespacedClass(): void
     {
@@ -231,8 +207,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testReturnsReferenceReturnsExpectedTrue
-     *
-     * @return void
      */
     public function testReturnsReferenceReturnsExpectedTrue(): void
     {
@@ -242,8 +216,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testReturnsReferenceReturnsExpectedFalse
-     *
-     * @return void
      */
     public function testReturnsReferenceReturnsExpectedFalse(): void
     {
@@ -253,8 +225,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsEmptyArrayByDefault
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsEmptyArrayByDefault(): void
     {
@@ -264,8 +234,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsFirstSetOfStaticVariables
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsFirstSetOfStaticVariables(): void
     {
@@ -279,8 +247,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetStaticVariablesReturnsMergeOfAllStaticVariables
-     *
-     * @return void
      */
     public function testGetStaticVariablesReturnsMergeOfAllStaticVariables(): void
     {
@@ -295,12 +261,11 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * testGetSourceFileThrowsExpectedExceptionWhenNoParentWasDefined
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTCompilationUnitNotFoundException
      */
     public function testGetSourceFileThrowsExpectedExceptionWhenNoParentWasDefined(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTCompilationUnitNotFoundException::class);
+        $this->expectException(ASTCompilationUnitNotFoundException::class);
 
         $method = new ASTMethod('method');
         $method->getCompilationUnit();
@@ -309,8 +274,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that build interface updates the source file information for null
      * values.
-     *
-     * @return void
      */
     public function testSetSourceFileInformationForNullValue(): void
     {
@@ -327,8 +290,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testByDefaultGetParentReturnsNull
-     *
-     * @return void
      */
     public function testByDefaultGetParentReturnsNull(): void
     {
@@ -338,8 +299,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testSetParentWithNullResetsPreviousParentToNull
-     *
-     * @return void
      */
     public function testSetParentWithNullResetsPreviousParentToNull(): void
     {
@@ -354,8 +313,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::getParent()} returns as
      * default value <b>null</b> and that the package could be set and unset.
-     *
-     * @return void
      */
     public function testGetSetParent(): void
     {
@@ -368,8 +325,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the visitor accept method.
-     *
-     * @return void
      */
     public function testVisitorAccept(): void
     {
@@ -383,8 +338,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method
      * fails with an exception for an invalid modifier value.
-     *
-     * @return void
      */
     public function testSetInvalidModifierFail(): void
     {
@@ -397,8 +350,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method
      * accepts the defined visibility value.
-     *
-     * @return void
      */
     public function testSetModifiersAcceptsPublicValue(): void
     {
@@ -415,7 +366,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * testGetModifiersReturnsZeroByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetModifiersReturnsZeroByDefault(): void
@@ -427,7 +377,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * testGetModifiersReturnsPreviousSetValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetModifiersReturnsPreviousSetValue(): void
@@ -443,8 +392,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsStaticDefaultByReturnsFalse
-     *
-     * @return void
      */
     public function testIsStaticDefaultByReturnsFalse(): void
     {
@@ -455,8 +402,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method marks
      * a method as static.
-     *
-     * @return void
      */
     public function testSetModifiersMarksMethodAsStatic(): void
     {
@@ -471,8 +416,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsFinalByDefaultReturnsFalse
-     *
-     * @return void
      */
     public function testIsFinalByDefaultReturnsFalse(): void
     {
@@ -483,8 +426,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method marks
      * a method as final.
-     *
-     * @return void
      */
     public function testSetModifiersMarksMethodAsFinal(): void
     {
@@ -500,8 +441,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method marks
      * a method as static+final.
-     *
-     * @return void
      */
     public function testSetModifiersMarksMethodAsStaticFinal(): void
     {
@@ -518,8 +457,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method
      * accepts the defined visibility value.
-     *
-     * @return void
      */
     public function testSetModifiersAcceptsProtectedValue(): void
     {
@@ -536,8 +473,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTMethod::setModifiers()} method
      * accepts the defined visibility value.
-     *
-     * @return void
      */
     public function testSetModifiersAcceptsPrivateValue(): void
     {
@@ -553,8 +488,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testIsPublicByDefaultReturnsFalse
-     *
-     * @return void
      */
     public function testIsPublicByDefaultReturnsFalse(): void
     {
@@ -564,8 +497,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
@@ -593,8 +524,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
@@ -628,8 +557,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
@@ -659,8 +586,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::findChildrenOfType()}.
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeReturnsExpectedResult(): void
     {
@@ -688,8 +613,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedMethodStillReferencesSameDependency
-     *
-     * @return void
      */
     public function testUnserializedMethodStillReferencesSameDependency(): void
     {
@@ -704,8 +627,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedMethodStillReferencesSameReturnClass
-     *
-     * @return void
      */
     public function testUnserializedMethodStillReferencesSameReturnClass(): void
     {
@@ -720,8 +641,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedMethodStillReferencesSameParameterClass
-     *
-     * @return void
      */
     public function testUnserializedMethodStillReferencesSameParameterClass(): void
     {
@@ -736,8 +655,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedMethodStillReferencesSameExceptionClass
-     *
-     * @return void
      */
     public function testUnserializedMethodStillReferencesSameExceptionClass(): void
     {
@@ -752,8 +669,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testUnserializedMethodStillReferencesSameDependencyInterface
-     *
-     * @return void
      */
     public function testUnserializedMethodStillReferencesSameDependencyInterface(): void
     {
@@ -770,7 +685,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
      * Returns the first method defined in a source file associated with the
      * given test case.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     protected function getFirstMethodInClass()
     {
@@ -785,7 +700,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Creates an abstract item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     protected function createItem()
     {
@@ -795,11 +710,9 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         return $method;
     }
 
-    /**
-     */
     public function testSetTokensWithEmptyArray(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('An AST node should contain at least one token');
 
         $method = new ASTMethod('FooBar');

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -48,10 +48,11 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTNamespace class.
  *
+ * @covers \PDepend\Source\AST\ASTNamespace
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTNamespace
  * @group unittest
  */
 class ASTNamespaceTest extends AbstractTestCase
@@ -59,7 +60,6 @@ class ASTNamespaceTest extends AbstractTestCase
     /**
      * testGetIdReturnsExpectedObjectHash
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetIdReturnsExpectedObjectHash(): void
@@ -71,37 +71,31 @@ class ASTNamespaceTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::getTypes()} method returns
      * an empty {@link \PDepend\Source\AST\ASTArtifactList}.
-     *
-     * @return void
      */
     public function testGetTypeNodeIterator(): void
     {
         $namespace = new ASTNamespace('package1');
         $types = $namespace->getTypes();
-        
+
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $types);
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::addType()}
      * method sets the package in the {@link \PDepend\Source\AST\ASTClass}
      * object and it tests the iterator to contain the new class.
-     *
-     * @return void
      */
     public function testAddTypeAddsTypeToPackage(): void
     {
         $namespace = new ASTNamespace('package1');
         $class = new ASTClass('Class', 0, 'class.php');
-        
+
         $namespace->addType($class);
         $this->assertEquals(1, $namespace->getTypes()->count());
     }
 
     /**
      * testAddTypeSetNamespaceOnAddedInstance
-     *
-     * @return void
      */
     public function testAddTypeSetNamespaceOnAddedInstance(): void
     {
@@ -111,19 +105,17 @@ class ASTNamespaceTest extends AbstractTestCase
         $namespace->addType($class);
         $this->assertSame($namespace, $class->getNamespace());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::addType()}
      * reparents a class.
-     *
-     * @return void
      */
     public function testAddTypeReparentTheGivenInstance(): void
     {
         $namespace1 = new ASTNamespace('package1');
         $namespace2 = new ASTNamespace('package2');
         $class    = new ASTClass('Class', 0, 'class.php');
-        
+
         $namespace1->addType($class);
         $namespace2->addType($class);
 
@@ -132,8 +124,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testAddTypeRemovesGivenTypeFromPreviousParentPackage
-     *
-     * @return void
      */
     public function testAddTypeRemovesGivenTypeFromPreviousParentPackage(): void
     {
@@ -149,8 +139,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * Tests that you cannot add the same type multiple times to a package.
-     *
-     * @return void
      */
     public function testPackageAcceptsTheSameTypeOnlyOneTime(): void
     {
@@ -165,8 +153,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testGetInterfacesReturnsAnEmptyResultByDefault
-     *
-     * @return void
      */
     public function testGetInterfacesReturnsAnEmptyResultByDefault(): void
     {
@@ -176,8 +162,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testGetInterfacesReturnsInjectInterfaceInstance
-     *
-     * @return void
      */
     public function testGetInterfacesReturnsInjectInterfaceInstance(): void
     {
@@ -189,8 +173,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testGetInterfacesReturnsInjectInterfaceInstance
-     *
-     * @return void
      */
     public function testGetInterfacesReturnsNotInjectClassInstance(): void
     {
@@ -199,13 +181,11 @@ class ASTNamespaceTest extends AbstractTestCase
 
         $this->assertCount(0, $namespace->getInterfaces());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::removeType()}
      * method unsets the package in the {@link \PDepend\Source\AST\ASTClass}
      * object and it tests the iterator to contain the new class.
-     *
-     * @return void
      */
     public function testRemoveType(): void
     {
@@ -220,8 +200,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testRemoveTypeResetsPackageReferenceFromRemovedType
-     *
-     * @return void
      */
     public function testRemoveTypeResetsPackageReferenceFromRemovedType(): void
     {
@@ -237,7 +215,6 @@ class ASTNamespaceTest extends AbstractTestCase
     /**
      * testGetTraitsReturnsExpectedNumberOfTraits
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetTraitsReturnsExpectedNumberOfTraits(): void
@@ -254,7 +231,6 @@ class ASTNamespaceTest extends AbstractTestCase
     /**
      * testGetTraitsContainsExpectedTrait
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetTraitsContainsExpectedTrait(): void
@@ -269,7 +245,6 @@ class ASTNamespaceTest extends AbstractTestCase
     /**
      * testAddTypeSetsParentPackageOfTrait
      *
-     * @return void
      * @since 1.0.0
      */
     public function testAddTypeSetsParentPackageOfTrait(): void
@@ -279,41 +254,35 @@ class ASTNamespaceTest extends AbstractTestCase
 
         $this->assertSame($namespace, $trait->getNamespace());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::getFunctions()}
      * method returns an empty {@link \PDepend\Source\AST\ASTArtifactList}.
-     *
-     * @return void
      */
     public function testGetFunctionsNodeIterator(): void
     {
         $namespace   = new ASTNamespace('package1');
         $functions = $namespace->getFunctions();
-        
+
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $functions);
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::addFunction()}
      * method sets the actual package as {@link \PDepend\Source\AST\ASTFunction}
      * owner.
-     *
-     * @return void
      */
     public function testAddFunction(): void
     {
         $namespace  = new ASTNamespace('package1');
         $function = new ASTFunction('function', 0);
-        
+
         $namespace->addFunction($function);
         $this->assertEquals(1, $namespace->getFunctions()->count());
     }
 
     /**
      * testAddFunctionSetsParentPackageOnGivenInstance
-     *
-     * @return void
      */
     public function testAddFunctionSetsParentPackageOnGivenInstance(): void
     {
@@ -323,19 +292,17 @@ class ASTNamespaceTest extends AbstractTestCase
         $namespace->addFunction($function);
         $this->assertSame($namespace, $function->getNamespace());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::addFunction()}
      * reparents a function.
-     *
-     * @return void
      */
     public function testAddFunctionReparent(): void
     {
         $namespace1 = new ASTNamespace('package1');
         $namespace2 = new ASTNamespace('package2');
         $function = new ASTFunction('func', 0);
-        
+
         $namespace1->addFunction($function);
         $namespace2->addFunction($function);
 
@@ -344,8 +311,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testAddFunctionRemovesFunctionFromPreviousParentPackage
-     *
-     * @return void
      */
     public function testAddFunctionRemovesFunctionFromPreviousParentPackage(): void
     {
@@ -358,20 +323,18 @@ class ASTNamespaceTest extends AbstractTestCase
 
         $this->assertEquals(0, $namespace1->getFunctions()->count());
     }
-    
+
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNamespace::removeFunction()}
      * method unsets the actual package as {@link \PDepend\Source\AST\ASTFunction}
      * owner.
-     *
-     * @return void
      */
     public function testRemoveFunction(): void
     {
         $namespace   = new ASTNamespace('package1');
         $function1 = new ASTFunction('func1', 0);
         $function2 = new ASTFunction('func2', 0);
-        
+
         $namespace->addFunction($function1);
         $namespace->addFunction($function2);
         $namespace->removeFunction($function2);
@@ -381,8 +344,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testRemoveFunctionSetsParentPackageToNull
-     *
-     * @return void
      */
     public function testRemoveFunctionSetsParentPackageToNull(): void
     {
@@ -394,25 +355,21 @@ class ASTNamespaceTest extends AbstractTestCase
 
         $this->assertNull($function->getNamespace());
     }
-    
+
     /**
      * Tests the visitor accept method.
-     *
-     * @return void
      */
     public function testVisitorAccept(): void
     {
         $namespace = new ASTNamespace('package1');
         $visitor = new StubASTVisitor();
-        
+
         $namespace->accept($visitor);
         $this->assertSame($namespace, $visitor->namespace);
     }
 
     /**
      * testIsUserDefinedReturnsFalseWhenPackageIsEmpty
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsFalseWhenPackageIsEmpty(): void
     {
@@ -422,21 +379,17 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testIsUserDefinedReturnsFalseWhenAllChildElementsAreNotUserDefined
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsFalseWhenAllChildElementsAreNotUserDefined(): void
     {
         $namespace = new ASTNamespace('package1');
         $namespace->addType(new ASTClass('class', 0));
-        
+
         $this->assertFalse($namespace->isUserDefined());
     }
 
     /**
      * testIsUserDefinedReturnsTrueWhenChildElementIsUserDefined
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsTrueWhenChildElementIsUserDefined(): void
     {
@@ -451,8 +404,6 @@ class ASTNamespaceTest extends AbstractTestCase
 
     /**
      * testIsUserDefinedReturnsTrueWhenAtLeastOneFunctionExists
-     *
-     * @return void
      */
     public function testIsUserDefinedReturnsTrueWhenAtLeastOneFunctionExists(): void
     {
@@ -462,18 +413,12 @@ class ASTNamespaceTest extends AbstractTestCase
         $this->assertTrue($namespace->isUserDefined());
     }
 
-    /**
-     * @return void
-     */
     public function testIsPackageAnnotationReturnsFalseByDefault(): void
     {
         $namespace = new ASTNamespace('namespace');
         $this->assertFalse($namespace->isPackageAnnotation());
     }
 
-    /**
-     * @return void
-     */
     public function testIsPackageAnnotationReturnsFalseTrue(): void
     {
         $namespace = new ASTNamespace('namespace');

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -42,15 +42,18 @@
 
 namespace PDepend\Source\AST;
 
+use OutOfBoundsException;
 use PDepend\AbstractTestCase;
+use ReflectionClass;
 
 /**
  * Abstract test case for classes derived {@link \PDepend\Source\AST\ASTNode}ö
  *
+ * @covers \PDepend\Source\AST\AbstractASTNode
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\AbstractASTNode
  * @group unittest
  */
 abstract class ASTNodeTestCase extends AbstractTestCase
@@ -58,7 +61,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetImageReturnsExpectedNodeImage
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageReturnsExpectedNodeImage(): void
@@ -72,8 +74,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetCommentReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetCommentReturnsNullByDefault(): void
     {
@@ -83,8 +83,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetCommentReturnsInjectedCommentValue
-     *
-     * @return void
      */
     public function testGetCommentReturnsInjectedCommentValue(): void
     {
@@ -97,7 +95,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testPrependChildSimplyAddsFirstChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testPrependChildSimplyAddsFirstChild(): void
@@ -111,7 +108,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testPrependChildMovesFirstChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testPrependChildMovesFirstChild(): void
@@ -126,7 +122,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testPrependChildPrependsNewChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testPrependChildPrependsNewChild(): void
@@ -141,7 +136,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetParentReturnsNullByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetParentReturnsNullByDefault(): void
@@ -153,7 +147,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetParentReturnsExpectedNode
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetParentReturnsExpectedNode(): void
@@ -167,7 +160,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetParentsOfTypeReturnsEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetParentsOfTypeReturnsEmptyArrayByDefault(): void
@@ -182,7 +174,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetParentsOfTypeReturnsExpectedParentNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetParentsOfTypeReturnsExpectedParentNodes(): void
@@ -208,7 +199,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetChildrenReturnsEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetChildrenReturnsEmptyArrayByDefault(): void
@@ -220,7 +210,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetChildrenReturnsArrayWithExpectedNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetChildrenReturnsArrayWithExpectedNodes(): void
@@ -235,12 +224,11 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetChildThrowsExpectedExceptionForInvalidChildIndex
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetChildThrowsExpectedExceptionForInvalidChildIndex(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $node = $this->createNodeInstance();
         $node->addChild($child0 = $this->getNodeMock());
@@ -252,7 +240,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetChildReturnsExpectedNodeInstance
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetChildReturnsExpectedNodeInstance(): void
@@ -268,7 +255,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetFirstChildOfTypeReturnsNullByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetFirstChildOfTypeReturnsNullByDefault(): void
@@ -283,7 +269,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetFirstChildOfTypeReturnsFirstMatchingChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetFirstChildOfTypeReturnsFirstMatchingChild(): void
@@ -304,7 +289,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testGetFirstChildOfTypeReturnsFirstMatchingChildRecursive
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetFirstChildOfTypeReturnsFirstMatchingChildRecursive(): void
@@ -329,7 +313,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testFindChildrenOfTypeReturnsEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFindChildrenOfTypeReturnsEmptyArrayByDefault(): void
@@ -344,7 +327,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testFindChildrenOfTypeReturnsDirectChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFindChildrenOfTypeReturnsDirectChild(): void
@@ -365,7 +347,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testFindChildrenOfTypeReturnsIndirectChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFindChildrenOfTypeReturnsIndirectChild(): void
@@ -386,7 +367,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testFindChildrenOfTypeReturnsDirectAndIndirectChild
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFindChildrenOfTypeReturnsDirectAndIndirectChild(): void
@@ -408,8 +388,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetStartColumnReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetStartColumnReturnsZeroByDefault(): void
     {
@@ -419,8 +397,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetStartColumnReturnsInjectedEndLineValue
-     *
-     * @return void
      */
     public function testGetStartColumnReturnsInjectedEndLineValue(): void
     {
@@ -432,8 +408,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetStartLineReturnsZeroByDefault(): void
     {
@@ -443,8 +417,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetStartLineReturnsInjectedEndLineValue
-     *
-     * @return void
      */
     public function testGetStartLineReturnsInjectedEndLineValue(): void
     {
@@ -456,8 +428,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetEndColumnReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetEndColumnReturnsZeroByDefault(): void
     {
@@ -467,8 +437,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetEndColumnReturnsInjectedEndLineValue
-     *
-     * @return void
      */
     public function testGetEndColumnReturnsInjectedEndLineValue(): void
     {
@@ -480,8 +448,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsZeroByDefault
-     *
-     * @return void
      */
     public function testGetEndLineReturnsZeroByDefault(): void
     {
@@ -491,8 +457,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testGetEndLineReturnsInjectedEndLineValue
-     *
-     * @return void
      */
     public function testGetEndLineReturnsInjectedEndLineValue(): void
     {
@@ -505,7 +469,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testConfigureLinesAndColumnsSetsExpectedStartLine
      *
-     * @return void
      * @since 1.0.0
      */
     public function testConfigureLinesAndColumnsSetsExpectedStartLine(): void
@@ -519,7 +482,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testConfigureLinesAndColumnsSetsExpectedEndLine
      *
-     * @return void
      * @since 1.0.0
      */
     public function testConfigureLinesAndColumnsSetsExpectedEndLine(): void
@@ -533,7 +495,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testConfigureLinesAndColumnsSetsExpectedStartColumn
      *
-     * @return void
      * @since 1.0.0
      */
     public function testConfigureLinesAndColumnsSetsExpectedStartColumn(): void
@@ -547,7 +508,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testConfigureLinesAndColumnsSetsExpectedEndColumn
      *
-     * @return void
      * @since 1.0.0
      */
     public function testConfigureLinesAndColumnsSetsExpectedEndColumn(): void
@@ -561,7 +521,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testSleepReturnsExpectedSetOfPropertyNames
      *
-     * @return void
      * @since 1.0.0
      */
     public function testSleepReturnsExpectedSetOfPropertyNames(): void
@@ -573,7 +532,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * testUnserializeSetsParentNodeOnChildren
      *
-     * @return void
      * @since 1.0.0
      */
     public function testUnserializeSetsParentNodeOnChildren(): void
@@ -590,7 +548,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * Returns a mocked ast node instance.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     private function getNodeMock()
     {
@@ -599,8 +557,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testPrependChildAddsChildAtFirstPosition
-     *
-     * @return void
      */
     public function testPrependChildAddsChildAtFirstPosition(): void
     {
@@ -618,8 +574,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testAcceptInvokesVisitOnGivenVisitor
-     *
-     * @return void
      */
     public function testAcceptInvokesVisitOnGivenVisitor(): void
     {
@@ -637,8 +591,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * testAcceptReturnsReturnValueOfVisitMethod
-     *
-     * @return void
      */
     public function testAcceptReturnsReturnValueOfVisitMethod(): void
     {
@@ -657,8 +609,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
@@ -678,8 +628,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
@@ -705,13 +653,11 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::getFirstChildOfType()}.
-     *
-     * @return void
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
         $name = 'PDepend_Source_AST_ASTNode_' . md5(microtime());
-        
+
         $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
             ->setMockClassName($name)
             ->getMock();
@@ -727,8 +673,6 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
     /**
      * Tests the behavior of {@link \PDepend\Source\AST\ASTMethod::findChildrenOfType()}.
-     *
-     * @return void
      */
     public function testFindChildrenOfTypeReturnsExpectedResult(): void
     {
@@ -751,12 +695,10 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTNode::getChild()} method throws
      * an exception for an undefined node offset.
-     *
-     * @return void
      */
     public function testGetChildThrowsExpectedExceptionForUndefinedOffset(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $node = $this->createNodeInstance();
         $node->getChild(42);
@@ -765,13 +707,13 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function createNodeInstance()
     {
         $class = substr(get_class($this), 0, -4);
 
-        $reflection = new \ReflectionClass($class);
+        $reflection = new ReflectionClass($class);
         if ($reflection->isAbstract()) {
             return $this->getAbstractClassMock($class, [__METHOD__]);
         }
@@ -783,7 +725,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param boolean $ignoreAnnotations
+     * @param bool   $ignoreAnnotations
      *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -47,10 +47,11 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the code parameter class.
  *
+ * @covers \PDepend\Source\AST\ASTParameter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTParameter
  * @group unittest
  */
 class ASTParameterTest extends AbstractTestCase
@@ -58,7 +59,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * testGetIdReturnsExpectedObjectHash
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetIdReturnsExpectedObjectHash(): void
@@ -69,8 +69,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * Tests that the allows null method returns <b>true</b> for a simple parameter.
-     *
-     * @return void
      */
     public function testParameterAllowsNullForSimpleVariableIssue67(): void
     {
@@ -81,8 +79,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the allows null method returns <b>true</b> for a simple
      * parameter passed by reference.
-     *
-     * @return void
      */
     public function testParameterAllowsNullForSimpleVariablePassedByReferenceIssue67(): void
     {
@@ -93,8 +89,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the allows null method returns <b>false</b> for an array
      * parameter without explicit <b>null</b> default value.
-     *
-     * @return void
      */
     public function testParameterNotAllowsNullForArrayHintVariableIssue67(): void
     {
@@ -105,8 +99,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the allows null method returns <b>true</b> for an array
      * parameter with explicit <b>null</b> default value.
-     *
-     * @return void
      */
     public function testParameterAllowsNullForArrayHintVariableIssue67(): void
     {
@@ -117,8 +109,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the allows null method returns <b>false</b> for a typed
      * parameter without explicit <b>null</b> default value.
-     *
-     * @return void
      */
     public function testParameterNotAllowsNullForTypeHintVariableIssue67(): void
     {
@@ -129,8 +119,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the allows null method returns <b>true</b> for a type
      * parameter with explicit <b>null</b> default value.
-     *
-     * @return void
      */
     public function testParameterAllowsNullForTypeHintVariableIssue67(): void
     {
@@ -141,8 +129,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the getDeclaringClass() method returns <b>null</b> for a
      * function.
-     *
-     * @return void
      */
     public function testParameterDeclaringClassReturnsNullForFunctionIssue67(): void
     {
@@ -153,8 +139,6 @@ class ASTParameterTest extends AbstractTestCase
     /**
      * Tests that the getDeclaringClass() method returns the declaring class
      * of a parent function/method.
-     *
-     * @return void
      */
     public function testParameterDeclaringClassReturnsExpectedInstanceForMethodIssue67(): void
     {
@@ -172,8 +156,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * Tests that the parameter class handles a type holder as expected.
-     *
-     * @return void
      */
     public function testParameterReturnsExpectedTypeFromASTClassOrInterfaceReference(): void
     {
@@ -191,8 +173,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * Tests that a parameter returns <b>null</b> when no type holder was set.
-     *
-     * @return void
      */
     public function testParameterReturnNullForTypeWhenNoASTClassOrInterfaceReferenceWasSet(): void
     {
@@ -202,8 +182,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * Tests that a parameter returns the expected function instance.
-     *
-     * @return void
      */
     public function testParameterReturnsExpectedDeclaringFunction(): void
     {
@@ -214,8 +192,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * Tests that a parameter returns the expected method instance.
-     *
-     * @return void
      */
     public function testParameterReturnsExpectedDeclaringMethod(): void
     {
@@ -228,7 +204,8 @@ class ASTParameterTest extends AbstractTestCase
      * Returns the first class method found in the test file associated with the
      * calling test method.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
+     *
      * @since 1.0.0
      */
     private function getFirstMethodInClass()
@@ -243,8 +220,6 @@ class ASTParameterTest extends AbstractTestCase
 
     /**
      * testAcceptInvokesVisitParameterOnSuppliedVisitor
-     *
-     * @return void
      */
     public function testAcceptInvokesVisitParameterOnSuppliedVisitor(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTParentReference} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTParentReference
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTParentReference
  * @group unittest
  */
 class ASTParentReferenceTest extends ASTNodeTestCase
@@ -57,14 +58,12 @@ class ASTParentReferenceTest extends ASTNodeTestCase
     /**
      * The mocked reference instance.
      *
-     * @var \PDepend\Source\AST\ASTClassOrInterfaceReference
+     * @var ASTClassOrInterfaceReference
      */
     protected $referenceMock = null;
 
     /**
      * testGetTypeDelegatesCallToInjectedReferenceObject
-     *
-     * @return void
      */
     public function testGetTypeDelegatesCallToInjectedReferenceObject(): void
     {
@@ -78,8 +77,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -90,7 +87,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
                 'context',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $reference->__sleep()
         );
@@ -98,8 +95,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceAllocationOutsideOfClassScopeThrowsExpectedException
-     *
-     * @return void
      */
     public function testParentReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -110,8 +105,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceInClassWithoutParentThrowsException
-     *
-     * @return void
      */
     public function testParentReferenceInClassWithoutParentThrowsException(): void
     {
@@ -122,8 +115,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException
-     *
-     * @return void
      */
     public function testParentReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -135,7 +126,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
     /**
      * testGetImageReturnsExpectedValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageReturnsExpectedValue(): void
@@ -146,8 +136,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceHasExpectedStartLine
-     *
-     * @return void
      */
     public function testParentReferenceHasExpectedStartLine(): void
     {
@@ -157,8 +145,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testParentReferenceHasExpectedStartColumn(): void
     {
@@ -168,8 +154,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceHasExpectedEndLine
-     *
-     * @return void
      */
     public function testParentReferenceHasExpectedEndLine(): void
     {
@@ -179,8 +163,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * testParentReferenceHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testParentReferenceHasExpectedEndColumn(): void
     {
@@ -191,7 +173,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @return ASTParentReference
      */
     protected function createNodeInstance()
     {
@@ -199,7 +181,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        return new \PDepend\Source\AST\ASTParentReference($this->referenceMock);
+        return new ASTParentReference($this->referenceMock);
     }
 
     /**
@@ -207,7 +189,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTParentReference
+     * @return ASTParentReference
      */
     private function getFirstParentReferenceInClass($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link ASTPostfixExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTPostfixExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTPostfixExpression
  * @group unittest
  */
 class ASTPostfixExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIncrementPostfixExpressionOnStaticClassMember
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnStaticClassMember(): void
     {
@@ -68,15 +67,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnSelfClassMember
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnSelfClassMember(): void
     {
@@ -87,15 +84,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnParentClassMember
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnParentClassMember(): void
     {
@@ -106,15 +101,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTParentReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnThisObjectMember
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnThisObjectMember(): void
     {
@@ -125,15 +118,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnFunctionPostfix
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnFunctionPostfix(): void
     {
@@ -144,15 +135,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnVariableVariable
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnVariableVariable(): void
     {
@@ -162,15 +151,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTVariableVariable',
                 'PDepend\\Source\\AST\\ASTVariableVariable',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnCompoundVariable
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnCompoundVariable(): void
     {
@@ -179,15 +166,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
             $expr,
             [
                 'PDepend\\Source\\AST\\ASTCompoundVariable',
-                'PDepend\\Source\\AST\\ASTConstant'
+                'PDepend\\Source\\AST\\ASTConstant',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnObjectMethodPostfix
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnObjectMethodPostfix(): void
     {
@@ -200,15 +185,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
                 'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionOnStaticMethodPostfix
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionOnStaticMethodPostfix(): void
     {
@@ -220,15 +203,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * testIncrementPostfixExpressionArrayPropertyPostfix
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionArrayPropertyPostfix(): void
     {
@@ -242,15 +223,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
-    
+
     /**
      * testIncrementPostfixExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionHasExpectedStartLine(): void
     {
@@ -260,8 +239,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncrementPostfixExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionHasExpectedStartColumn(): void
     {
@@ -271,8 +248,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncrementPostfixExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionHasExpectedEndLine(): void
     {
@@ -282,8 +257,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testIncrementPostfixExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testIncrementPostfixExpressionHasExpectedEndColumn(): void
     {
@@ -293,8 +266,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testDecrementPostfixExpressionArrayPropertyPostfix
-     *
-     * @return void
      */
     public function testDecrementPostfixExpressionArrayPropertyPostfix(): void
     {
@@ -308,15 +279,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
                 'PDepend\\Source\\AST\\ASTArrayIndexExpression',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
-    
+
     /**
      * testDecrementPostfixExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testDecrementPostfixExpressionHasExpectedStartLine(): void
     {
@@ -326,8 +295,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testDecrementPostfixExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testDecrementPostfixExpressionHasExpectedStartColumn(): void
     {
@@ -337,8 +304,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testDecrementPostfixExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testDecrementPostfixExpressionHasExpectedEndLine(): void
     {
@@ -348,8 +313,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * testDecrementPostfixExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testDecrementPostfixExpressionHasExpectedEndColumn(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPreDecrementExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTPreDecrementExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTPreDecrementExpression
  * @group unittest
  */
 class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 {
     /**
      * testPreDecrementExpressionOnStaticClassMember
-     *
-     * @return void
      */
     public function testPreDecrementExpressionOnStaticClassMember(): void
     {
@@ -68,15 +67,13 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreDecrementExpressionOnSelfClassMember
-     *
-     * @return void
      */
     public function testPreDecrementExpressionOnSelfClassMember(): void
     {
@@ -87,15 +84,13 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreDecrementExpressionOnParentClassMember
-     *
-     * @return void
      */
     public function testPreDecrementExpressionOnParentClassMember(): void
     {
@@ -106,15 +101,13 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTParentReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreDecrementExpressionOnFunctionPostfix
-     *
-     * @return void
      */
     public function testPreDecrementExpressionOnFunctionPostfix(): void
     {
@@ -124,15 +117,13 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * testPreDecrementExpressionOnStaticVariableMember
-     *
-     * @return void
      */
     public function testPreDecrementExpressionOnStaticVariableMember(): void
     {
@@ -143,15 +134,13 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreDecrementExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testPreDecrementExpressionHasExpectedStartLine(): void
     {
@@ -161,8 +150,6 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreDecrementExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testPreDecrementExpressionHasExpectedStartColumn(): void
     {
@@ -172,8 +159,6 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreDecrementExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testPreDecrementExpressionHasExpectedEndLine(): void
     {
@@ -183,8 +168,6 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreDecrementExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testPreDecrementExpressionHasExpectedEndColumn(): void
     {
@@ -196,7 +179,8 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     *
+     * @return ASTPreDecrementExpression
      */
     private function getFirstPreDecrementExpressionInClass($testCase)
     {
@@ -211,7 +195,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTPreDecrementExpression
+     * @return ASTPreDecrementExpression
      */
     private function getFirstPreDecrementExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -45,20 +45,19 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPreIncrementExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\AST\ASTPreIncrementExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 {
     /**
      * testPreIncrementExpressionOnStaticClassMember
-     *
-     * @return void
      */
     public function testPreIncrementExpressionOnStaticClassMember(): void
     {
@@ -69,15 +68,13 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreIncrementExpressionOnSelfClassMember
-     *
-     * @return void
      */
     public function testPreIncrementExpressionOnSelfClassMember(): void
     {
@@ -88,15 +85,13 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreIncrementExpressionOnParentClassMember
-     *
-     * @return void
      */
     public function testPreIncrementExpressionOnParentClassMember(): void
     {
@@ -107,15 +102,13 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTParentReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreIncrementExpressionOnFunctionPostfix
-     *
-     * @return void
      */
     public function testPreIncrementExpressionOnFunctionPostfix(): void
     {
@@ -125,15 +118,13 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
             [
                 'PDepend\\Source\\AST\\ASTFunctionPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * testPreIncrementExpressionOnStaticVariableMember
-     *
-     * @return void
      */
     public function testPreIncrementExpressionOnStaticVariableMember(): void
     {
@@ -144,15 +135,13 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * testPreIncrementExpressionsInArithmeticOperation
-     *
-     * @return void
      */
     public function testPreIncrementExpressionsInArithmeticOperation(): void
     {
@@ -166,8 +155,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreIncrementExpressionHasExpectedStartLine
-     *
-     * @return void
      */
     public function testPreIncrementExpressionHasExpectedStartLine(): void
     {
@@ -177,8 +164,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreIncrementExpressionHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testPreIncrementExpressionHasExpectedStartColumn(): void
     {
@@ -188,8 +173,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreIncrementExpressionHasExpectedEndLine
-     *
-     * @return void
      */
     public function testPreIncrementExpressionHasExpectedEndLine(): void
     {
@@ -199,8 +182,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * testPreIncrementExpressionHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testPreIncrementExpressionHasExpectedEndColumn(): void
     {
@@ -212,7 +193,8 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     *
+     * @return ASTPreIncrementExpression
      */
     private function getFirstPreIncrementExpressionInClass($testCase)
     {
@@ -226,7 +208,8 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     * @return \PDepend\Source\AST\ASTPreIncrementExpression
+     *
+     * @return ASTPreIncrementExpression
      */
     private function getFirstPreIncrementExpressionInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -45,17 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPrintExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTPrintExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTPrintExpression
  * @group unittest
  */
 class ASTPrintExpressionTest extends ASTNodeTestCase
 {
     /**
-     * @return \PDepend\Source\AST\ASTPrintExpression
+     * @return ASTPrintExpression
      */
     public function testSimplePrintExpression()
     {
@@ -66,8 +67,6 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTPrintExpression $expr
-     * @return void
      * @depends testSimplePrintExpression
      */
     public function testSimplePrintExpressionHasExpectedStartLine(ASTPrintExpression $expr): void
@@ -76,8 +75,6 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTPrintExpression $expr
-     * @return void
      * @depends testSimplePrintExpression
      */
     public function testSimplePrintExpressionHasExpectedEndLine(ASTPrintExpression $expr): void
@@ -86,8 +83,6 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTPrintExpression $expr
-     * @return void
      * @depends testSimplePrintExpression
      */
     public function testSimplePrintExpressionHasExpectedStartColumn(ASTPrintExpression $expr): void
@@ -96,8 +91,6 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTPrintExpression $expr
-     * @return void
      * @depends testSimplePrintExpression
      */
     public function testSimplePrintExpressionHasExpectedEndColumn(ASTPrintExpression $expr): void
@@ -106,7 +99,7 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTPrintExpression
+     * @return ASTPrintExpression
      */
     private function getFirstPrintInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -45,23 +45,22 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPropertyPostfix} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\AST\ASTPropertyPostfix
+ *
  * @group unittest
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPropertyPostfix
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 class ASTPropertyPostfixTest extends ASTNodeTestCase
 {
     /**
      * testGetImageForArrayIndexedRegularProperty
-     *
-     * @return void
      */
     public function testGetImageForArrayIndexedRegularProperty(): void
     {
@@ -71,8 +70,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testGetImageForMultiDimensionalArrayIndexedRegularProperty
-     *
-     * @return void
      */
     public function testGetImageForMultiDimensionalArrayIndexedRegularProperty(): void
     {
@@ -82,8 +79,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testGetImageForVariableProperty
-     *
-     * @return void
      */
     public function testGetImageForVariableProperty(): void
     {
@@ -93,8 +88,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testGetImageForArrayIndexedVariableProperty
-     *
-     * @return void
      */
     public function testGetImageForArrayIndexedVariableProperty(): void
     {
@@ -108,8 +101,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * <code>
      * $this->$foo[0];
      * </code>
-     *
-     * @return void
      */
     public function testPropertyPostfixGraphForArrayElementInvocation(): void
     {
@@ -119,7 +110,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -131,8 +122,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * <code>
      * $this->foo[$bar]();
      * </code>
-     *
-     * @return void
      */
     public function testPropertyPostfixGraphForPropertyArrayElementInvocation(): void
     {
@@ -142,7 +131,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -150,8 +139,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForSimpleIdentifierAccess(): void
     {
@@ -159,7 +146,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier'
+            'PDepend\\Source\\AST\\ASTIdentifier',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -167,8 +154,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForVariableAccess(): void
     {
@@ -176,7 +161,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -184,8 +169,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForVariableVariableAccess(): void
     {
@@ -194,7 +177,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTVariableVariable',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -202,8 +185,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForCompoundVariableAccess(): void
     {
@@ -215,7 +196,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTExpression',
             'PDepend\\Source\\AST\\ASTConstant',
             'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -223,8 +204,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForCompoundExpressionAccess(): void
     {
@@ -233,7 +212,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTCompoundExpression',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -241,8 +220,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForStaticVariableAccess(): void
     {
@@ -250,7 +227,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -258,8 +235,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed method postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForStaticAccessOnVariable(): void
     {
@@ -267,7 +242,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTVariable',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -275,8 +250,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForSelfVariableAccess(): void
     {
@@ -284,7 +257,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTSelfReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -292,8 +265,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixStructureForParentVariableAccess(): void
     {
@@ -301,7 +272,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTParentReference',
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable'
+            'PDepend\\Source\\AST\\ASTVariable',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -313,8 +284,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * <code>
      * $this->arguments[42] = func_get_args();
      * </code>
-     *
-     * @return void
      */
     public function testPropertyPostfixGraphForObjectPropertyArrayIndexExpression(): void
     {
@@ -324,7 +293,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -336,8 +305,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * <code>
      * self::$arguments[42] = func_get_args();
      * </code>
-     *
-     * @return void
      */
     public function testPropertyPostfixGraphForStaticPropertyArrayIndexExpression(): void
     {
@@ -347,7 +314,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
             'PDepend\\Source\\AST\\ASTPropertyPostfix',
             'PDepend\\Source\\AST\\ASTArrayIndexExpression',
             'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral'
+            'PDepend\\Source\\AST\\ASTLiteral',
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -355,8 +322,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixSelfVariableInFunctionThrowsExpectedException(): void
     {
@@ -367,8 +332,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixParentVariableInFunctionThrowsExpectedException(): void
     {
@@ -379,8 +342,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Tests that a parsed property postfix has the expected object structure.
-     *
-     * @return void
      */
     public function testPropertyPostfixParentVariableInClassWithoutParentThrowsExpectedException(): void
     {
@@ -391,8 +352,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testPropertyPostfixHasExpectedStartLine
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedStartLine(): void
     {
@@ -402,8 +361,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testPropertyPostfixHasExpectedStartColumn
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedStartColumn(): void
     {
@@ -413,8 +370,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testPropertyPostfixHasExpectedEndLine
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedEndLine(): void
     {
@@ -424,8 +379,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * testPropertyPostfixHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testPropertyPostfixHasExpectedEndColumn(): void
     {
@@ -436,17 +389,17 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     /**
      * Creates a field declaration node.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTPropertyPostfix(__CLASS__);
+        return new ASTPropertyPostfix(__CLASS__);
     }
 
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTPropertyPostfix
+     * @return ASTPropertyPostfix
      */
     private function getFirstPropertyPostfixInFunction()
     {
@@ -461,7 +414,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInFunction($testCase)
     {
@@ -476,7 +429,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMemberPrimaryPrefix
+     * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -47,10 +47,11 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the code property class.
  *
+ * @covers \PDepend\Source\AST\ASTProperty
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTProperty
  * @group unittest
  */
 class ASTPropertyTest extends AbstractTestCase
@@ -58,7 +59,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * testGetDeclaringClass
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetDeclaringClass(): void
@@ -69,8 +69,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassForPropertyWithNamespacedInternalType
-     *
-     * @return void
      */
     public function testGetClassForPropertyWithNamespacedRootType(): void
     {
@@ -80,8 +78,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassForPropertyWithNamespacedType
-     *
-     * @return void
      */
     public function testGetClassForPropertyWithNamespacedType(): void
     {
@@ -91,8 +87,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassForPropertyWithNamespacedArrayRootType
-     *
-     * @return void
      */
     public function testGetClassForPropertyWithNamespacedArrayRootType(): void
     {
@@ -102,8 +96,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassForPropertyWithNamespacedArrayType
-     *
-     * @return void
      */
     public function testGetClassForPropertyWithNamespacedArrayType(): void
     {
@@ -113,8 +105,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassReturnsNullForPropertyWithScalarType
-     *
-     * @return void
      */
     public function testGetClassReturnsNullForPropertyWithScalarType(): void
     {
@@ -124,8 +114,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassReturnsNullForPropertyWithoutTypeHint
-     *
-     * @return void
      */
     public function testGetClassReturnsNullForPropertyWithoutTypeHint(): void
     {
@@ -135,8 +123,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetClassReturnsNullForPropertyWithoutDocComment
-     *
-     * @return void
      */
     public function testGetClassReturnsNullForPropertyWithoutDocComment(): void
     {
@@ -146,8 +132,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetSourceFileReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetCompilationUnitReturnsNullByDefault(): void
     {
@@ -157,8 +141,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetSourceFileReturnsInjectedFileInstance
-     *
-     * @return void
      */
     public function testGetCompilationUnitReturnsInjectedFileInstance(): void
     {
@@ -172,8 +154,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsNullByDefault(): void
     {
@@ -183,8 +163,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetDocCommentReturnsExpectedPropertyComment
-     *
-     * @return void
      */
     public function testGetDocCommentReturnsExpectedPropertyComment(): void
     {
@@ -195,8 +173,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the <b>isDefaultValueAvailable()</b> method returns the
      * expected result.
-     *
-     * @return void
      */
     public function testPropertyIsDefaultValueAvailableReturnsFalseWhenNoValueExists(): void
     {
@@ -207,8 +183,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the <b>isDefaultValueAvailable()</b> method returns the
      * expected result.
-     *
-     * @return void
      */
     public function testPropertyIsDefaultValueAvailableReturnsTrueWhenValueExists(): void
     {
@@ -218,8 +192,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsDefaultValueAvailableReturnsExpectedTrueForNullValue
-     *
-     * @return void
      */
     public function testIsDefaultValueAvailableReturnsExpectedTrueForNullValue(): void
     {
@@ -229,8 +201,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetDefaultValueReturnsByDefaultExpectedNull
-     *
-     * @return void
      */
     public function testGetDefaultValueReturnsByDefaultExpectedNull(): void
     {
@@ -240,8 +210,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testGetDefaultValueReturnsExpectedNullForNullDefaultValue
-     *
-     * @return void
      */
     public function testGetDefaultValueReturnsExpectedNullForNullDefaultValue(): void
     {
@@ -251,8 +219,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that the property default value matches the expected PHP type.
-     *
-     * @return void
      */
     public function testPropertyContainsExpectDefaultValueBooleanTrue(): void
     {
@@ -262,8 +228,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that the property default value matches the expected PHP type.
-     *
-     * @return void
      */
     public function testPropertyContainsExpectDefaultValueBooleanFalse(): void
     {
@@ -273,8 +237,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that the property default value matches the expected PHP type.
-     *
-     * @return void
      */
     public function testPropertyContainsExpectDefaultValueArray(): void
     {
@@ -284,8 +246,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that the property default value matches the expected PHP type.
-     *
-     * @return void
      */
     public function testPropertyContainsExpectedDefaultValueFloat(): void
     {
@@ -296,8 +256,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isArray()} method
      * returns <b>true</b> for an as array annotated property.
-     *
-     * @return void
      */
     public function testIsArrayReturnsExpectedValueTrueForVarAnnotationWithArray(): void
     {
@@ -308,8 +266,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isArray()} method
      * returns <b>false</b> for an as class/interface annotated property.
-     *
-     * @return void
      */
     public function testIsArrayReturnsExpectedValueFalseForVarAnnotationWithClassType(): void
     {
@@ -320,8 +276,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isArray()} method
      * returns <b>false</b> for an property without var annotation.
-     *
-     * @return void
      */
     public function testIsArrayReturnsExpectedValueFalseForPropertyWithoutVarAnnotation(): void
     {
@@ -332,8 +286,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isScalar()}
      * method returns <b>true</b> for an as integer annotated property.
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsExpectedValueTrueForVarAnnotationWithIntegerTypeHint(): void
     {
@@ -344,8 +296,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isScalar()} method
      * returns <b>false</b> for an as class/interface annotated property.
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsExpectedValueFalseForVarAnnotationWithClassType(): void
     {
@@ -356,7 +306,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * testGetDefaultValueReturnsExpectedStringFromHeredoc
      *
-     * @return void
      * @since 0.10.9
      */
     public function testGetDefaultValueReturnsExpectedStringFromHeredoc(): void
@@ -368,8 +317,6 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Tests that the {@link \PDepend\Source\AST\ASTProperty::isScalar()} method
      * returns <b>false</b> for an property without var annotation.
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsExpectedValueFalseForPropertyWithoutVarAnnotation(): void
     {
@@ -379,8 +326,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsPublicReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPublicReturnsFalseByDefault(): void
     {
@@ -390,8 +335,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsPublicReturnsTrueForPublicProperty
-     *
-     * @return void
      */
     public function testIsPublicReturnsTrueForPublicProperty(): void
     {
@@ -401,8 +344,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsProtectedReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsProtectedReturnsFalseByDefault(): void
     {
@@ -412,8 +353,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsProtectedReturnsTrueForProtectedProperty
-     *
-     * @return void
      */
     public function testIsProtectedReturnsTrueForProtectedProperty(): void
     {
@@ -423,8 +362,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsPrivateReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPrivateReturnsFalseByDefault(): void
     {
@@ -434,8 +371,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsPrivateReturnsTrueForPrivateProperty
-     *
-     * @return void
      */
     public function testIsPrivateReturnsTrueForPrivateProperty(): void
     {
@@ -445,8 +380,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsStaticReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsStaticReturnsFalseByDefault(): void
     {
@@ -456,8 +389,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testIsStaticReturnsTrueForStaticProperty
-     *
-     * @return void
      */
     public function testIsStaticReturnsTrueForStaticProperty(): void
     {
@@ -467,8 +398,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * testAcceptCallsVisitorMethodVisitProperty
-     *
-     * @return void
      */
     public function testAcceptCallsVisitorMethodVisitProperty(): void
     {
@@ -487,8 +416,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that a property node has the expected start line.
-     *
-     * @return void
      */
     public function testPropertyHasExpectedStartLine(): void
     {
@@ -498,8 +425,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that a property node has the expected start column.
-     *
-     * @return void
      */
     public function testPropertyHasExpectedStartColumn(): void
     {
@@ -509,8 +434,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that a property node has the expected end line.
-     *
-     * @return void
      */
     public function testPropertyHasExpectedEndLine(): void
     {
@@ -520,8 +443,6 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Tests that a property node has the expected end column.
-     *
-     * @return void
      */
     public function testPropertyHasExpectedEndColumn(): void
     {
@@ -532,7 +453,7 @@ class ASTPropertyTest extends AbstractTestCase
     /**
      * Returns the first property found in the corresponding test file.
      *
-     * @return \PDepend\Source\AST\ASTProperty
+     * @return ASTProperty
      */
     private function getFirstPropertyInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -46,31 +47,29 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTRequireExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.12
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTRequireExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.12
+ *
  * @group unittest
  */
 class ASTRequireExpressionTest extends ASTNodeTestCase
 {
     /**
      * testIsOnceReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsOnceReturnsFalseByDefault(): void
     {
-        $expr = new \PDepend\Source\AST\ASTRequireExpression();
+        $expr = new ASTRequireExpression();
         $this->assertFalse($expr->isOnce());
     }
 
     /**
      * testIsOnceReturnsTrueForRequireOnceExpression
-     *
-     * @return void
      */
     public function testIsOnceReturnsTrueForRequireOnceExpression(): void
     {
@@ -80,18 +79,16 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
-        $expr = new \PDepend\Source\AST\ASTRequireExpression();
+        $expr = new ASTRequireExpression();
         $this->assertEquals(
             [
                 'once',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $expr->__sleep()
         );
@@ -100,7 +97,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpression
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
+     *
      * @since 1.0.2
      */
     public function testRequireExpression()
@@ -114,9 +112,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpression
      */
     public function testRequireExpressionHasExpectedStartLine($expr): void
@@ -127,9 +124,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpression
      */
     public function testRequireExpressionHasExpectedStartColumn($expr): void
@@ -140,9 +136,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpression
      */
     public function testRequireExpressionHasExpectedEndLine($expr): void
@@ -153,9 +148,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpression
      */
     public function testRequireExpressionHasExpectedEndColumn($expr): void
@@ -166,7 +160,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesis
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
+     *
      * @since 1.0.2
      */
     public function testRequireExpressionWithParenthesis()
@@ -180,9 +175,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpressionWithParenthesis
      */
     public function testRequireExpressionWithParenthesisHasExpectedStartLine($expr): void
@@ -193,9 +187,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpressionWithParenthesis
      */
     public function testRequireExpressionWithParenthesisHasExpectedStartColumn($expr): void
@@ -206,9 +199,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpressionWithParenthesis
      */
     public function testRequireExpressionWithParenthesisHasExpectedEndLine($expr): void
@@ -219,9 +211,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTRequireExpression $expr
+     * @param ASTRequireExpression $expr
      *
-     * @return void
      * @depends testRequireExpressionWithParenthesis
      */
     public function testRequireExpressionWithParenthesisHasExpectedEndColumn($expr): void
@@ -232,7 +223,7 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTRequireExpression
+     * @return ASTRequireExpression
      */
     private function getFirstRequireExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTReturnStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTReturnStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTReturnStatement
  * @group unittest
  */
 class ASTReturnStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatement
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
+     *
      * @since 1.0.2
      */
     public function testReturnStatement()
@@ -71,9 +73,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTReturnStatement $stmt
+     * @param ASTReturnStatement $stmt
      *
-     * @return void
      * @depends testReturnStatement
      */
     public function testReturnStatementHasExpectedStartLine($stmt): void
@@ -84,9 +85,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTReturnStatement $stmt
+     * @param ASTReturnStatement $stmt
      *
-     * @return void
      * @depends testReturnStatement
      */
     public function testReturnStatementHasExpectedStartColumn($stmt): void
@@ -97,9 +97,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTReturnStatement $stmt
+     * @param ASTReturnStatement $stmt
      *
-     * @return void
      * @depends testReturnStatement
      */
     public function testReturnStatementHasExpectedEndLine($stmt): void
@@ -110,9 +109,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTReturnStatement $stmt
+     * @param ASTReturnStatement $stmt
      *
-     * @return void
      * @depends testReturnStatement
      */
     public function testReturnStatementHasExpectedEndColumn($stmt): void
@@ -122,8 +120,6 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesEmptyReturnStatement
-     *
-     * @return void
      */
     public function testParserHandlesEmptyReturnStatement(): void
     {
@@ -133,8 +129,6 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesReturnStatementWithSimpleBoolean
-     *
-     * @return void
      */
     public function testParserHandlesReturnStatementWithSimpleBoolean(): void
     {
@@ -145,7 +139,7 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTReturnStatement
+     * @return ASTReturnStatement
      */
     private function getFirstReturnStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScalarType} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTScalarType
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTScalarType
  * @group unittest
  */
 class ASTScalarTypeTest extends ASTNodeTestCase
 {
     /**
      * testIsArrayReturnsFalse
-     *
-     * @return void
      */
     public function testIsArrayReturnsFalse(): void
     {
@@ -67,8 +66,6 @@ class ASTScalarTypeTest extends ASTNodeTestCase
 
     /**
      * testIsPrimitiveReturnsTrue
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsTrue(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScopeStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTScopeStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTScopeStatement
  * @group unittest
  */
 class ASTScopeStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testParserHandlesInlineScopeStatement
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.0
      */
     public function testParserHandlesInlineScopeStatement()
@@ -71,10 +73,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.0
+     *
      * @depends testParserHandlesInlineScopeStatement
      */
     public function testInlineScopeStatementHasExpectedStartLine($stmt)
@@ -87,10 +91,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.0
+     *
      * @depends testInlineScopeStatementHasExpectedStartLine
      */
     public function testInlineScopeStatementHasExpectedStartColumn($stmt)
@@ -103,10 +109,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.0
+     *
      * @depends testInlineScopeStatementHasExpectedStartColumn
      */
     public function testInlineScopeStatementHasExpectedEndLine($stmt)
@@ -119,10 +127,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.0
+     *
      * @depends testInlineScopeStatementHasExpectedEndLine
      */
     public function testInlineScopeStatementHasExpectedEndColumn($stmt)
@@ -133,7 +143,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatement
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.2
      */
     public function testScopeStatement()
@@ -143,13 +154,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
         return $stmt;
     }
-    
+
     /**
      * Tests that the scope-statement has the expected start line value.
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatement
      */
     public function testScopeStatementHasExpectedStartLine($stmt): void
@@ -160,9 +170,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start column value.
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatement
      */
     public function testScopeStatementHasExpectedStartColumn($stmt): void
@@ -173,9 +182,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end line value.
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatement
      */
     public function testScopeStatementHasExpectedEndLine($stmt): void
@@ -186,9 +194,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end column value.
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatement
      */
     public function testScopeStatementHasExpectedEndColumn($stmt): void
@@ -199,7 +206,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternative
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
+     *
      * @since 1.0.2
      */
     public function testScopeStatementWithAlternative()
@@ -213,9 +221,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatementWithAlternative
      */
     public function testScopeStatementWithAlternativeHasExpectedStartLine($stmt): void
@@ -226,9 +233,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatementWithAlternative
      */
     public function testScopeStatementWithAlternativeHasExpectedStartColumn($stmt): void
@@ -239,9 +245,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatementWithAlternative
      */
     public function testScopeStatementWithAlternativeHasExpectedEndLine($stmt): void
@@ -252,9 +257,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTScopeStatement $stmt
+     * @param ASTScopeStatement $stmt
      *
-     * @return void
      * @depends testScopeStatementWithAlternative
      */
     public function testScopeStatementWithAlternativeHasExpectedEndColumn($stmt): void
@@ -265,7 +269,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTScopeStatement
+     * @return ASTScopeStatement
      */
     private function getFirstScopeStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScope} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTScope
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTScope
  * @group unittest
  */
 class ASTScopeTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * testScope
      *
-     * @return \PDepend\Source\AST\ASTScope
+     * @return ASTScope
+     *
      * @since 1.0.2
      */
     public function testScope()
@@ -71,9 +73,8 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start line value.
      *
-     * @param \PDepend\Source\AST\ASTScope $scope
+     * @param ASTScope $scope
      *
-     * @return void
      * @depends testScope
      */
     public function testScopeHasExpectedStartLine($scope): void
@@ -84,9 +85,8 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start column value.
      *
-     * @param \PDepend\Source\AST\ASTScope $scope
+     * @param ASTScope $scope
      *
-     * @return void
      * @depends testScope
      */
     public function testScopeHasExpectedStartColumn($scope): void
@@ -97,9 +97,8 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end line value.
      *
-     * @param \PDepend\Source\AST\ASTScope $scope
+     * @param ASTScope $scope
      *
-     * @return void
      * @depends testScope
      */
     public function testScopeHasExpectedEndLine($scope): void
@@ -110,9 +109,8 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end column value.
      *
-     * @param \PDepend\Source\AST\ASTScope $scope
+     * @param ASTScope $scope
      *
-     * @return void
      * @depends testScope
      */
     public function testScopeHasExpectedEndColumn($scope): void
@@ -123,7 +121,7 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTScope
+     * @return ASTScope
      */
     private function getFirstScopeInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -43,24 +43,22 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
-use PDepend\Source\Builder\BuilderContext;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSelfReference} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTSelfReference
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTSelfReference
  * @group unittest
  */
 class ASTSelfReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeReturnsInjectedConstructorTargetArgument
-     *
-     * @return void
      */
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
@@ -71,14 +69,12 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
 
-        $reference = new \PDepend\Source\AST\ASTSelfReference($context, $target);
+        $reference = new ASTSelfReference($context, $target);
         $this->assertSame($target, $reference->getType());
     }
 
     /**
      * testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull
-     *
-     * @return void
      */
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
@@ -94,15 +90,13 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
         $context = new GlobalBuilderContext($builder);
 
-        $reference = new \PDepend\Source\AST\ASTSelfReference($context, $target);
+        $reference = new ASTSelfReference($context, $target);
         $reference = unserialize(serialize($reference));
         $reference->getType();
     }
 
     /**
      * testSelfReferenceAllocationOutsideOfClassScopeThrowsExpectedException
-     *
-     * @return void
      */
     public function testSelfReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -113,8 +107,6 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testSelfReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException
-     *
-     * @return void
      */
     public function testSelfReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -125,8 +117,6 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testMagicSelfReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSelfReturnsExpectedSetOfPropertyNames(): void
     {
@@ -137,7 +127,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
                 'context',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $reference->__sleep()
         );
@@ -146,7 +136,6 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testGetImageReturnsExpectedValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageReturnsExpectedValue(): void
@@ -158,7 +147,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReference
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
+     *
      * @since 1.0.2
      */
     public function testSelfReference()
@@ -172,9 +162,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTSelfReference $reference
+     * @param ASTSelfReference $reference
      *
-     * @return void
      * @depends testSelfReference
      */
     public function testSelfReferenceHasExpectedStartLine($reference): void
@@ -185,9 +174,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTSelfReference $reference
+     * @param ASTSelfReference $reference
      *
-     * @return void
      * @depends testSelfReference
      */
     public function testSelfReferenceHasExpectedStartColumn($reference): void
@@ -198,9 +186,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTSelfReference $reference
+     * @param ASTSelfReference $reference
      *
-     * @return void
      * @depends testSelfReference
      */
     public function testSelfReferenceHasExpectedEndLine($reference): void
@@ -211,9 +198,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTSelfReference $reference
+     * @param ASTSelfReference $reference
      *
-     * @return void
      * @depends testSelfReference
      */
     public function testSelfReferenceHasExpectedEndColumn($reference): void
@@ -224,14 +210,14 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      */
     protected function createNodeInstance()
     {
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
 
-        return new \PDepend\Source\AST\ASTSelfReference(
+        return new ASTSelfReference(
             $context,
             $this->getAbstractClassMock('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', [__CLASS__])
         );
@@ -240,7 +226,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTSelfReference
+     * @return ASTSelfReference
      */
     private function getFirstSelfReferenceInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.1
  */
 
@@ -46,31 +47,31 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTShiftLeftExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.1
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTShiftLeftExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.1
+ *
  * @group unittest
  */
 class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 {
     /**
      * testShiftLeftExpressionReturnsExpectedImage
-     *
-     * @return void
      */
     public function testShiftLeftExpressionReturnsExpectedImage(): void
     {
-        $expr = new \PDepend\Source\AST\ASTShiftLeftExpression();
+        $expr = new ASTShiftLeftExpression();
         $this->assertEquals('<<', $expr->getImage());
     }
 
     /**
      * testShiftLeftExpression
      *
-     * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     * @return ASTShiftLeftExpression
      */
     public function testShiftLeftExpression()
     {
@@ -83,9 +84,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTShiftLeftExpression $expr
+     * @param ASTShiftLeftExpression $expr
      *
-     * @return void
      * @depends testShiftLeftExpression
      */
     public function testShiftLeftExpressionHasExpectedStartLine($expr): void
@@ -96,9 +96,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTShiftLeftExpression $expr
+     * @param ASTShiftLeftExpression $expr
      *
-     * @return void
      * @depends testShiftLeftExpression
      */
     public function testShiftLeftExpressionHasExpectedStartColumn($expr): void
@@ -109,9 +108,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTShiftLeftExpression $expr
+     * @param ASTShiftLeftExpression $expr
      *
-     * @return void
      * @depends testShiftLeftExpression
      */
     public function testShiftLeftExpressionHasExpectedEndLine($expr): void
@@ -122,9 +120,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTShiftLeftExpression $expr
+     * @param ASTShiftLeftExpression $expr
      *
-     * @return void
      * @depends testShiftLeftExpression
      */
     public function testShiftLeftExpressionHasExpectedEndColumn($expr): void
@@ -135,7 +132,7 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTShiftLeftExpression
+     * @return ASTShiftLeftExpression
      */
     private function getFirstShiftLeftExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.1
  */
 
@@ -46,31 +47,31 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTShiftRightExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.1
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTShiftRightExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.1
+ *
  * @group unittest
  */
 class ASTShiftRightExpressionTest extends ASTNodeTestCase
 {
     /**
      * testShiftRightExpressionReturnsExpectedImage
-     *
-     * @return void
      */
     public function testShiftRightExpressionReturnsExpectedImage(): void
     {
-        $expr = new \PDepend\Source\AST\ASTShiftRightExpression();
+        $expr = new ASTShiftRightExpression();
         $this->assertEquals('>>', $expr->getImage());
     }
 
     /**
      * testShiftRightExpression
      *
-     * @return \PDepend\Source\AST\ASTShiftRightExpression
+     * @return ASTShiftRightExpression
      */
     public function testShiftRightExpression()
     {
@@ -83,9 +84,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTShiftRightExpression $expr
+     * @param ASTShiftRightExpression $expr
      *
-     * @return void
      * @depends testShiftRightExpression
      */
     public function testShiftRightExpressionHasExpectedStartLine($expr): void
@@ -96,9 +96,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTShiftRightExpression $expr
+     * @param ASTShiftRightExpression $expr
      *
-     * @return void
      * @depends testShiftRightExpression
      */
     public function testShiftRightExpressionHasExpectedStartColumn($expr): void
@@ -109,9 +108,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTShiftRightExpression $expr
+     * @param ASTShiftRightExpression $expr
      *
-     * @return void
      * @depends testShiftRightExpression
      */
     public function testShiftRightExpressionHasExpectedEndLine($expr): void
@@ -122,9 +120,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTShiftRightExpression $expr
+     * @param ASTShiftRightExpression $expr
      *
-     * @return void
      * @depends testShiftRightExpression
      */
     public function testShiftRightExpressionHasExpectedEndColumn($expr): void
@@ -135,7 +132,7 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTShiftRightExpression
+     * @return ASTShiftRightExpression
      */
     private function getFirstShiftRightExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTStatement
  * @group unittest
  */
 class ASTStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatement
      *
-     * @return \PDepend\Source\AST\ASTStatement
+     * @return ASTStatement
+     *
      * @since 1.0.2
      */
     public function testStatement()
@@ -71,9 +73,8 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTStatement $stmt
+     * @param ASTStatement $stmt
      *
-     * @return void
      * @depends testStatement
      */
     public function testStatementHasExpectedStartLine($stmt): void
@@ -84,9 +85,8 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTStatement $stmt
+     * @param ASTStatement $stmt
      *
-     * @return void
      * @depends testStatement
      */
     public function testStatementHasExpectedStartColumn($stmt): void
@@ -97,9 +97,8 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTStatement $stmt
+     * @param ASTStatement $stmt
      *
-     * @return void
      * @depends testStatement
      */
     public function testStatementHasExpectedEndLine($stmt): void
@@ -110,9 +109,8 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTStatement $stmt
+     * @param ASTStatement $stmt
      *
-     * @return void
      * @depends testStatement
      */
     public function testStatementHasExpectedEndColumn($stmt): void
@@ -125,7 +123,7 @@ class ASTStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTStatement
+     * @return ASTStatement
      */
     private function getFirstStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -47,19 +47,18 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStaticReference} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTStaticReference
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTStaticReference
  * @group unittest
  */
 class ASTStaticReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTypeReturnsInjectedConstructorTargetArgument
-     *
-     * @return void
      */
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
@@ -70,14 +69,12 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
         $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
 
-        $reference = new \PDepend\Source\AST\ASTStaticReference($context, $target);
+        $reference = new ASTStaticReference($context, $target);
         $this->assertSame($target, $reference->getType());
     }
 
     /**
      * testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull
-     *
-     * @return void
      */
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
@@ -93,15 +90,13 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
         $context = new GlobalBuilderContext($builder);
 
-        $reference = new \PDepend\Source\AST\ASTStaticReference($context, $target);
+        $reference = new ASTStaticReference($context, $target);
         $reference = unserialize(serialize($reference));
         $reference->getType();
     }
 
     /**
      * Tests that an invalid static results in the expected exception.
-     *
-     * @return void
      */
     public function testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -117,8 +112,6 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * Tests that an invalid static results in the expected exception.
-     *
-     * @return void
      */
     public function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
@@ -134,8 +127,6 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * testMagicSelfReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSelfReturnsExpectedSetOfPropertyNames(): void
     {
@@ -146,7 +137,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
                 'context',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $reference->__sleep()
         );
@@ -155,7 +146,6 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testGetImageReturnsExpectedValue
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetImageReturnsExpectedValue(): void
@@ -167,7 +157,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReference
      *
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
+     *
      * @since 1.0.2
      */
     public function testStaticReference()
@@ -181,9 +172,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTStaticReference $reference
+     * @param ASTStaticReference $reference
      *
-     * @return void
      * @depends testStaticReference
      */
     public function testStaticReferenceHasExpectedStartLine($reference): void
@@ -194,9 +184,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTStaticReference $reference
+     * @param ASTStaticReference $reference
      *
-     * @return void
      * @depends testStaticReference
      */
     public function testStaticReferenceHasExpectedStartColumn($reference): void
@@ -207,9 +196,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTStaticReference $reference
+     * @param ASTStaticReference $reference
      *
-     * @return void
      * @depends testStaticReference
      */
     public function testStaticReferenceHasExpectedEndLine($reference): void
@@ -220,9 +208,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTStaticReference $reference
+     * @param ASTStaticReference $reference
      *
-     * @return void
      * @depends testStaticReference
      */
     public function testStaticReferenceHasExpectedEndColumn($reference): void
@@ -233,14 +220,14 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      */
     protected function createNodeInstance()
     {
         $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
 
-        return new \PDepend\Source\AST\ASTStaticReference(
+        return new ASTStaticReference(
             $context,
             $this->getAbstractClassMock(
                 '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
@@ -252,8 +239,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @param string $testCase Name of the calling test case.
-     * @return \PDepend\Source\AST\ASTStaticReference
+     * @return ASTStaticReference
      */
     private function getFirstStaticReferenceInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStaticVariableDeclaration} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTStaticVariableDeclaration
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTStaticVariableDeclaration
  * @group unittest
  */
 class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * testStaticVariableDeclaration
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
+     *
      * @since 1.0.2
      */
     public function testStaticVariableDeclaration()
@@ -71,9 +73,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected start line value.
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $declaration
+     * @param ASTStringIndexExpression $declaration
      *
-     * @return void
      * @depends testStaticVariableDeclaration
      */
     public function testStaticVariableDeclarationHasExpectedStartLine($declaration): void
@@ -84,9 +85,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected start column value.
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $declaration
+     * @param ASTStringIndexExpression $declaration
      *
-     * @return void
      * @depends testStaticVariableDeclaration
      */
     public function testStaticVariableDeclarationHasExpectedStartColumn($declaration): void
@@ -97,9 +97,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected end line value.
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $declaration
+     * @param ASTStringIndexExpression $declaration
      *
-     * @return void
      * @depends testStaticVariableDeclaration
      */
     public function testStaticVariableDeclarationHasExpectedEndLine($declaration): void
@@ -110,9 +109,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected end column value.
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $declaration
+     * @param ASTStringIndexExpression $declaration
      *
-     * @return void
      * @depends testStaticVariableDeclaration
      */
     public function testStaticVariableDeclarationHasExpectedEndColumn($declaration): void
@@ -123,7 +121,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
      */
     private function getFirstStaticVariableDeclarationInFunction()
     {
@@ -136,10 +134,10 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Creates a static variable declaration node.
      *
-     * @return \PDepend\Source\AST\ASTStaticVariableDeclaration
+     * @return ASTStaticVariableDeclaration
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTStaticVariableDeclaration(__FUNCTION__);
+        return new ASTStaticVariableDeclaration(__FUNCTION__);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -46,13 +47,15 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStringIndexExpression} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 0.9.12
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIndexExpression
  * @covers \PDepend\Source\AST\ASTStringIndexExpression
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 0.9.12
+ *
  * @group unittest
  */
 class ASTStringIndexExpressionTest extends ASTNodeTestCase
@@ -60,7 +63,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpression
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
+     *
      * @since 1.0.2
      */
     public function testStringIndexExpression()
@@ -74,9 +78,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $expr
+     * @param ASTStringIndexExpression $expr
      *
-     * @return void
      * @depends testStringIndexExpression
      */
     public function testStringIndexExpressionHasExpectedStartLine($expr): void
@@ -87,9 +90,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $expr
+     * @param ASTStringIndexExpression $expr
      *
-     * @return void
      * @depends testStringIndexExpression
      */
     public function testStringIndexExpressionHasExpectedStartColumn($expr): void
@@ -100,9 +102,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $expr
+     * @param ASTStringIndexExpression $expr
      *
-     * @return void
      * @depends testStringIndexExpression
      */
     public function testStringIndexExpressionHasExpectedEndLine($expr): void
@@ -113,9 +114,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTStringIndexExpression $expr
+     * @param ASTStringIndexExpression $expr
      *
-     * @return void
      * @depends testStringIndexExpression
      */
     public function testStringIndexExpressionHasExpectedEndColumn($expr): void
@@ -126,7 +126,7 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTStringIndexExpression
+     * @return ASTStringIndexExpression
      */
     private function getFirstStringIndexExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTString} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTString
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTString
  * @group unittest
  */
 class ASTStringTest extends ASTNodeTestCase
 {
     /**
      * testDoubleQuoteStringContainsTwoChildNodes
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsTwoChildNodes(): void
     {
@@ -67,8 +66,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsExpectedTextContent
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsExpectedTextContent(): void
     {
@@ -78,8 +75,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testBacktickExpressionContainsTwoChildNodes
-     *
-     * @return void
      */
     public function testBacktickExpressionContainsTwoChildNodes(): void
     {
@@ -89,8 +84,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testBacktickExpressionContainsExpectedCompoundVariable
-     *
-     * @return void
      */
     public function testBacktickExpressionContainsExpectedCompoundVariable(): void
     {
@@ -100,8 +93,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringWithEmbeddedComplexBacktickExpression
-     *
-     * @return void
      */
     public function testDoubleQuoteStringWithEmbeddedComplexBacktickExpression(): void
     {
@@ -117,8 +108,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testBacktickExpressionWithEmbeddedComplexDoubleQuoteString
-     *
-     * @return void
      */
     public function testBacktickExpressionWithEmbeddedComplexDoubleQuoteString(): void
     {
@@ -134,8 +123,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsVariable
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsVariable(): void
     {
@@ -145,8 +132,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsVariableAfterNotOperator
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsVariableAfterNotOperator(): void
     {
@@ -156,8 +141,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsVariableAfterSilenceOperator
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsVariableAfterSilenceOperator(): void
     {
@@ -167,8 +150,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsCompoundVariable
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsCompoundVariable(): void
     {
@@ -178,8 +159,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsCompoundExpressionAfterLiteral
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsCompoundExpressionAfterLiteral(): void
     {
@@ -189,8 +168,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsVariableAfterDollarTwoLiterals
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsVariableAfterDollarTwoLiterals(): void
     {
@@ -200,8 +177,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testDoubleQuoteStringContainsDollarLiteralForVariableVariable
-     *
-     * @return void
      */
     public function testDoubleQuoteStringContainsDollarLiteralForVariableVariable(): void
     {
@@ -211,8 +186,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * Tests that an invalid literal results in the expected exception.
-     *
-     * @return void
      */
     public function testUnclosedDoubleQuoteStringResultsInExpectedException(): void
     {
@@ -223,8 +196,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testStringStartLine
-     *
-     * @return void
      */
     public function testStringStartLine(): void
     {
@@ -234,8 +205,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testStringEndLine
-     *
-     * @return void
      */
     public function testStringEndLine(): void
     {
@@ -245,8 +214,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testStringStartColumn
-     *
-     * @return void
      */
     public function testStringStartColumn(): void
     {
@@ -256,8 +223,6 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * testStringEndColumn
-     *
-     * @return void
      */
     public function testStringEndColumn(): void
     {
@@ -268,11 +233,11 @@ class ASTStringTest extends ASTNodeTestCase
     /**
      * Creates a string node.
      *
-     * @return \PDepend\Source\AST\ASTString
+     * @return ASTString
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTString();
+        return new ASTString();
     }
 
     /**
@@ -280,7 +245,7 @@ class ASTStringTest extends ASTNodeTestCase
      *
      * @param string $testCase The calling test case.
      *
-     * @return \PDepend\Source\AST\ASTString
+     * @return ASTString
      */
     private function getFirstStringInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -45,29 +45,28 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchLabel} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTSwitchLabel
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTSwitchLabel
  * @group unittest
  */
 class ASTSwitchLabelTest extends ASTNodeTestCase
 {
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
-        $label = new \PDepend\Source\AST\ASTSwitchLabel();
+        $label = new ASTSwitchLabel();
         $this->assertEquals(
             [
                 'default',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $label->__sleep()
         );
@@ -76,8 +75,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests that the default flag is set to <b>true</b> on the default switch
      * label.
-     *
-     * @return void
      */
     public function testDefaultFlagIsSetOnDefaultLabel(): void
     {
@@ -88,8 +85,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests that the default flag is set to <b>false</b> on a regular case
      * label.
-     *
-     * @return void
      */
     public function testDefaultFlagIsNotSetOnCaseLabel(): void
     {
@@ -100,7 +95,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabel
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
+     *
      * @since 1.0.2
      */
     public function testSwitchLabel()
@@ -114,9 +110,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabel
      */
     public function testSwitchLabelHasExpectedStartLine($label): void
@@ -127,9 +122,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabel
      */
     public function testSwitchLabelHasExpectedStartColumn($label): void
@@ -140,9 +134,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabel
      */
     public function testSwitchLabelHasExpectedEndLine($label): void
@@ -153,9 +146,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabel
      */
     public function testSwitchLabelHasExpectedEndColumn($label): void
@@ -165,8 +157,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testSwitchLabelCanBeTerminatedWithSemicolon
-     *
-     * @return void
      */
     public function testSwitchLabelCanBeTerminatedWithSemicolon(): void
     {
@@ -175,8 +165,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testSwitchLabelWithNestedSwitchStatementHasExpectedChildren
-     *
-     * @return void
      */
     public function testSwitchLabelWithNestedSwitchStatementHasExpectedChildren(): void
     {
@@ -190,7 +178,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
         $expected = [
             'PDepend\\Source\\AST\\ASTExpression',
             'PDepend\\Source\\AST\\ASTSwitchStatement',
-            'PDepend\\Source\\AST\\ASTBreakStatement'
+            'PDepend\\Source\\AST\\ASTBreakStatement',
         ];
 
         $this->assertEquals($expected, $actual);
@@ -199,7 +187,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCode
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
+     *
      * @since 2.1.0
      */
     public function testSwitchLabelWithNestedNonePhpCode()
@@ -213,9 +202,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeStartLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelWithNestedNonePhpCode
      */
     public function testSwitchLabelWithNestedNonePhpCodeStartLine(ASTSwitchLabel $label): void
@@ -226,9 +214,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeEndLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelWithNestedNonePhpCode
      */
     public function testSwitchLabelWithNestedNonePhpCodeEndLine(ASTSwitchLabel $label): void
@@ -239,9 +226,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeStartColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelWithNestedNonePhpCode
      */
     public function testSwitchLabelWithNestedNonePhpCodeStartColumn(ASTSwitchLabel $label): void
@@ -252,9 +238,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeEndColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelWithNestedNonePhpCode
      */
     public function testSwitchLabelWithNestedNonePhpCodeEndColumn(ASTSwitchLabel $label): void
@@ -265,7 +250,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelDefault
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
+     *
      * @since 1.0.2
      */
     public function testSwitchLabelDefault()
@@ -279,9 +265,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabelDefault
      */
     public function testSwitchLabelDefaultHasExpectedStartLine($label): void
@@ -292,9 +277,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabelDefault
      */
     public function testSwitchLabelDefaultHasExpectedStartColumn($label): void
@@ -305,9 +289,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabelDefault
      */
     public function testSwitchLabelDefaultHasExpectedEndLine($label): void
@@ -318,9 +301,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
+     * @param ASTSwitchLabel $label
      *
-     * @return void
      * @depends testSwitchLabelDefault
      */
     public function testSwitchLabelDefaultHasExpectedEndColumn($label): void
@@ -330,8 +312,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testSwitchDefaultLabelCanBeTerminatedWithSemicolon
-     *
-     * @return void
      */
     public function testSwitchDefaultLabelCanBeTerminatedWithSemicolon(): void
     {
@@ -340,8 +320,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testSwitchLabelDefaultWithNestedSwitchStatementHasExpectedChildren
-     *
-     * @return void
      */
     public function testSwitchLabelDefaultWithNestedSwitchStatementHasExpectedChildren(): void
     {
@@ -354,7 +332,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
         $expected = [
             'PDepend\\Source\\AST\\ASTSwitchStatement',
-            'PDepend\\Source\\AST\\ASTBreakStatement'
+            'PDepend\\Source\\AST\\ASTBreakStatement',
         ];
 
         $this->assertEquals($expected, $actual);
@@ -363,7 +341,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCode
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
+     *
      * @since 2.1.0
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCode()
@@ -377,9 +356,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeStartLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelWithNestedNonePhpCode
      */
     public function testSwitchLabelDefaultDefaultWithNestedNonePhpCodeStartLine(ASTSwitchLabel $label): void
@@ -390,9 +368,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeEndLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCodeEndLine(ASTSwitchLabel $label): void
@@ -403,9 +380,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeStartColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCodeStartColumn(ASTSwitchLabel $label): void
@@ -416,9 +392,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCodeEndColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchLabel $label
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCodeEndColumn(ASTSwitchLabel $label): void
@@ -428,8 +403,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testParserHandlesSwitchLabelWithNestedScopeStatement
-     *
-     * @return void
      */
     public function testParserHandlesSwitchLabelWithNestedScopeStatement(): void
     {
@@ -438,8 +411,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * testParserThrowsExceptionForUnclosedSwitchLabelBody
-     *
-     * @return void
      */
     public function testParserThrowsExceptionForUnclosedSwitchLabelBody(): void
     {
@@ -451,7 +422,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTSwitchLabel
+     * @return ASTSwitchLabel
      */
     private function getFirstSwitchLabelInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTSwitchStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTSwitchStatement
  * @group unittest
  */
 class ASTSwitchStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the generated object graph of a switch statement.
-     *
-     * @return void
      */
     public function testSwitchStatementGraphWithBooleanExpressions(): void
     {
@@ -69,8 +68,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the generated object graph of a switch statement.
-     *
-     * @return void
      */
     public function testSwitchStatementGraphWithLabels(): void
     {
@@ -84,7 +81,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatement
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
+     *
      * @since 1.0.2
      */
     public function testSwitchStatement()
@@ -98,9 +96,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatement
      */
     public function testSwitchStatementHasExpectedStartLine($stmt): void
@@ -111,9 +108,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatement
      */
     public function testSwitchStatementHasExpectedStartColumn($stmt): void
@@ -124,9 +120,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatement
      */
     public function testSwitchStatementHasExpectedEndLine($stmt): void
@@ -137,9 +132,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatement
      */
     public function testSwitchStatementHasExpectedEndColumn($stmt): void
@@ -149,8 +143,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testParserIgnoresDocCommentInSwitchStatement
-     *
-     * @return void
      */
     public function testParserIgnoresDocCommentInSwitchStatement(): void
     {
@@ -159,8 +151,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testParserIgnoresCommentInSwitchStatement
-     *
-     * @return void
      */
     public function testParserIgnoresCommentInSwitchStatement(): void
     {
@@ -169,8 +159,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testInvalidStatementInSwitchStatementResultsInExpectedException
-     *
-     * @return void
      */
     public function testInvalidStatementInSwitchStatementResultsInExpectedException(): void
     {
@@ -181,8 +169,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testUnclosedSwitchStatementResultsInExpectedException
-     *
-     * @return void
      */
     public function testUnclosedSwitchStatementResultsInExpectedException(): void
     {
@@ -194,7 +180,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithAlternativeScope
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
+     *
      * @since 1.0.2
      */
     public function testSwitchStatementWithAlternativeScope()
@@ -208,9 +195,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatementWithAlternativeScope
      */
     public function testSwitchStatementAlternativeScopeHasExpectedStartLine($stmt): void
@@ -221,9 +207,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatementWithAlternativeScope
      */
     public function testSwitchStatementAlternativeScopeHasExpectedStartColumn($stmt): void
@@ -234,9 +219,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatementWithAlternativeScope
      */
     public function testSwitchStatementAlternativeScopeHasExpectedEndLine($stmt): void
@@ -247,9 +231,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $stmt
+     * @param ASTSwitchStatement $stmt
      *
-     * @return void
      * @depends testSwitchStatementWithAlternativeScope
      */
     public function testSwitchStatementAlternativeScopeHasExpectedEndColumn($stmt): void
@@ -259,8 +242,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementTerminatedByPhpCloseTag
-     *
-     * @return void
      */
     public function testSwitchStatementTerminatedByPhpCloseTag(): void
     {
@@ -271,7 +252,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCode
      *
-     * @return \PDepend\Source\AST\ASTSwitch
+     * @return ASTSwitch
+     *
      * @since 2.1.0
      */
     public function testSwitchStatementWithNestedNonePhpCode()
@@ -285,9 +267,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCodeStartLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $switch
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchStatementWithNestedNonePhpCode
      */
     public function testSwitchStatementWithNestedNonePhpCodeStartLine(ASTSwitchStatement $switch): void
@@ -298,9 +279,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCodeEndLine
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $switch
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchStatementWithNestedNonePhpCode
      */
     public function testSwitchStatementWithNestedNonePhpCodeEndLine(ASTSwitchStatement $switch): void
@@ -311,9 +291,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCodeStartColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $switch
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchStatementWithNestedNonePhpCode
      */
     public function testSwitchStatementWithNestedNonePhpCodeStartColumn(ASTSwitchStatement $switch): void
@@ -324,9 +303,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCodeEndColumn
      *
-     * @param \PDepend\Source\AST\ASTSwitchStatement $switch
-     * @return void
      * @since 2.1.0
+     *
      * @depends testSwitchStatementWithNestedNonePhpCode
      */
     public function testSwitchStatementWithNestedNonePhpCodeEndColumn(ASTSwitchStatement $switch): void
@@ -337,7 +315,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTSwitchStatement
+     * @return ASTSwitchStatement
      */
     private function getFirstSwitchStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTThrowStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTThrowStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTThrowStatement
  * @group unittest
  */
 class ASTThrowStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatement
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
+     *
      * @since 1.0.2
      */
     public function testThrowStatement()
@@ -71,9 +73,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTThrowStatement $stmt
+     * @param ASTThrowStatement $stmt
      *
-     * @return void
      * @depends testThrowStatement
      */
     public function testThrowStatementHasExpectedStartLine($stmt): void
@@ -84,9 +85,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTThrowStatement $stmt
+     * @param ASTThrowStatement $stmt
      *
-     * @return void
      * @depends testThrowStatement
      */
     public function testThrowStatementHasExpectedStartColumn($stmt): void
@@ -97,9 +97,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTThrowStatement $stmt
+     * @param ASTThrowStatement $stmt
      *
-     * @return void
      * @depends testThrowStatement
      */
     public function testThrowStatementHasExpectedEndLine($stmt): void
@@ -110,9 +109,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTThrowStatement $stmt
+     * @param ASTThrowStatement $stmt
      *
-     * @return void
      * @depends testThrowStatement
      */
     public function testThrowStatementHasExpectedEndColumn($stmt): void
@@ -123,7 +121,7 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTThrowStatement
+     * @return ASTThrowStatement
      */
     private function getFirstThrowStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptationAlias} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptationAlias
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 {
     /**
      * testGetNewNameReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetNewNameReturnsNullByDefault(): void
     {
@@ -69,8 +70,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testGetNewNameReturnsExpectedValue
-     *
-     * @return void
      */
     public function testGetNewNameReturnsExpectedValue(): void
     {
@@ -80,8 +79,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testGetNewModifierReturnsMinusOneByDefault
-     *
-     * @return void
      */
     public function testGetNewModifierReturnsMinusOneByDefault(): void
     {
@@ -91,8 +88,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testGetNewModifierReturnsExpectedIsPublicValue
-     *
-     * @return void
      */
     public function testGetNewModifierReturnsExpectedIsPublicValue(): void
     {
@@ -105,8 +100,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testGetNewModifierReturnsExpectedIsProtectedValue
-     *
-     * @return void
      */
     public function testGetNewModifierReturnsExpectedIsProtectedValue(): void
     {
@@ -119,19 +112,17 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepMethodReturnsExpectedSetOfPropertyNames(): void
     {
-        $alias = new \PDepend\Source\AST\ASTTraitAdaptationAlias();
+        $alias = new ASTTraitAdaptationAlias();
         $this->assertSame(
             [
                 'newName',
                 'newModifier',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $alias->__sleep()
         );
@@ -139,8 +130,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testGetNewModifierReturnsExpectedIsPrivateValue
-     *
-     * @return void
      */
     public function testGetNewModifierReturnsExpectedIsPrivateValue(): void
     {
@@ -151,7 +140,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAlias
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     * @return ASTTraitAdaptationAlias
+     *
      * @since 1.0.2
      */
     public function testTraitAdaptationAlias()
@@ -161,13 +151,12 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
         return $alias;
     }
-    
+
     /**
      * testTraitAdaptationAliasHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationAlias $alias
+     * @param ASTTraitAdaptationAlias $alias
      *
-     * @return void
      * @depends testTraitAdaptationAlias
      */
     public function testTraitAdaptationAliasHasExpectedStartLine($alias): void
@@ -178,9 +167,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationAlias $alias
+     * @param ASTTraitAdaptationAlias $alias
      *
-     * @return void
      * @depends testTraitAdaptationAlias
      */
     public function testTraitAdaptationAliasHasExpectedStartColumn($alias): void
@@ -191,9 +179,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationAlias $alias
+     * @param ASTTraitAdaptationAlias $alias
      *
-     * @return void
      * @depends testTraitAdaptationAlias
      */
     public function testTraitAdaptationAliasHasExpectedEndLine($alias): void
@@ -204,9 +191,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationAlias $alias
+     * @param ASTTraitAdaptationAlias $alias
      *
-     * @return void
      * @depends testTraitAdaptationAlias
      */
     public function testTraitAdaptationAliasHasExpectedEndColumn($alias): void
@@ -217,7 +203,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationAlias
+     * @return ASTTraitAdaptationAlias
      */
     private function getFirstTraitAdaptationAliasInClass()
     {
@@ -230,7 +216,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReference
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
+     *
      * @since 1.0.2
      */
     public function testTraitReference()
@@ -244,9 +231,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartLine($reference): void
@@ -257,9 +243,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartColumn($reference): void
@@ -270,9 +255,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndLine($reference): void
@@ -283,9 +267,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndColumn($reference): void
@@ -296,7 +279,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      */
     private function getFirstTraitReferenceInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptationPrecedence} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 {
     /**
      * testTraitAdaptationPrecedenceHasExpectedNumberOfTraitReferences
-     *
-     * @return void
      */
     public function testTraitAdaptationPrecedenceHasExpectedNumberOfTraitReferences(): void
     {
@@ -74,8 +75,6 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationPrecedenceWithoutQualifiedReferenceThrowsExpectedException
-     *
-     * @return void
      */
     public function testTraitAdaptationPrecedenceWithoutQualifiedReferenceThrowsExpectedException(): void
     {
@@ -87,7 +86,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedence
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @return ASTTraitAdaptationPrecedence
+     *
      * @since 1.0.2
      */
     public function testTraitAdaptationPrecedence()
@@ -101,9 +101,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationPrecedence $precedence
+     * @param ASTTraitAdaptationPrecedence $precedence
      *
-     * @return void
      * @depends testTraitAdaptationPrecedence
      */
     public function testTraitAdaptationPrecedenceHasExpectedStartLine($precedence): void
@@ -114,9 +113,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationPrecedence $precedence
+     * @param ASTTraitAdaptationPrecedence $precedence
      *
-     * @return void
      * @depends testTraitAdaptationPrecedence
      */
     public function testTraitAdaptationPrecedenceHasExpectedStartColumn($precedence): void
@@ -127,9 +125,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationPrecedence $precedence
+     * @param ASTTraitAdaptationPrecedence $precedence
      *
-     * @return void
      * @depends testTraitAdaptationPrecedence
      */
     public function testTraitAdaptationPrecedenceHasExpectedEndLine($precedence): void
@@ -140,9 +137,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptationPrecedence $precedence
+     * @param ASTTraitAdaptationPrecedence $precedence
      *
-     * @return void
      * @depends testTraitAdaptationPrecedence
      */
     public function testTraitAdaptationPrecedenceHasExpectedEndColumn($precedence): void
@@ -153,7 +149,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptationPrecedence
+     * @return ASTTraitAdaptationPrecedence
      */
     private function getFirstTraitAdaptationPrecedenceInClass()
     {
@@ -166,7 +162,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReference
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
+     *
      * @since 1.0.2
      */
     public function testTraitReference()
@@ -180,9 +177,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartLine($reference): void
@@ -193,9 +189,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartColumn($reference): void
@@ -206,9 +201,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndLine($reference): void
@@ -219,9 +213,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndColumn($reference): void
@@ -232,7 +225,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      */
     private function getFirstTraitReferenceInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,12 +47,14 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptation} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptation
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitAdaptationTest extends ASTNodeTestCase
@@ -59,23 +62,23 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptation
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptation
+     * @return ASTTraitAdaptation
+     *
      * @since 1.0.2
      */
     public function testTraitAdaptation()
     {
         $scope = $this->getFirstTraitAdaptationInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptation', $scope);
-        
+
         return $scope;
     }
-   
+
     /**
      * testTraitAdaptationHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptation $scope
+     * @param ASTTraitAdaptation $scope
      *
-     * @return void
      * @depends testTraitAdaptation
      */
     public function testTraitAdaptationHasExpectedStartLine($scope): void
@@ -86,9 +89,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptation $scope
+     * @param ASTTraitAdaptation $scope
      *
-     * @return void
      * @depends testTraitAdaptation
      */
     public function testTraitAdaptationHasExpectedStartColumn($scope): void
@@ -99,9 +101,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptation $scope
+     * @param ASTTraitAdaptation $scope
      *
-     * @return void
      * @depends testTraitAdaptation
      */
     public function testTraitAdaptationHasExpectedEndLine($scope): void
@@ -112,9 +113,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitAdaptation $scope
+     * @param ASTTraitAdaptation $scope
      *
-     * @return void
      * @depends testTraitAdaptation
      */
     public function testTraitAdaptationHasExpectedEndColumn($scope): void
@@ -125,7 +125,7 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitAdaptation
+     * @return ASTTraitAdaptation
      */
     private function getFirstTraitAdaptationInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -48,20 +49,20 @@ use PDepend\Source\Builder\BuilderContext;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitReference} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitReference
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitReferenceTest extends ASTNodeTestCase
 {
     /**
      * testGetTraitDelegatesToContextGetTraitMethod
-     *
-     * @return void
      */
     public function testGetTraitDelegatesToContextGetTraitMethod(): void
     {
@@ -71,30 +72,30 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
             ->method('getTrait')
             ->with($this->equalTo(__CLASS__));
 
-        $reference = new \PDepend\Source\AST\ASTTraitReference($context, __CLASS__);
+        $reference = new ASTTraitReference($context, __CLASS__);
         $reference->getType();
     }
-    
+
     /**
      * testTraitReference
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
+     *
      * @since 1.0.2
      */
     public function testTraitReference()
     {
         $reference = $this->getFirstTraitReferenceInClass();
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
-        
+
         return $reference;
     }
 
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartLine($reference): void
@@ -105,9 +106,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedStartColumn($reference): void
@@ -118,9 +118,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndLine($reference): void
@@ -131,9 +130,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitReference $reference
+     * @param ASTTraitReference $reference
      *
-     * @return void
      * @depends testTraitReference
      */
     public function testTraitReferenceHasExpectedEndColumn($reference): void
@@ -144,7 +142,7 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitReference
+     * @return ASTTraitReference
      */
     private function getFirstTraitReferenceInClass()
     {
@@ -157,11 +155,11 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * Creates a concrete node implementation.
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     protected function createNodeInstance()
     {
-        return new \PDepend\Source\AST\ASTTraitReference(
+        return new ASTTraitReference(
             $this->getBuilderContextMock(),
             __CLASS__
         );
@@ -170,13 +168,13 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * Returns a mocked builder context instance.
      *
-     * @return \PDepend\Source\Builder\BuilderContext
+     * @return BuilderContext
      */
     protected function getBuilderContextMock()
     {
         $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
             ->getMock();
-        
+
         return $context;
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -38,32 +38,30 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
   * @since 1.0.0
  */
 
 namespace PDepend\Source\AST;
 
-use PDepend\Source\Builder\BuilderContext;
-use PDepend\Source\ASTVisitor\ASTVisitor;
-
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTrait} class.
- *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTrait
  * @covers \PDepend\Source\AST\AbstractASTType
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitTest extends AbstractASTArtifactTestCase
 {
     /**
      * testGetAllMethodsOnSimpleTraitReturnsExpectedResult
-     *
-     * @return void
      */
     public function testGetAllMethodsOnSimpleTraitReturnsExpectedResult(): void
     {
@@ -76,8 +74,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult
-     *
-     * @return void
      */
     public function testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult(): void
     {
@@ -90,8 +86,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithRedeclaredMethodReturnsExpectedInstance
-     *
-     * @return void
      */
     public function testGetAllMethodsWithRedeclaredMethodReturnsExpectedInstance(): void
     {
@@ -103,8 +97,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithAliasedMethodCollision
-     *
-     * @return void
      */
     public function testGetAllMethodsWithAliasedMethodCollision(): void
     {
@@ -117,8 +109,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithAliasedMethodTwice
-     *
-     * @return void
      */
     public function testGetAllMethodsWithAliasedMethodTwice(): void
     {
@@ -131,8 +121,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToPublic
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToPublic(): void
     {
@@ -147,8 +135,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToProtected
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToProtected(): void
     {
@@ -163,8 +149,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToPrivate
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToPrivate(): void
     {
@@ -179,8 +163,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier(): void
     {
@@ -195,8 +177,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsStaticModifier
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsStaticModifier(): void
     {
@@ -211,8 +191,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsHandlesTraitMethodPrecedence
-     *
-     * @return void
      */
     public function testGetAllMethodsHandlesTraitMethodPrecedence(): void
     {
@@ -227,8 +205,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsExcludeTraitMethodWithPrecedence
-     *
-     * @return void
      */
     public function testGetAllMethodsExcludeTraitMethodWithPrecedence(): void
     {
@@ -239,14 +215,13 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithMethodCollisionThrowsExpectedException
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
      *
      * @group issue-154
      */
     public function testGetAllMethodsWithMethodCollisionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTTraitMethodCollisionException::class);
+        $this->expectException(ASTTraitMethodCollisionException::class);
 
         $trait = $this->getFirstTraitForTest();
         $trait->getAllMethods();
@@ -258,7 +233,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      * No ASTTraitMethodCollisionException is thrown if only one method is not abstract.
      * Fix issue 154.
      *
-     * @return void
      * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
      *
      * @group issue-154
@@ -272,7 +246,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsAnEmptyArrayByDefault
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsAnEmptyArrayByDefault(): void
@@ -284,7 +257,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllChildrenReturnsArrayWithExpectedNumberOfNodes(): void
@@ -295,8 +267,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitHasExpectedStartLine
-     *
-     * @return void
      */
     public function testTraitHasExpectedStartLine(): void
     {
@@ -306,8 +276,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitHasExpectedEndLine
-     *
-     * @return void
      */
     public function testTraitHasExpectedEndLine(): void
     {
@@ -317,8 +285,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitHasExpectedPackage
-     *
-     * @return void
      */
     public function testTraitHasExpectedPackage(): void
     {
@@ -328,8 +294,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitHasExpectedNamespace
-     *
-     * @return void
      */
     public function testTraitHasExpectedNamespace(): void
     {
@@ -339,8 +303,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetNamespaceNameReturnsExpectedName
-     *
-     * @return void
      */
     public function testGetNamespaceNameReturnsExpectedName(): void
     {
@@ -350,8 +312,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetMethodsReturnsExpectedNumberOfMethods
-     *
-     * @return void
      */
     public function testGetMethodsReturnsExpectedNumberOfMethods(): void
     {
@@ -361,8 +321,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitCanUseParentKeywordInMethodBody
-     *
-     * @return void
      */
     public function testTraitCanUseParentKeywordInMethodBody(): void
     {
@@ -372,8 +330,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testTraitCanUseParentKeywordAsMethodTypeHint
-     *
-     * @return void
      */
     public function testTraitCanUseParentKeywordAsMethodTypeHint(): void
     {
@@ -381,18 +337,12 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
         $this->assertNotNull($trait);
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedName(): void
     {
         $trait = new ASTTrait('MyTrait');
         $this->assertSame('MyTrait', $trait->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithNamespaceDeclaration(): void
     {
         $trait = new ASTTrait('MyTrait');
@@ -401,9 +351,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
         $this->assertSame('My\\Namespace\\MyTrait', $trait->getNamespacedName());
     }
 
-    /**
-     * @return void
-     */
     public function testGetNamespacedNameWithPackageAnnotation(): void
     {
         $namespace = new ASTNamespace('My\\Namespace');
@@ -417,8 +364,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testAcceptInvokesVisitTraitOnGivenVisitor
-     *
-     * @return void
      */
     public function testAcceptInvokesVisitTraitOnGivenVisitor(): void
     {
@@ -435,8 +380,6 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testMagicWakeupCallsRegisterTraitOnBuilderContext
-     *
-     * @return void
      */
     public function testMagicWakeupCallsRegisterTraitOnBuilderContext(): void
     {
@@ -455,7 +398,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     /**
      * Returns the first trait found the code under test.
      *
-     * @return \PDepend\Source\AST\ASTTrait
+     * @return ASTTrait
      */
     protected function getFirstTraitForTest()
     {
@@ -465,7 +408,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
     /**
      * Creates an item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     protected function createItem()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -49,20 +50,20 @@ use ReflectionMethod;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitUseStatement} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitUseStatement
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTraitUseStatementTest extends ASTNodeTestCase
 {
     /**
      * testHasExcludeForReturnsFalseIfNoInsteadExists
-     *
-     * @return void
      */
     public function testHasExcludeForReturnsFalseIfNoInsteadExists(): void
     {
@@ -77,8 +78,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testHasExcludeForReturnsFalseIfMethodNotAffectedByInstead
-     *
-     * @return void
      */
     public function testHasExcludeForReturnsFalseIfMethodNotAffectedByInstead(): void
     {
@@ -93,8 +92,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testHasExcludeForReturnsTrueIfMethodAffectedByInstead
-     *
-     * @return void
      */
     public function testHasExcludeForReturnsTrueIfMethodAffectedByInstead(): void
     {
@@ -109,8 +106,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testHasExcludeForReturnsTrueIfMethodAffectedBySecondInstead
-     *
-     * @return void
      */
     public function testHasExcludeForReturnsTrueIfMethodAffectedBySecondInstead(): void
     {
@@ -127,8 +122,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      * testTraitUseInsteadOfSelf
      *
      * @throws ReflectionException
-     *
-     * @return void
      *
      * @group issue-154
      */
@@ -148,8 +141,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      *
      * @throws ReflectionException
      *
-     * @return void
-     *
      * @group issue-154
      */
     public function testTraitMethodAlias(): void
@@ -165,8 +156,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsOnClassWithParentReturnsTraitMethod
-     *
-     * @return void
      */
     public function testGetAllMethodsOnClassWithParentReturnsTraitMethod(): void
     {
@@ -182,7 +171,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testGetAllMethodsOnClassWithParentAndPrecedenceReturnsParentMethod
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnClassWithParentAndPrecedenceReturnsParentMethod(): void
@@ -199,7 +187,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetAllMethodsOnTraitUsingTraitReturnsExpectedResult(): void
@@ -212,8 +199,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithAliasedMethodCollision
-     *
-     * @return void
      */
     public function testGetAllMethodsWithAliasedMethodCollision(): void
     {
@@ -223,8 +208,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithAliasedMethodTwice
-     *
-     * @return void
      */
     public function testGetAllMethodsWithAliasedMethodTwice(): void
     {
@@ -234,8 +217,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToPublic
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToPublic(): void
     {
@@ -250,8 +231,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToProtected
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToProtected(): void
     {
@@ -266,8 +245,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedToPrivate
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedToPrivate(): void
     {
@@ -282,8 +259,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsAbstractModifier(): void
     {
@@ -298,8 +273,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsWithVisibilityChangedKeepsStaticModifier
-     *
-     * @return void
      */
     public function testGetAllMethodsWithVisibilityChangedKeepsStaticModifier(): void
     {
@@ -314,8 +287,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsHandlesTraitMethodPrecedence
-     *
-     * @return void
      */
     public function testGetAllMethodsHandlesTraitMethodPrecedence(): void
     {
@@ -330,8 +301,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testGetAllMethodsExcludeTraitMethodWithPrecedence
-     *
-     * @return void
      */
     public function testGetAllMethodsExcludeTraitMethodWithPrecedence(): void
     {
@@ -341,8 +310,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithSimpleAliasHasExpectedEndLine
-     *
-     * @return void
      */
     public function testTraitUseStatementWithSimpleAliasHasExpectedEndLine(): void
     {
@@ -352,8 +319,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithSimpleAliasHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testTraitUseStatementWithSimpleAliasHasExpectedEndColumn(): void
     {
@@ -363,8 +328,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithQualifiedAliasHasExpectedEndLine
-     *
-     * @return void
      */
     public function testTraitUseStatementWithQualifiedAliasHasExpectedEndLine(): void
     {
@@ -374,8 +337,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithQualifiedAliasHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testTraitUseStatementWithQualifiedAliasHasExpectedEndColumn(): void
     {
@@ -385,8 +346,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithSingleInsteadofHasExpectedEndLine
-     *
-     * @return void
      */
     public function testTraitUseStatementWithSingleInsteadofHasExpectedEndLine(): void
     {
@@ -396,8 +355,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithSingleInsteadofHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testTraitUseStatementWithSingleInsteadofHasExpectedEndColumn(): void
     {
@@ -407,8 +364,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithMultipleInsteadofHasExpectedEndLine
-     *
-     * @return void
      */
     public function testTraitUseStatementWithMultipleInsteadofHasExpectedEndLine(): void
     {
@@ -418,8 +373,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementWithMultipleInsteadofHasExpectedEndColumn
-     *
-     * @return void
      */
     public function testTraitUseStatementWithMultipleInsteadofHasExpectedEndColumn(): void
     {
@@ -430,7 +383,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatement
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
+     *
      * @since 1.0.2
      */
     public function testTraitUseStatement()
@@ -444,9 +398,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatement
      */
     public function testTraitUseStatementHasExpectedStartLine($stmt): void
@@ -457,9 +410,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatement
      */
     public function testTraitUseStatementHasExpectedStartColumn($stmt): void
@@ -470,9 +422,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatement
      */
     public function testTraitUseStatementHasExpectedEndLine($stmt): void
@@ -483,9 +434,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatement
      */
     public function testTraitUseStatementHasExpectedEndColumn($stmt): void
@@ -496,7 +446,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTrait
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
+     *
      * @since 1.0.2
      */
     public function testTraitUseStatementInTrait()
@@ -510,9 +461,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatementInTrait
      */
     public function testTraitUseStatementInTraitHasExpectedStartLine($stmt): void
@@ -523,9 +473,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatementInTrait
      */
     public function testTraitUseStatementInTraitHasExpectedStartColumn($stmt): void
@@ -536,9 +485,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatementInTrait
      */
     public function testTraitUseStatementInTraitHasExpectedEndLine($stmt): void
@@ -549,9 +497,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTraitUseStatement $stmt
+     * @param ASTTraitUseStatement $stmt
      *
-     * @return void
      * @depends testTraitUseStatementInTrait
      */
     public function testTraitUseStatementInTraitHasExpectedEndColumn($stmt): void
@@ -562,7 +509,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
      */
     private function getFirstTraitUseStatementInClass()
     {
@@ -575,7 +522,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTraitUseStatement
+     * @return ASTTraitUseStatement
      */
     private function getFirstTraitUseStatementInTrait()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTryStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTTryStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTTryStatement
  * @group unittest
  */
 class ASTTryStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testTryStatement
      *
-     * @return \PDepend\Source\AST\ASTTryStatement
+     * @return ASTTryStatement
+     *
      * @since 1.0.2
      */
     public function testTryStatement()
@@ -71,9 +73,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected start line value.
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testTryStatementHasExpectedStartLine($stmt): void
@@ -84,9 +85,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected start column value.
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testTryStatementHasExpectedStartColumn($stmt): void
@@ -97,9 +97,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected end line value.
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testTryStatementHasExpectedEndLine($stmt): void
@@ -110,9 +109,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected end column value.
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testTryStatementHasExpectedEndColumn($stmt): void
@@ -123,9 +121,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testFirstChildOfTryStatementIsInstanceOfScopeStatement
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testFirstChildOfTryStatementIsInstanceOfScopeStatement($stmt): void
@@ -136,9 +133,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testSecondChildOfTryStatementIsInstanceOfCatchStatement
      *
-     * @param \PDepend\Source\AST\ASTTryStatement $stmt
+     * @param ASTTryStatement $stmt
      *
-     * @return void
      * @depends testTryStatement
      */
     public function testSecondChildOfTryStatementIsInstanceOfCatchStatement($stmt): void
@@ -148,8 +144,6 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * testTryStatementContainsMultipleChildInstancesOfCatchStatement
-     *
-     * @return void
      */
     public function testTryStatementContainsMultipleChildInstancesOfCatchStatement(): void
     {
@@ -171,8 +165,6 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * testParserThrowsExceptionWhenNoCatchStatementFollows
-     *
-     * @return void
      */
     public function testParserThrowsExceptionWhenNoCatchStatementFollows(): void
     {
@@ -184,7 +176,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTryStatement
+     * @return ASTTryStatement
      */
     private function getFirstTryStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeArray} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTTypeArray
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTTypeArray
  * @group unittest
  */
 class ASTTypeArrayTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayType
      *
-     * @return \PDepend\Source\AST\ASTTypeArray
+     * @return ASTTypeArray
+     *
      * @since 1.0.2
      */
     public function testArrayType()
@@ -71,9 +73,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTypeArray $type
+     * @param ASTTypeArray $type
      *
-     * @return void
      * @depends testArrayType
      */
     public function testArrayTypeHasExpectedStartLine($type): void
@@ -84,9 +85,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeArray $type
+     * @param ASTTypeArray $type
      *
-     * @return void
      * @depends testArrayType
      */
     public function testArrayTypeHasExpectedStartColumn($type): void
@@ -97,9 +97,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTypeArray $type
+     * @param ASTTypeArray $type
      *
-     * @return void
      * @depends testArrayType
      */
     public function testArrayTypeHasExpectedEndLine($type): void
@@ -110,9 +109,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeArray $type
+     * @param ASTTypeArray $type
      *
-     * @return void
      * @depends testArrayType
      */
     public function testArrayTypeHasExpectedEndColumn($type): void
@@ -122,30 +120,26 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * testIsArrayReturnsTrue
-     *
-     * @return void
      */
     public function testIsArrayReturnsTrue(): void
     {
-        $type = new \PDepend\Source\AST\ASTTypeArray();
+        $type = new ASTTypeArray();
         $this->assertTrue($type->isArray());
     }
 
     /**
      * testIsPrimitiveReturnsFalse
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsFalse(): void
     {
-        $type = new \PDepend\Source\AST\ASTTypeArray();
+        $type = new ASTTypeArray();
         $this->assertFalse($type->isScalar());
     }
 
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTypeArray
+     * @return ASTTypeArray
      */
     private function getFirstArrayTypeInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,20 +47,20 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeCallable} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 1.0.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTypeCallable
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @since 1.0.0
+ *
  * @group unittest
  */
 class ASTTypeCallableTest extends ASTNodeTestCase
 {
     /**
      * testCallableTypeIsHandledCaseInsensitive
-     *
-     * @return void
      */
     public function testCallableTypeIsHandledCaseInsensitive(): void
     {
@@ -69,7 +70,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableType
      *
-     * @return \PDepend\Source\AST\ASTTypeCallable
+     * @return ASTTypeCallable
+     *
      * @since 1.0.2
      */
     public function testCallableType()
@@ -83,9 +85,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTypeCallable $type
+     * @param ASTTypeCallable $type
      *
-     * @return void
      * @depends testCallableType
      */
     public function testCallableTypeHasExpectedStartLine($type): void
@@ -96,9 +97,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTypeCallable $type
+     * @param ASTTypeCallable $type
      *
-     * @return void
      * @depends testCallableType
      */
     public function testCallableTypeHasExpectedEndLine($type): void
@@ -109,9 +109,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeCallable $type
+     * @param ASTTypeCallable $type
      *
-     * @return void
      * @depends testCallableType
      */
     public function testCallableTypeHasExpectedStartColumn($type): void
@@ -122,9 +121,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeCallable $type
+     * @param ASTTypeCallable $type
      *
-     * @return void
      * @depends testCallableType
      */
     public function testCallableTypeHasExpectedEndColumn($type): void
@@ -135,7 +133,7 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTypeCallable
+     * @return ASTTypeCallable
      */
     private function getFirstCallableTypeInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeIterable} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTTypeIterable
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTTypeIterable
  * @group unittest
  */
 class ASTTypeIterableTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableType
      *
-     * @return \PDepend\Source\AST\ASTTypeIterable
+     * @return ASTTypeIterable
+     *
      * @since 2.5.1
      */
     public function testIterableType()
@@ -71,9 +73,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTTypeIterable $type
+     * @param ASTTypeIterable $type
      *
-     * @return void
      * @depends testIterableType
      */
     public function testIterableTypeHasExpectedStartLine($type): void
@@ -84,9 +85,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeIterable $type
+     * @param ASTTypeIterable $type
      *
-     * @return void
      * @depends testIterableType
      */
     public function testIterableTypeHasExpectedStartColumn($type): void
@@ -97,9 +97,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTTypeIterable $type
+     * @param ASTTypeIterable $type
      *
-     * @return void
      * @depends testIterableType
      */
     public function testIterableTypeHasExpectedEndLine($type): void
@@ -110,9 +109,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTTypeIterable $type
+     * @param ASTTypeIterable $type
      *
-     * @return void
      * @depends testIterableType
      */
     public function testIterableTypeHasExpectedEndColumn($type): void
@@ -122,30 +120,26 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * testIsArrayReturnsTrue
-     *
-     * @return void
      */
     public function testIsArrayReturnsTrue(): void
     {
-        $type = new \PDepend\Source\AST\ASTTypeIterable();
+        $type = new ASTTypeIterable();
         $this->assertTrue($type->isArray());
     }
 
     /**
      * testIsPrimitiveReturnsFalse
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsFalse(): void
     {
-        $type = new \PDepend\Source\AST\ASTTypeIterable();
+        $type = new ASTTypeIterable();
         $this->assertFalse($type->isScalar());
     }
 
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTTypeIterable
+     * @return ASTTypeIterable
      */
     private function getFirstArrayTypeInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeTest.php
@@ -45,18 +45,17 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTType} class.
  *
+ * @covers \PDepend\Source\AST\ASTType
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTType
  * @group unittest
  */
 class ASTTypeTest extends ASTNodeTestCase
 {
     /**
      * testIsArrayReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsArrayReturnsFalseByDefault(): void
     {
@@ -66,8 +65,6 @@ class ASTTypeTest extends ASTNodeTestCase
 
     /**
      * testIsPrimitiveReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsPrimitiveReturnsFalseByDefault(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTUnaryExpression} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTUnaryExpression
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTUnaryExpression
  * @group unittest
  */
 class ASTUnaryExpressionTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpression
      *
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
+     *
      * @since 1.0.2
      */
     public function testUnaryExpression()
@@ -71,9 +73,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
+     * @param ASTUnaryExpression $expr
      *
-     * @return void
      * @depends testUnaryExpression
      */
     public function testUnaryExpressionHasExpectedStartLine($expr): void
@@ -84,9 +85,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
+     * @param ASTUnaryExpression $expr
      *
-     * @return void
      * @depends testUnaryExpression
      */
     public function testUnaryExpressionHasExpectedEndLine($expr): void
@@ -97,9 +97,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
+     * @param ASTUnaryExpression $expr
      *
-     * @return void
      * @depends testUnaryExpression
      */
     public function testUnaryExpressionHasExpectedStartColumn($expr): void
@@ -110,9 +109,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
+     * @param ASTUnaryExpression $expr
      *
-     * @return void
      * @depends testUnaryExpression
      */
     public function testUnaryExpressionHasExpectedEndColumn($expr): void
@@ -121,7 +119,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      */
     public function testUnaryExpressionNot()
     {
@@ -132,8 +130,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionNot
      */
     public function testUnaryExpressionNotHasExpectedStartLine(ASTUnaryExpression $expr): void
@@ -142,8 +138,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionNot
      */
     public function testUnaryExpressionNotHasExpectedEndLine(ASTUnaryExpression $expr): void
@@ -152,8 +146,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionNot
      */
     public function testUnaryExpressionNotHasExpectedStartColumn(ASTUnaryExpression $expr): void
@@ -162,8 +154,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionNot
      */
     public function testUnaryExpressionNotHasExpectedEndColumn(ASTUnaryExpression $expr): void
@@ -172,7 +162,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      */
     public function testUnaryExpressionSuppressWarning()
     {
@@ -183,8 +173,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionSuppressWarning
      */
     public function testUnaryExpressionSuppressWarningHasExpectedStartLine(ASTUnaryExpression $expr): void
@@ -193,8 +181,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionSuppressWarning
      */
     public function testUnaryExpressionSuppressWarningHasExpectedEndLine(ASTUnaryExpression $expr): void
@@ -203,8 +189,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionSuppressWarning
      */
     public function testUnaryExpressionSuppressWarningHasExpectedStartColumn(ASTUnaryExpression $expr): void
@@ -213,8 +197,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTUnaryExpression $expr
-     * @return void
      * @depends testUnaryExpressionSuppressWarning
      */
     public function testUnaryExpressionSuppressWarningHasExpectedEndColumn(ASTUnaryExpression $expr): void
@@ -225,7 +207,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTUnaryExpression
+     * @return ASTUnaryExpression
      */
     private function getFirstUnaryExpressionInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTUnsetStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTUnsetStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTUnsetStatement
  * @group unittest
  */
 class ASTUnsetStatementTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatement
      *
-     * @return \PDepend\Source\AST\ASTUnsetStatement
+     * @return ASTUnsetStatement
+     *
      * @since 1.0.2
      */
     public function testUnsetStatement()
@@ -71,9 +73,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTUnsetStatement $stmt
+     * @param ASTUnsetStatement $stmt
      *
-     * @return void
      * @depends testUnsetStatement
      */
     public function testUnsetStatementHasExpectedStartLine($stmt): void
@@ -84,9 +85,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTUnsetStatement $stmt
+     * @param ASTUnsetStatement $stmt
      *
-     * @return void
      * @depends testUnsetStatement
      */
     public function testUnsetStatementHasExpectedStartColumn($stmt): void
@@ -97,9 +97,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTUnsetStatement $stmt
+     * @param ASTUnsetStatement $stmt
      *
-     * @return void
      * @depends testUnsetStatement
      */
     public function testUnsetStatementHasExpectedEndLine($stmt): void
@@ -110,9 +109,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTUnsetStatement $stmt
+     * @param ASTUnsetStatement $stmt
      *
-     * @return void
      * @depends testUnsetStatement
      */
     public function testUnsetStatementHasExpectedEndColumn($stmt): void
@@ -125,7 +123,7 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
      *
      * @param string $testCase Name of the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTUnsetStatement
+     * @return ASTUnsetStatement
      */
     private function getFirstUnsetStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/ASTValueTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTValueTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
   * @since 0.10.2
  */
 
@@ -48,19 +49,19 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTValue} class.
  *
+ * @covers \PDepend\Source\AST\ASTValue
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  *
- * @covers \PDepend\Source\AST\ASTValue
  * @group unittest
  */
 class ASTValueTest extends AbstractTestCase
 {
     /**
      * testIsValueAvailableReturnsFalseByDefault
-     *
-     * @return void
      */
     public function testIsValueAvailableReturnsFalseByDefault(): void
     {
@@ -70,8 +71,6 @@ class ASTValueTest extends AbstractTestCase
 
     /**
      * testIsValueAvailableReturnsTrueWhenValueWasSet
-     *
-     * @return void
      */
     public function testIsValueAvailableReturnsTrueWhenValueWasSet(): void
     {
@@ -83,8 +82,6 @@ class ASTValueTest extends AbstractTestCase
 
     /**
      * testIsValueAvailableReturnsTrueForNullValue
-     *
-     * @return void
      */
     public function testIsValueAvailableReturnsTrueForNullValue(): void
     {
@@ -96,8 +93,6 @@ class ASTValueTest extends AbstractTestCase
 
     /**
      * testGetValueReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetValueReturnsNullByDefault(): void
     {
@@ -107,8 +102,6 @@ class ASTValueTest extends AbstractTestCase
 
     /**
      * testGetValueReturnsPreviouslySetValue
-     *
-     * @return void
      */
     public function testGetValueReturnsPreviouslySetValue(): void
     {
@@ -120,8 +113,6 @@ class ASTValueTest extends AbstractTestCase
 
     /**
      * testSetValueMutatesInternalStateOnlyOnce
-     *
-     * @return void
      */
     public function testSetValueMutatesInternalStateOnlyOnce(): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariableDeclarator} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTVariableDeclarator
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTVariableDeclarator
  * @group unittest
  */
 class ASTVariableDeclaratorTest extends ASTNodeTestCase
 {
     /**
      * testGetValueReturnsNullByDefault
-     *
-     * @return void
      */
     public function testGetValueReturnsNullByDefault(): void
     {
@@ -67,8 +66,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testGetValueReturnsInjectedValueInstance
-     *
-     * @return void
      */
     public function testGetValueReturnsInjectedValueInstance(): void
     {
@@ -80,8 +77,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testMagicSleepReturnsExpectedSetOfPropertyNames
-     *
-     * @return void
      */
     public function testMagicSleepReturnsExpectedSetOfPropertyNames(): void
     {
@@ -91,7 +86,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
                 'value',
                 'comment',
                 'metadata',
-                'nodes'
+                'nodes',
             ],
             $declarator->__sleep()
         );
@@ -101,6 +96,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
      * testVariableDeclarator
      *
      * @return ASTVariableDeclarator
+     *
      * @since 1.0.2
      */
     public function testVariableDeclarator()
@@ -114,8 +110,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * testVariableDeclaratorHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTVariableDeclarator $declarator
-     * @return void
      * @depends testVariableDeclarator
      */
     public function testVariableDeclaratorHasExpectedStartLine(ASTVariableDeclarator $declarator): void
@@ -126,8 +120,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * testVariableDeclaratorHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTVariableDeclarator $declarator
-     * @return void
      * @depends testVariableDeclarator
      */
     public function testVariableDeclaratorHasExpectedStartColumn(ASTVariableDeclarator $declarator): void
@@ -138,8 +130,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * testVariableDeclaratorHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTVariableDeclarator $declarator
-     * @return void
      * @depends testVariableDeclarator
      */
     public function testVariableDeclaratorHasExpectedEndLine(ASTVariableDeclarator $declarator): void
@@ -150,8 +140,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * testVariableDeclaratorHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTVariableDeclarator $declarator
-     * @return void
      * @depends testVariableDeclarator
      */
     public function testVariableDeclaratorHasExpectedEndColumn(ASTVariableDeclarator $declarator): void
@@ -162,7 +150,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTVariableDeclarator
+     * @return ASTVariableDeclarator
      */
     private function getFirstVariableDeclaratorInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -45,52 +45,45 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariable} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTVariable
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTVariable
  * @group unittest
  */
 class ASTVariableTest extends ASTNodeTestCase
 {
     /**
      * testIsThisReturnsTrueForThisImageName
-     *
-     * @return void
      */
     public function testIsThisReturnsTrueForThisImageName(): void
     {
-        $variable = new \PDepend\Source\AST\ASTVariable('$this');
+        $variable = new ASTVariable('$this');
         $this->assertTrue($variable->isThis());
     }
 
     /**
      * testIsThisReturnsFalseForThisImageButDifferentCase
-     *
-     * @return void
      */
     public function testIsThisReturnsFalseForThisImageButDifferentCase(): void
     {
-        $variable = new \PDepend\Source\AST\ASTVariable('$This');
+        $variable = new ASTVariable('$This');
         $this->assertFalse($variable->isThis());
     }
 
     /**
      * testIsThisReturnsFalseForDifferentImage
-     *
-     * @return void
      */
     public function testIsThisReturnsFalseForDifferentImage(): void
     {
-        $variable = new \PDepend\Source\AST\ASTVariable('$foo');
+        $variable = new ASTVariable('$foo');
         $this->assertFalse($variable->isThis());
     }
 
     /**
      * testAcceptInvokesAcceptOnChildNode
-     *
-     * @return void
      */
     public function testAcceptInvokesAcceptOnChildNode(): void
     {
@@ -100,7 +93,8 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariable
      *
-     * @return \PDepend\Source\AST\ASTVariable
+     * @return ASTVariable
+     *
      * @since 1.0.2
      */
     public function testVariable()
@@ -114,9 +108,8 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTVariable $variable
+     * @param ASTVariable $variable
      *
-     * @return void
      * @depends testVariable
      */
     public function testVariableHasExpectedStartLine($variable): void
@@ -127,9 +120,8 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTVariable $variable
+     * @param ASTVariable $variable
      *
-     * @return void
      * @depends testVariable
      */
     public function testVariableHasExpectedStartColumn($variable): void
@@ -140,9 +132,8 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTVariable $variable
+     * @param ASTVariable $variable
      *
-     * @return void
      * @depends testVariable
      */
     public function testVariableHasExpectedEndLine($variable): void
@@ -153,9 +144,8 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTVariable $variable
+     * @param ASTVariable $variable
      *
-     * @return void
      * @depends testVariable
      */
     public function testVariableHasExpectedEndColumn($variable): void
@@ -166,7 +156,7 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTVariable
+     * @return ASTVariable
      */
     private function getFirstVariableInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -45,11 +45,12 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariableVariable} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTVariableVariable
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTVariableVariable
  * @group unittest
  */
 class ASTVariableVariableTest extends ASTNodeTestCase
@@ -57,7 +58,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariable
      *
-     * @return \PDepend\Source\AST\ASTVariableVariable
+     * @return ASTVariableVariable
+     *
      * @since 1.0.2
      */
     public function testVariableVariable()
@@ -67,13 +69,12 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
         return $variable;
     }
-    
+
     /**
      * testVariableVariableHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTVariableVariable $variable
+     * @param ASTVariableVariable $variable
      *
-     * @return void
      * @depends testVariableVariable
      */
     public function testVariableVariableHasExpectedStartLine($variable): void
@@ -84,9 +85,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTVariableVariable $variable
+     * @param ASTVariableVariable $variable
      *
-     * @return void
      * @depends testVariableVariable
      */
     public function testVariableVariableHasExpectedStartColumn($variable): void
@@ -97,9 +97,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTVariableVariable $variable
+     * @param ASTVariableVariable $variable
      *
-     * @return void
      * @depends testVariableVariable
      */
     public function testVariableVariableHasExpectedEndLine($variable): void
@@ -110,9 +109,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTVariableVariable $variable
+     * @param ASTVariableVariable $variable
      *
-     * @return void
      * @depends testVariableVariable
      */
     public function testVariableVariableHasExpectedEndColumn($variable): void
@@ -123,9 +121,7 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @param string $testCase Name of the calling test case.
-     *
-     * @return \PDepend\Source\AST\ASTVariableVariable
+     * @return ASTVariableVariable
      */
     private function getFirstVariableVariableInClass()
     {

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTWhileStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTWhileStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTWhileStatement
  * @group unittest
  */
 class ASTWhileStatementTest extends ASTNodeTestCase
 {
     /**
      * Tests the generated object graph of a while statement.
-     *
-     * @return void
      */
     public function testWhileStatementGraphWithBooleanExpressions(): void
     {
@@ -67,8 +66,6 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testFirstChildOfWhileStatementIsASTExpression
-     *
-     * @return void
      */
     public function testFirstChildOfWhileStatementIsASTExpression(): void
     {
@@ -78,8 +75,6 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testSecondChildOfWhileStatementIsASTScopeStatement
-     *
-     * @return void
      */
     public function testSecondChildOfWhileStatementIsASTScopeStatement(): void
     {
@@ -90,7 +85,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatement
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
+     *
      * @since 1.0.2
      */
     public function testWhileStatement()
@@ -104,9 +100,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatement
      */
     public function testWhileStatementHasExpectedStartLine($stmt): void
@@ -117,9 +112,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatement
      */
     public function testWhileStatementHasExpectedStartColumn($stmt): void
@@ -130,9 +124,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatement
      */
     public function testWhileStatementHasExpectedEndLine($stmt): void
@@ -143,9 +136,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatement
      */
     public function testWhileStatementHasExpectedEndColumn($stmt): void
@@ -156,7 +148,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementWithAlternativeScope
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
+     *
      * @since 1.0.2
      */
     public function testWhileStatementWithAlternativeScope()
@@ -170,9 +163,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartLine
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatementWithAlternativeScope
      */
     public function testWhileStatementAlternativeScopeHasExpectedStartLine($stmt): void
@@ -183,9 +175,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartColumn
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatementWithAlternativeScope
      */
     public function testWhileStatementAlternativeScopeHasExpectedStartColumn($stmt): void
@@ -196,9 +187,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndLine
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatementWithAlternativeScope
      */
     public function testWhileStatementAlternativeScopeHasExpectedEndLine($stmt): void
@@ -209,9 +199,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndColumn
      *
-     * @param \PDepend\Source\AST\ASTWhileStatement $stmt
+     * @param ASTWhileStatement $stmt
      *
-     * @return void
      * @depends testWhileStatementWithAlternativeScope
      */
     public function testWhileStatementAlternativeScopeHasExpectedEndColumn($stmt): void
@@ -221,8 +210,6 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementTerminatedByPhpCloseTag
-     *
-     * @return void
      */
     public function testWhileStatementTerminatedByPhpCloseTag(): void
     {
@@ -233,7 +220,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTWhileStatement
+     * @return ASTWhileStatement
      */
     private function getFirstWhileStatementInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -45,19 +45,18 @@ namespace PDepend\Source\AST;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTYieldStatement} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ * @covers \PDepend\Source\AST\ASTForeachStatement
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\AST\ASTForeachStatement
  * @group unittest
  */
 class ASTYieldStatementTest extends ASTNodeTestCase
 {
     /**
      * testYield
-     *
-     * @return void
      */
     public function testYield(): void
     {
@@ -67,8 +66,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldAssignment
-     *
-     * @return void
      */
     public function testYieldAssignment(): void
     {
@@ -87,8 +84,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldWithLiteral
-     *
-     * @return void
      */
     public function testYieldWithLiteral(): void
     {
@@ -98,8 +93,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldWithVariable
-     *
-     * @return void
      */
     public function testYieldWithVariable(): void
     {
@@ -109,8 +102,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldWithKeyValue
-     *
-     * @return void
      */
     public function testYieldWithKeyValue(): void
     {
@@ -121,8 +112,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldWithFunctionCalls
-     *
-     * @return void
      */
     public function testYieldWithFunctionCalls(): void
     {
@@ -133,8 +122,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldInsideForeach
-     *
-     * @return void
      */
     public function testYieldInsideForeach(): void
     {
@@ -161,7 +148,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
      * testYieldKeyValueChildNodes
      *
      * @param \PDepend\Source\AST\ASTExpression[] $nodes
-     * @return void
+     *
      * @depends testYieldKeyValue
      */
     public function testYieldKeyValueChildNodes(array $nodes): void
@@ -173,7 +160,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     /**
      * testYieldValueAssignmentSimple
      *
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     * @return ASTYieldStatement
      */
     public function testYieldValueAssignmentSimple()
     {
@@ -188,8 +175,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     /**
      * testYieldValueAssignmentSimpleParent
      *
-     * @param \PDepend\Source\AST\ASTStatement $yield
-     * @return void
      * @depends testYieldValueAssignmentSimple
      */
     public function testYieldValueAssignmentSimpleParent(ASTStatement $yield): void
@@ -203,7 +188,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     /**
      * testYieldValueAssignmentKeyValue
      *
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     * @return ASTYieldStatement
      */
     public function testYieldValueAssignmentKeyValue()
     {
@@ -218,8 +203,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     /**
      * testYieldValueAssignmentKeyValueParent
      *
-     * @param \PDepend\Source\AST\ASTYieldStatement $yield
-     * @return void
      * @depends testYieldValueAssignmentKeyValue
      */
     public function testYieldValueAssignmentKeyValueParent(ASTYieldStatement $yield): void
@@ -233,8 +216,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     /**
      * testYieldValueAssignmentKeyValueChildren
      *
-     * @param \PDepend\Source\AST\ASTYieldStatement $yield
-     * @return void
      * @depends testYieldValueAssignmentKeyValue
      */
     public function testYieldValueAssignmentKeyValueChildren(ASTYieldStatement $yield): void
@@ -249,7 +230,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     * @return \PDepend\Source\AST\ASTYieldStatement
+     *
+     * @return ASTYieldStatement
      */
     private function getFirstYieldStatementInFunction($testCase)
     {

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -47,10 +47,11 @@ use PDepend\AbstractTestCase;
 /**
  * Base test case for abstract item implementations.
  *
+ * @covers \PDepend\Source\AST\AbstractASTArtifact
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @group unittest
  */
 abstract class AbstractASTArtifactTestCase extends AbstractTestCase
@@ -58,7 +59,6 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
     /**
      * testSetNameChangesPreviousName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testSetNameChangesPreviousName(): void
@@ -73,8 +73,9 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string  $testCase
-     * @param boolean $ignoreAnnotations
+     * @param string $testCase
+     * @param bool   $ignoreAnnotations
+     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -96,7 +97,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
     /**
      * Creates an abstract item instance.
      *
-     * @return \PDepend\Source\AST\AbstractASTArtifact
+     * @return AbstractASTArtifact
      */
     abstract protected function createItem();
 }

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -50,19 +51,19 @@ use PDepend\Source\AST\ASTClass;
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter}
  * class.
  *
+ * @covers \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
  * @group unittest
  */
 class CollectionArtifactFilterTest extends AbstractTestCase
 {
     /**
      * testAcceptsReturnsTrueByDefault
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueByDefault(): void
     {
@@ -72,8 +73,6 @@ class CollectionArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsCallsNestedFilterWhenSet
-     *
-     * @return void
      */
     public function testAcceptsCallsNestedFilterWhenSet(): void
     {

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -55,19 +56,19 @@ use PDepend\Source\AST\ASTTrait;
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter} class.
  *
+ * @covers \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter
  * @group unittest
  */
 class NullArtifactFilterTest extends AbstractTestCase
 {
     /**
      * testAcceptsReturnsTrueForClass
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForClass(): void
     {
@@ -77,8 +78,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForFile
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForFile(): void
     {
@@ -88,8 +87,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForFunction
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForFunction(): void
     {
@@ -99,8 +96,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForInterface
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForInterface(): void
     {
@@ -110,8 +105,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForMethod
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForMethod(): void
     {
@@ -121,8 +114,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForPackage
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForPackage(): void
     {
@@ -132,8 +123,6 @@ class NullArtifactFilterTest extends AbstractTestCase
 
     /**
      * testAcceptsReturnsTrueForTrait
-     *
-     * @return void
      */
     public function testAcceptsReturnsTrueForTrait(): void
     {

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
@@ -52,18 +52,17 @@ use PDepend\Source\AST\ASTNamespace;
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter}
  * class.
  *
+ * @covers \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter
  * @group unittest
  */
 class PackageArtifactFilterTest extends AbstractTestCase
 {
     /**
      * Tests that the package filter accepts valid packages.
-     *
-     * @return void
      */
     public function testFilterAcceptsPackage(): void
     {
@@ -73,8 +72,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the package filter not accepts invalid packages.
-     *
-     * @return void
      */
     public function testFilterNotAcceptsPackage(): void
     {
@@ -84,8 +81,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the package filter accepts and rejects the expected package.
-     *
-     * @return void
      */
     public function testFilterAcceptsAndNotAcceptsExpectedPackage(): void
     {
@@ -96,8 +91,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter accepts a class with a valid package.
-     *
-     * @return void
      */
     public function testFilterAcceptsClass(): void
     {
@@ -110,8 +103,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter rejects a class with an invalid package.
-     *
-     * @return void
      */
     public function testFilterNotAcceptsClass(): void
     {
@@ -124,8 +115,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter accepts an interface with a valid package.
-     *
-     * @return void
      */
     public function testFilterAcceptsInterface(): void
     {
@@ -138,8 +127,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter not accepts an interface with an invalid package.
-     *
-     * @return void
      */
     public function testFilterNotAcceptsInterface(): void
     {
@@ -152,8 +139,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter accepts a function with a valid package.
-     *
-     * @return void
      */
     public function testFilterAcceptsFunction(): void
     {
@@ -166,8 +151,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the filter not accepts a function with an invalid package.
-     *
-     * @return void
      */
     public function testFilterNotAcceptsFunction(): void
     {
@@ -180,8 +163,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the package filter works with wild cards.
-     *
-     * @return void
      */
     public function testFilterAcceptsPackageWithWildcard(): void
     {
@@ -193,8 +174,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
 
     /**
      * Tests that the package filter rejects unmatching packages.
-     *
-     * @return void
      */
     public function testFilterNotAcceptsPackageWithWildcard(): void
     {
@@ -207,8 +186,6 @@ class PackageArtifactFilterTest extends AbstractTestCase
     /**
      * Tests that the package filter selects the accepts and rejects the expected
      * packages.
-     *
-     * @return void
      */
     public function testFilterAcceptsAndNotAcceptsPackageWithWildcard(): void
     {

--- a/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
   * @since 1.0.0
  */
 
@@ -49,19 +50,19 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator}
  * class.
  *
+ * @covers \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @since 1.0.0
  *
- * @covers \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator
  * @group unittest
  */
 class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
 {
     /**
      * testIteratorReturnsExpectedClasses
-     *
-     * @return void
      */
     public function testIteratorReturnsExpectedClasses(): void
     {
@@ -98,8 +99,6 @@ class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
 
     /**
      * testIteratorReturnsSameClassOnlyOnce
-     *
-     * @return void
      */
     public function testIteratorReturnsSameClassOnlyOnce(): void
     {

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -44,24 +44,22 @@ namespace PDepend\Source\ASTVisitor;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
-use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTTrait;
 
 /**
  * Test case for the default visit listener implementation.
  *
+ * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @group unittest
  */
 class DefaultListenerTest extends AbstractTestCase
 {
     /**
      * testDefaultImplementationCallsListeners
-     *
-     * @return void
      */
     public function testDefaultImplementationCallsListeners(): void
     {
@@ -106,8 +104,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * Tests that the default listener implementation delegates a class call
      * to the startVisitNode() and endVisitNode() methods.
-     *
-     * @return void
      */
     public function testListenerCallsStartNodeEndNodeForClass(): void
     {
@@ -134,8 +130,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * Tests that the default listener implementation delegates an interface
      * call to the startVisitNode() and endVisitNode() methods.
-     *
-     * @return void
      */
     public function testListenerCallsStartNodeEndNodeForInterface(): void
     {
@@ -162,8 +156,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * Tests that the default listener implementation delegates a function
      * call to the startVisitNode() and endVisitNode() methods.
-     *
-     * @return void
      */
     public function testListenerCallsStartNodeEndNodeForFunction(): void
     {
@@ -190,8 +182,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * Tests that the default listener implementation delegates a method call to
      * the startVisitNode() and endVisitNode() methods.
-     *
-     * @return void
      */
     public function testListenerCallsStartNodeEndNodeForMethod(): void
     {
@@ -215,8 +205,6 @@ class DefaultListenerTest extends AbstractTestCase
 
     /**
      * testListenerCallsStartVisitNodeForPassedParameterInstance
-     *
-     * @return void
      */
     public function testListenerCallsStartVisitNodeForPassedParameterInstance(): void
     {
@@ -234,8 +222,6 @@ class DefaultListenerTest extends AbstractTestCase
 
     /**
      * testListenerCallsEndVisitNodeForPassedParameterInstance
-     *
-     * @return void
      */
     public function testListenerCallsEndVisitNodeForPassedParameterInstance(): void
     {
@@ -254,7 +240,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * testListenerInvokesStartVisitNotForTrait
      *
-     * @return void
      * @since 1.0.0
      */
     public function testListenerInvokesStartVisitNotForTrait(): void
@@ -271,7 +256,6 @@ class DefaultListenerTest extends AbstractTestCase
     /**
      * testListenerInvokesEndVisitNotForTrait
      *
-     * @return void
      * @since 1.0.0
      */
     public function testListenerInvokesEndVisitNotForTrait(): void

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -51,18 +51,17 @@ use PDepend\Source\AST\ASTTrait;
 /**
  * Test case for the default visitor implementation.
  *
+ * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @group unittest
  */
 class DefaultVisitorTest extends AbstractTestCase
 {
     /**
      * Tests the execution order of the default visitor implementation.
-     *
-     * @return void
      */
     public function testDefaultVisitOrder(): void
     {
@@ -89,7 +88,7 @@ class DefaultVisitorTest extends AbstractTestCase
             'methodCB',
             'methodCA',
             'funcD',
-            'PDepend\\Source\\AST\\ASTCompilationUnit'
+            'PDepend\\Source\\AST\\ASTCompilationUnit',
         ];
 
         $this->assertEquals($expected, $visitor->visits);
@@ -97,8 +96,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorVisitsFunctionParameter
-     *
-     * @return void
      */
     public function testVisitorVisitsFunctionParameter(): void
     {
@@ -115,8 +112,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorVisitsMethodParameter
-     *
-     * @return void
      */
     public function testVisitorVisitsMethodParameter(): void
     {
@@ -133,8 +128,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesStartVisitParameterOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesStartVisitParameterOnListener(): void
     {
@@ -155,8 +148,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesEndVisitParameterOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesEndVisitParameterOnListener(): void
     {
@@ -177,8 +168,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesStartVisitInterfaceOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesStartVisitInterfaceOnListener(): void
     {
@@ -199,8 +188,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesEndVisitInterfaceOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesEndVisitInterfaceOnListener(): void
     {
@@ -221,8 +208,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesStartVisitPropertyOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesStartVisitPropertyOnListener(): void
     {
@@ -243,8 +228,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testVisitorInvokesEndVisitPropertyOnListener
-     *
-     * @return void
      */
     public function testVisitorInvokesEndVisitPropertyOnListener(): void
     {
@@ -266,7 +249,6 @@ class DefaultVisitorTest extends AbstractTestCase
     /**
      * testVisitorVisitsTrait
      *
-     * @return void
      * @since 1.0.0
      */
     public function testVisitorVisitsTrait(): void
@@ -289,7 +271,6 @@ class DefaultVisitorTest extends AbstractTestCase
     /**
      * testVisitorInvokesAcceptOnTraitMethods
      *
-     * @return void
      * @since 1.0.0
      */
     public function testVisitorInvokesAcceptOnTraitMethods(): void
@@ -309,7 +290,6 @@ class DefaultVisitorTest extends AbstractTestCase
     /**
      * testVisitorInvokesStartTraitOnListener
      *
-     * @return void
      * @since 1.0.0
      */
     public function testVisitorInvokesStartTraitOnListener(): void
@@ -336,7 +316,6 @@ class DefaultVisitorTest extends AbstractTestCase
     /**
      * testVisitorInvokesEndTraitOnListener
      *
-     * @return void
      * @since 1.0.0
      */
     public function testVisitorInvokesEndTraitOnListener(): void
@@ -347,11 +326,11 @@ class DefaultVisitorTest extends AbstractTestCase
         $namespace = new ASTNamespace('MyPackage');
         $namespace->addType($trait);
 
-        $listener = $this->createMock(\PDepend\Source\ASTVisitor\ASTVisitListener::class);
+        $listener = $this->createMock(ASTVisitListener::class);
         $listener->expects($this->once())
             ->method('endVisitTrait');
 
-        $visitor = $this->getMockBuilder(\PDepend\Source\ASTVisitor\AbstractASTVisitor::class)
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -361,8 +340,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testGetVisitListenersReturnsIterator
-     *
-     * @return void
      */
     public function testGetVisitListenersReturnsIterator(): void
     {
@@ -372,8 +349,6 @@ class DefaultVisitorTest extends AbstractTestCase
 
     /**
      * testGetVisitListenersContainsAddedListener
-     *
-     * @return void
      */
     public function testGetVisitListenersContainsAddedListener(): void
     {

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -64,21 +64,22 @@ class StubASTVisitor implements ASTVisitor
     /**
      * The last visited class instance.
      *
-     * @var \PDepend\Source\AST\ASTClass
+     * @var ASTClass
      */
     public $class;
 
     /**
      * The last visited class instance.
      *
-     * @var \PDepend\Source\AST\ASTEnum
+     * @var ASTEnum
      */
     public $enum;
 
     /**
      * The last visited trait instance.
      *
-     * @var \PDepend\Source\AST\ASTTrait
+     * @var ASTTrait
+     *
      * @since 1.0.0
      */
     public $trait;
@@ -86,165 +87,44 @@ class StubASTVisitor implements ASTVisitor
     /**
      * The last visited interface instance.
      *
-     * @var \PDepend\Source\AST\ASTInterface
+     * @var ASTInterface
      */
     public $interface;
 
     /**
      * The last visited method instance.
      *
-     * @var \PDepend\Source\AST\ASTMethod
+     * @var ASTMethod
      */
     public $method;
 
     /**
      * The last visited package instance.
      *
-     * @var \PDepend\Source\AST\ASTNamespace
+     * @var ASTNamespace
      */
     public $namespace;
 
     /**
      * The last visited parameter instance.
      *
-     * @var \PDepend\Source\AST\ASTParameter
+     * @var ASTParameter
      */
     public $parameter;
 
     /**
      * The last visited property instance.
      *
-     * @var \PDepend\Source\AST\ASTProperty
+     * @var ASTProperty
      */
     public $property;
 
     /**
      * The last visited function instance.
      *
-     * @var \PDepend\Source\AST\ASTFunction
+     * @var ASTFunction
      */
     public $function;
-
-    /**
-     * Adds a new listener to this node visitor.
-     *
-     * @param \PDepend\Source\ASTVisitor\ASTVisitListener $listener
-     * @return void
-     */
-    public function addVisitListener(ASTVisitListener $listener): void
-    {
-    }
-
-    /**
-     * Visits a class node.
-     *
-     * @param \PDepend\Source\AST\ASTClass $class
-     * @return void
-     */
-    public function visitClass(ASTClass $class): void
-    {
-        $this->class = $class;
-    }
-
-    /**
-     * Visits an enum node.
-     *
-     * @param \PDepend\Source\AST\ASTEnum $enum
-     * @return void
-     */
-    public function visitEnum(ASTEnum $enum): void
-    {
-        $this->enum = $enum;
-    }
-
-    /**
-     * Visits a trait node.
-     *
-     * @param \PDepend\Source\AST\ASTTrait $trait
-     * @return void
-     * @since 1.0.0
-     */
-    public function visitTrait(ASTTrait $trait): void
-    {
-        $this->trait = $trait;
-    }
-
-
-    /**
-     * Visits a code interface object.
-     *
-     * @param \PDepend\Source\AST\ASTInterface $interface
-     * @return void
-     */
-    public function visitInterface(ASTInterface $interface): void
-    {
-        $this->interface = $interface;
-    }
-
-    /**
-     * Visits a method node.
-     *
-     * @param \PDepend\Source\AST\ASTMethod $method
-     * @return void
-     */
-    public function visitMethod(ASTMethod $method): void
-    {
-        $this->method = $method;
-    }
-
-    /**
-     * Visits a package node.
-     *
-     * @param \PDepend\Source\AST\ASTNamespace $namespace The package class node.
-     * @return void
-     */
-    public function visitNamespace(ASTNamespace $namespace): void
-    {
-        $this->namespace = $namespace;
-    }
-
-    /**
-     * Visits a parameter node.
-     *
-     * @param \PDepend\Source\AST\ASTParameter $parameter
-     * @return void
-     */
-    public function visitParameter(ASTParameter $parameter): void
-    {
-        $this->parameter = $parameter;
-    }
-
-    /**
-     * Visits a property node.
-     *
-     * @param \PDepend\Source\AST\ASTProperty $property
-     * @return void
-     */
-    public function visitProperty(ASTProperty $property): void
-    {
-        $this->property = $property;
-    }
-
-    /**
-     * Visits a function node.
-     *
-     * @param \PDepend\Source\AST\ASTFunction $function
-     * @return void
-     */
-    public function visitFunction(ASTFunction $function): void
-    {
-        $this->function = $function;
-    }
-
-    /**
-     * Visits a file node.
-     *
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
-     * @return void
-     */
-    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit): void
-    {
-    }
 
     /**
      * Magic call method used to provide simplified visitor implementations.
@@ -264,12 +144,104 @@ class StubASTVisitor implements ASTVisitor
      * by the concrete visit method.
      *
      * @param string $method Name of the called method.
-     * @param array $args Array with method argument.
+     * @param array  $args   Array with method argument.
      *
      * @return array
+     *
      * @since 0.9.12
      */
     public function __call($method, $args)
+    {
+    }
+
+    /**
+     * Adds a new listener to this node visitor.
+     */
+    public function addVisitListener(ASTVisitListener $listener): void
+    {
+    }
+
+    /**
+     * Visits a class node.
+     */
+    public function visitClass(ASTClass $class): void
+    {
+        $this->class = $class;
+    }
+
+    /**
+     * Visits an enum node.
+     */
+    public function visitEnum(ASTEnum $enum): void
+    {
+        $this->enum = $enum;
+    }
+
+    /**
+     * Visits a trait node.
+     *
+     * @since 1.0.0
+     */
+    public function visitTrait(ASTTrait $trait): void
+    {
+        $this->trait = $trait;
+    }
+
+
+    /**
+     * Visits a code interface object.
+     */
+    public function visitInterface(ASTInterface $interface): void
+    {
+        $this->interface = $interface;
+    }
+
+    /**
+     * Visits a method node.
+     */
+    public function visitMethod(ASTMethod $method): void
+    {
+        $this->method = $method;
+    }
+
+    /**
+     * Visits a package node.
+     *
+     * @param ASTNamespace $namespace The package class node.
+     */
+    public function visitNamespace(ASTNamespace $namespace): void
+    {
+        $this->namespace = $namespace;
+    }
+
+    /**
+     * Visits a parameter node.
+     */
+    public function visitParameter(ASTParameter $parameter): void
+    {
+        $this->parameter = $parameter;
+    }
+
+    /**
+     * Visits a property node.
+     */
+    public function visitProperty(ASTProperty $property): void
+    {
+        $this->property = $property;
+    }
+
+    /**
+     * Visits a function node.
+     */
+    public function visitFunction(ASTFunction $function): void
+    {
+        $this->function = $function;
+    }
+
+    /**
+     * Visits a file node.
+     */
+    public function visitCompilationUnit(ASTCompilationUnit $compilationUnit): void
     {
     }
 

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
@@ -53,18 +53,18 @@ use PDepend\Source\AST\AbstractASTArtifact;
 class StubAbstractASTVisitListener extends AbstractASTVisitListener
 {
     public $nodes = [];
-    
+
     public function startVisitNode(AbstractASTArtifact $node): void
     {
         $this->nodes[$node->getName() . '#start'] = true;
-        
+
         parent::startVisitNode($node);
     }
 
     public function endVisitNode(AbstractASTArtifact $node): void
     {
         $this->nodes[$node->getName() . '#end'] = true;
-        
+
         parent::endVisitNode($node);
     }
 }

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
@@ -61,15 +61,12 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
     /**
      * Collected visit order.
      *
-     * @var array<string, integer>
+     * @var array<string, int>
      */
     public $visits = [];
 
     /**
      * Visits a class node.
-     *
-     * @param \PDepend\Source\AST\ASTClass $class
-     * @return void
      */
     public function visitClass(ASTClass $class): void
     {
@@ -80,9 +77,6 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
 
     /**
      * Visits a file node.
-     *
-     * @param \PDepend\Source\AST\ASTCompilationUnit $compilationUnit
-     * @return void
      */
     public function visitCompilationUnit(ASTCompilationUnit $compilationUnit): void
     {
@@ -93,9 +87,6 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
 
     /**
      * Visits a function node.
-     *
-     * @param \PDepend\Source\AST\ASTFunction $function
-     * @return void
      */
     public function visitFunction(ASTFunction $function): void
     {
@@ -106,9 +97,6 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
 
     /**
      * Visits a code interface object.
-     *
-     * @param \PDepend\Source\AST\ASTInterface $interface
-     * @return void
      */
     public function visitInterface(ASTInterface $interface): void
     {
@@ -119,9 +107,6 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
 
     /**
      * Visits a method node.
-     *
-     * @param \PDepend\Source\AST\ASTMethod $method
-     * @return void
      */
     public function visitMethod(ASTMethod $method): void
     {
@@ -133,8 +118,7 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
     /**
      * Visits a package node.
      *
-     * @param \PDepend\Source\AST\ASTNamespace $namespace The package class node.
-     * @return void
+     * @param ASTNamespace $namespace The package class node.
      */
     public function visitNamespace(ASTNamespace $namespace): void
     {
@@ -145,9 +129,6 @@ class StubAbstractASTVisitor extends AbstractASTVisitor
 
     /**
      * Visits a property node.
-     *
-     * @param \PDepend\Source\AST\ASTProperty $property
-     * @return void
      */
     public function visitProperty(ASTProperty $property): void
     {

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -52,10 +52,11 @@ use PDepend\Source\AST\ASTTrait;
  * Test case for the {@link \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext}
  * class.
  *
+ * @covers \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext
  * @group unittest
  */
 class GlobalBuilderContextTest extends AbstractTestCase
@@ -63,7 +64,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
     /**
      * testRegisterTraitCallsRestoreClassOnBuilder
      *
-     * @return void
      * @since 1.0.0
      */
     public function testRegisterTraitCallsRestoreClassOnBuilder(): void
@@ -80,8 +80,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
 
     /**
      * testRegisterClassCallsRestoreClassOnBuilder
-     *
-     * @return void
      */
     public function testRegisterClassCallsRestoreClassOnBuilder(): void
     {
@@ -97,8 +95,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
 
     /**
      * testRegisterInterfaceCallsRestoreInterfaceOnBuilder
-     *
-     * @return void
      */
     public function testRegisterInterfaceCallsRestoreInterfaceOnBuilder(): void
     {
@@ -114,8 +110,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
 
     /**
      * testRegisterFunctionCallsRestoreFunctionOnBuilder
-     *
-     * @return void
      */
     public function testRegisterFunctionCallsRestoreFunctionOnBuilder(): void
     {
@@ -132,7 +126,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
     /**
      * testGetTraitDelegatesCallToWrappedBuilder
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetTraitDelegatesCallToWrappedBuilder(): void
@@ -149,8 +142,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
 
     /**
      * testGetClassDelegatesCallToWrappedBuilder
-     *
-     * @return void
      */
     public function testGetClassDelegatesCallToWrappedBuilder(): void
     {
@@ -166,8 +157,6 @@ class GlobalBuilderContextTest extends AbstractTestCase
 
     /**
      * testGetClassOrInterfaceDelegatesCallToWrappedBuilder
-     *
-     * @return void
      */
     public function testGetClassOrInterfaceDelegatesCallToWrappedBuilder(): void
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -44,17 +44,16 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class AttributeTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testAttribute(): void
     {
         $types = $this->parseCodeResourceForTest()

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -40,24 +40,20 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
-use PDepend\Source\AST\ASTArguments;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
-use PDepend\Source\AST\ASTMethod;
-use PDepend\Source\AST\ASTNamedArgument;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testConstructorPropertyPromotion(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -93,9 +89,6 @@ class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
         $this->assertFalse($parameters[3]->isPrivate());
     }
 
-    /**
-     * @return void
-     */
     public function testConstructorPropertyPromotionWithComments(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -131,9 +124,6 @@ class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
         $this->assertFalse($parameters[3]->isPrivate());
     }
 
-    /**
-     * @return void
-     */
     public function testPropertyPromotionOnRandomMethod(): void
     {
         $this->expectException(\PDepend\Source\Parser\TokenException::class);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
@@ -40,20 +40,22 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
+use InvalidArgumentException;
+
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8.0
  */
 class ExplicitOctalNotationTest extends PHPParserVersion80TestCase
 {
-    /**
-     */
     public function testExplicitOctalNotation(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid number 0o16');
 
         $this->getFirstClassForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -40,38 +40,30 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
-use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTReturnStatement;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class MatchExpressionTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testMatchExpression(): void
     {
         $this->checkMatchExpression();
     }
 
-    /**
-     * @return void
-     */
     public function testMatchExpressionWithNamespace(): void
     {
         $this->checkMatchExpression('Baz');
     }
 
-    /**
-     * @return void
-     */
     private function checkMatchExpression($namespacePrefix = null): void
     {
         $matchImage = implode('\\', array_filter([$namespacePrefix, 'match']));
@@ -138,7 +130,7 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
         $this->assertSame('new', $new->getImage());
         $this->assertSame(['\InvalidArgumentException', ''], array_map(
-            static fn ($node) => $node->getImage(),
+            static fn($node) => $node->getImage(),
             $new->getChildren(),
         ));
         $this->assertSame([
@@ -146,14 +138,11 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
             ['PDepend\\Source\\AST\\ASTVariable', '$in'],
             ['PDepend\\Source\\AST\\ASTLiteral', ']'],
         ], array_map(
-            static fn ($node) => [$node::class, $node->getImage()],
+            static fn($node) => [$node::class, $node->getImage()],
             $new->getChild(1)->getChild(0)->getChildren(),
         ));
     }
 
-    /**
-     * @return void
-     */
     public function testMatchExpressionWithMultipleKeyExpressions(): void
     {
         /** @var ASTMethod $method */
@@ -218,7 +207,7 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
         $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
         $this->assertSame('new', $new->getImage());
         $this->assertSame(['\InvalidArgumentException', ''], array_map(
-            static fn ($node) => $node->getImage(),
+            static fn($node) => $node->getImage(),
             $new->getChildren(),
         ));
         $this->assertSame([
@@ -226,14 +215,11 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
             ['PDepend\\Source\\AST\\ASTVariable', '$in'],
             ['PDepend\\Source\\AST\\ASTLiteral', ']'],
         ], array_map(
-            static fn ($node) => [$node::class, $node->getImage()],
+            static fn($node) => [$node::class, $node->getImage()],
             $new->getChild(1)->getChild(0)->getChildren(),
         ));
     }
 
-    /**
-     * @return void
-     */
     public function testMatchExpressionWithTooManyArguments(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -47,17 +47,16 @@ use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\AST\ASTVariable;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class NamedArgumentsTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testNamedArguments(): void
     {
         /** @var ASTMethod $method */

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -45,17 +45,16 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class NullsafeOperatorTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testNullsafeOperator(): void
     {
         /** @var ASTMethod $method */
@@ -68,9 +67,6 @@ class NullsafeOperatorTest extends PHPParserVersion80TestCase
         $this->assertSame('$obj', $variable->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testNullsafeOperatorChain(): void
     {
         /** @var ASTMethod $method */

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
@@ -46,17 +46,16 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  */
 abstract class PHPParserVersion80TestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
@@ -42,20 +42,18 @@ namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTReturnStatement;
-use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class ThrowExpressionTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testNullcoalescingThrow(): void
     {
         /** @var ASTMethod $method */
@@ -80,9 +78,6 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         $this->assertSame('\'should not be null\'', $exceptionMessage[0]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testShorthandTernaryOperator(): void
     {
         /** @var ASTMethod $method */
@@ -108,9 +103,6 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         $this->assertSame('\'should not be empty\'', $exceptionMessage[0]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testTernaryOperator(): void
     {
         /** @var ASTMethod $method */
@@ -141,9 +133,6 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         $this->assertSame('$value', $elseValue->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testThrowFromArrowFunction(): void
     {
         /** @var ASTMethod $method */
@@ -164,9 +153,6 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         $this->assertSame('\'not implemented\'', $exceptionMessage[0]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testThrowFromArrowFunctionAsParameter(): void
     {
         /** @var ASTMethod $method */

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -47,17 +47,16 @@ use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  * @group php8
  */
 class UnionTypesTest extends PHPParserVersion80TestCase
 {
-    /**
-     * @return void
-     */
     public function testUnionTypes(): void
     {
         /** @var ASTMethod $method */
@@ -79,9 +78,6 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $this->assertSame('$number', $variable->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testUnionTypesAsReturn(): void
     {
         /** @var ASTMethod $method */
@@ -95,9 +91,6 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $this->assertSame('int|float|Bar\Biz|null', $return->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testUnionTypesAsReturnWithArray(): void
     {
         /** @var ASTMethod $method */
@@ -111,8 +104,6 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $this->assertSame('array|iterable', $return->getImage());
     }
 
-    /**
-     */
     public function testUnionTypesStandaloneNull(): void
     {
         $this->expectException(\PDepend\Source\Parser\ParserException::class);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -41,16 +41,17 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class ArrayUnpackingWithStringKeysTest extends PHPParserVersion81TestCase
 {
     /**
-     * @return void
      * @group y
      */
     public function testArrayUnpackingWithStringKeys(): void

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -47,17 +47,16 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class EnumTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testEnum(): void
     {
         $types = $this->parseCodeResourceForTest()
@@ -108,7 +107,7 @@ class EnumTest extends PHPParserVersion81TestCase
                 'HasColor' => 'HasColor',
             ],
             array_map(
-                static fn (ASTInterface $interface) => $interface->getName(),
+                static fn(ASTInterface $interface) => $interface->getName(),
                 iterator_to_array($enum->getInterfaces())
             )
         );
@@ -120,7 +119,7 @@ class EnumTest extends PHPParserVersion81TestCase
                 'getcolor' => 'getColor',
             ],
             array_map(
-                static fn (ASTMethod $interface) => $interface->getName(),
+                static fn(ASTMethod $interface) => $interface->getName(),
                 $enum->getAllMethods()
             )
         );
@@ -134,7 +133,7 @@ class EnumTest extends PHPParserVersion81TestCase
                 'SPADES' => "'spades'",
             ],
             array_map(
-                static fn (ASTEnumCase $case) => $case->getValue()->getImage(),
+                static fn(ASTEnumCase $case) => $case->getValue()->getImage(),
                 iterator_to_array($cases)
             )
         );

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -43,10 +43,12 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 use PDepend\Source\AST\ASTConstantDeclarator;
 
 /**
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  * @group php8.1
  */
@@ -57,7 +59,7 @@ class ExplicitOctalNotationTest extends PHPParserVersion81TestCase
         $class = $this->getFirstClassForTestCase();
 
         $values = array_map(
-            static fn (ASTConstantDeclarator $constantDeclarator) => $constantDeclarator->getValue()->getValue(),
+            static fn(ASTConstantDeclarator $constantDeclarator) => $constantDeclarator->getValue()->getValue(),
             $class->getConstantDeclarators()
         );
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -43,17 +43,16 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 use PDepend\Source\AST\State;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class FinalClassConstantTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testFinalClassConstant(): void
     {
         $class = $this->getFirstClassForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -43,17 +43,16 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 use PDepend\Source\AST\ASTMethodPostfix;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class FirstClassCallableSyntaxTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testFirstClassCallable(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -41,71 +41,52 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class FirstClassCallableTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testFirstClassCallable(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableWithComments(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableObjectMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableDynamicMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableStaticMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableDynamicStaticMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
     }
 
-    /**
-     * @return void
-     */
     public function testFirstClassCallableInvocableObject(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -49,16 +49,15 @@ use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  * @group php8.1
  */
 class InInitializersTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testInInitializers(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -96,9 +95,6 @@ class InInitializersTest extends PHPParserVersion81TestCase
         $this->assertSame('Bar', $expression->getChild(0)->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testInInitializersMultipleProperties(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -47,17 +47,16 @@ use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class IntersectionTypesTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testIntersectionTypes(): void
     {
         /** @var ASTMethod $method */
@@ -77,9 +76,6 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         $this->assertSame('$iterator', $variable->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionTypesWithByReference(): void
     {
         /** @var ASTMethod $method */
@@ -94,9 +90,6 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $intersectionType->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionTypesAsReturn(): void
     {
         /** @var ASTMethod $method */
@@ -110,8 +103,6 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $return->getImage());
     }
 
-    /**
-     */
     public function testIntersectionTypesCantBeMixedWithUnionTypes(): void
     {
         $this->expectException(\PDepend\Source\Parser\ParserException::class);
@@ -120,8 +111,6 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         $this->getFirstMethodForTestCase();
     }
 
-    /**
-     */
     public function testIntersectionTypesCantBeScalar(): void
     {
         $this->expectException(\PDepend\Source\Parser\ParserException::class);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -41,17 +41,16 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class NeverReturnTypeTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testFunctionReturnType(): void
     {
         $type = $this->getFirstFunctionForTestCase()->getReturnType();
@@ -60,9 +59,6 @@ class NeverReturnTypeTest extends PHPParserVersion81TestCase
         $this->assertSame('never', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testMethodReturnType(): void
     {
         $type = $this->getFirstMethodForTestCase()->getReturnType();
@@ -71,9 +67,6 @@ class NeverReturnTypeTest extends PHPParserVersion81TestCase
         $this->assertSame('never', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testClosureReturnType(): void
     {
         $type = $this->getFirstClosureForTestCase()->getReturnType();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -46,17 +46,16 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  */
 abstract class PHPParserVersion81TestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -41,17 +41,16 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class ReadonlyClassTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testReadonlyClass(): void
     {
         $this->expectException(

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -43,17 +43,16 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 use PDepend\Source\AST\State;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.1
  */
 class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @return void
-     */
     public function testReadonlyProperty(): void
     {
         $class = $this->getFirstClassForTestCase();
@@ -66,9 +65,6 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
         $this->assertSame(0, ($expectedModifiers & $property->getModifiers()));
     }
 
-    /**
-     * @return void
-     */
     public function testReadonlyPropertyInConstructor(): void
     {
         $class = $this->getFirstClassForTestCase();
@@ -93,9 +89,6 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
         $this->assertSame($expectedModifiers, $parameter->getFormalParameter()->getModifiers());
     }
 
-    /**
-     * @return void
-     */
     public function testReadonlyNameUsedElsewhere(): void
     {
         $class = $this->getFirstClassForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -46,17 +46,16 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @group unittest
  * @group php8.2
  */
 class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testTypedProperties(): void
     {
         /** @var ASTClass $class */
@@ -96,9 +95,6 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testReturnTypes(): void
     {
         $class = $this->getFirstClassForTestCase();
@@ -114,9 +110,6 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('false', $falsy->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testParameters(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -41,17 +41,16 @@
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @group unittest
  * @group php8.2
  */
 class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testReturnParenthesesFirst(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -68,9 +67,6 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('D', $children[1]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testReturnParenthesesLast(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -90,9 +86,6 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('D&E&F', $children[2]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testReturnNestedParentheses(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -102,9 +95,6 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('(A&B&C)|true|(D&((E&F)|G))', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testParameterParenthesesFirst(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -127,9 +117,6 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('null', $children[2]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testParameterParenthesesLast(): void
     {
         $method = $this->getFirstMethodForTestCase();
@@ -152,9 +139,6 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $this->assertSame('D&E&F', $children[2]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testParameterNestedParentheses(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -49,17 +49,16 @@ use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTPropertyPostfix;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @group unittest
  * @group php8.2
  */
 class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testEnumConst(): void
     {
         $enums = $this->parseCodeResourceForTest()

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -46,17 +46,16 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @group unittest
  */
 abstract class PHPParserVersion82TestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
@@ -41,17 +41,16 @@
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
+ *
  * @group unittest
  * @group php8.2
  */
 class ReadonlyClassTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testReadonlyClass(): void
     {
         $class = $this->getFirstClassForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -47,17 +47,16 @@ use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
+ *
  * @group unittest
  * @group php8.2
  */
 class TrueTypeTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testTypedProperties(): void
     {
         /** @var ASTClass $class */
@@ -96,9 +95,6 @@ class TrueTypeTest extends PHPParserVersion82TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testReturnTypes(): void
     {
         $class = $this->getFirstClassForTestCase();
@@ -112,9 +108,6 @@ class TrueTypeTest extends PHPParserVersion82TestCase
         $this->assertTrue($truthy->isTrue());
     }
 
-    /**
-     * @return void
-     */
     public function testParameters(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -41,17 +41,16 @@
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @group unittest
  * @group php8.2
  */
 class TypedClassConstantsTest extends PHPParserVersion82TestCase
 {
-    /**
-     * @return void
-     */
     public function testInterface(): void
     {
         $this->expectException(
@@ -64,9 +63,6 @@ class TypedClassConstantsTest extends PHPParserVersion82TestCase
         $this->getFirstInterfaceForTestCase();
     }
 
-    /**
-     * @return void
-     */
     public function testBroken(): void
     {
         $this->expectException(

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -44,18 +44,17 @@ use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTScope;
 
 /**
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  * @group php8.3
  */
 class DynamicClassConstantFetchTest extends PHPParserVersion83TestCase
 {
-    /**
-     * @return void
-     */
     public function testFetch(): void
     {
         $method = $this->getFirstClassMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -46,17 +46,16 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
 /**
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
+ *
  * @group unittest
  */
 abstract class PHPParserVersion83TestCase extends AbstractTestCase
 {
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
      * @return \PDepend\Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -51,18 +51,17 @@ use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTValue;
 
 /**
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  * @group php8.3
  */
 class TypedClassConstantsTest extends PHPParserVersion83TestCase
 {
-    /**
-     * @return void
-     */
     public function testInterface(): void
     {
         /** @var ASTInterface $interface */
@@ -90,9 +89,6 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testEnum(): void
     {
         /** @var ASTEnum $enum */
@@ -117,9 +113,6 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('"Test1"', $constant->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testTrait(): void
     {
         /** @var ASTTrait $trait */
@@ -149,9 +142,6 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testClass(): void
     {
         $classes = $this->parseCodeResourceForTest()
@@ -198,9 +188,6 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('"Test2"', $constant->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testBroken(): void
     {
         $this->expectException(

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -52,18 +52,17 @@ use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTValue;
 
 /**
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  * @group php8.3
  */
 class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
 {
-    /**
-     * @return void
-     */
     public function testInterface(): void
     {
         /** @var ASTInterface $interface */
@@ -98,9 +97,6 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testEnum(): void
     {
         /** @var ASTEnum $enum */
@@ -132,9 +128,6 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('"Test1"', $constant->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testTrait(): void
     {
         /** @var ASTTrait $trait */
@@ -170,9 +163,6 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testClass(): void
     {
         $classes = $this->parseCodeResourceForTest()
@@ -224,9 +214,6 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         $this->assertSame('"Test2"', $constant->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testBroken(): void
     {
         $this->expectException(

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -43,26 +43,22 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\AST\ASTClassFqnPostfix;
-use PDepend\Source\AST\ASTComment;
-use PDepend\Source\AST\ASTConstantPostfix;
 use PDepend\Source\AST\ASTFunction;
 
 /**
  * Test case implementation for the default node builder implementation.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPBuilder
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @group unittest
  */
 class PHPBuilderTest extends AbstractTestCase
 {
     /**
      * testBuilderAddsMultiplePackagesForClassesToListOfPackages
-     *
-     * @return void
      */
     public function testBuilderAddsMultiplePackagesForClassesToListOfPackages(): void
     {
@@ -79,8 +75,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderAddsMultiplePackagesForFunctionsToListOfPackages
-     *
-     * @return void
      */
     public function testBuilderAddsMultiplePackagesForFunctionsToListOfPackages(): void
     {
@@ -97,8 +91,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderNotAddsNewPackagesOnceItHasReturnedTheListOfPackages
-     *
-     * @return void
      */
     public function testBuilderNotAddsNewPackagesOnceItHasReturnedTheListOfPackages(): void
     {
@@ -117,8 +109,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testRestoreFunctionAddsFunctionToPackage
-     *
-     * @return void
      */
     public function testRestoreFunctionAddsFunctionToPackage(): void
     {
@@ -134,8 +124,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testRestoreFunctionUsesGetNamespaceNameMethod
-     *
-     * @return void
      */
     public function testRestoreFunctionUsesGetNamespaceNameMethod(): void
     {
@@ -152,7 +140,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildTraitWithSameQualifiedNameUnique
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildTraitWithSameQualifiedNameUnique(): void
@@ -170,7 +157,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetTraitReturnsDummyIfNoMatchingTraitExists
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetTraitReturnsDummyIfNoMatchingTraitExists(): void
@@ -183,8 +169,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that the {@link \PDepend\Source\Language\PHP\PHPBuilder::buildTrait()}
      * method creates two different trait instances for the same class name, but
      * different packages.
-     *
-     * @return void
      */
     public function testBuildTraitCreatesTwoDifferentInstancesForDifferentPackages(): void
     {
@@ -200,8 +184,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that {@link \PDepend\Source\Language\PHP\PHPBuilder::buildTrait()} returns
      * a previous trait instance for a specified package, if it is called for a
      * same named trait in the default package.
-     *
-     * @return void
      */
     public function testBuildTraitReusesExistingNonDefaultPackageInstanceForDefaultPackage(): void
     {
@@ -220,8 +202,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder creates a class for the same name only once.
-     *
-     * @return void
      */
     public function testBuildClassUnique(): void
     {
@@ -238,7 +218,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetClassReturnsDummyIfNoMatchingTraitExists
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetClassReturnsDummyIfNoMatchingClassExists(): void
@@ -254,8 +233,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that the {@link \PDepend\Source\Language\PHP\PHPBuilder::buildClass()} method
      * creates two different class instances for the same class name, but
      * different packages.
-     *
-     * @return void
      */
     public function testBuildClassCreatesTwoDifferentInstancesForDifferentPackages(): void
     {
@@ -271,8 +248,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that {@link \PDepend\Source\Language\PHP\PHPBuilder::buildClass()}
      * returns a previous class instance for a specified package, if it is called
      * for a same named class in the default package.
-     *
-     * @return void
      */
     public function testBuildClassReusesExistingNonDefaultPackageInstanceForDefaultPackage(): void
     {
@@ -292,8 +267,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the node build generates an unique interface instance for the
      * same identifier.
-     *
-     * @return void
      */
     public function testBuildInterfaceUnique(): void
     {
@@ -310,7 +283,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetInterfaceReturnsDummyIfNoMatchingInterfaceExists
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetInterfaceReturnsDummyIfNoMatchingInterfaceExists(): void
@@ -327,8 +299,6 @@ class PHPBuilderTest extends AbstractTestCase
      * method only removes/replaces a previously created class instance, when
      * this class is part of the default namespace. Otherwise there are two user
      * types with the same local or package internal name.
-     *
-     * @return void
      */
     public function testBuildInterfaceDoesntRemoveClassForSameNamedInterface(): void
     {
@@ -350,8 +320,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that {@link \PDepend\Source\Language\PHP\PHPBuilder::buildInterface()}
      * creates different interface instances for different parent packages.
-     *
-     * @return void
      */
     public function testBuildInterfacesCreatesDifferentInstancesForDifferentPackages(): void
     {
@@ -367,8 +335,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that {@link \PDepend\Source\Language\PHP\PHPBuilder::buildInterface()}
      * replaces an existing default package interface instance, if it creates a
      * more specific version.
-     *
-     * @return void
      */
     public function testCanCreateMultipleInterfaceInstancesWithIdenticalNames(): void
     {
@@ -388,8 +354,6 @@ class PHPBuilderTest extends AbstractTestCase
      * Tests that {@link \PDepend\Source\Language\PHP\PHPBuilder::buildInterface()}
      * returns a previous interface instance for a specified package, if it is called
      * for a same named interface in the default package.
-     *
-     * @return void
      */
     public function testBuildInterfaceReusesExistingNonDefaultPackageInstanceForDefaultPackage(): void
     {
@@ -409,8 +373,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests the 'PDepend\\Source\\AST\\ASTMethod build method.
-     *
-     * @return void
      */
     public function testBuildMethod(): void
     {
@@ -422,8 +384,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder creates a package for the same name only once.
-     *
-     * @return void
      */
     public function testBuildPackageUnique(): void
     {
@@ -436,8 +396,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests the implemented {@link IteratorAggregate}.
-     *
-     * @return void
      */
     public function testGetIteratorWithPackages(): void
     {
@@ -446,7 +404,7 @@ class PHPBuilderTest extends AbstractTestCase
         $expected = [
             'package1'  =>  $builder->buildNamespace('package1'),
             'package2'  =>  $builder->buildNamespace('package2'),
-            'package3'  =>  $builder->buildNamespace('package3')
+            'package3'  =>  $builder->buildNamespace('package3'),
         ];
 
         $actual = [];
@@ -460,8 +418,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests the {@link \PDepend\Source\Language\PHP\PHPBuilder::getNamespaces()}
      * method.
-     *
-     * @return void
      */
     public function testGetNamespaces(): void
     {
@@ -470,7 +426,7 @@ class PHPBuilderTest extends AbstractTestCase
         $expected = [
             'package1'  =>  $builder->buildNamespace('package1'),
             'package2'  =>  $builder->buildNamespace('package2'),
-            'package3'  =>  $builder->buildNamespace('package3')
+            'package3'  =>  $builder->buildNamespace('package3'),
         ];
 
         $actual = [];
@@ -484,8 +440,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * There was a missing check within an if statement, so that the builder
      * has alway overwritten previously created instances.
-     *
-     * @return void
      */
     public function testBuildClassDoesNotOverwritePreviousInstances(): void
     {
@@ -508,8 +462,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * There was a missing check within an if statement, so that the builder
      * has alway overwritten previously created instances.
-     *
-     * @return void
      */
     public function testBuildInterfaceDoesNotOverwritePreviousInstances(): void
     {
@@ -526,8 +478,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder works case insensitive for class names.
-     *
-     * @return void
      */
     public function testBuildClassWorksCaseInsensitiveIssue26(): void
     {
@@ -543,8 +493,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder works case insensitive for interface names.
-     *
-     * @return void
      */
     public function testBuildInterfaceWorksCaseInsensitiveIssue26(): void
     {
@@ -564,7 +512,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetClassOrInterfaceReturnsDummyIfNoMatchingTypeExists
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetClassOrInterfaceReturnsDummyIfNoMatchingTypeExists(): void
@@ -579,7 +526,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetClassOrInterfaceReturnsClassInExtensionPackage
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetClassOrInterfaceReturnsClassInExtensionPackage(): void
@@ -594,7 +540,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testGetClassOrInterfaceStripsLeadingBackslashFromClass
      *
-     * @return void
      * @since 1.0.0
      */
     public function testGetClassOrInterfaceStripsLeadingBackslashFromClass(): void
@@ -608,8 +553,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder works case insensitive for interface names.
-     *
-     * @return void
      */
     public function testBuildClassOrInterfaceWorksCaseInsensitive1Issue26(): void
     {
@@ -628,8 +571,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Tests that the node builder works case insensitive for interface names.
-     *
-     * @return void
      */
     public function testBuildClassOrInterfaceWorksCaseInsensitive2Issue26(): void
     {
@@ -646,8 +587,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildASTClassOrInterfaceReferenceThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -670,8 +609,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildClassThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -694,8 +631,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildASTClassReferenceThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -718,8 +653,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildInterfaceThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -742,8 +675,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildMethodThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -766,8 +697,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Tests that the builder throws the expected exception when some one tries
      * to build a new node, when the internal state flag is frozen.
-     *
-     * @return void
      */
     public function testBuildFunctionThrowsExpectedExceptionWhenStateIsFrozen(): void
     {
@@ -789,8 +718,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCommentReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCommentReturnsExpectedType(): void
     {
@@ -802,8 +729,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTScalarTypeReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTScalarTypeReturnsExpectedType(): void
     {
@@ -815,8 +740,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTTypeArrayReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTTypeArrayReturnsExpectedType(): void
     {
@@ -829,7 +752,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTypeCallableReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTypeCallableReturnsExpectedType(): void
@@ -843,7 +765,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTypeCallableReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTypeIterableReturnsExpectedType(): void
@@ -856,8 +777,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTHeredocReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTHeredocReturnsExpectedType(): void
     {
@@ -869,8 +788,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTIdentifierReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTIdentifierReturnsExpectedType(): void
     {
@@ -882,8 +799,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTLiteralReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTLiteralReturnsExpectedType(): void
     {
@@ -895,8 +810,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTStringReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTStringReturnsExpectedType(): void
     {
@@ -909,7 +822,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTArrayReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTArrayReturnsExpectedType(): void
@@ -923,7 +835,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTArrayElementReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTArrayElementReturnsExpectedType(): void
@@ -936,8 +847,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTScopeReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTScopeReturnsExpectedType(): void
     {
@@ -949,8 +858,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTVariableReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTVariableReturnsExpectedType(): void
     {
@@ -962,8 +869,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTVariableVariableReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTVariableVariableReturnsExpectedType(): void
     {
@@ -975,8 +880,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCompoundVariableReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCompoundVariableReturnsExpectedType(): void
     {
@@ -988,8 +891,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTFieldDeclarationReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTFieldDeclarationReturnsExpectedType(): void
     {
@@ -1001,8 +902,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTConstantReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTConstantReturnsExpectedType(): void
     {
@@ -1014,8 +913,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTConstantDeclaratorReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTConstantDeclaratorReturnsExpectedType(): void
     {
@@ -1027,8 +924,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTConstantDefinitionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTConstantDefinitionReturnsExpectedType(): void
     {
@@ -1040,8 +935,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTConstantPostfixReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTConstantPostfixReturnsExpectedType(): void
     {
@@ -1053,8 +946,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTClassFqnPostfixReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTClassFqnPostfixReturnsExpectedType(): void
     {
@@ -1066,8 +957,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTAssignmentExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTAssignmentExpressionReturnsExpectedType(): void
     {
@@ -1080,7 +969,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTShiftLeftExpressionReturnsExpectedType
      *
-     * @return void
      * @since 1.0.1
      */
     public function testBuildASTShiftLeftExpressionReturnsExpectedType(): void
@@ -1094,7 +982,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTShiftRightExpressionReturnsExpectedType
      *
-     * @return void
      * @since 1.0.1
      */
     public function testBuildASTShiftRightExpressionReturnsExpectedType(): void
@@ -1107,8 +994,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTBooleanAndExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTBooleanAndExpressionReturnsExpectedType(): void
     {
@@ -1120,8 +1005,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTBooleanOrExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTBooleanOrExpressionReturnsExpectedType(): void
     {
@@ -1133,8 +1016,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCastExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCastExpressionReturnsExpectedType(): void
     {
@@ -1146,8 +1027,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCloneExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCloneExpressionReturnsExpectedType(): void
     {
@@ -1159,8 +1038,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCompoundExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCompoundExpressionReturnsExpectedType(): void
     {
@@ -1172,8 +1049,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTConditionalExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTConditionalExpressionReturnsExpectedType(): void
     {
@@ -1185,8 +1060,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTEvalExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTEvalExpressionReturnsExpectedType(): void
     {
@@ -1198,8 +1071,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTExitExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTExitExpressionReturnsExpectedType(): void
     {
@@ -1211,8 +1082,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTExpressionReturnsExpectedType(): void
     {
@@ -1224,8 +1093,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTIncludeExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTIncludeExpressionReturnsExpectedType(): void
     {
@@ -1237,8 +1104,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTInstanceOfExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTInstanceOfExpressionReturnsExpectedType(): void
     {
@@ -1250,8 +1115,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTIssetExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTIssetExpressionReturnsExpectedType(): void
     {
@@ -1263,8 +1126,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTListExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTListExpressionReturnsExpectedType(): void
     {
@@ -1276,8 +1137,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTLogicalAndExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTLogicalAndExpressionReturnsExpectedType(): void
     {
@@ -1289,8 +1148,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTLogicalOrExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTLogicalOrExpressionReturnsExpectedType(): void
     {
@@ -1302,8 +1159,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTLogicalXorExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTLogicalXorExpressionReturnsExpectedType(): void
     {
@@ -1315,8 +1170,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTRequireExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTRequireExpressionReturnsExpectedType(): void
     {
@@ -1328,8 +1181,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTStringIndexExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTStringIndexExpressionReturnsExpectedType(): void
     {
@@ -1341,8 +1192,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTUnaryExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTUnaryExpressionReturnsExpectedType(): void
     {
@@ -1354,8 +1203,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTBreakStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTBreakStatementReturnsExpectedType(): void
     {
@@ -1367,8 +1214,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTCatchStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTCatchStatementReturnsExpectedType(): void
     {
@@ -1380,8 +1225,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTFinallyStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTFinallyStatementReturnsExpectedType(): void
     {
@@ -1393,8 +1236,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTDeclareStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTDeclareStatementReturnsExpectedType(): void
     {
@@ -1406,8 +1247,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTIfStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTIfStatementReturnsExpectedType(): void
     {
@@ -1419,8 +1258,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTElseIfStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTElseIfStatementReturnsExpectedType(): void
     {
@@ -1432,8 +1269,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTContinueStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTContinueStatementReturnsExpectedType(): void
     {
@@ -1445,8 +1280,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTDoWhileStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTDoWhileStatementReturnsExpectedType(): void
     {
@@ -1458,8 +1291,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTForStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTForStatementReturnsExpectedType(): void
     {
@@ -1471,8 +1302,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTForInitReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTForInitReturnsExpectedType(): void
     {
@@ -1484,8 +1313,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTForUpdateReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTForUpdateReturnsExpectedType(): void
     {
@@ -1497,8 +1324,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTForeachStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTForeachStatementReturnsExpectedType(): void
     {
@@ -1510,8 +1335,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTFormalParametersReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTFormalParametersReturnsExpectedType(): void
     {
@@ -1523,8 +1346,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTFormalParameterReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTFormalParameterReturnsExpectedType(): void
     {
@@ -1536,8 +1357,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTGlobalStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTGlobalStatementReturnsExpectedType(): void
     {
@@ -1549,8 +1368,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTGotoStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTGotoStatementReturnsExpectedType(): void
     {
@@ -1562,8 +1379,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTLabelStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTLabelStatementReturnsExpectedType(): void
     {
@@ -1575,8 +1390,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTReturnStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTReturnStatementReturnsExpectedType(): void
     {
@@ -1588,8 +1401,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTScopeStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTScopeStatementReturnsExpectedType(): void
     {
@@ -1601,8 +1412,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTStatementReturnsExpectedType(): void
     {
@@ -1615,7 +1424,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTraitUseStatementReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTraitUseStatementReturnsExpectedType(): void
@@ -1629,7 +1437,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTraitAdaptationReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTraitAdaptationReturnsExpectedType(): void
@@ -1643,7 +1450,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTraitAdaptationAliasReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTraitAdaptationAliasReturnsExpectedType(): void
@@ -1657,7 +1463,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTraitAdaptationPrecedenceReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTraitAdaptationPrecedenceReturnsExpectedType(): void
@@ -1670,8 +1475,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTSwitchStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTSwitchStatementReturnsExpectedType(): void
     {
@@ -1683,8 +1486,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTThrowStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTThrowStatementReturnsExpectedType(): void
     {
@@ -1696,8 +1497,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTTryStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTTryStatementReturnsExpectedType(): void
     {
@@ -1709,8 +1508,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTUnsetStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTUnsetStatementReturnsExpectedType(): void
     {
@@ -1722,8 +1519,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTWhileStatementReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTWhileStatementReturnsExpectedType(): void
     {
@@ -1735,8 +1530,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTArrayIndexExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTArrayIndexExpressionReturnsExpectedType(): void
     {
@@ -1748,8 +1541,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTClosureReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTClosureReturnsExpectedType(): void
     {
@@ -1761,8 +1552,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTParentReferenceReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTParentReferenceReturnsExpectedType(): void
     {
@@ -1776,8 +1565,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTSelfReferenceReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTSelfReferenceReturnsExpectedType(): void
     {
@@ -1791,8 +1578,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTStaticReferenceReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTStaticReferenceReturnsExpectedType(): void
     {
@@ -1807,7 +1592,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTTraitReferenceReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTTraitReferenceReturnsExpectedType(): void
@@ -1820,8 +1604,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTClassReferenceReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTClassOrInterfaceReferenceReturnsExpectedType(): void
     {
@@ -1833,8 +1615,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTClassReferenceReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTClassReferenceReturnsExpectedType(): void
     {
@@ -1846,8 +1626,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTScalarTypeReturnsInstanceOfExpectedType
-     *
-     * @return void
      */
     public function testBuildASTScalarTypeReturnsInstanceOfExpectedType(): void
     {
@@ -1859,8 +1637,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTAllocationExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTAllocationExpressionReturnsExpectedType(): void
     {
@@ -1875,8 +1651,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTArgumentsReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTArgumentsReturnsExpectedType(): void
     {
@@ -1888,8 +1662,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTSwitchLabel
-     *
-     * @return void
      */
     public function testBuildASTSwitchLabel(): void
     {
@@ -1901,8 +1673,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTEchoStatetmentReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTEchoStatetmentReturnsExpectedType(): void
     {
@@ -1914,8 +1684,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTVariableDeclaratorReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTVariableDeclaratorReturnsExpectedType(): void
     {
@@ -1927,8 +1695,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTStaticVariableDeclarationReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTStaticVariableDeclarationReturnsExpectedType(): void
     {
@@ -1940,8 +1706,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTPostfixExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTPostfixExpressionReturnsExpectedType(): void
     {
@@ -1953,8 +1717,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTPreDecrementExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTPreDecrementExpressionReturnsExpectedType(): void
     {
@@ -1966,8 +1728,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTPreIncrementExpressionReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTPreIncrementExpressionReturnsExpectedType(): void
     {
@@ -1980,7 +1740,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTMemberPrimaryPrefixReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTMemberPrimaryPrefixReturnsExpectedType(): void
@@ -1994,7 +1753,6 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * testBuildASTMethodPostfixReturnsExpectedType
      *
-     * @return void
      * @since 1.0.0
      */
     public function testBuildASTMethodPostfixReturnsExpectedType(): void
@@ -2007,8 +1765,6 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * testBuildASTFunctionPostfixReturnsExpectedType
-     *
-     * @return void
      */
     public function testBuildASTFunctionPostfixReturnsExpectedType(): void
     {
@@ -2021,7 +1777,7 @@ class PHPBuilderTest extends AbstractTestCase
     /**
      * Creates a clean builder test instance.
      *
-     * @return \PDepend\Source\Language\PHP\PHPBuilder
+     * @return PHPBuilder
      */
     protected function createBuilder()
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 
@@ -48,19 +49,19 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  *
- * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
  * @group unittest
  */
 class PHPParserGenericTest extends AbstractTestCase
 {
     /**
      * testParserAcceptsStringAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsStringAsClassName(): void
     {
@@ -70,8 +71,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsStringAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsStringAsInterfaceName(): void
     {
@@ -81,8 +80,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsNullAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsClassName(): void
     {
@@ -92,8 +89,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsNullAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsInterfaceName(): void
     {
@@ -103,8 +98,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTrueAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsClassName(): void
     {
@@ -114,8 +107,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTrueAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsInterfaceName(): void
     {
@@ -125,8 +116,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsFalseAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsClassName(): void
     {
@@ -136,8 +125,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsFalseAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsInterfaceName(): void
     {
@@ -147,8 +134,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsInsteadofAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsInsteadofAsClassName(): void
     {
@@ -158,8 +143,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsInsteadofAsFunctionName
-     *
-     * @return void
      */
     public function testParserAcceptsInsteadofAsFunctionName(): void
     {
@@ -169,8 +152,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsInsteadofAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsInsteadofAsInterfaceName(): void
     {
@@ -180,8 +161,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsInsteadofAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsInsteadofAsMethodName(): void
     {
@@ -191,8 +170,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsInsteadofAsNamespaceName
-     *
-     * @return void
      */
     public function testParserAcceptsInsteadofAsNamespaceName(): void
     {
@@ -202,8 +179,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsUseAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsUseAsClassName(): void
     {
@@ -213,8 +188,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsUseAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsUseAsInterfaceName(): void
     {
@@ -225,7 +198,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceAsClassName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceAsClassName(): void
@@ -237,7 +209,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceAsInterfaceName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceAsInterfaceName(): void
@@ -249,7 +220,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceConstantAsClassName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceConstantAsClassName(): void
@@ -261,7 +231,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceConstantAsInterfaceName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceConstantAsInterfaceName(): void
@@ -273,7 +242,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsTraitAsClassName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsTraitAsClassName(): void
@@ -285,7 +253,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsTraitAsInterfaceName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsTraitAsInterfaceName(): void
@@ -297,7 +264,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsTraitConstantAsClassName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsTraitConstantAsClassName(): void
@@ -309,7 +275,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsTraitConstantAsInterfaceName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsTraitConstantAsInterfaceName(): void
@@ -320,8 +285,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsGotoKeywordAsClassName
-     *
-     * @return void
      */
     public function testParserAcceptsGotoKeywordAsClassName(): void
     {
@@ -331,8 +294,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsGotoKeywordAsInterfaceName
-     *
-     * @return void
      */
     public function testParserAcceptsGotoKeywordAsInterfaceName(): void
     {
@@ -343,7 +304,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsDirConstantAsClassName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsDirConstantAsClassName(): void
@@ -355,7 +315,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsDirConstantAsInterfaceName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsDirConstantAsInterfaceName(): void
@@ -367,7 +326,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserThrowsExpectedExceptionOnTokenStreamEnd
      *
-     * @return void
      * @covers \PDepend\Source\Parser\TokenStreamEndException
      */
     public function testParserThrowsExpectedExceptionOnTokenStreamEnd(): void
@@ -380,7 +338,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserThrowsExpectedExceptionForUnexpectedTokenType
      *
-     * @return void
      * @covers \PDepend\Source\Parser\UnexpectedTokenException
      */
     public function testParserThrowsExpectedExceptionForUnexpectedTokenType(): void
@@ -392,8 +349,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsStringAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsStringAsMethodName(): void
     {
@@ -403,8 +358,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsUseKeywordAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsUseKeywordAsMethodName(): void
     {
@@ -414,8 +367,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsGotoKeywordAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsGotoKeywordAsMethodName(): void
     {
@@ -425,8 +376,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsSelfKeywordAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsSelfKeywordAsMethodName(): void
     {
@@ -436,8 +385,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsNullAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsNullAsMethodName(): void
     {
@@ -447,8 +394,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTrueAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsTrueAsMethodName(): void
     {
@@ -458,8 +403,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsFalseAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsFalseAsMethodName(): void
     {
@@ -469,8 +412,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsDirConstantAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsDirConstantAsMethodName(): void
     {
@@ -481,7 +422,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceKeywordAsMethodName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceKeywordAsMethodName(): void
@@ -493,7 +433,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceConstantAsMethodName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceConstantAsMethodName(): void
@@ -504,8 +443,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsParentKeywordAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsParentKeywordAsMethodName(): void
     {
@@ -516,7 +453,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesCallableTypeHint
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesCallableTypeHint(): void
@@ -530,7 +466,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesNamespaceTypeHint
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesNamespaceTypeHint(): void
@@ -544,7 +479,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesArrayTypeHint
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesArrayTypeHint(): void
@@ -558,7 +492,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesSelfTypeHint
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesSelfTypeHint(): void
@@ -572,7 +505,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesCompoundStaticMethodInvocation
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesCompoundStaticMethodInvocation(): void
@@ -586,7 +518,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesVariableStaticMethodInvocation
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesVariableStaticMethodInvocation(): void
@@ -599,8 +530,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInvalidToken
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInvalidToken(): void
     {
@@ -611,8 +540,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTokenStreamEnd
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTokenStreamEnd(): void
     {
@@ -624,7 +551,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesRegularArraySyntax
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesRegularArraySyntax(): void
@@ -639,7 +565,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserHandlesShortArraySyntax
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserHandlesShortArraySyntax(): void
@@ -652,7 +577,6 @@ class PHPParserGenericTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 1.1.1
      */
     public function testParserHandlesShortArraySyntaxForFormalParameter(): void
@@ -661,7 +585,6 @@ class PHPParserGenericTest extends AbstractTestCase
     }
 
     /**
-     * @return void
      * @since 1.1.1
      */
     public function testParserHandlesShortArraySyntaxForFieldDeclaration(): void
@@ -672,7 +595,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsGotoAsFunctionName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsGotoAsFunctionName(): void
@@ -684,7 +606,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsDirConstantAsFunctionName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsDirConstantAsFunctionName(): void
@@ -696,7 +617,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceKeywordAsFunctionName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceKeywordAsFunctionName(): void
@@ -708,7 +628,6 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * testParserAcceptsNamespaceConstantAsFunctionName
      *
-     * @return void
      * @since 1.0.0
      */
     public function testParserAcceptsNamespaceConstantAsFunctionName(): void
@@ -719,8 +638,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTraitAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsTraitAsMethodName(): void
     {
@@ -730,8 +647,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTraitConstantAsMethodName
-     *
-     * @return void
      */
     public function testParserAcceptsTraitConstantAsMethodName(): void
     {
@@ -741,8 +656,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTraitAsFunctionName
-     *
-     * @return void
      */
     public function testParserAcceptsTraitAsFunctionName(): void
     {
@@ -752,8 +665,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAcceptsTraitConstantAsFunctionName
-     *
-     * @return void
      */
     public function testParserAcceptsTraitConstantAsFunctionName(): void
     {
@@ -763,8 +674,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserAllowsKeywordCallableAsPropertyName
-     *
-     * @return void
      */
     public function testParserAllowsKeywordCallableAsPropertyName(): void
     {
@@ -772,9 +681,6 @@ class PHPParserGenericTest extends AbstractTestCase
         $this->assertNotNull($method);
     }
 
-    /**
-     * @return void
-     */
     public function testParserHandlesExtraParenthesisForIsset(): void
     {
         $this->assertEmpty($this->parseCodeResourceForTest());

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 
@@ -48,21 +49,21 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @since 2.1.0
- *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
+ *
  * @link https://github.com/pdepend/pdepend/issues/180
+ * @since 2.1.0
  */
 class PHPParserGenericVersion56Test extends AbstractTestCase
 {
     /**
      * testShiftLeftInConstantInitializer
-     *
-     * @return void
      */
     public function testShiftLeftInConstantInitializer(): void
     {
@@ -74,8 +75,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testShiftRightInConstantInitializer
-     *
-     * @return void
      */
     public function testShiftRightInConstantInitializer(): void
     {
@@ -87,8 +86,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testShiftLeftInConstantInitializer
-     *
-     * @return void
      */
     public function testMultipleShiftLeftInConstantInitializer(): void
     {
@@ -100,8 +97,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testShiftRightInConstantInitializer
-     *
-     * @return void
      */
     public function testMultipleShiftRightInConstantInitializer(): void
     {
@@ -114,7 +109,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     /**
      * testConstantSupportForScalarArrayValues
      *
-     * @return void
      * @link https://github.com/pdepend/pdepend/issues/209
      */
     public function testConstantSupportForArrayWithValues(): void
@@ -128,7 +122,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     /**
      * testConstantSupportForArrayWithKeyValuePairs
      *
-     * @return void
      * @link https://github.com/pdepend/pdepend/issues/209
      */
     public function testConstantSupportForArrayWithKeyValuePairs(): void
@@ -142,7 +135,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     /**
      * testConstantSupportForArrayWithSelfReferenceInClass
      *
-     * @return void
      * @link https://github.com/pdepend/pdepend/issues/192
      */
     public function testConstantSupportForArrayWithSelfReferenceInClass(): void
@@ -156,7 +148,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     /**
      * testConstantSupportForArrayWithSelfReferenceInInterface
      *
-     * @return void
      * @link https://github.com/pdepend/pdepend/issues/192
      */
     public function testConstantSupportForArrayWithSelfReferenceInInterface(): void
@@ -169,8 +160,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInParameterInitializer
-     *
-     * @return void
      */
     public function testComplexExpressionInParameterInitializer(): void
     {
@@ -182,8 +171,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInConstantDeclarator
-     *
-     * @return void
      */
     public function testComplexExpressionInConstantDeclarator(): void
     {
@@ -195,8 +182,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInFieldDeclaration
-     *
-     * @return void
      */
     public function testComplexExpressionInFieldDeclaration(): void
     {
@@ -208,8 +193,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testPowExpressionInMethodBody
-     *
-     * @return void
      */
     public function testPowExpressionInMethodBody(): void
     {
@@ -221,8 +204,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
 
     /**
      * testPowExpressionInFieldDeclaration
-     *
-     * @return void
      */
     public function testPowExpressionInFieldDeclaration(): void
     {
@@ -232,9 +213,6 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $this->assertNotNull($node);
     }
 
-    /**
-     * @return void
-     */
     public function testEllipsisOperatorInFunctionCall(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since     0.9.20
  */
 
@@ -50,18 +51,18 @@ use PDepend\Source\AST\ASTNamespace;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
- * @copyright 2008-2013 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
+ *
+ * @copyright 2008-2013 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class PHPParserGenericVersion70Test extends AbstractTestCase
 {
     /**
      * testFormalParameterScalarTypeHintInt
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintInt(): void
     {
@@ -73,8 +74,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintString
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintString(): void
     {
@@ -86,8 +85,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintFloat
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintFloat(): void
     {
@@ -99,8 +96,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintBool
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintBool(): void
     {
@@ -112,8 +107,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFormalParameterStillWorksWithTypeHintArray
-     *
-     * @return void
      */
     public function testFormalParameterStillWorksWithTypeHintArray(): void
     {
@@ -124,8 +117,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintInt
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintInt(): void
     {
@@ -137,8 +128,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintSelf
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintSelf(): void
     {
@@ -150,8 +139,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintParent
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintParent(): void
     {
@@ -163,8 +150,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintFloat
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintFloat(): void
     {
@@ -176,8 +161,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintString
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintString(): void
     {
@@ -189,8 +172,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintBool
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintBool(): void
     {
@@ -202,8 +183,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintArray
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintArray(): void
     {
@@ -215,8 +194,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintCallable
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintCallable(): void
     {
@@ -230,8 +207,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintClass
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintClass(): void
     {
@@ -245,8 +220,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintInt
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintInt(): void
     {
@@ -258,8 +231,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintFloat
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintFloat(): void
     {
@@ -271,8 +242,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintString
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintString(): void
     {
@@ -284,8 +253,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintBool
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintBool(): void
     {
@@ -297,8 +264,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintArray
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintArray(): void
     {
@@ -310,8 +275,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintCallable
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintCallable(): void
     {
@@ -325,8 +288,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintClass
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintClass(): void
     {
@@ -340,8 +301,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithStrings
-     *
-     * @return void
      */
     public function testSpaceshipOperatorWithStrings(): void
     {
@@ -354,8 +313,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithNumbers
-     *
-     * @return void
      */
     public function testSpaceshipOperatorWithNumbers(): void
     {
@@ -383,8 +340,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedStartLine(ASTExpression $expr): void
@@ -393,8 +348,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedEndLine(ASTExpression $expr): void
@@ -403,8 +356,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedStartColumn(ASTExpression $expr): void
@@ -413,8 +364,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedEndColumn(ASTExpression $expr): void
@@ -424,8 +373,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     /**
      * testNullCoalesceOperator
-     *
-     * @return void
      */
     public function testNullCoalesceOperator(): void
     {
@@ -436,18 +383,12 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
         $this->assertSame('??', $expr->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testListKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertNotNull($method);
     }
 
-    /**
-     * @return void
-     */
     public function testListKeywordAsFunctionNameThrowsException(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
@@ -456,7 +397,7 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function testGroupUseStatement()
     {
@@ -467,8 +408,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testGroupUseStatement
      */
     public function testGroupUseStatementClassNameResolution(ASTNamespace $namespace): void
@@ -483,8 +422,6 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testGroupUseStatement
      */
     public function testGroupUseStatementAliasResolution(ASTNamespace $namespace): void
@@ -498,65 +435,41 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testUniformVariableSyntax(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testConstantNameArray(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassConstantNames(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassConstantNamesAccessed(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassMethodNames(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassMethodNamesInvoked(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testMethodsCanBeCallOnInstancesReturnedByInvokableObject(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testMultipleArgumentsInInvocation(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since     0.9.20
  */
 
@@ -48,33 +49,26 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
- * @copyright 2008-2013 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
+ *
+ * @copyright 2008-2013 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @group unittest
  */
 class PHPParserGenericVersion71Test extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
     public function testConstVisibility(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testNullableTypeHintParameter(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testNullableTypeHintReturn(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -64,17 +64,17 @@ use ReflectionMethod;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion72} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
+ *
  * @group unittest
  */
 class PHPParserVersion72Test extends AbstractTestCase
 {
     /**
      * testParserAllowsKeywordCallableAsPropertyName
-     *
-     * @return void
      */
     public function testParserAllowsKeywordCallableAsPropertyName(): void
     {
@@ -99,8 +99,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     /**
      * Tests that the parser throws an exception when trying to parse an array
      * when being at the end of the file.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForArrayWithEOF(): void
     {
@@ -130,8 +128,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserHandlesBinaryIntegerLiteral
-     *
-     * @return void
      */
     public function testParserHandlesBinaryIntegerLiteral(): void
     {
@@ -143,8 +139,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserHandlesStaticMemberExpressionSyntax
-     *
-     * @return void
      */
     public function testParserHandlesStaticMemberExpressionSyntax(): void
     {
@@ -156,8 +150,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTraitAsClassName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTraitAsClassName(): void
     {
@@ -168,8 +160,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTraitAsFunctionName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTraitAsFunctionName(): void
     {
@@ -180,8 +170,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTraitAsInterfaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTraitAsInterfaceName(): void
     {
@@ -192,8 +180,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTraitAsNamespaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTraitAsNamespaceName(): void
     {
@@ -204,8 +190,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForTraitAsCalledFunction
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForTraitAsCalledFunction(): void
     {
@@ -216,8 +200,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInsteadOfAsClassName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInsteadOfAsClassName(): void
     {
@@ -228,8 +210,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInsteadOfAsFunctionName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInsteadOfAsFunctionName(): void
     {
@@ -240,8 +220,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInsteadOfAsInterfaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInsteadOfAsInterfaceName(): void
     {
@@ -252,8 +230,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInsteadOfAsInterfaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInsteadOfAsNamespaceName(): void
     {
@@ -264,8 +240,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForInsteadOfAsCalledFunction
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForInsteadOfAsCalledFunction(): void
     {
@@ -276,8 +250,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForCallableAsClassName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForCallableAsClassName(): void
     {
@@ -288,8 +260,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForCallableAsFunctionName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForCallableAsFunctionName(): void
     {
@@ -300,8 +270,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForCallableAsInterfaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForCallableAsInterfaceName(): void
     {
@@ -312,8 +280,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForCallableAsInterfaceName
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForCallableAsNamespaceName(): void
     {
@@ -324,8 +290,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForCallableAsCalledFunction
-     *
-     * @return void
      */
     public function testParserThrowsExpectedExceptionForCallableAsCalledFunction(): void
     {
@@ -334,9 +298,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return void
-     */
     public function testMagicTraitConstantInString(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
@@ -344,8 +305,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * Tests that ::class is allowed PHP >= 5.5.
-     *
-     * @return void
      */
     public function testDoubleColonClass(): void
     {
@@ -354,8 +313,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInParameterInitializer
-     *
-     * @return void
      */
     public function testComplexExpressionInParameterInitializer(): void
     {
@@ -367,8 +324,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInConstantInitializer
-     *
-     * @return void
      */
     public function testComplexExpressionInConstantDeclarator(): void
     {
@@ -380,8 +335,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testComplexExpressionInFieldDeclaration
-     *
-     * @return void
      */
     public function testComplexExpressionInFieldDeclaration(): void
     {
@@ -393,8 +346,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testPowExpressionInMethodBody
-     *
-     * @return void
      */
     public function testPowExpressionInMethodBody(): void
     {
@@ -406,8 +357,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testPowExpressionInFieldDeclaration
-     *
-     * @return void
      */
     public function testPowExpressionInFieldDeclaration(): void
     {
@@ -417,17 +366,11 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertNotNull($node);
     }
 
-    /**
-     * @return void
-     */
     public function testUseStatement(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testEllipsisOperatorInFunctionCall(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
@@ -435,8 +378,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * Test that static array property is well linked to its self:: / static:: accesses.
-     *
-     * @return void
      */
     public function testStaticArrayProperty(): void
     {
@@ -464,8 +405,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     /**
      * Tests issue with constant array concatenation.
      * https://github.com/pdepend/pdepend/issues/299
-     *
-     * @return void
      */
     public function testConstantArrayConcatenation(): void
     {
@@ -505,8 +444,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     /**
      * Tests that the parser throws an exception when trying to parse a value
      * when given a non-value token type.
-     *
-     * @return void
      */
     public function testParserThrowsUnexpectedTokenExceptionForOF(): void
     {
@@ -536,8 +473,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintInt
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintInt(): void
     {
@@ -549,8 +484,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintString
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintString(): void
     {
@@ -562,8 +495,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintFloat
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintFloat(): void
     {
@@ -575,8 +506,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFormalParameterScalarTypeHintBool
-     *
-     * @return void
      */
     public function testFormalParameterScalarTypeHintBool(): void
     {
@@ -588,8 +517,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFormalParameterStillWorksWithTypeHintArray
-     *
-     * @return void
      */
     public function testFormalParameterStillWorksWithTypeHintArray(): void
     {
@@ -600,8 +527,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintInt
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintInt(): void
     {
@@ -613,8 +538,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintFloat
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintFloat(): void
     {
@@ -626,8 +549,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintString
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintString(): void
     {
@@ -639,8 +560,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintBool
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintBool(): void
     {
@@ -652,8 +571,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintArray
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintArray(): void
     {
@@ -665,8 +582,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintCallable
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintCallable(): void
     {
@@ -680,8 +595,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintClass
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintClass(): void
     {
@@ -695,8 +608,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintInt
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintInt(): void
     {
@@ -708,8 +619,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintFloat
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintFloat(): void
     {
@@ -721,8 +630,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintString
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintString(): void
     {
@@ -734,8 +641,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintBool
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintBool(): void
     {
@@ -747,8 +652,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintArray
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintArray(): void
     {
@@ -760,8 +663,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintCallable
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintCallable(): void
     {
@@ -775,8 +676,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testClosureReturnTypeHintClass
-     *
-     * @return void
      */
     public function testClosureReturnTypeHintClass(): void
     {
@@ -790,8 +689,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithStrings
-     *
-     * @return void
      */
     public function testSpaceshipOperatorWithStrings(): void
     {
@@ -804,8 +701,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithNumbers
-     *
-     * @return void
      */
     public function testSpaceshipOperatorWithNumbers(): void
     {
@@ -819,7 +714,7 @@ class PHPParserVersion72Test extends AbstractTestCase
     /**
      * testSpaceshipOperatorWithArrays
      *
-     * @return \PDepend\Source\AST\ASTExpression
+     * @return ASTExpression
      */
     public function testSpaceshipOperatorWithArrays()
     {
@@ -833,8 +728,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedStartLine(ASTExpression $expr): void
@@ -843,8 +736,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedEndLine(ASTExpression $expr): void
@@ -853,8 +744,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedStartColumn(ASTExpression $expr): void
@@ -863,8 +752,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTExpression $expr
-     * @return void
      * @depends testSpaceshipOperatorWithArrays
      */
     public function testSpaceshipOperatorHasExpectedEndColumn(ASTExpression $expr): void
@@ -874,8 +761,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testNullCoalesceOperator
-     *
-     * @return void
      */
     public function testNullCoalesceOperator(): void
     {
@@ -886,18 +771,12 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('??', $expr->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testListKeywordAsMethodName(): void
     {
         $method = $this->getFirstMethodForTestCase();
         $this->assertNotNull($method);
     }
 
-    /**
-     * @return void
-     */
     public function testListKeywordAsFunctionNameThrowsException(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
@@ -906,7 +785,7 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function testGroupUseStatement()
     {
@@ -917,8 +796,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testGroupUseStatement
      */
     public function testGroupUseStatementClassNameResolution(ASTNamespace $namespace): void
@@ -933,8 +810,6 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace $namespace
-     * @return void
      * @depends testGroupUseStatement
      */
     public function testGroupUseStatementAliasResolution(ASTNamespace $namespace): void
@@ -948,65 +823,41 @@ class PHPParserVersion72Test extends AbstractTestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testUniformVariableSyntax(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testConstantNameArray(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassConstantNames(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassConstantNamesAccessed(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassMethodNames(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testClassMethodNamesInvoked(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testYieldFrom(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testParseList(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
@@ -1117,33 +968,22 @@ class PHPParserVersion72Test extends AbstractTestCase
     /**
      * Tests that the parser does not throw an exception when it detects a reserved
      * keyword in constant class names.
-     *
-     * @return void
      */
     public function testReservedKeyword(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testConstVisibility(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testConstVisibilityInInterfacePublic(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testConstVisibilityInInterfaceProtected(): void
     {
         $this->expectException(
@@ -1156,9 +996,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return void
-     */
     public function testConstVisibilityInInterfacePrivate(): void
     {
         $this->expectException(
@@ -1171,41 +1008,26 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return void
-     */
     public function testCatchMultipleExceptionClasses(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testNullableTypeHintParameter(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testNullableTypeHintReturn(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testParseListWithVariableKey(): void
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
     }
 
-    /**
-     * @return void
-     */
     public function testIterableTypeHintParameter(): void
     {
         $type = $this->getFirstFormalParameterForTestCase()->getType();
@@ -1215,9 +1037,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('iterable', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testIterableTypeHintReturn(): void
     {
         $type = $this->getFirstFunctionForTestCase()->getReturnType();
@@ -1227,9 +1046,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('iterable', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testVoidTypeHintReturn(): void
     {
         $type = $this->getFirstFunctionForTestCase()->getReturnType();
@@ -1239,9 +1055,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('void', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testVoidTypeHintReturnNamespaced(): void
     {
         $type = $this->getFirstFunctionForTestCase()->getReturnType();
@@ -1252,8 +1065,6 @@ class PHPParserVersion72Test extends AbstractTestCase
 
     /**
      * testSymmetricArrayDestructuringEmptySlot
-     *
-     * @return void
      */
     public function testSymmetricArrayDestructuringEmptySlot(): void
     {
@@ -1266,17 +1077,11 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('$b', $array->getChild(0)->getChild(0)->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testClassStartLine(): void
     {
         $this->assertSame(6, $this->getFirstClassForTestCase()->getStartLine());
     }
 
-    /**
-     * @return void
-     */
     public function testObjectTypeHintReturn(): void
     {
         $type = $this->getFirstFunctionForTestCase()->getReturnType();
@@ -1286,9 +1091,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         $this->assertSame('object', $type->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testObjectTypeHintParameter(): void
     {
         $type = $this->getFirstFormalParameterForTestCase()->getType();
@@ -1319,7 +1121,7 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     public function testGroupUseStatementTrailingComma()
     {
@@ -1329,10 +1131,7 @@ class PHPParserVersion72Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
@@ -1342,8 +1141,6 @@ class PHPParserVersion72Test extends AbstractTestCase
         );
     }
 
-    /**
-     */
     public function testTrailingCommasInUnsetCall(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
@@ -56,16 +56,15 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion73} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion73
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion73
+ *
  * @group unittest
  */
 class PHPParserVersion73Test extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
     public function testArrowFunctions(): void
     {
         $this->expectException(
@@ -78,9 +77,6 @@ class PHPParserVersion73Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return void
-     */
     public function testHereDocAndNowDoc(): void
     {
         /** @var ASTHeredoc $heredoc */
@@ -101,9 +97,6 @@ class PHPParserVersion73Test extends AbstractTestCase
         $this->assertSame('second,', $literal->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testDestructuringArrayReference(): void
     {
         $functionChildren = $this->getFirstFunctionForTestCase()->getChildren();
@@ -143,9 +136,6 @@ class PHPParserVersion73Test extends AbstractTestCase
         $this->assertSame('$c', $cVariable->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testInstanceOfLiterals(): void
     {
         $functionChildren = $this->getFirstFunctionForTestCase()->getChildren();
@@ -166,9 +156,6 @@ class PHPParserVersion73Test extends AbstractTestCase
         $this->assertSame('DateTimeInterface', $variables[0]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testTrailingCommasInCall(): void
     {
         $functionChildren = $this->getFirstFunctionForTestCase()->getChildren();
@@ -192,9 +179,6 @@ class PHPParserVersion73Test extends AbstractTestCase
         $this->assertSame('$i', $arguments[0]->getImage());
     }
 
-    /**
-     * @return void
-     */
     public function testTrailingCommasInUnsetCall(): void
     {
         $functionChildren = $this->getFirstFunctionForTestCase()->getChildren();
@@ -207,10 +191,7 @@ class PHPParserVersion73Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -62,16 +62,15 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion74} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion74
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion74
+ *
  * @group unittest
  */
 class PHPParserVersion74Test extends AbstractTestCase
 {
-    /**
-     * @return void
-     */
     public function testTypedProperties(): void
     {
         /** @var ASTClass $class */
@@ -208,7 +207,7 @@ class PHPParserVersion74Test extends AbstractTestCase
             '*',
             '2',
         ], array_map(
-            static fn (ASTNode $node) => $node->getImage(),
+            static fn(ASTNode $node) => $node->getImage(),
             $expression->getChildren(),
         ));
     }
@@ -255,7 +254,7 @@ class PHPParserVersion74Test extends AbstractTestCase
             '*',
             '2',
         ], array_map(
-            static fn (ASTNode $node) => $node->getImage(),
+            static fn(ASTNode $node) => $node->getImage(),
             $expression->getChildren(),
         ));
     }
@@ -291,7 +290,7 @@ class PHPParserVersion74Test extends AbstractTestCase
         ], array_map('get_class', $expression->getChildren()));
         /** @var ASTNode[] $elements */
         $elements = array_map(
-            static fn ($node) => $node->getChild(0),
+            static fn($node) => $node->getChild(0),
             $expression->getChildren(),
         );
         $this->assertSame([
@@ -307,7 +306,7 @@ class PHPParserVersion74Test extends AbstractTestCase
             '...',
             '$numbers',
         ], array_map(
-            static fn (ASTNode $node) => $node->getImage(),
+            static fn(ASTNode $node) => $node->getImage(),
             $expression->getChildren(),
         ));
     }
@@ -340,8 +339,6 @@ class PHPParserVersion74Test extends AbstractTestCase
      *
      * Already checked in PHPParserVersion56Test, the level it belongs.
      * Here we ensure it's still working in 7.4 parser.
-     *
-     * @return void
      */
     public function testConstantArrayConcatenation(): void
     {
@@ -380,13 +377,11 @@ class PHPParserVersion74Test extends AbstractTestCase
 
     public function testReadOnlyNamedImport(): void
     {
-        $this->expectException(\OutOfBoundsException::class);
+        $this->expectException(OutOfBoundsException::class);
 
         $this->parseCodeResourceForTest()->current();
     }
 
-    /**
-     */
     public function testCatchWithoutVariable(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
@@ -395,8 +390,6 @@ class PHPParserVersion74Test extends AbstractTestCase
         $this->getFirstClassForTestCase();
     }
 
-    /**
-     */
     public function testTrailingCommaInClosureUseListError(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
@@ -405,8 +398,6 @@ class PHPParserVersion74Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     */
     public function testTrailingCommaInParameterList(): void
     {
         $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
@@ -416,10 +407,7 @@ class PHPParserVersion74Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -50,17 +50,17 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion80} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
+ *
  * @group unittest
  */
 class PHPParserVersion80Test extends AbstractTestCase
 {
     /**
      * testCatchWithoutVariable
-     *
-     * @return void
      */
     public function testCatchWithoutVariable(): void
     {
@@ -73,8 +73,6 @@ class PHPParserVersion80Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintStatic
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintStatic(): void
     {
@@ -86,8 +84,6 @@ class PHPParserVersion80Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintNullableStatic
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintNullableStatic(): void
     {
@@ -99,8 +95,6 @@ class PHPParserVersion80Test extends AbstractTestCase
 
     /**
      * testFunctionReturnTypeHintStaticWithComments
-     *
-     * @return void
      */
     public function testFunctionReturnTypeHintStaticWithComments(): void
     {
@@ -112,8 +106,6 @@ class PHPParserVersion80Test extends AbstractTestCase
 
     /**
      * testFunctionParameterTypeHintByReferenceVariableArguments
-     *
-     * @return void
      */
     public function testFunctionParameterTypeHintByReferenceVariableArguments(): void
     {
@@ -127,9 +119,6 @@ class PHPParserVersion80Test extends AbstractTestCase
         $this->assertTrue($formalParameter->isVariableArgList());
     }
 
-    /**
-     * @return void
-     */
     public function testTrailingCommaInClosureUseList(): void
     {
         $this->parseCodeResourceForTest();
@@ -137,8 +126,6 @@ class PHPParserVersion80Test extends AbstractTestCase
 
     /**
      * testTrailingCommaInParameterList
-     *
-     * @return void
      */
     public function testTrailingCommaInParameterList(): void
     {
@@ -187,10 +174,7 @@ class PHPParserVersion80Test extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\Tokenizer\Tokenizer $tokenizer
-     * @param \PDepend\Source\Builder\Builder $builder
-     * @param \PDepend\Util\Cache\CacheDriver $cache
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -49,10 +49,11 @@ use PDepend\Source\Tokenizer\Tokens;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPTokenizerInternal} class.
  *
+ * @covers \PDepend\Source\Language\PHP\PHPTokenizerInternal
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Language\PHP\PHPTokenizerInternal
  * @group unittest
  */
 class PHPTokenizerInternalTest extends AbstractTestCase
@@ -60,7 +61,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
     /**
      * testTokenizerReturnsExpectedConstantForTraitKeyword
      *
-     * @return void
      * @since 1.0.0
      */
     public function testTokenizerReturnsExpectedConstantForTraitKeyword(): void
@@ -90,7 +90,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
     /**
      * testTokenizerReturnsExpectedConstantForTraitMagicConstant
      *
-     * @return void
      * @since 1.0.0
      */
     public function testTokenizerReturnsExpectedConstantForTraitMagicConstant(): void
@@ -119,8 +118,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Tests the tokenizer with a source file that contains only classes.
-     *
-     * @return void
      */
     public function testInternalWithClasses(): void
     {
@@ -158,7 +155,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
             Tokens::T_TRUE,
             Tokens::T_SEMICOLON,
             Tokens::T_CURLY_BRACE_CLOSE,
-            Tokens::T_CURLY_BRACE_CLOSE
+            Tokens::T_CURLY_BRACE_CLOSE,
         ];
 
         $this->assertEquals($expected, $this->getTokenTypesForTest());
@@ -167,8 +164,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
     /**
      * Tests the tokenizer with a source file that contains mixed content of
      * classes and functions.
-     *
-     * @return void
      */
     public function testInternalWithMixedContent(): void
     {
@@ -201,7 +196,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
             [Tokens::T_CURLY_BRACE_OPEN, 13],
             [Tokens::T_COMMENT, 14],
             [Tokens::T_CURLY_BRACE_CLOSE, 15],
-            [Tokens::T_CLOSE_TAG, 16]
+            [Tokens::T_CLOSE_TAG, 16],
         ];
 
         $actual = [];
@@ -215,8 +210,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
     /**
      * Tests that the tokenizer returns <b>T_BOF</b> if there is no previous
      * token.
-     *
-     * @return void
      */
     public function testInternalReturnsBOFTokenForPrevCall(): void
     {
@@ -228,8 +221,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Tests the tokenizer with a combination of procedural code and functions.
-     *
-     * @return void
      */
     public function testInternalWithProceduralCodeAndFunction(): void
     {
@@ -266,7 +257,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
             Tokens::T_PARENTHESIS_CLOSE,
             Tokens::T_PARENTHESIS_CLOSE,
             Tokens::T_SEMICOLON,
-            Tokens::T_CLOSE_TAG
+            Tokens::T_CLOSE_TAG,
         ];
 
         $this->assertEquals($expected, $this->getTokenTypesForTest());
@@ -274,8 +265,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Test case for undetected static method call added.
-     *
-     * @return void
      */
     public function testInternalStaticCallBug01(): void
     {
@@ -316,8 +305,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
      * </code>
      *
      * http://bugs.xplib.de/index.php?do=details&task_id=9&project=3
-     *
-     * @return void
      */
     public function testInternalDollarSyntaxBug09(): void
     {
@@ -350,8 +337,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Test case for the inline html bug.
-     *
-     * @return void
      */
     public function testTokenizerWithInlineHtmlBug24(): void
     {
@@ -409,8 +394,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Tests the tokenizer's column calculation implementation.
-     *
-     * @return void
      */
     public function testTokenizerCalculatesCorrectColumnForInlinePhpIssue88(): void
     {
@@ -444,7 +427,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
                 $token->startLine,
                 $token->endLine,
                 $token->startColumn,
-                $token->endColumn
+                $token->endColumn,
             ];
         }
 
@@ -453,8 +436,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Tests the tokenizer support short-echo-tags with multiple variables separated by comas.
-     *
-     * @return void
      */
     public function testTokenizingShortTagsWithMultipleVariables(): void
     {
@@ -477,7 +458,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
                 $token->startLine,
                 $token->endLine,
                 $token->startColumn,
-                $token->endColumn
+                $token->endColumn,
             ];
         }
 
@@ -490,8 +471,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * Tests the tokenizer's column calculation implementation.
-     *
-     * @return void
      */
     public function testTokenizerCalculatesCorrectColumnForInlinePhpInTextIssue88(): void
     {
@@ -522,7 +501,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
                 $token->startLine,
                 $token->endLine,
                 $token->startColumn,
-                $token->endColumn
+                $token->endColumn,
             ];
         }
 
@@ -531,8 +510,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * testTokenizerSubstitutesDollarCurlyOpenWithTwoSeparateTokens
-     *
-     * @return void
      */
     public function testTokenizerSubstitutesDollarCurlyOpenWithTwoSeparateTokens(): void
     {
@@ -560,8 +537,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * testReturnsExpectedTokensForStringWithEmbeddedBacktickExpression
-     *
-     * @return void
      */
     public function testReturnsExpectedTokensForStringWithEmbeddedBacktickExpression(): void
     {
@@ -588,8 +563,6 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
     /**
      * testReturnsExpectedTokensForBacktickExpressionWithEmbeddedString
-     *
-     * @return void
      */
     public function testReturnsExpectedTokensForBacktickExpressionWithEmbeddedString(): void
     {
@@ -610,7 +583,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
      * Returns an array with the token types found in a file associated with
      * the currently running test.
      *
-     * @return array<integer>
+     * @return array<int>
      */
     private function getTokenTypesForTest()
     {

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -38,29 +38,24 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  */
 
 namespace PDepend\Source\Parser;
 
 use PDepend\Source\AST\ASTAllocationExpression;
-use PDepend\Source\AST\ASTClassReference;
-use PDepend\Source\AST\ASTFunctionPostfix;
-use PDepend\Source\AST\ASTMemberPrimaryPrefix;
-use PDepend\Source\AST\ASTParentReference;
-use PDepend\Source\AST\ASTSelfReference;
-use PDepend\Source\AST\ASTStaticReference;
-use PDepend\Source\AST\ASTVariable;
-use PDepend\Source\AST\ASTVariableVariable;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
@@ -68,7 +63,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * testAllocationExpressionForSelfProperty
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAllocationExpressionForSelfProperty(): void
@@ -80,7 +74,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * testAllocationExpressionForParentProperty
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAllocationExpressionForParentProperty(): void
@@ -92,7 +85,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * testAllocationExpressionForStaticProperty
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAllocationExpressionForStaticProperty(): void
@@ -104,7 +96,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * testAllocationExpressionForThisProperty
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAllocationExpressionForThisProperty(): void
@@ -116,7 +107,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * testAllocationExpressionForObjectProperty
      *
-     * @return void
      * @since 1.0.1
      */
     public function testAllocationExpressionForObjectProperty(): void
@@ -127,8 +117,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForSimpleIdentifier(): void
     {
@@ -142,8 +130,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForSelfKeyword(): void
     {
@@ -158,8 +144,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForParentKeyword(): void
     {
@@ -173,8 +157,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForLocalNamespaceIdentifier(): void
     {
@@ -188,8 +170,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForAbsoluteNamespaceIdentifier(): void
     {
@@ -203,8 +183,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForAbsoluteNamespacedNamespaceIdentifier(): void
     {
@@ -218,8 +196,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForVariableIdentifier(): void
     {
@@ -233,8 +209,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForVariableVariableIdentifier(): void
     {
@@ -252,8 +226,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the allocation object graph contains the expected objects
-     *
-     * @return void
      */
     public function testAllocationExpressionGraphForStaticReference(): void
     {
@@ -268,8 +240,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     /**
      * Tests that invalid allocation expression results in the expected
      * exception.
-     *
-     * @return void
      */
     public function testInvalidAllocationExpressionResultsInExpectedException(): void
     {
@@ -287,6 +257,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
      * with the calling test method.
      *
      * @return ASTAllocationExpression
+     *
      * @since 1.0.1
      */
     private function getFirstAllocationInClass()

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  */
 
@@ -46,19 +47,19 @@ namespace PDepend\Source\Parser;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class ASTArgumentsParsingTest extends AbstractParserTestCase
 {
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsStaticMethodPostfixExpression(): void
     {
@@ -69,15 +70,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsMethodPostfixExpression(): void
     {
@@ -88,15 +87,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTVariable',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsConstantsPostfixExpression(): void
     {
@@ -106,15 +103,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTConstantPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier'
+                'PDepend\\Source\\AST\\ASTIdentifier',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsPropertyPostfixExpression(): void
     {
@@ -124,15 +119,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsSelfPropertyPostfixExpression(): void
     {
@@ -142,15 +135,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
                 'PDepend\\Source\\AST\\ASTSelfReference',
                 'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable'
+                'PDepend\\Source\\AST\\ASTVariable',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsParentMethodPostfixExpression(): void
     {
@@ -161,15 +152,13 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
                 'PDepend\\Source\\AST\\ASTParentReference',
                 'PDepend\\Source\\AST\\ASTMethodPostfix',
                 'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments'
+                'PDepend\\Source\\AST\\ASTArguments',
             ]
         );
     }
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsContainsAllocationExpression(): void
     {
@@ -181,8 +170,6 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsWithSeveralParameters(): void
     {
@@ -196,8 +183,6 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsWithInlineComments(): void
     {
@@ -209,8 +194,6 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
 
     /**
      * Tests that the parser adds the expected children to an argument instance.
-     *
-     * @return void
      */
     public function testArgumentsWithInlineConcatExpression(): void
     {
@@ -225,12 +208,10 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
     /**
      * Tests that an invalid arguments expression results in the expected
      * exception.
-     *
-     * @return void
      */
     public function testUnclosedArgumentsExpressionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
  */
 
@@ -48,18 +49,19 @@ use PDepend\Source\AST\ASTFormalParameter;
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.2
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @group unittest
  */
 class ASTFormalParameterParsingTest extends AbstractParserTestCase
 {
     /**
      * testWithParentTypeHint
-     *
-     * @return void
      */
     public function testWithParentTypeHint(): void
     {
@@ -69,24 +71,20 @@ class ASTFormalParameterParsingTest extends AbstractParserTestCase
 
     /**
      * testWithParentTypeHintInFunctionThrowsExpectedException
-     *
-     * @return void
      */
     public function testWithParentTypeHintInFunctionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
 
     /**
      * testWithParentTypeHintInRootClassThrowsExpectedException
-     *
-     * @return void
      */
     public function testWithParentTypeHintInRootClassThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -94,7 +92,7 @@ class ASTFormalParameterParsingTest extends AbstractParserTestCase
     /**
      * Returns the first formal parameter found in the associated test file.
      *
-     * @return \PDepend\Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      */
     private function getFirstMethodFormalParameter()
     {

--- a/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
+++ b/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 
@@ -50,6 +51,7 @@ use PDepend\AbstractTestCase;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.20
  */
 abstract class AbstractParserTestCase extends AbstractTestCase

--- a/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -38,28 +38,28 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.5
  */
 
 namespace PDepend\Source\Parser;
 
-use PDepend\Source\AST\ASTClassOrInterfaceReference;
-
 /**
  * Test case for the namespace resolving in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.5
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @group unittest
  */
 class NamespaceResovingTest extends AbstractParserTestCase
 {
     /**
      * testNamespacesAreCorrectlyLookedUp
-     *
-     * @return void
      */
     public function testNamespacesAreCorrectlyLookedUp(): void
     {
@@ -85,8 +85,6 @@ class NamespaceResovingTest extends AbstractParserTestCase
 
     /**
      * testNamespacesAreLookedUpCorrectlyInFirstOfMultipleNamespaces
-     *
-     * @return void
      */
     public function testNamespacesAreLookedUpCorrectlyInFirstOfMultipleNamespaces(): void
     {
@@ -112,8 +110,6 @@ class NamespaceResovingTest extends AbstractParserTestCase
 
     /**
      * testNamespacesAreLookedUpCorrectlyInSecondOfMultipleNamespaces
-     *
-     * @return void
      */
     public function testNamespacesAreLookedUpCorrectlyInSecondOfMultipleNamespaces(): void
     {
@@ -147,8 +143,6 @@ class NamespaceResovingTest extends AbstractParserTestCase
 
     /**
      * testNamespacesAreLookedUpCorrectlyInThirdOfMultipleNamespaces
-     *
-     * @return void
      */
     public function testNamespacesAreLookedUpCorrectlyInThirdOfMultipleNamespaces(): void
     {

--- a/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
+++ b/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
@@ -49,6 +49,7 @@ use PDepend\Source\Parser\SymbolTable;
  * Test case for the {@link SymbolTable} class.
  *
  * @covers \PDepend\Source\Parser\SymbolTable
+ *
  * @group unittest
  */
 class SymbolTableTest extends AbstractTestCase

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -48,19 +49,19 @@ use PDepend\Source\Tokenizer\Token;
 /**
  * Test case for the {@link \PDepend\Source\Parser\TokenStack} class.
  *
+ * @covers \PDepend\Source\Parser\TokenStack
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  *
- * @covers \PDepend\Source\Parser\TokenStack
  * @group unittest
  */
 class TokenStackTest extends AbstractParserTestCase
 {
     /**
      * testAddReturnsGivenTokenInstance
-     *
-     * @return void
      */
     public function testAddReturnsGivenTokenInstance(): void
     {
@@ -72,8 +73,6 @@ class TokenStackTest extends AbstractParserTestCase
 
     /**
      * testPopReturnsExpectedTokenArray
-     *
-     * @return void
      */
     public function testPopReturnsExpectedTokenArray(): void
     {
@@ -83,7 +82,7 @@ class TokenStackTest extends AbstractParserTestCase
         $expected = [
             $stack->add($this->createToken()),
             $stack->add($this->createToken()),
-            $stack->add($this->createToken())
+            $stack->add($this->createToken()),
         ];
 
         $this->assertSame($expected, $stack->pop());
@@ -91,8 +90,6 @@ class TokenStackTest extends AbstractParserTestCase
 
     /**
      * testPopOnlyReturnsExpectedTokenArrayInCurrentScope
-     *
-     * @return void
      */
     public function testPopOnlyReturnsExpectedTokenArrayInCurrentScope(): void
     {
@@ -104,7 +101,7 @@ class TokenStackTest extends AbstractParserTestCase
 
         $expected = [
             $stack->add($this->createToken()),
-            $stack->add($this->createToken())
+            $stack->add($this->createToken()),
         ];
 
         $this->assertSame($expected, $stack->pop());
@@ -112,8 +109,6 @@ class TokenStackTest extends AbstractParserTestCase
 
     /**
      * testPopOnRootReturnsExpectedTokenArrayWithAllTokens
-     *
-     * @return void
      */
     public function testPopOnRootReturnsExpectedTokenArrayWithAllTokens(): void
     {
@@ -122,7 +117,7 @@ class TokenStackTest extends AbstractParserTestCase
 
         $expected = [
             $stack->add($this->createToken()),
-            $stack->add($this->createToken())
+            $stack->add($this->createToken()),
         ];
 
         $stack->push();
@@ -136,7 +131,7 @@ class TokenStackTest extends AbstractParserTestCase
     /**
      * Returns a test token instance.
      *
-     * @return \PDepend\Source\Tokenizer\Token
+     * @return Token
      */
     protected function createToken()
     {

--- a/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  */
 
@@ -46,19 +47,19 @@ namespace PDepend\Source\Parser;
 /**
  * Tests for unstructured code handling in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 1.0.0
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @group unittest
  */
 class UnstructuredCodeTest extends AbstractParserTestCase
 {
     /**
      * testParserHandlesNonPhpCodeInFileProlog
-     *
-     * @return void
      */
     public function testParserHandlesNonPhpCodeInFileProlog(): void
     {
@@ -67,8 +68,6 @@ class UnstructuredCodeTest extends AbstractParserTestCase
 
     /**
      * testParserHandlesConditionalClassDeclaration
-     *
-     * @return void
      */
     public function testParserHandlesConditionalClassDeclaration(): void
     {
@@ -78,8 +77,6 @@ class UnstructuredCodeTest extends AbstractParserTestCase
 
     /**
      * testParserHandlesConditionalInterfaceDeclaration
-     *
-     * @return void
      */
     public function testParserHandlesConditionalInterfaceDeclaration(): void
     {
@@ -89,8 +86,6 @@ class UnstructuredCodeTest extends AbstractParserTestCase
 
     /**
      * testParserHandlesConditionalFunctionDeclaration
-     *
-     * @return void
      */
     public function testParserHandlesConditionalFunctionDeclaration(): void
     {

--- a/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
+++ b/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Source\Tokenizer\Token} class.
  *
+ * @covers \PDepend\Source\Tokenizer\Token
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Source\Tokenizer\Token
  * @group unittest
  */
 class TokenTest extends AbstractTestCase
 {
     /**
      * testConstructorSetsTypeProperty
-     *
-     * @return void
      */
     public function testConstructorSetsTypeProperty(): void
     {
@@ -68,8 +67,6 @@ class TokenTest extends AbstractTestCase
 
     /**
      * testConstructorSetsImageProperty
-     *
-     * @return void
      */
     public function testConstructorSetsImageProperty(): void
     {
@@ -79,8 +76,6 @@ class TokenTest extends AbstractTestCase
 
     /**
      * testConstructorSetsStartLineProperty
-     *
-     * @return void
      */
     public function testConstructorSetsStartLineProperty(): void
     {
@@ -90,8 +85,6 @@ class TokenTest extends AbstractTestCase
 
     /**
      * testConstructorSetsEndLineProperty
-     *
-     * @return void
      */
     public function testConstructorSetsEndLineProperty(): void
     {
@@ -101,8 +94,6 @@ class TokenTest extends AbstractTestCase
 
     /**
      * testConstructorSetsStartColumnProperty
-     *
-     * @return void
      */
     public function testConstructorSetsStartColumnProperty(): void
     {
@@ -112,8 +103,6 @@ class TokenTest extends AbstractTestCase
 
     /**
      * testConstructorSetsEndColumnProperty
-     *
-     * @return void
      */
     public function testConstructorSetsEndColumnProperty(): void
     {

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -46,16 +46,16 @@ use PDepend\AbstractTestCase;
 use PDepend\MockCommand;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
-use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 
 /**
  * Test case for the text ui command.
  *
+ * @covers \PDepend\TextUI\Command
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\TextUI\Command
  * @group unittest
  */
 class CommandTest extends AbstractTestCase
@@ -86,8 +86,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests the result of the print version option.
-     *
-     * @return void
      */
     public function testPrintVersion(): void
     {
@@ -97,8 +95,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testPrintVersionReturnsExitCodeSuccess
-     *
-     * @return void
      */
     public function testPrintVersionReturnsExitCodeSuccess(): void
     {
@@ -108,8 +104,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests the result of the print usage option.
-     *
-     * @return void
      */
     public function testPrintUsage(): void
     {
@@ -119,8 +113,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testPrintUsageReturnsExitCodeSuccess
-     *
-     * @return void
      */
     public function testPrintUsageReturnsExitCodeSuccess(): void
     {
@@ -130,8 +122,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests the output of the print help option.
-     *
-     * @return void
      */
     public function testPrintHelp(): void
     {
@@ -141,8 +131,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testPrintHelpReturnsExitCodeSuccess
-     *
-     * @return void
      */
     public function testPrintHelpReturnsExitCodeSuccess(): void
     {
@@ -152,8 +140,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command exits with an cli error if no $argv array exists.
-     *
-     * @return void
      */
     public function testCommandCliReturnsErrorExitCodeIfNoArgvArrayExists(): void
     {
@@ -163,8 +149,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testCommandCliErrorMessageIfNoArgvArrayExists
-     *
-     * @return void
      */
     public function testCommandCliErrorMessageIfNoArgvArrayExists(): void
     {
@@ -175,8 +159,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command exits with a cli error for an empty option list.
-     *
-     * @return void
      */
     public function testCommandDisplaysHelpIfNoOptionsWereSpecified(): void
     {
@@ -186,8 +168,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testCommandReturnsErrorExitCodeIfNoOptionsWereSpecified
-     *
-     * @return void
      */
     public function testCommandReturnsErrorExitCodeIfNoOptionsWereSpecified(): void
     {
@@ -197,8 +177,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command starts the text ui runner.
-     *
-     * @return void
      */
     public function testCommandStartsProcessWithDummyLogger(): void
     {
@@ -213,7 +191,7 @@ class CommandTest extends AbstractTestCase
             '--exclude=pdepend.test2',
             '--configuration=' . __DIR__ . '/../../../resources/pdepend.xml.dist',
             '--dummy-logger=' . $logFile,
-            $resource
+            $resource,
         ];
 
         [$exitCode, ] = $this->executeCommand($argv);
@@ -224,8 +202,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testCommandReturnsExitCodeSuccessByDefault
-     *
-     * @return void
      */
     public function testCommandReturnsExitCodeSuccessByDefault(): void
     {
@@ -238,7 +214,7 @@ class CommandTest extends AbstractTestCase
             '--suffix=inc',
             '--configuration=' . __DIR__ . '/../../../resources/pdepend.xml.dist',
             '--dummy-logger=' . $logFile,
-            $resource
+            $resource,
         ];
 
         [$exitCode, ] = $this->executeCommand($argv);
@@ -247,8 +223,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command exits with a cli error for an unknown option.
-     *
-     * @return void
      */
     public function testCommandExitsWithCliErrorForUnknownOption(): void
     {
@@ -259,8 +233,6 @@ class CommandTest extends AbstractTestCase
     /**
      * Tests that the command handles the <b>--without-annotations</b> option
      * correct.
-     *
-     * @return void
      */
     public function testCommandHandlesWithoutAnnotationsOptionCorrect(): void
     {
@@ -269,21 +241,21 @@ class CommandTest extends AbstractTestCase
                 'functions'   =>  ['foo'],
                 'classes'     =>  ['MyException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
+                'exceptions'  =>  [],
             ],
             'pdepend.test2'  =>  [
                 'functions'   =>  [],
                 'classes'     =>  ['YourException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
-            ]
+                'exceptions'  =>  [],
+            ],
         ];
 
         $actual = $this->runCommandAndReturnStatistics(
             [
                 '--suffix=inc',
                 '--without-annotations',
-                '--coderank-mode=property'
+                '--coderank-mode=property',
             ],
             $this->createCodeResourceUriForTest()
         );
@@ -293,8 +265,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testCommandHandlesBadDocumentedSourceCode
-     *
-     * @return void
      */
     public function testCommandHandlesBadDocumentedSourceCode(): void
     {
@@ -314,10 +284,10 @@ class CommandTest extends AbstractTestCase
                 'interfaces'  =>  [
                     'pkg1FooI',
                     'pkg2FooI',
-                    'pkg3FooI'
+                    'pkg3FooI',
                 ],
-                'exceptions'  =>  []
-            ]
+                'exceptions'  =>  [],
+            ],
         ];
 
         $actual = $this->runCommandAndReturnStatistics(
@@ -330,8 +300,8 @@ class CommandTest extends AbstractTestCase
     /**
      * Executes the command class and returns an array with namespace statistics.
      *
-     * @param array $argv
      * @param string $pathName
+     *
      * @return array
      */
     private function runCommandAndReturnStatistics(array $argv, $pathName)
@@ -357,7 +327,7 @@ class CommandTest extends AbstractTestCase
                 'functions'   =>  [],
                 'classes'     =>  [],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
+                'exceptions'  =>  [],
             ];
             foreach ($namespace->getFunctions() as $function) {
                 $statistics['functions'][] = $function->getName();
@@ -388,8 +358,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command interpretes a "-d key" as "on".
-     *
-     * @return void
      */
     public function testCommandHandlesIniOptionWithoutValueToON(): void
     {
@@ -403,7 +371,7 @@ class CommandTest extends AbstractTestCase
                 '-d',
                 'html_errors',
                 '--dummy-logger=' . $this->createRunResourceURI(),
-                __FILE__
+                __FILE__,
             ]
         );
 
@@ -414,8 +382,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the text ui command handles an ini option "-d key=value" correct.
-     *
-     * @return void
      */
     public function testCommandHandlesIniOptionWithValue(): void
     {
@@ -429,7 +395,7 @@ class CommandTest extends AbstractTestCase
                 '-d',
                 'html_errors=off',
                 '--dummy-logger=' . $this->createRunResourceURI(),
-                __FILE__
+                __FILE__,
             ]
         );
 
@@ -441,8 +407,6 @@ class CommandTest extends AbstractTestCase
     /**
      * Tests that the command sets a configuration instance for a specified
      * config file.
-     *
-     * @return void
      */
     public function testCommandHandlesConfigurationFileCorrect(): void
     {
@@ -467,7 +431,7 @@ class CommandTest extends AbstractTestCase
         $argv = [
             '--configuration=' . $configFile,
             '--dummy-logger=' . $this->createRunResourceURI(),
-            __FILE__
+            __FILE__,
         ];
 
         // Result previous instance
@@ -481,8 +445,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testTextUiCommandOutputContainsExpectedCoverageReportOption
-     *
-     * @return void
      */
     public function testTextUiCommandOutputContainsExpectedCoverageReportOption(): void
     {
@@ -492,8 +454,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testTextUiCommandFailesWithExpectedErrorCodeWhenCoverageReportFileDoesNotExist
-     *
-     * @return void
      */
     public function testTextUiCommandFailesWithExpectedErrorCodeWhenCoverageReportFileDoesNotExist(): void
     {
@@ -512,8 +472,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * testTextUiCommandAcceptsExistingFileForCoverageReportOption
-     *
-     * @return void
      */
     public function testTextUiCommandAcceptsExistingFileForCoverageReportOption(): void
     {
@@ -531,8 +489,6 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Tests that the command fails for an invalid config file.
-     *
-     * @return void
      */
     public function testCommandFailsIfAnInvalidConfigFileWasSpecified(): void
     {
@@ -613,8 +569,6 @@ class CommandTest extends AbstractTestCase
      *
      * @param string $actual     The cli output.
      * @param string $prologText Optional prolog text.
-     *
-     * @return void
      */
     protected function assertHelpOutput($actual, $prologText = ''): void
     {
@@ -657,8 +611,6 @@ class CommandTest extends AbstractTestCase
      * Prepares a fake <b>$argv</b>.
      *
      * @param ?array $argv The cli parameters.
-     *
-     * @return void
      */
     private function prepareArgv(?array $argv = null): void
     {

--- a/src/test/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/src/test/php/PDepend/TextUI/ResultPrinterTest.php
@@ -52,18 +52,17 @@ use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 /**
  * Test case for the default text ui result printer.
  *
+ * @covers \PDepend\TextUI\ResultPrinter
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\TextUI\ResultPrinter
  * @group unittest
  */
 class ResultPrinterTest extends AbstractTestCase
 {
     /**
      * Tests the output for a single file entry.
-     *
-     * @return void
      */
     public function testResultPrinterOutputForSingleEntry(): void
     {
@@ -87,8 +86,6 @@ class ResultPrinterTest extends AbstractTestCase
 
     /**
      * Tests the result printer with multiple entries.
-     *
-     * @return void
      */
     public function testResultPrinterOutputForMultipleEntries(): void
     {
@@ -115,8 +112,6 @@ class ResultPrinterTest extends AbstractTestCase
 
     /**
      * Tests the result printer with multiple entries.
-     *
-     * @return void
      */
     public function testResultPrinterForMultipleEntries(): void
     {
@@ -142,8 +137,6 @@ class ResultPrinterTest extends AbstractTestCase
 
     /**
      * Tests the result printer with multiple entries.
-     *
-     * @return void
      */
     public function testResultPrinterForCompleteLine(): void
     {

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -42,20 +42,22 @@
 
 namespace PDepend\TextUI;
 
+use Exception;
 use PDepend\AbstractTestCase;
-use PDepend\Input\ExtensionFilter;
 use PDepend\Input\Filter;
 use PDepend\Report\ReportGeneratorFactory;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
  * Test case for the text ui runner.
  *
+ * @covers \PDepend\TextUI\Runner
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\TextUI\Runner
  * @group unittest
  */
 class RunnerTest extends AbstractTestCase
@@ -63,12 +65,10 @@ class RunnerTest extends AbstractTestCase
     /**
      * Tests that the runner exits with an exception for an invalud source
      * directory.
-     *
-     * @return void
      */
     public function testRunnerThrowsRuntimeExceptionForInvalidSourceDirectory(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $runner = $this->createTextUiRunner();
         $runner->setSourceArguments(['foo/bar']);
@@ -77,12 +77,10 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * Tests that the runner stops processing if no logger is specified.
-     *
-     * @return void
      */
     public function testRunnerThrowsRuntimeExceptionIfNoLoggerIsSpecified(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $runner = $this->createTextUiRunner();
         $runner->setSourceArguments([$this->createCodeResourceUriForTest()]);
@@ -91,8 +89,6 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testRunnerUsesCorrectFileFilter
-     *
-     * @return void
      */
     public function testRunnerUsesCorrectFileFilter(): void
     {
@@ -101,14 +97,14 @@ class RunnerTest extends AbstractTestCase
                 'functions'   =>  ['foo'],
                 'classes'     =>  ['MyException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
+                'exceptions'  =>  [],
             ],
             'pdepend.test2'  =>  [
                 'functions'   =>  [],
                 'classes'     =>  ['YourException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
-            ]
+                'exceptions'  =>  [],
+            ],
         ];
 
         $runner = $this->createTextUiRunner();
@@ -123,9 +119,6 @@ class RunnerTest extends AbstractTestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @return void
-     */
     public function testSetExcludeDirectories(): void
     {
         /** @var Filter[] $record */
@@ -147,7 +140,7 @@ class RunnerTest extends AbstractTestCase
 
         try {
             $this->silentRun($runner);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             // noop
         }
 
@@ -156,9 +149,6 @@ class RunnerTest extends AbstractTestCase
         $this->assertInstanceOf('PDepend\\Input\\ExcludePathFilter', $record[1]);
     }
 
-    /**
-     * @return void
-     */
     public function testSetExcludeNamespaces(): void
     {
         /** @var object[] $record */
@@ -183,7 +173,7 @@ class RunnerTest extends AbstractTestCase
 
         try {
             $this->silentRun($runner);
-        } catch (\Exception $exception) {
+        } catch (Exception $exception) {
             // noop
         }
 
@@ -196,8 +186,6 @@ class RunnerTest extends AbstractTestCase
     /**
      * Tests that the runner handles the <b>--without-annotations</b> option
      * correct.
-     *
-     * @return void
      */
     public function testRunnerHandlesWithoutAnnotationsOptionCorrect(): void
     {
@@ -206,14 +194,14 @@ class RunnerTest extends AbstractTestCase
                 'functions'   =>  ['foo'],
                 'classes'     =>  ['MyException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
+                'exceptions'  =>  [],
             ],
             'pdepend.test2'  =>  [
                 'functions'   =>  [],
                 'classes'     =>  ['YourException'],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
-            ]
+                'exceptions'  =>  [],
+            ],
         ];
 
         $runner = $this->createTextUiRunner();
@@ -229,8 +217,6 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testSupportBadDocumentation
-     *
-     * @return void
      */
     public function testSupportBadDocumentation(): void
     {
@@ -250,10 +236,10 @@ class RunnerTest extends AbstractTestCase
                 'interfaces'  =>  [
                     'pkg1FooI',
                     'pkg2FooI',
-                    'pkg3FooI'
+                    'pkg3FooI',
                 ],
-                'exceptions'  =>  []
-            ]
+                'exceptions'  =>  [],
+            ],
         ];
 
         $runner = $this->createTextUiRunner();
@@ -267,8 +253,6 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testRunnerHasParseErrorsReturnsFalseForValidSource
-     *
-     * @return void
      */
     public function testRunnerHasParseErrorsReturnsFalseForValidSource(): void
     {
@@ -283,8 +267,6 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testRunnerHasParseErrorsReturnsTrueForInvalidSource
-     *
-     * @return void
      */
     public function testRunnerHasParseErrorsReturnsTrueForInvalidSource(): void
     {
@@ -299,8 +281,6 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testRunnerGetParseErrorsReturnsArrayWithParsingExceptionMessages
-     *
-     * @return void
      */
     public function testRunnerGetParseErrorsReturnsArrayWithParsingExceptionMessages(): void
     {
@@ -318,12 +298,10 @@ class RunnerTest extends AbstractTestCase
 
     /**
      * testRunnerThrowsExceptionForUndefinedLoggerClass
-     *
-     * @return void
      */
     public function testRunnerThrowsExceptionForUndefinedLoggerClass(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $runner = $this->createTextUiRunner();
         $runner->addReportGenerator('FooBarLogger', $this->createRunResourceURI());
@@ -333,8 +311,9 @@ class RunnerTest extends AbstractTestCase
     /**
      * Executes the runner class and returns an array with namespace statistics.
      *
-     * @param \PDepend\TextUI\Runner $runner The runner instance.
-     * @param $pathName The source path.
+     * @param Runner $runner   The runner instance.
+     * @param        $pathName The source path.
+     *
      * @return array
      */
     private function runRunnerAndReturnStatistics(Runner $runner, $pathName)
@@ -355,7 +334,7 @@ class RunnerTest extends AbstractTestCase
                 'functions'   =>  [],
                 'classes'     =>  [],
                 'interfaces'  =>  [],
-                'exceptions'  =>  []
+                'exceptions'  =>  [],
             ];
             foreach ($namespace->getFunctions() as $function) {
                 $statistics['functions'][] = $function->getName();

--- a/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
+++ b/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
@@ -51,14 +51,12 @@ use PDepend\AbstractTestCase;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
-   * @group unittest
+ * @group unittest
  */
 abstract class AbstractDriverTestCase extends AbstractTestCase
 {
     /**
      * testTypeMethodReturnsSameObjectInstance
-     *
-     * @return void
      */
     public function testTypeMethodReturnsSameObjectInstance(): void
     {
@@ -68,8 +66,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRestoreMethodReturnsNullByDefault
-     *
-     * @return void
      */
     public function testRestoreMethodReturnsNullByDefault(): void
     {
@@ -79,8 +75,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testStoreMethodPersistsGivenData
-     *
-     * @return void
      */
     public function testStoreMethodPersistsGivenData(): void
     {
@@ -92,8 +86,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testStoreMethodPersistsGivenDataWithHash
-     *
-     * @return void
      */
     public function testStoreMethodPersistsGivenDataWithHash(): void
     {
@@ -105,8 +97,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRestoreMethodWithDifferentHashReturnsNull
-     *
-     * @return void
      */
     public function testRestoreMethodWithDifferentHashReturnsNull(): void
     {
@@ -118,8 +108,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testStoreAndRestoreMethodsWithSpecialType
-     *
-     * @return void
      */
     public function testStoreAndRestoreMethodsWithSpecialType(): void
     {
@@ -131,8 +119,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testStoreMethodWithSpecialTypeNotOverwriteRecordInDefaultType
-     *
-     * @return void
      */
     public function testStoreMethodWithSpecialTypeNotOverwriteRecordInDefaultType(): void
     {
@@ -145,8 +131,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRemoveDeletesExistingCacheEntry
-     *
-     * @return void
      */
     public function testRemoveDeletesExistingCacheEntry(): void
     {
@@ -162,8 +146,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRemoveDeletesExistingCacheEntriesWithEqualCacheKeyPrefix
-     *
-     * @return void
      */
     public function testRemoveDeletesExistingCacheEntriesWithEqualCacheKeyPrefix(): void
     {
@@ -179,8 +161,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRemoveDeletesExistingCacheEntryOfDifferentType
-     *
-     * @return void
      */
     public function testRemoveDeletesExistingCacheEntryOfDifferentType(): void
     {
@@ -196,8 +176,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * testRemoveSilentlyIgnoresPatternsWithoutMatch
-     *
-     * @return void
      */
     public function testRemoveSilentlyIgnoresPatternsWithoutMatch(): void
     {
@@ -214,7 +192,7 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
     /**
      * Creates a test fixture.
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     abstract protected function createDriver();
 }

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -43,24 +43,21 @@
 namespace PDepend\Util\Cache;
 
 use PDepend\AbstractTestCase;
-use PDepend\Util\Cache\Driver\FileCacheDriver;
-use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\CacheFactory} class.
  *
+ * @covers \PDepend\Util\Cache\CacheFactory
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Util\Cache\CacheFactory
  * @group unittest
  */
 class CacheFactoryTest extends AbstractTestCase
 {
     /**
      * testCreateReturnsDriverInstance
-     *
-     * @return void
      */
     public function testCreateReturnsDriverInstance(): void
     {
@@ -72,8 +69,6 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * testCreateHasSingletonBehaviorForIdenticalCacheNames
-     *
-     * @return void
      */
     public function testCreateHasSingletonBehaviorForIdenticalCacheNames(): void
     {
@@ -89,8 +84,6 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * testCreateReturnsDifferentInstancesForDifferentCacheNames
-     *
-     * @return void
      */
     public function testCreateReturnsDifferentInstancesForDifferentCacheNames(): void
     {
@@ -106,8 +99,6 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * testCreateReturnsCacheInstanceOfTypeFile
-     *
-     * @return void
      */
     public function testCreateReturnsCacheInstanceOfTypeFile(): void
     {
@@ -121,8 +112,6 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * testCreateReturnsCacheInstanceOfTypeMemory
-     *
-     * @return void
      */
     public function testCreateReturnsCacheInstanceOfTypeMemory(): void
     {
@@ -136,8 +125,6 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * testCreateThrowsExpectedExceptionForUnknownCacheDriver
-     *
-     * @return void
      */
     public function testCreateThrowsExpectedExceptionForUnknownCacheDriver(): void
     {
@@ -153,7 +140,7 @@ class CacheFactoryTest extends AbstractTestCase
     /**
      * Creates a prepared factory instance.
      *
-     * @return \PDepend\Util\Cache\CacheFactory
+     * @return CacheFactory
      */
     protected function createFactoryFixture()
     {

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
@@ -49,11 +50,13 @@ use PDepend\Util\Cache\CacheDriver;
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheDirectory} class.
  *
+ * @covers \PDepend\Util\Cache\Driver\File\FileCacheDirectory
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  *
- * @covers \PDepend\Util\Cache\Driver\File\FileCacheDirectory
  * @group unittest
  */
 class FileCacheDirectoryTest extends AbstractTestCase
@@ -74,8 +77,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * Initializes a temporary working directory.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -88,8 +89,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testCreatesNotExistingCacheDirectory
-     *
-     * @return void
      */
     public function testCreatesNotExistingCacheDirectory(): void
     {
@@ -99,8 +98,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testAddsCacheVersionFileToNewlyCreatedCache
-     *
-     * @return void
      */
     public function testAddsCacheVersionFileToNewlyCreatedCache(): void
     {
@@ -110,8 +107,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testCacheVersionFileContainsExpectedVersionString
-     *
-     * @return void
      */
     public function testCacheVersionFileContainsExpectedVersionString(): void
     {
@@ -124,8 +119,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testOverwritesPreviousCacheVersionFileWithActualVersionString
-     *
-     * @return void
      */
     public function testOverwritesPreviousCacheVersionFileWithActualVersionString(): void
     {
@@ -141,8 +134,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testDeletesCacheFileIfVersionFileNotExists
-     *
-     * @return void
      */
     public function testDeletesCacheFileIfVersionFileNotExists(): void
     {
@@ -158,8 +149,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testDeletesCacheDirectoryIfVersionFileNotExists
-     *
-     * @return void
      */
     public function testDeletesCacheDirectoryIfVersionFileNotExists(): void
     {
@@ -174,8 +163,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testDeletesCacheDirectoriesRecusiveIfVersionFileNotExists
-     *
-     * @return void
      */
     public function testDeletesCacheDirectoriesRecusiveIfVersionFileNotExists(): void
     {
@@ -192,8 +179,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testCreateCacheDirectoryReturnsExpectedSubDirectory
-     *
-     * @return void
      */
     public function testCreateCacheDirectoryReturnsExpectedSubDirectory(): void
     {
@@ -205,8 +190,6 @@ class FileCacheDirectoryTest extends AbstractTestCase
 
     /**
      * testCreateCacheDirectoryAlsoCreatesThePhysicalDirectory
-     *
-     * @return void
      */
     public function testCreateCacheDirectoryAlsoCreatesThePhysicalDirectory(): void
     {

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -47,10 +47,11 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector} class.
  *
+ * @covers \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector
  * @group unittest
  */
 class FileCacheGarbageCollectorTest extends AbstractTestCase
@@ -71,8 +72,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
 
     /**
      * Initializes a temporary working directory.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -85,9 +84,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
         mkdir($this->cacheDir);
     }
 
-    /**
-     * @return void
-     */
     public function testKeepsRecentFiles(): void
     {
         $this->createFile();
@@ -97,9 +93,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
         $this->assertSame(0, $garbageCollector->garbageCollect());
     }
 
-    /**
-     * @return void
-     */
     public function testRemovesOutdatedFiles(): void
     {
         $time = 31 * 86400;
@@ -111,9 +104,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
         $this->assertSame(2, $garbageCollector->garbageCollect());
     }
 
-    /**
-     * @return void
-     */
     public function testKeepsFilesWithRecentATime(): void
     {
         $time = 31 * 86400;
@@ -125,9 +115,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
         $this->assertSame(1, $garbageCollector->garbageCollect());
     }
 
-    /**
-     * @return void
-     */
     public function testKeepsFilesWithRecentMTime(): void
     {
         $time = 31 * 86400;

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -43,14 +43,16 @@
 namespace PDepend\Util\Cache\Driver;
 
 use PDepend\Util\Cache\AbstractDriverTestCase;
+use RuntimeException;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\FileCacheDriver} class.
  *
+ * @covers \PDepend\Util\Cache\Driver\FileCacheDriver
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Cache\Driver\FileCacheDriver
  * @group unittest
  */
 class FileCacheDriverTest extends AbstractDriverTestCase
@@ -71,8 +73,6 @@ class FileCacheDriverTest extends AbstractDriverTestCase
 
     /**
      * Initializes a temporary working directory.
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -96,7 +96,6 @@ class FileCacheDriverTest extends AbstractDriverTestCase
     /**
      * testFileDriverStoresFileWithCacheKeyIfPresent
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFileDriverStoresFileWithCacheKeyIfPresent(): void
@@ -113,7 +112,6 @@ class FileCacheDriverTest extends AbstractDriverTestCase
     /**
      * testFileDriverRestoresFileWithCacheKeyIfPresent
      *
-     * @return void
      * @since 1.0.0
      */
     public function testFileDriverRestoresFileWithCacheKeyIfPresent(): void
@@ -140,7 +138,7 @@ class FileCacheDriverTest extends AbstractDriverTestCase
         $corruptCacheContent = 'this is not a valid serialized value';
         $written = file_put_contents($file, $corruptCacheContent);
         if ($written !== strlen($corruptCacheContent)) {
-            throw new \RuntimeException('Could not write to cache file during test. Path: ' . $file);
+            throw new RuntimeException('Could not write to cache file during test. Path: ' . $file);
         }
 
         // Try to retrieve the cached value

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -47,10 +47,11 @@ use PDepend\Util\Cache\AbstractDriverTestCase;
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\MemoryCacheDriver} class.
  *
+ * @covers \PDepend\Util\Cache\Driver\MemoryCacheDriver
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Cache\Driver\MemoryCacheDriver
  * @group unittest
  */
 class MemoryCacheDriverTest extends AbstractDriverTestCase

--- a/src/test/php/PDepend/Util/ConfigurationTest.php
+++ b/src/test/php/PDepend/Util/ConfigurationTest.php
@@ -38,33 +38,36 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.10.0
  */
 
 namespace PDepend\Util;
 
+use OutOfRangeException;
 use PDepend\AbstractTestCase;
+use stdClass;
 
 /**
  * Test case for the {@link \PDepend\Util\Configuration} class.
  *
+ * @covers \PDepend\Util\Configuration
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @since 0.10.0
  *
- * @covers \PDepend\Util\Configuration
  * @group unittest
  */
 class ConfigurationTest extends AbstractTestCase
 {
     /**
      * testPropertyAccessForExistingValue
-     *
-     * @return void
      */
     public function testPropertyAccessForExistingValue(): void
     {
-        $settings      = new \stdClass();
+        $settings      = new stdClass();
         $settings->foo = 42;
 
         $configuration = new Configuration($settings);
@@ -74,14 +77,12 @@ class ConfigurationTest extends AbstractTestCase
 
     /**
      * testPropertyAccessForNotExistingValueThrowsExpectedException
-     *
-     * @return void
      */
     public function testPropertyAccessForNotExistingValueThrowsExpectedException(): void
     {
-        $this->expectException(\OutOfRangeException::class);
+        $this->expectException(OutOfRangeException::class);
 
-        $settings      = new \stdClass();
+        $settings      = new stdClass();
         $settings->foo = 42;
 
         $configuration = new Configuration($settings);
@@ -90,25 +91,21 @@ class ConfigurationTest extends AbstractTestCase
 
     /**
      * testPropertiesAreNotWritableAndExpectedExceptionIsThrown
-     *
-     * @return void
      */
     public function testPropertiesAreNotWritableAndExpectedExceptionIsThrown(): void
     {
-        $this->expectException(\OutOfRangeException::class);
+        $this->expectException(OutOfRangeException::class);
 
-        $configuration      = new Configuration(new \stdClass());
+        $configuration      = new Configuration(new stdClass());
         $configuration->foo = 42;
     }
 
     /**
      * testIssetReturnsTrueForExistingValue
-     *
-     * @return void
      */
     public function testIssetReturnsTrueForExistingValue(): void
     {
-        $settings      = new \stdClass();
+        $settings      = new stdClass();
         $settings->foo = 42;
 
         $configuration = new Configuration($settings);
@@ -118,12 +115,10 @@ class ConfigurationTest extends AbstractTestCase
 
     /**
      * testIssetReturnsFalseForNotExistingValue
-     *
-     * @return void
      */
     public function testIssetReturnsFalseForNotExistingValue(): void
     {
-        $settings      = new \stdClass();
+        $settings      = new stdClass();
         $settings->foo = 42;
 
         $configuration = new Configuration($settings);

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Util\Coverage\CloverReport} class.
  *
+ * @covers \PDepend\Util\Coverage\CloverReport
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Coverage\CloverReport
  * @group unittest
  */
 class CloverReportTest extends AbstractTestCase
 {
     /**
      * testReportReturnsExpected0PercentCoverage
-     *
-     * @return void
      */
     public function testReportReturnsExpected0PercentCoverage(): void
     {
@@ -70,8 +69,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testReportReturnsExpected50PercentCoverage
-     *
-     * @return void
      */
     public function testReportReturnsExpected50PercentCoverage(): void
     {
@@ -83,8 +80,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testReportReturnsExpected100PercentCoverage
-     *
-     * @return void
      */
     public function testReportReturnsExpected100PercentCoverage(): void
     {
@@ -96,8 +91,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testReportReturnsExpected100PercentCoverageWithCoverageIgnore
-     *
-     * @return void
      */
     public function testReportReturnsExpected100PercentCoverageWithCoverageIgnore(): void
     {
@@ -109,8 +102,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testReportReturnsExpected0PercentCoverageForOneLineMethod
-     *
-     * @return void
      */
     public function testReportReturnsExpected0PercentCoverageForOneLineMethod(): void
     {
@@ -122,8 +113,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testNamespacedReportReturnsExpected0PercentCoverage
-     *
-     * @return void
      */
     public function testNamespacedReportReturnsExpected0PercentCoverage(): void
     {
@@ -135,8 +124,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testNamespacedReportReturnsExpected50PercentCoverage
-     *
-     * @return void
      */
     public function testNamespacedReportReturnsExpected50PercentCoverage(): void
     {
@@ -148,8 +135,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testNamespacedReportReturnsExpected100PercentCoverage
-     *
-     * @return void
      */
     public function testNamespacedReportReturnsExpected100PercentCoverage(): void
     {
@@ -161,8 +146,6 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * testGetCoverageReturnsZeroCoverageWhenNoMatchingEntryExists
-     *
-     * @return void
      */
     public function testGetCoverageReturnsZeroCoverageWhenNoMatchingEntryExists(): void
     {
@@ -175,7 +158,7 @@ class CloverReportTest extends AbstractTestCase
     /**
      * Creates a clover coverage report instance.
      *
-     * @return \PDepend\Util\Coverage\CloverReport
+     * @return CloverReport
      */
     private function createCloverReport()
     {
@@ -186,7 +169,7 @@ class CloverReportTest extends AbstractTestCase
     /**
      * Creates a clover coverage report instance.
      *
-     * @return \PDepend\Util\Coverage\CloverReport
+     * @return CloverReport
      */
     private function createNamespacedCloverReport()
     {
@@ -197,9 +180,10 @@ class CloverReportTest extends AbstractTestCase
     /**
      * Creates a mocked method instance.
      *
-     * @param string $name Name of the mock method.
-     * @param int $startLine
-     * @param int $endLine
+     * @param string $name      Name of the mock method.
+     * @param int    $startLine
+     * @param int    $endLine
+     *
      * @return \PDepend\Source\AST\ASTMethod
      */
     private function createMethodMock($name, $startLine = 1, $endLine = 4)

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -43,22 +43,22 @@
 namespace PDepend\Util\Coverage;
 
 use PDepend\AbstractTestCase;
+use RuntimeException;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\Factory} class.
  *
+ * @covers \PDepend\Util\Coverage\Factory
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Coverage\Factory
  * @group unittest
  */
 class FactoryTest extends AbstractTestCase
 {
     /**
      * testCreateReturnsCloverReportInstanceForCloverInputFile
-     *
-     * @return void
      */
     public function testCreateReturnsCloverReportInstanceForCloverInputFile(): void
     {
@@ -70,12 +70,10 @@ class FactoryTest extends AbstractTestCase
 
     /**
      * testCreateMethodThrowsExceptionWhenFileDoesNotExist
-     *
-     * @return void
      */
     public function testCreateMethodThrowsExceptionWhenFileDoesNotExist(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $factory = new Factory();
         $factory->create(__FUNCTION__);
@@ -83,12 +81,10 @@ class FactoryTest extends AbstractTestCase
 
     /**
      * testCreateMethodThrowsExceptionWhenFileIsNotValidXml
-     *
-     * @return void
      */
     public function testCreateMethodThrowsExceptionWhenFileIsNotValidXml(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $factory = new Factory();
         $factory->create(__FILE__);
@@ -96,12 +92,10 @@ class FactoryTest extends AbstractTestCase
 
     /**
      * testCreateMethodThrowsExceptionForUnsupportedReportFormat
-     *
-     * @return void
      */
     public function testCreateMethodThrowsExceptionForUnsupportedReportFormat(): void
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
 
         $factory = new Factory();
         $factory->create(__DIR__ . '/_files/fail.xml');

--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for the {@link \PDepend\Util\FileUtil} class.
  *
+ * @covers \PDepend\Util\FileUtil
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Util\FileUtil
  * @group unittest
  */
 class FileUtilTest extends AbstractTestCase
 {
     /**
      * testGetSysTempDirReturnsExpectedDirectory
-     *
-     * @return void
      */
     public function testGetSysTempDirReturnsExpectedDirectory(): void
     {
@@ -70,8 +69,6 @@ class FileUtilTest extends AbstractTestCase
 
     /**
      * testGetUserHomeDirReturnsExpectedDirectory
-     *
-     * @return void
      */
     public function testGetUserHomeDirReturnsExpectedDirectory(): void
     {
@@ -83,8 +80,6 @@ class FileUtilTest extends AbstractTestCase
 
     /**
      * testGetUserHomeDirOrSysTempDirReturnsExpectedUserHomeDirectory
-     *
-     * @return void
      */
     public function testGetUserHomeDirOrSysTempDirReturnsExpectedUserHomeDirectory(): void
     {

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -38,6 +38,7 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
  * @since 0.9.12
  */
 
@@ -53,19 +54,19 @@ use PDepend\Source\AST\ASTMethod;
 /**
  * Test case for the {@link \PDepend\Util\IdBuilder} class.
  *
+ * @covers \PDepend\Util\IdBuilder
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
+ *
  * @since 0.9.12
  *
- * @covers \PDepend\Util\IdBuilder
  * @group unittest
  */
 class IdBuilderTest extends AbstractTestCase
 {
     /**
      * testBuilderCreatesExpectedIdentifierForFile
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForFile(): void
     {
@@ -77,8 +78,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesCaseSensitiveFileIdentifiers
-     *
-     * @return void
      */
     public function testBuilderCreatesCaseSensitiveFileIdentifiers(): void
     {
@@ -103,8 +102,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForClass
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForClass(): void
     {
@@ -121,8 +118,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForSecondIdenticalClass
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForSecondIdenticalClass(): void
     {
@@ -140,8 +135,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForSecondClass
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForSecondClass(): void
     {
@@ -162,8 +155,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesCaseInSensitiveClassIdentifiers
-     *
-     * @return void
      */
     public function testBuilderCreatesCaseInSensitiveClassIdentifiers(): void
     {
@@ -187,8 +178,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesCaseInSensitiveInterfaceIdentifiers
-     *
-     * @return void
      */
     public function testBuilderCreatesCaseInSensitiveInterfaceIdentifiers(): void
     {
@@ -212,8 +201,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForFunction
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForFunction(): void
     {
@@ -230,8 +217,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesCaseInSensitiveFunctionIdentifiers
-     *
-     * @return void
      */
     public function testBuilderCreatesCaseInSensitiveFunctionIdentifiers(): void
     {
@@ -255,8 +240,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForMethod
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForMethod(): void
     {
@@ -273,8 +256,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForSecondIdenticalFunction
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForSecondIdenticalFunction(): void
     {
@@ -292,8 +273,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesExpectedIdentifierForSecondFunction
-     *
-     * @return void
      */
     public function testBuilderCreatesExpectedIdentifierForSecondFunction(): void
     {
@@ -314,8 +293,6 @@ class IdBuilderTest extends AbstractTestCase
 
     /**
      * testBuilderCreatesCaseInSensitiveMethodIdentifiers
-     *
-     * @return void
      */
     public function testBuilderCreatesCaseInSensitiveMethodIdentifiers(): void
     {

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -43,22 +43,22 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
+use stdClass;
 
 /**
  * Test case for the image convert utility class.
  *
+ * @covers \PDepend\Util\ImageConvert
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
- * @covers \PDepend\Util\ImageConvert
  * @group unittest
  */
 class ImageConvertTest extends AbstractTestCase
 {
     /**
      * Tests the copy behaviour for same mime types.
-     *
-     * @return void
      */
     public function testConvertMakesCopyForSameMimeType(): void
     {
@@ -71,8 +71,6 @@ class ImageConvertTest extends AbstractTestCase
 
     /**
      * Tests the image convert behaviour of the image magick execution path.
-     *
-     * @return void
      */
     public function testConvertWithImageMagickExtension(): void
     {
@@ -87,8 +85,6 @@ class ImageConvertTest extends AbstractTestCase
 
     /**
      * Tests that the image convert util appends the default extension as fallback.
-     *
-     * @return void
      */
     public function testConvertAppendDefaultFileExtensionAsFallback(): void
     {
@@ -105,8 +101,6 @@ class ImageConvertTest extends AbstractTestCase
 
     /**
      * testSvgFixtureContainsExpectedNumberOfFontFamilyDefinitions
-     *
-     * @return void
      */
     public function testSvgFixtureContainsExpectedNumberOfFontFamilyDefinitions(): void
     {
@@ -117,13 +111,11 @@ class ImageConvertTest extends AbstractTestCase
     /**
      * Tests that the convert util recognizes the imageConvert configuration
      * for the font-family:
-     *
-     * @return void
      */
     public function testConvertRecognizesFontFamilyInConfiguration(): void
     {
-        $settings                           = new \stdClass();
-        $settings->imageConvert             = new \stdClass();
+        $settings                           = new stdClass();
+        $settings->imageConvert             = new stdClass();
         $settings->imageConvert->fontFamily = 'Verdana';
 
         $config = new Configuration($settings);
@@ -140,8 +132,6 @@ class ImageConvertTest extends AbstractTestCase
 
     /**
      * testSvgFixtureContainsExpectedNumberOfFontSizeDefinitions
-     *
-     * @return void
      */
     public function testSvgFixtureContainsExpectedNumberOfFontSizeDefinitions(): void
     {
@@ -152,13 +142,11 @@ class ImageConvertTest extends AbstractTestCase
     /**
      * Tests that the convert util recognizes the imageConvert configuration
      * for the font-size:
-     *
-     * @return void
      */
     public function testConvertRecognizesFontSizeInConfiguration(): void
     {
-        $settings                         = new \stdClass();
-        $settings->imageConvert           = new \stdClass();
+        $settings                         = new stdClass();
+        $settings->imageConvert           = new stdClass();
         $settings->imageConvert->fontSize = 14;
 
         $config = new Configuration($settings);

--- a/src/test/php/PDepend/Util/TypeTest.php
+++ b/src/test/php/PDepend/Util/TypeTest.php
@@ -47,18 +47,17 @@ use PDepend\AbstractTestCase;
 /**
  * Test case for type utility class.
  *
+ * @covers \PDepend\Util\Type
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Type
  * @group unittest
  */
 class TypeTest extends AbstractTestCase
 {
     /**
      * testIsInternalTypeDetectsInternalClassPrefixedWithBackslash
-     *
-     * @return void
      */
     public function testIsInternalTypeDetectsInternalClassPrefixedWithBackslash(): void
     {
@@ -67,8 +66,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetTypePackageReturnsNullWhenGivenClassIsNotExtensionClass
-     *
-     * @return void
      */
     public function testGetTypePackageReturnsNullWhenGivenClassIsNotExtensionClass(): void
     {
@@ -77,8 +74,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsScalarTypeReturnsTrueCaseInsensitive
-     *
-     * @return void
      */
     public function testIsScalarTypeReturnsTrueCaseInsensitive(): void
     {
@@ -87,8 +82,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsScalarTypeReturnsTrueMetaphone
-     *
-     * @return void
      */
     public function testIsScalarTypeReturnsTrueMetaphone(): void
     {
@@ -97,8 +90,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsScalarTypeReturnsTrueSoundex
-     *
-     * @return void
      */
     public function testIsScalarTypeReturnsTrueSoundex(): void
     {
@@ -107,8 +98,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeReturnsExpectedValueForExactMatch
-     *
-     * @return void
      */
     public function testIsPrimitiveTypeReturnsTrueForMatchingInput(): void
     {
@@ -117,8 +106,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsPrimitiveTypeReturnsFalseForNotMatchingInput
-     *
-     * @return void
      */
     public function testIsPrimitiveTypeReturnsFalseForNotMatchingInput(): void
     {
@@ -127,8 +114,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeReturnsExpectedValueForExactMatch
-     *
-     * @return void
      */
     public function testGetPrimitiveTypeReturnsExpectedValueForExactMatch(): void
     {
@@ -138,8 +123,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeWorksCaseInsensitive
-     *
-     * @return void
      */
     public function testGetPrimitiveTypeWorksCaseInsensitive(): void
     {
@@ -149,8 +132,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeReturnsNullForNonPrimitive
-     *
-     * @return void
      */
     public function testGetPrimitiveTypeReturnsNullForNonPrimitive(): void
     {
@@ -159,8 +140,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeFindsTypeByMetaphone
-     *
-     * @return void
      */
     public function testGetPrimitiveTypeFindsTypeByMetaphone(): void
     {
@@ -170,8 +149,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetPrimitiveTypeFindsTypeBySoundex
-     *
-     * @return void
      */
     public function testGetPrimitiveTypeFindsTypeBySoundex(): void
     {
@@ -181,8 +158,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsInternalPackageReturnsTrueForPhpStandardLibrary
-     *
-     * @return void
      */
     public function testIsInternalPackageReturnsTrueForPhpStandardLibrary(): void
     {
@@ -194,19 +169,15 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testGetTypePackageReturnsExpectedExtensionNameForClassPrefixedWithBackslash
-     *
-     * @return void
      */
     public function testGetTypePackageReturnsExpectedExtensionNameForClassPrefixedWithBackslash(): void
     {
         $extensionName = Type::getTypePackage('\LogicException');
         $this->assertEquals('+spl', $extensionName);
     }
-    
+
     /**
      * testIsArrayReturnsFalseForNonArrayString
-     *
-     * @return void
      */
     public function testIsArrayReturnsFalseForNonArrayString(): void
     {
@@ -215,8 +186,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsArrayReturnsTrueForLowerCaseArrayString
-     *
-     * @return void
      */
     public function testIsArrayReturnsTrueForLowerCaseArrayString(): void
     {
@@ -225,8 +194,6 @@ class TypeTest extends AbstractTestCase
 
     /**
      * testIsArrayPerformsCheckCaseInsensitive
-     *
-     * @return void
      */
     public function testIsArrayPerformsCheckCaseInsensitive(): void
     {

--- a/src/test/php/PDepend/Util/Utf8UtilTest.php
+++ b/src/test/php/PDepend/Util/Utf8UtilTest.php
@@ -43,15 +43,15 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
-use ReflectionMethod;
 
 /**
  * Test case for type utility class.
  *
+ * @covers \PDepend\Util\Utf8Util
+ *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
- * @covers \PDepend\Util\Utf8Util
  * @group unittest
  */
 class Utf8UtilTest extends AbstractTestCase


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Simply enable the configured code style for the test folder and apply it.