### PR TITLE
Resolve PHPStan level 7 issues

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
         - src/main/php/PDepend/DbusUI/ResultPrinter.php
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
-    level: 6
+    level: 7
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -73,7 +73,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
     /**
      * Metrics restored from the cache. This property is only used temporary.
      *
-     * @var array<string, mixed>
+     * @var array<string, array<string, int>>
      */
     private $metricsCached = [];
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -111,7 +111,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * )
      * </code>
      *
-     * @var array<string, array<string, int>>
+     * @var array<string, array<string, float>>
      */
     private $nodeMetrics = null;
 
@@ -211,19 +211,19 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         $ranks = [];
 
         foreach (array_keys($this->nodes) as $name) {
-            $ranks[$name] = 1;
+            $ranks[$name] = 1.0;
         }
 
         for ($i = 0; $i < self::ALGORITHM_LOOPS; $i++) {
             foreach ($this->nodes as $name => $info) {
-                $rank = 0;
+                $rank = 0.0;
                 foreach ($info[$id1] as $ref) {
                     $previousRank = $ranks[$ref];
                     $refCount = count($this->nodes[$ref][$id2]);
 
                     $rank += ($previousRank / $refCount);
                 }
-                $ranks[$name] = ((1 - $dampingFactory)) + $dampingFactory * $rank;
+                $ranks[$name] = ((1.0 - $dampingFactory)) + $dampingFactory * $rank;
             }
         }
         return $ranks;

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -59,14 +59,14 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
     /**
      * All found nodes.
      *
-     * @var array<string, array<string, array<int, string>>>
+     * @var array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     private $nodes = [];
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array<string, array<int, string>>>
+     * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -58,14 +58,14 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * All found nodes.
      *
-     * @var array<string, array<string, array<int, string>>>
+     * @var array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     private $nodes = [];
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array<string, array<int, string>>>
+     * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -57,14 +57,14 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
     /**
      * All found nodes.
      *
-     * @var array<string, array<string, array<int, string>>>
+     * @var array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     private $nodes = [];
 
     /**
      * Returns the collected nodes.
      *
-     * @return array<string, array<string, array<int, string>>>
+     * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
     public function getCollectedNodes()
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -74,7 +74,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
     /**
      * @var array<string, ASTNamespace>
      */
-    protected $nodeSet = [];
+    private $nodeSet = [];
     /**
      * Hash with all calculated node metrics.
      *

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -110,7 +110,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * )
      * </code>
      *
-     * @return array<string, string>
+     * @return array<string, array<string, int>>
      */
     public function getNodeMetrics(ASTArtifact $artifact)
     {

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -94,6 +94,13 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         M_NON_COMMENT_LINES_OF_CODE = 'ncloc';
 
     /**
+     * Collected node metrics
+     *
+     * @var array<string, array<string, int>>
+     */
+    protected $metrics = null;
+
+    /**
      * Collected project metrics.
      *
      * @var array<string, int>

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -65,7 +65,7 @@ class ReportGeneratorFactory
     /**
      * Set of created logger instances.
      *
-     * @var ReportGenerator[]
+     * @var array<string, ReportGenerator>
      */
     protected $instances = [];
     /**
@@ -107,7 +107,7 @@ class ReportGeneratorFactory
                 }
             }
 
-            if (!$logger) {
+            if (!$logger instanceof ReportGenerator) {
                 throw new RuntimeException(sprintf('Unknown generator with identifier "%s".', $identifier));
             }
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -136,13 +136,13 @@ abstract class AbstractASTNode implements ASTNode
     }
 
     /**
-     * @template T of array<string, mixed>|string|null
+     * @template T of array<string, mixed>|numeric-string
      *
      * @param T $data
      *
      * @return T
      */
-    public function accept(ASTVisitor $visitor, $data = null)
+    public function accept(ASTVisitor $visitor, $data = [])
     {
         $methodName = 'visit' . substr(get_class($this), 22);
         $callable = [$visitor, $methodName];


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

This resolves all of the renaming PHPStan level 7 issues and bumps the config:
> report partially wrong union types - if you call a method that only exists on some types in a union type, level 7 starts to report that; other possibly incorrect situations

Level 8 will deal with nullable types which should make it safe for us to apply all PHPDoc types as native ones, level 9 is the final level and clears things that where left as mixed type which can catch a few more issues that would have previously gone unnoticed.

Things of note:
`ClassDependencyAnalyzer` had unused bits that where probably left over from having been copied from `DependencyAnalyzer`. It also made dual use of a class property which I have instead split in to a different property so that the type stays stable.

I made a few properties private as it made it easier to reason about, and left them like that as I think it's better to lock them down as part of 3.0 then let them stay accessible from the outside.

`AbstractCachingAnalyzer::$metrics` isn't ideal as it has a different implicit type depending on which extending class we are looking at. This could do with a refactor at a later point.

Lastly I had to use a few array shapes and these like in most other places would IMO be better replaced with DTOs at some later point (for now I prefer focusing on documenting what is there before doing any invasive refactoring).