### PR TITLE
Drop aligned PHPDoc groups

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -75,7 +75,6 @@ class Application
 
     /**
      * @param string $configurationFile
-     *
      * @throws InvalidArgumentException
      */
     public function setConfigurationFile($configurationFile): void
@@ -91,7 +90,6 @@ class Application
 
     /**
      * @return Configuration
-     *
      * @throws Exception
      */
     public function getConfiguration()
@@ -104,7 +102,6 @@ class Application
 
     /**
      * @return Engine
-     *
      * @throws Exception
      */
     public function getEngine()
@@ -117,7 +114,6 @@ class Application
 
     /**
      * @return Runner
-     *
      * @throws Exception
      */
     public function getRunner()
@@ -130,7 +126,6 @@ class Application
 
     /**
      * @return ReportGeneratorFactory
-     *
      * @throws Exception
      */
     public function getReportGeneratorFactory()
@@ -143,7 +138,6 @@ class Application
 
     /**
      * @return AnalyzerFactory
-     *
      * @throws Exception
      */
     public function getAnalyzerFactory()
@@ -156,7 +150,6 @@ class Application
 
     /**
      * @return TaggedContainerInterface
-     *
      * @throws Exception
      */
     private function getContainer()
@@ -170,7 +163,6 @@ class Application
 
     /**
      * @return TaggedContainerInterface
-     *
      * @throws Exception
      */
     private function createContainer()
@@ -200,7 +192,6 @@ class Application
      * Returns available logger options and documentation messages.
      *
      * @return array<string, array<string, string>>
-     *
      * @throws Exception
      */
     public function getAvailableLoggerOptions()
@@ -212,7 +203,6 @@ class Application
      * Returns available analyzer options and documentation messages.
      *
      * @return array<string, array<string, string>>
-     *
      * @throws Exception
      */
     public function getAvailableAnalyzerOptions()
@@ -222,9 +212,7 @@ class Application
 
     /**
      * @param string $serviceTag
-     *
      * @return array<string, array<string, string>>
-     *
      * @throws Exception
      */
     private function getAvailableOptionsFor($serviceTag)

--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -50,7 +50,6 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @see ConfigurationInterface
  * @see TreeBuilder
  */

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -57,7 +57,6 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
  * Copied from Behat
  *
  * @author Konstantin Kudryashov <ever.zet@gmail.com>
- *
  * @link   https://github.com/Behat/Behat/blob/3.0/src/Behat/Behat/Extension/Extension.php
  */
 abstract class Extension
@@ -72,7 +71,7 @@ abstract class Extension
     /**
      * Loads a specific configuration.
      *
-     * @param array<mixed>     $config    Extension configuration hash (from behat.yml)
+     * @param array<mixed> $config Extension configuration hash (from behat.yml)
      * @param ContainerBuilder $container ContainerBuilder instance
      */
     public function load(array $config, ContainerBuilder $container): void

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -61,7 +61,6 @@ class ExtensionManager
      * Activate an extension based on a class name.
      *
      * @param class-string<Extension> $className
-     *
      * @throws RuntimeException
      */
     public function activateExtension($className): void

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -60,7 +60,6 @@ class PdependExtension extends SymfonyExtension
 {
     /**
      * @param array<array<array<array<string>>>> $configs
-     *
      * @return void
      *
      * {@inheritDoc}
@@ -115,7 +114,6 @@ class PdependExtension extends SymfonyExtension
 
     /**
      * @param array<string, array<string, string>> $config
-     *
      * @return stdClass
      */
     private function createSettings($config)

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -90,7 +90,6 @@ class Engine
      * The system configuration.
      *
      * @var Configuration
-     *
      * @since 0.10.0
      */
     protected $configuration = null;
@@ -184,7 +183,6 @@ class Engine
      * The configured cache factory.
      *
      * @var CacheFactory
-     *
      * @since 1.0.0
      */
     private $cacheFactory;
@@ -217,7 +215,6 @@ class Engine
      * Adds the specified directory to the list of directories to be analyzed.
      *
      * @param string $directory The php source directory.
-     *
      * @throws InvalidArgumentException
      */
     public function addDirectory($directory): void
@@ -235,7 +232,6 @@ class Engine
      * Adds a single source code file to the list of files to be analysed.
      *
      * @param string $file The source file name.
-     *
      * @throws InvalidArgumentException
      */
     public function addFile($file): void
@@ -322,7 +318,6 @@ class Engine
      * analyzed namespace.
      *
      * @return ASTArtifactList<ASTNamespace>
-     *
      * @throws InvalidArgumentException
      */
     public function analyze()
@@ -363,7 +358,6 @@ class Engine
      * Returns the number of analyzed php classes and interfaces.
      *
      * @return int
-     *
      * @throws RuntimeException
      */
     public function countClasses()
@@ -395,7 +389,6 @@ class Engine
      * Returns the number of analyzed namespaces.
      *
      * @return int
-     *
      * @throws RuntimeException
      */
     public function countNamespaces()
@@ -418,9 +411,7 @@ class Engine
      * Returns the analyzed namespace for the given name.
      *
      * @param string $name
-     *
      * @return ASTNamespace
-     *
      * @throws OutOfBoundsException
      * @throws RuntimeException
      */
@@ -442,7 +433,6 @@ class Engine
      * Returns an array with the analyzed namespace.
      *
      * @return ASTArtifactList<ASTNamespace>
-     *
      * @throws RuntimeException
      */
     public function getNamespaces()
@@ -624,7 +614,6 @@ class Engine
      * that are part of the parsing process.
      *
      * @return ArrayIterator<int, string>
-     *
      * @throws RuntimeException
      */
     private function createFileIterator()
@@ -685,9 +674,7 @@ class Engine
 
     /**
      * @param array<string, mixed> $options
-     *
      * @return Analyzer[]
-     *
      * @throws InvalidArgumentException
      */
     private function createAnalyzers($options)
@@ -717,7 +704,6 @@ class Engine
 
     /**
      * @param string $path
-     *
      * @return bool
      */
     private function isPhpStream($path)

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -54,7 +54,6 @@ class ExcludePathFilter implements Filter
      * Regular expression that should not match against the absolute file paths or a chunk of a relative path.
      *
      * @var string
-     *
      * @since 0.10.0
      */
     protected $pattern = '';
@@ -92,9 +91,7 @@ class ExcludePathFilter implements Filter
      * exclude patterns as an absolute path.
      *
      * @param string $path The absolute path to a source file.
-     *
      * @return bool
-     *
      * @since  0.10.0
      */
     protected function notAbsolute($path)
@@ -107,9 +104,7 @@ class ExcludePathFilter implements Filter
      * exclude patterns as an relative path.
      *
      * @param string $path The relative path to a source file.
-     *
      * @return bool
-     *
      * @since  0.10.0
      */
     protected function notRelative($path)

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -64,7 +64,6 @@ class Iterator extends FilterIterator
      * Optional root path for the files.
      *
      * @var string|null
-     *
      * @since 0.10.0
      */
     protected $rootPath = null;
@@ -73,8 +72,8 @@ class Iterator extends FilterIterator
      * Constructs a new file filter iterator.
      *
      * @param \Iterator<SplFileInfo> $iterator The inner iterator.
-     * @param Filter                 $filter   The filter object.
-     * @param string                 $rootPath Optional root path for the files.
+     * @param Filter $filter The filter object.
+     * @param string $rootPath Optional root path for the files.
      */
     public function __construct(\Iterator $iterator, Filter $filter, $rootPath = null)
     {
@@ -99,7 +98,6 @@ class Iterator extends FilterIterator
      * Returns the full qualified realpath for the currently active file.
      *
      * @return string
-     *
      * @since  0.10.0
      */
     protected function getFullPath()
@@ -112,7 +110,6 @@ class Iterator extends FilterIterator
      * set. If not, this method returns the absolute file path.
      *
      * @return string
-     *
      * @since  0.10.0
      */
     protected function getLocalPath()

--- a/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
@@ -109,7 +109,6 @@ abstract class AbstractAnalyzer extends AbstractASTVisitor implements Analyzer
      * state based disabling/enabling.
      *
      * @return bool
-     *
      * @since  0.9.10
      */
     public function isEnabled()

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -58,7 +57,6 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements AnalyzerCacheAware
@@ -108,7 +106,6 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * value will be <b>FALSE</b>.
      *
      * @param ASTClass|ASTCompilationUnit|ASTFunction|ASTInterface|ASTMethod $node
-     *
      * @return bool
      */
     protected function restoreFromCache(AbstractASTArtifact $node)

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -81,7 +81,6 @@ interface Analyzer
      * for any reason should return <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.10
      */
     public function isEnabled();
@@ -90,7 +89,6 @@ interface Analyzer
      * Set global options
      *
      * @param array<string, mixed> $options
-     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void;

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -265,7 +265,6 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
      * @param AbstractASTArtifact[] $list
-     *
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -304,7 +304,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * counts protected and public properties of parent classes.
      *
      * @param ASTClass|ASTEnum|ASTTrait $class The context class instance.
-     *
      * @return int
      */
     private function calculateVarsi(AbstractASTClassOrInterface $class)
@@ -355,7 +354,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Weight Method Per Class metric for a trait.
      *
      * @return int
-     *
      * @since  1.0.6
      */
     private function calculateWmciForTrait(ASTTrait $trait)
@@ -367,7 +365,6 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Weight Method Per Class metric.
      *
      * @return int[]
-     *
      * @since  1.0.6
      */
     private function calculateWmci(AbstractASTType $type)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -201,7 +201,6 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      *
      * @param string $id1 Identifier for the incoming edges.
      * @param string $id2 Identifier for the outgoing edges.
-     *
      * @return array<string, float>
      */
     protected function computeCodeRank($id1, $id2)

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -99,9 +99,7 @@ class StrategyFactory
      * Creates a code rank strategy for the given identifier.
      *
      * @param string $strategyName The strategy identifier.
-     *
      * @return CodeRankStrategyI
-     *
      * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -96,7 +96,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * Has this analyzer already processed the source under test?
      *
      * @var bool
-     *
      * @since 0.10.2
      */
     private $uninitialized = true;
@@ -120,7 +119,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * depender.
      *
      * @var array<string, array<string, array<string, bool>>>
-     *
      * @since 0.10.2
      */
     private $dependencyMap = [];
@@ -130,7 +128,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * the node's metrics.
      *
      * @var array<string, array<string, mixed>>
-     *
      * @since 0.10.2
      */
     private $nodeMetrics = [];
@@ -194,7 +191,6 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * the coupling metrics for them.
      *
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
      * @since  0.10.2
      */
     private function doAnalyze($namespaces): void

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -224,7 +224,6 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * values.
      *
      * @param string $nodeId Identifier of the analyzed item.
-     *
      * @since  1.0.0
      */
     private function updateProjectMetrics($nodeId): void
@@ -236,11 +235,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a boolean AND-expression.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitBooleanAndExpression($node, $data)
@@ -252,11 +249,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a boolean OR-expression.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitBooleanOrExpression($node, $data)
@@ -268,11 +263,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a switch label.
      *
-     * @param ASTSwitchLabel     $node The currently visited node.
+     * @param ASTSwitchLabel $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitSwitchLabel($node, $data)
@@ -287,11 +280,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a catch statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitCatchStatement($node, $data)
@@ -305,11 +296,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits an elseif statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitElseIfStatement($node, $data)
@@ -323,11 +312,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a for statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitForStatement($node, $data)
@@ -341,11 +328,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a foreach statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitForeachStatement($node, $data)
@@ -359,11 +344,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits an if statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitIfStatement($node, $data)
@@ -377,11 +360,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a logical AND expression.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitLogicalAndExpression($node, $data)
@@ -393,11 +374,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a logical OR expression.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitLogicalOrExpression($node, $data)
@@ -409,11 +388,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a ternary operator.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitConditionalExpression($node, $data)
@@ -427,11 +404,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a while-statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.8
      */
     public function visitWhileStatement($node, $data)
@@ -445,11 +420,9 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Visits a do/while-statement.
      *
-     * @param ASTNode            $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param array<string, int> $data The previously calculated ccn values.
-     *
      * @return array<string, int>
-     *
      * @since  0.9.12
      */
     public function visitDoWhileStatement($node, $data)

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -206,7 +206,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * returns <b>null</b> if no cycle exists .
      *
      * @param ASTNamespace $node
-     *
      * @return AbstractASTArtifact[]
      */
     public function getCycle(AbstractASTArtifact $node)
@@ -433,7 +432,6 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
      * @param ASTNamespace[] $list
-     *
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -359,9 +359,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      * Calculates Halstead measures from n1, n2, N1 & N2.
      *
      * @param array<string, int> $basis [n1, n2, N1, N2]
-     *
      * @return array<string, float>
-     *
      * @see http://www.verifysoft.com/en_halstead_metrics.html
      * @see http://www.grammatech.com/codesonar/workflow-features/halstead
      */

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -187,7 +187,6 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * namespaces.
      *
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
      * @since  0.9.10
      */
     private function doAnalyze($namespaces): void

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -184,11 +184,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(?) = NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 2 --
      * </code>
      *
-     * @param ASTNode        $node
+     * @param ASTNode $node
      * @param numeric-string $data
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitConditionalExpression($node, $data)
@@ -227,11 +225,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(do) = NP(<do-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitDoWhileStatement($node, $data)
@@ -267,10 +263,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * </code>
      *
      * @param ASTElseIfStatement $node The currently visited node.
-     * @param numeric-string     $data The previously calculated npath value.
-     *
+     * @param numeric-string $data The previously calculated npath value.
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitElseIfStatement($node, $data)
@@ -302,11 +296,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(for) = NP(<for-range>) + NP(<expr1>) + NP(<expr2>) + NP(<expr3>) + 1 --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitForStatement($node, $data)
@@ -337,11 +329,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(foreach) = NP(<foreach-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitForeachStatement($node, $data)
@@ -382,9 +372,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      *
      * @param ASTIfStatement $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitIfStatement($node, $data)
@@ -415,11 +403,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(return) = NP(<expr>) --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitReturnStatement($node, $data)
@@ -444,11 +430,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(switch) = NP(<expr>) + NP(<default-range>) +  NP(<case-range1>) ... --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitSwitchStatement($node, $data)
@@ -487,11 +471,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(try) = NP(<try-range>) + NP(<catch-range1>) + NP(<catch-range2>) ... --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitTryStatement($node, $data)
@@ -518,11 +500,9 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * -- NP(while) = NP(<while-range>) + NP(<expr>) + 1 --
      * </code>
      *
-     * @param ASTNode        $node The currently visited node.
+     * @param ASTNode $node The currently visited node.
      * @param numeric-string $data The previously calculated npath value.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
      */
     public function visitWhileStatement($node, $data)
@@ -540,11 +520,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      * Calculates the expression sum of the given node.
      *
      * @param ASTNode $node The currently visited node.
-     *
      * @return numeric-string
-     *
      * @since  0.9.12
-     *
      * @todo   I don't like this method implementation, it should be possible to
      *       implement this method with more visitor behavior for the boolean
      *       and logical expressions.

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -118,7 +118,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * this property with each method's ELOC value.
      *
      * @var int
-     *
      * @since 0.9.12
      */
     private $classExecutableLines = 0;
@@ -128,7 +127,6 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * property with each method's LLOC value.
      *
      * @var int
-     *
      * @since 0.9.13
      */
     private $classLogicalLines = 0;
@@ -406,8 +404,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * </code>
      *
      * @param array<int, Token> $tokens The raw token stream.
-     * @param bool              $search Optional boolean flag, search start.
-     *
+     * @param bool $search Optional boolean flag, search start.
      * @return array<int, int>
      */
     private function linesOfCode(array $tokens, $search = false)

--- a/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -53,7 +52,6 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 interface AnalyzerCacheAware extends Analyzer

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -71,9 +71,7 @@ class AnalyzerFactory
      * Create and configure all analyzers required for given set of loggers.
      *
      * @param ReportGenerator[] $generators
-     *
      * @return Analyzer[]
-     *
      * @throws InvalidArgumentException
      */
     public function createRequiredForGenerators(array $generators)

--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 
@@ -53,7 +52,6 @@ use FilterIterator;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 class AnalyzerIterator extends FilterIterator

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -140,7 +140,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer)
@@ -316,7 +315,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement          $xml             The parent xml element.
+     * @param DOMElement $xml The parent xml element.
      * @param ?ASTCompilationUnit $compilationUnit The code file instance.
      */
     protected function writeFileReference(DOMElement $xml, ?ASTCompilationUnit $compilationUnit = null): void

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -122,7 +122,6 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer)

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -172,7 +172,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer)

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -157,7 +157,6 @@ class Pyramid implements FileAwareGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer)
@@ -236,9 +235,8 @@ class Pyramid implements FileAwareGenerator
      * If no threshold is defined for the given name, this method will return
      * <b>null</b>.
      *
-     * @param string $name  The metric/field identfier.
-     * @param mixed  $value The metric/field value.
-     *
+     * @param string $name The metric/field identfier.
+     * @param mixed $value The metric/field value.
      * @return string|null
      */
     private function computeThreshold($name, $value)
@@ -267,7 +265,6 @@ class Pyramid implements FileAwareGenerator
      * Computes the proportions between the given metrics.
      *
      * @param array<string, float> $metrics The aggregated project metrics.
-     *
      * @return array<string, float>
      */
     private function computeProportions(array $metrics)
@@ -299,7 +296,6 @@ class Pyramid implements FileAwareGenerator
      * Aggregates the required metrics from the registered analyzers.
      *
      * @return array<string, mixed>
-     *
      * @throws RuntimeException If one of the required analyzers isn't set.
      */
     private function collectMetrics()

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -57,7 +57,6 @@ interface ReportGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer);

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -86,10 +86,8 @@ class ReportGeneratorFactory
      * <b>$identifier</b>.
      *
      * @param string $identifier The generator identifier.
-     * @param string $fileName   The log output file name.
-     *
+     * @param string $fileName The log output file name.
      * @return ReportGenerator
-     *
      * @throws RuntimeException
      */
     public function createGenerator($identifier, $fileName)

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -164,7 +164,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(Analyzer $analyzer)
@@ -235,7 +234,6 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * Returns an array with all collected project metrics.
      *
      * @return array<string, mixed>
-     *
      * @since  0.9.10
      */
     private function getProjectMetrics()
@@ -422,7 +420,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *   </class>
      * </code>
      *
-     * @param DOMElement          $xml             The parent xml element.
+     * @param DOMElement $xml The parent xml element.
      * @param ?ASTCompilationUnit $compilationUnit The code file instance.
      */
     protected function writeFileReference(DOMElement $xml, ?ASTCompilationUnit $compilationUnit = null): void

--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -62,7 +61,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTAllocationExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 class ASTAnonymousClass extends ASTClass implements ASTNode
@@ -60,7 +58,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * image in a colon separated string.
      *
      * @var string
-     *
      * @since 0.10.4
      */
     protected $metadata = ':::';
@@ -71,7 +68,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array
-     *
      * @since 0.10.0
      */
     public function __sleep()
@@ -162,7 +158,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * @param int $endLine
      * @param int $startColumn
      * @param int $endColumn
-     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns($startLine, $endLine, $startColumn, $endColumn): void
@@ -197,9 +192,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns an integer value that was stored under the given index.
      *
      * @param int $index
-     *
      * @return int
-     *
      * @since 0.10.4
      */
     protected function getMetadataInteger($index)
@@ -213,7 +206,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      *
      * @param int $index
      * @param int $value
-     *
      * @since 0.10.4
      */
     protected function setMetadataInteger($index, $value): void
@@ -225,9 +217,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns the value that was stored under the given index.
      *
      * @param int $index
-     *
      * @return string
-     *
      * @since 0.10.4
      */
     protected function getMetadata($index)
@@ -240,9 +230,8 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int    $index
+     * @param int $index
      * @param string $value
-     *
      * @since 0.10.4
      */
     protected function setMetadata($index, $value): void
@@ -257,7 +246,6 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @since 0.10.4
      */
     protected function getMetadataSize()

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -62,7 +61,6 @@ use InvalidArgumentException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTArguments extends AbstractASTNode
@@ -71,7 +69,6 @@ class ASTArguments extends AbstractASTNode
      * This method will return true if the argument list is declared as foo(...)
      *
      * @return bool
-     *
      * @since 2.11.0
      */
     public function isVariadicPlaceholder()

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTArray extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTArrayElement extends ASTExpression
@@ -87,7 +85,6 @@ class ASTArrayElement extends ASTExpression
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTArrayIndexExpression extends ASTIndexExpression

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -54,7 +54,6 @@ interface ASTArtifact extends ASTNode
      * Returns the artifact name.
      *
      * @return string
-     *
      * @deprecated Use getImage() inherit from ASTNode class.
      */
     public function getName();

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -124,7 +124,6 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Returns the current node
      *
      * @return T
-     *
      * @throws OutOfBoundsException
      */
     public function current(): false|ASTArtifact
@@ -171,10 +170,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Whether a offset exists
      *
      * @param mixed $offset An offset to check for.
-     *
      * @return bool Returns true on success or false on failure. The return
      *              value will be casted to boolean if non-boolean was returned.
-     *
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
      * @since  1.0.0
      */
@@ -187,11 +184,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Offset to retrieve
      *
      * @param int|string $offset
-     *
      * @return T Can return all value types.
-     *
      * @throws OutOfBoundsException
-     *
      * @link   http://php.net/manual/en/arrayaccess.offsetget.php
      * @since  1.0.0
      */
@@ -207,10 +201,8 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Offset to set
      *
      * @param int|string $offset
-     * @param T          $value
-     *
+     * @param T $value
      * @throws BadMethodCallException
-     *
      * @link   http://php.net/manual/en/arrayaccess.offsetset.php
      * @since  1.0.0
      */
@@ -223,9 +215,7 @@ class ASTArtifactList implements ArrayAccess, Iterator, Countable
      * Offset to unset
      *
      * @param int|string $offset
-     *
      * @throws BadMethodCallException
-     *
      * @link   http://php.net/manual/en/arrayaccess.offsetunset.php
      * @since  1.0.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -95,7 +95,6 @@ final class CollectionArtifactFilter implements ArtifactFilter
      * Sets the used filter instance.
      *
      * @param ?ArtifactFilter $filter
-     *
      * @since  0.9.12
      */
     public function setFilter(?ArtifactFilter $filter = null): void

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTBooleanAndExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTBooleanOrExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTBreakStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.15
  */
 
@@ -79,7 +78,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.15
  */
 class ASTCastExpression extends ASTUnaryExpression

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -172,7 +172,6 @@ class ASTClass extends AbstractASTClassOrInterface
      * Returns the declared modifiers for this type.
      *
      * @return int
-     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -188,10 +187,8 @@ class ASTClass extends AbstractASTClassOrInterface
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers
-     *
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
-     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers): void

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.0.0
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.0.0
  */
 class ASTClassFqnPostfix extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -52,7 +51,6 @@ use RuntimeException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTClassOrInterfaceRecursiveInheritanceException extends RuntimeException

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 class ASTClassOrInterfaceReference extends ASTType
@@ -88,7 +86,6 @@ class ASTClassOrInterfaceReference extends ASTType
      * be cached for this node instance.
      *
      * @return array
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -70,7 +70,6 @@ class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
      * objects from the given reference array.
      *
      * @param ASTClassOrInterfaceReference[] $references
-     *
      * @return AbstractASTClassOrInterface[]
      */
     protected function createClassesAndInterfaces(array $references)

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 class ASTClassReference extends ASTClassOrInterfaceReference

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTCloneExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTClosure extends AbstractASTNode implements ASTCallable
@@ -109,7 +107,6 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * </code>
      *
      * @return bool
-     *
      * @since  1.0.0
      */
     public function isStatic()
@@ -121,7 +118,6 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * This method can be used to flag this closure instance as static.
      *
      * @param bool $static Whether this closure is static or not.
-     *
      * @since  1.0.0
      */
     public function setStatic($static): void
@@ -133,7 +129,6 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @see    ASTNode#getMetadataSize()
      * @since  1.0.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -58,7 +58,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * The internal used cache instance.
      *
      * @var CacheDriver|null
-     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -88,7 +87,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * The files start line. This property must always have the value <em>1</em>.
      *
      * @var int
-     *
      * @since 0.10.0
      */
     protected $startLine = 0;
@@ -97,7 +95,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * The files end line.
      *
      * @var int
-     *
      * @since 0.10.0
      */
     protected $endLine = 0;
@@ -106,7 +103,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * List of classes, interfaces and functions that parsed from this file.
      *
      * @var AbstractASTArtifact[]
-     *
      * @since 0.10.0
      */
     protected $childNodes = [];
@@ -115,7 +111,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * Was this file instance restored from the cache?
      *
      * @var bool
-     *
      * @since 0.10.0
      */
     protected $cached = false;
@@ -147,7 +142,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * array with those property names that should be serialized.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -225,7 +219,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * Sets the unique identifier for this file instance.
      *
      * @param string $id Identifier for this file.
-     *
      * @since  0.9.12
      */
     public function setId($id): void
@@ -237,7 +230,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * Setter method for the used parser and token cache.
      *
      * @return $this
-     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -302,7 +294,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * not existing dummy file.
      *
      * @return int
-     *
      * @since  0.10.0
      */
     public function getStartLine()
@@ -319,7 +310,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * for a not existing dummy file.
      *
      * @return int
-     *
      * @since  0.10.0
      */
     public function getEndLine()
@@ -336,7 +326,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.10.0
      */
     public function isCached()

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -52,7 +51,6 @@ use RuntimeException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class ASTCompilationUnitNotFoundException extends RuntimeException

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTCompoundExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTCompoundVariable extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -55,7 +54,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTConditionalExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTConstant.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstant.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTConstant extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -81,7 +81,6 @@ class ASTConstantDefinition extends AbstractASTNode
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers The declared modifiers for this node.
-     *
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
      */
     public function setModifiers($modifiers): void
@@ -138,7 +137,6 @@ class ASTConstantDefinition extends AbstractASTNode
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -54,7 +53,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTConstantPostfix extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTContinueStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -67,7 +66,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class ASTDeclareStatement extends ASTStatement
@@ -85,7 +83,6 @@ class ASTDeclareStatement extends ASTStatement
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTDoWhileStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTEchoStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTElseIfStatement extends ASTStatement
@@ -59,7 +57,6 @@ class ASTElseIfStatement extends ASTStatement
      * <b>else</b>-statement.
      *
      * @return bool
-     *
      * @since  0.9.12
      */
     public function hasElse()

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -251,7 +251,6 @@ class ASTEnum extends AbstractASTClassOrInterface
      * Returns the declared modifiers for this type.
      *
      * @return int
-     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -267,10 +266,8 @@ class ASTEnum extends AbstractASTClassOrInterface
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers
-     *
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
-     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers): void

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTEvalExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTExitExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTExpression extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -66,7 +65,6 @@ use OutOfBoundsException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTFieldDeclaration extends AbstractASTNode
@@ -115,7 +113,6 @@ class ASTFieldDeclaration extends AbstractASTNode
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers The declared modifiers for this node.
-     *
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
      */
     public function setModifiers($modifiers): void
@@ -184,7 +181,6 @@ class ASTFieldDeclaration extends AbstractASTNode
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTForStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -55,7 +54,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTForUpdate extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTForeachStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -57,7 +56,6 @@ use OutOfBoundsException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTFormalParameter extends AbstractASTNode
@@ -104,7 +102,6 @@ class ASTFormalParameter extends AbstractASTNode
      * variable argument list <b>...</b>.
      *
      * @return bool
-     *
      * @since 2.0.7
      */
     public function isVariableArgList()
@@ -144,7 +141,6 @@ class ASTFormalParameter extends AbstractASTNode
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */
@@ -157,7 +153,6 @@ class ASTFormalParameter extends AbstractASTNode
      * Returns the declared modifiers for this type.
      *
      * @return int
-     *
      * @since  0.9.4
      */
     public function getModifiers()
@@ -173,10 +168,8 @@ class ASTFormalParameter extends AbstractASTNode
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers
-     *
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
-     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers): void

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -66,7 +65,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTFormalParameters extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -56,7 +56,6 @@ class ASTFunction extends AbstractASTCallable
      * The currently used builder context.
      *
      * @var BuilderContext|null
-     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -72,7 +71,6 @@ class ASTFunction extends AbstractASTCallable
      * The parent namespace for this function.
      *
      * @var ASTNamespace|null
-     *
      * @since 0.10.0
      */
     private $namespace = null;
@@ -83,7 +81,6 @@ class ASTFunction extends AbstractASTCallable
      * cached for all function instances.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -108,9 +105,7 @@ class ASTFunction extends AbstractASTCallable
      * Sets the currently active builder context.
      *
      * @param BuilderContext $context Current builder context.
-     *
      * @return $this
-     *
      * @since  0.10.0
      */
     public function setContext(BuilderContext $context)
@@ -154,7 +149,6 @@ class ASTFunction extends AbstractASTCallable
      * function does not belong to a namespace.
      *
      * @return string
-     *
      * @since  0.10.0
      */
     public function getNamespaceName()

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTFunctionPostfix extends ASTInvocation

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTGlobalStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTGotoStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTHeredoc extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -50,7 +49,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTIdentifier extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTIfStatement extends ASTStatement
@@ -59,7 +57,6 @@ class ASTIfStatement extends ASTStatement
      * <b>else</b>-statement.
      *
      * @return bool
-     *
      * @since  0.9.12
      */
     public function hasElse()

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTIncludeExpression extends ASTExpression
@@ -67,7 +65,6 @@ class ASTIncludeExpression extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 abstract class ASTIndexExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTInstanceOfExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -89,7 +89,6 @@ class ASTInterface extends AbstractASTClassOrInterface
      * Sets a reference onto the parent class of this class node.
      *
      * @throws BadMethodCallException
-     *
      * @since  0.9.5
      */
     public function setParentClassReference(ASTClassReference $classReference): void
@@ -122,7 +121,6 @@ class ASTInterface extends AbstractASTClassOrInterface
      * Returns the declared modifiers for this type.
      *
      * @return int
-     *
      * @since  0.9.4
      */
     public function getModifiers()

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @see https://php.watch/versions/8.1/intersection-types
  */
 class ASTIntersectionType extends AbstractASTCombinationType

--- a/src/main/php/PDepend/Source/AST/ASTInvocation.php
+++ b/src/main/php/PDepend/Source/AST/ASTInvocation.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 abstract class ASTInvocation extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTIssetExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTLabelStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTListExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTLiteral extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTLogicalAndExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTLogicalOrExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTLogicalXorExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -53,7 +52,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.9.0
  */
 class ASTMatchArgument extends ASTArguments

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -58,7 +57,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.9.0
  */
 class ASTMatchBlock extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -54,7 +53,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.9.0
  */
 class ASTMatchEntry extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -68,7 +67,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTMemberPrimaryPrefix extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -67,7 +67,6 @@ class ASTMethod extends AbstractASTCallable
      * cached for method instances.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -80,7 +79,6 @@ class ASTMethod extends AbstractASTCallable
      * this method.
      *
      * @return int
-     *
      * @since  1.0.0
      */
     public function getModifiers()
@@ -96,9 +94,7 @@ class ASTMethod extends AbstractASTCallable
      * contains an invalid/unexpected modifier
      *
      * @param int $modifiers
-     *
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
-     *
      * @since  0.9.4
      */
     public function setModifiers($modifiers): void
@@ -206,9 +202,7 @@ class ASTMethod extends AbstractASTCallable
      * Returns the source file where this method was declared.
      *
      * @return ASTCompilationUnit
-     *
      * @throws ASTCompilationUnitNotFoundException When no parent was set.
-     *
      * @since  0.10.0
      */
     public function getCompilationUnit()

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -59,7 +58,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTMethodPostfix extends ASTInvocation

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.9.0
  */
 class ASTNamedArgument extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -112,7 +112,6 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.10
      */
     public function isUserDefined()
@@ -129,7 +128,6 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.10
      */
     private function checkUserDefined()
@@ -147,7 +145,6 @@ class ASTNamespace extends AbstractASTArtifact
      * instances declared in this namespace.
      *
      * @return ASTArtifactList<ASTTrait>
-     *
      * @since  1.0.0
      */
     public function getTraits()
@@ -195,9 +192,7 @@ class ASTNamespace extends AbstractASTArtifact
      * @template T of AbstractASTClassOrInterface
      *
      * @param class-string<T> $className The class/type we are looking for.
-     *
      * @return ASTArtifactList<T>
-     *
      * @since  1.0.0
      */
     private function getTypesOfType($className)
@@ -226,7 +221,6 @@ class ASTNamespace extends AbstractASTArtifact
      * Adds the given type to this namespace and returns the input type instance.
      *
      * @param AbstractASTClassOrInterface $type
-     *
      * @return AbstractASTClassOrInterface
      */
     public function addType(AbstractASTType $type)

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 interface ASTNode
@@ -63,7 +61,6 @@ interface ASTNode
      * @template T of array<string, mixed>|numeric-string
      *
      * @param T $data
-     *
      * @return T
      */
     public function accept(ASTVisitor $visitor, $data = []);
@@ -107,9 +104,7 @@ interface ASTNode
      * Returns the node instance for the given index or throws an exception.
      *
      * @param int $index
-     *
      * @return ASTNode
-     *
      * @throws OutOfBoundsException When no node exists at the given index.
      */
     public function getChild($index);
@@ -129,7 +124,6 @@ interface ASTNode
      * @template T of ASTNode
      *
      * @param class-string<T> $targetType
-     *
      * @return T|null
      */
     public function getFirstChildOfType($targetType);
@@ -142,9 +136,8 @@ interface ASTNode
      * @template T of ASTNode
      *
      * @param class-string<T> $targetType Searched class or interface type.
-     * @param T[]             $results    Already found node instances. This parameter
-     *                                    is only for internal usage.
-     *
+     * @param T[] $results Already found node instances. This parameter
+     *                     is only for internal usage.
      * @return T[]
      */
     public function findChildrenOfType($targetType, array &$results = []);
@@ -167,7 +160,6 @@ interface ASTNode
      * of <b>$parentType</b>.
      *
      * @param string $parentType
-     *
      * @return ASTNode[]
      */
     public function getParentsOfType($parentType);
@@ -195,7 +187,6 @@ interface ASTNode
      * @param int $endLine
      * @param int $startColumn
      * @param int $endColumn
-     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns($startLine, $endLine, $startColumn, $endColumn): void;

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -194,7 +194,6 @@ class ASTParameter extends AbstractASTArtifact
      * Returns the parent function or method instance or <b>null</b>
      *
      * @return AbstractASTCallable
-     *
      * @since  0.9.5
      */
     public function getDeclaringFunction()
@@ -217,9 +216,7 @@ class ASTParameter extends AbstractASTArtifact
      * The returned value will be <b>null</b> if the parent is a function.
      *
      * @return AbstractASTClassOrInterface|null
-     *
      * @since  0.9.5
-     *
      * @todo Review this for refactoring, maybe create a empty getParent()?
      */
     public function getDeclaringClass()
@@ -255,7 +252,6 @@ class ASTParameter extends AbstractASTArtifact
      * <b>null</b> for all scalar type, only classes or interfaces are used.
      *
      * @return AbstractASTClassOrInterface|null
-     *
      * @since  0.9.5
      */
     public function getClass()
@@ -274,7 +270,6 @@ class ASTParameter extends AbstractASTArtifact
      * reference.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function isPassedByReference()
@@ -287,7 +282,6 @@ class ASTParameter extends AbstractASTArtifact
      * the array type hint, otherwise the it will return <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function isArray()
@@ -302,7 +296,6 @@ class ASTParameter extends AbstractASTArtifact
      * value <b>null</b>.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function allowsNull()
@@ -332,7 +325,6 @@ class ASTParameter extends AbstractASTArtifact
      * can be left blank on invocation.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function isOptional()
@@ -347,7 +339,6 @@ class ASTParameter extends AbstractASTArtifact
      *
      * @param bool $optional Boolean flag that marks this parameter a
      *                       optional or not.
-     *
      * @since  0.9.5
      */
     public function setOptional($optional): void
@@ -360,7 +351,6 @@ class ASTParameter extends AbstractASTArtifact
      * contains a default value.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function isDefaultValueAvailable()
@@ -400,7 +390,6 @@ class ASTParameter extends AbstractASTArtifact
 
     /**
      * @param ASTNode $node
-     *
      * @return bool
      */
     private function isTypeAllowingNull($node)

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -50,7 +49,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 final class ASTParentReference extends ASTClassOrInterfaceReference
@@ -71,7 +69,6 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * Constructs a new type holder instance.
      *
      * @param ASTClassOrInterfaceReference $reference The type instance that reference the concrete target of self.
-     *
      * @todo Call parent constructor, otherwise this could cause bad side effects.
      */
     public function __construct(ASTClassOrInterfaceReference $reference)
@@ -85,7 +82,6 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -97,7 +93,6 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * Returns the visual representation for this node type.
      *
      * @return string
-     *
      * @since  0.10.4
      */
     public function getImage()

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class ASTPostfixExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class ASTPreDecrementExpression extends ASTUnaryExpression

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class ASTPreIncrementExpression extends ASTUnaryExpression

--- a/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 class ASTPrintExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -61,7 +61,6 @@ class ASTProperty extends AbstractASTArtifact
      * The wrapped field declaration instance.
      *
      * @var ASTFieldDeclaration
-     *
      * @since 0.9.6
      */
     private $fieldDeclaration = null;
@@ -70,7 +69,6 @@ class ASTProperty extends AbstractASTArtifact
      * The wrapped variable declarator instance.
      *
      * @var ASTVariableDeclarator
-     *
      * @since 0.9.6
      */
     private $variableDeclarator = null;
@@ -79,7 +77,7 @@ class ASTProperty extends AbstractASTArtifact
      * Constructs a new item for the given field declaration and variable
      * declarator.
      *
-     * @param ASTFieldDeclaration   $fieldDeclaration   The context field declaration where this property was declared in the source.
+     * @param ASTFieldDeclaration $fieldDeclaration The context field declaration where this property was declared in the source.
      * @param ASTVariableDeclarator $variableDeclarator The context variable declarator for this property instance.
      */
     public function __construct(
@@ -96,7 +94,6 @@ class ASTProperty extends AbstractASTArtifact
      * This method returns a string representation of this parameter.
      *
      * @return string
-     *
      * @since  0.9.6
      */
     public function __toString()
@@ -138,7 +135,6 @@ class ASTProperty extends AbstractASTArtifact
      * this property.
      *
      * @return int
-     *
      * @since  0.9.6
      */
     public function getModifiers()
@@ -195,7 +191,6 @@ class ASTProperty extends AbstractASTArtifact
      * contains an array type hint, otherwise the it will return <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.6
      */
     public function isArray()
@@ -214,7 +209,6 @@ class ASTProperty extends AbstractASTArtifact
      * contains a primitive type hint, otherwise the it will return <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.6
      */
     public function isScalar()
@@ -233,7 +227,6 @@ class ASTProperty extends AbstractASTArtifact
      * for all scalar type, only class properties will have a type.
      *
      * @return AbstractASTClassOrInterface|null
-     *
      * @since  0.9.5
      */
     public function getClass()
@@ -261,7 +254,6 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the line number where the property declaration can be found.
      *
      * @return int
-     *
      * @since  0.9.6
      */
     public function getStartLine()
@@ -273,7 +265,6 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the column number where the property declaration starts.
      *
      * @return int
-     *
      * @since  0.9.8
      */
     public function getStartColumn()
@@ -285,7 +276,6 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the line number where the property declaration ends.
      *
      * @return int
-     *
      * @since  0.9.6
      */
     public function getEndLine()
@@ -297,7 +287,6 @@ class ASTProperty extends AbstractASTArtifact
      * Returns the column number where the property declaration ends.
      *
      * @return int
-     *
      * @since  0.9.8
      */
     public function getEndColumn()
@@ -309,7 +298,6 @@ class ASTProperty extends AbstractASTArtifact
      * This method will return the class where this property was declared.
      *
      * @return AbstractASTClassOrInterface
-     *
      * @since  0.9.6
      */
     public function getDeclaringClass()
@@ -332,7 +320,6 @@ class ASTProperty extends AbstractASTArtifact
      * contains a default value.
      *
      * @return bool
-     *
      * @since  0.9.6
      */
     public function isDefaultValueAvailable()

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTPropertyPostfix extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTRequireExpression extends ASTExpression
@@ -67,7 +65,6 @@ class ASTRequireExpression extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTReturnStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -50,7 +49,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTScalarType extends ASTType

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTScope extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTScopeStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTSelfReference extends ASTClassOrInterfaceReference
@@ -66,7 +64,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * The currently used builder context.
      *
      * @var BuilderContext
-     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -75,9 +72,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * The full qualified class name, including the namespace or namespace name.
      *
      * @var string
-     *
      * @since 0.10.0
-     *
      * @todo  To reduce memory usage, move property into new metadata string
      */
     protected $qualifiedName = null;
@@ -97,7 +92,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * array with those property names that should be serialized for this class.
      *
      * @return array
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -112,7 +106,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * Returns the visual representation for this node type.
      *
      * @return string
-     *
      * @since  0.10.4
      */
     public function getImage()
@@ -124,7 +117,6 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * Returns the class or interface instance that this node instance represents.
      *
      * @return AbstractASTClassOrInterface
-     *
      * @since  0.10.0
      */
     public function getType()

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  */
 class ASTShiftLeftExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  */
 class ASTShiftRightExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTStatement extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -50,7 +49,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTStaticReference extends ASTSelfReference
@@ -64,7 +62,6 @@ class ASTStaticReference extends ASTSelfReference
      * Returns the visual representation for this node type.
      *
      * @return string
-     *
      * @since  0.10.4
      */
     public function getImage()

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTStaticVariableDeclaration extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 
@@ -61,7 +60,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 class ASTString extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -55,7 +54,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTStringIndexExpression extends ASTIndexExpression

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTSwitchLabel extends AbstractASTNode
@@ -67,7 +65,6 @@ class ASTSwitchLabel extends AbstractASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTThrowStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTrait extends ASTClass
@@ -70,9 +68,7 @@ class ASTTrait extends ASTClass
      * Returns all properties for this class.
      *
      * @return ASTArtifactList<ASTProperty>
-     *
      * @since  1.0.6
-     *
      * @todo   Return properties declared by a trait.
      */
     public function getProperties()
@@ -104,7 +100,6 @@ class ASTTrait extends ASTClass
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
      *
      * @return bool
-     *
      * @todo   Should we handle trait subtypes?
      */
     public function isSubtypeOf(AbstractASTType $type)

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitAdaptation extends ASTScope

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitAdaptationAlias extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitAdaptationPrecedence extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -7,7 +7,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -21,7 +20,6 @@ use RuntimeException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitMethodCollisionException extends RuntimeException

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitReference extends ASTClassOrInterfaceReference

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTraitUseStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTTryStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTType extends AbstractASTNode

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTTypeArray extends ASTType

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 class ASTTypeCallable extends ASTType

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.5.1
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.5.1
  */
 class ASTTypeIterable extends ASTType

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.11
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.11
  */
 class ASTUnaryExpression extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -50,7 +49,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTUnionType extends AbstractASTCombinationType

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class ASTUnsetStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 
@@ -51,7 +50,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.5
  */
 class ASTValue

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -55,7 +54,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTVariable extends ASTExpression
@@ -65,7 +63,6 @@ class ASTVariable extends ASTExpression
      * the <b>$this</b> scope of a class instance.
      *
      * @return bool
-     *
      * @since  0.10.0
      */
     public function isThis()

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -51,7 +50,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTVariableDeclarator extends ASTExpression
@@ -69,7 +67,6 @@ class ASTVariableDeclarator extends ASTExpression
      * array with those property names that should be serialized for this class.
      *
      * @return array<string>
-     *
      * @since  0.10.0
      */
     public function __sleep()

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class ASTVariableVariable extends ASTExpression

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 class ASTWhileStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -63,7 +62,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since @TODO
  */
 class ASTYieldStatement extends ASTStatement

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -138,7 +138,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Sets the item name.
      *
      * @param string $name The item name.
-     *
      * @since  1.0.0
      */
     public function setName($name): void
@@ -163,7 +162,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * Sets the unique identifier for this node instance.
      *
      * @param string $id Identifier for this node.
-     *
      * @since  0.9.12
      */
     public function setId($id): void
@@ -326,7 +324,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * @template T of array<string, mixed>|numeric-string
      *
      * @param T $data
-     *
      * @return T
      */
     public function accept(ASTVisitor $visitor, $data = [])

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -60,7 +60,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * The internal used cache instance.
      *
      * @var CacheDriver|null
-     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -70,7 +69,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * default and for any scalar type this property is <b>null</b>.
      *
      * @var ASTClassOrInterfaceReference|null
-     *
      * @since 0.9.5
      */
     protected $returnClassReference = null;
@@ -79,7 +77,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * List of all exceptions classes referenced by this callable.
      *
      * @var ASTClassOrInterfaceReference[]
-     *
      * @since 0.9.5
      */
     protected $exceptionClassReferences = [];
@@ -95,7 +92,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * List of all parsed child nodes.
      *
      * @var AbstractASTNode[]
-     *
      * @since 0.9.6
      */
     protected $nodes = [];
@@ -104,7 +100,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * The start line number of the method or function declaration.
      *
      * @var int
-     *
      * @since 0.9.12
      */
     protected $startLine = 0;
@@ -113,7 +108,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * The end line number of the method or function declaration.
      *
      * @var int
-     *
      * @since 0.9.12
      */
     protected $endLine = 0;
@@ -131,7 +125,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * cached for all callable instances.
      *
      * @return array
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -168,7 +161,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * instance can store the associated tokens.
      *
      * @return $this
-     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -196,7 +188,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns all child nodes of this method.
      *
      * @return AbstractASTNode[]
-     *
      * @since  0.9.8
      */
     public function getChildren()
@@ -239,7 +230,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns the line number where the callable declaration starts.
      *
      * @return int
-     *
      * @since  0.9.6
      */
     public function getStartLine()
@@ -251,7 +241,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns the line number where the callable declaration ends.
      *
      * @return int
-     *
      * @since  0.9.6
      */
     public function getEndLine()
@@ -280,7 +269,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * if there is no return value or the return value is scalat.
      *
      * @return AbstractASTClassOrInterface|null
-     *
      * @since  0.9.5
      */
     public function getReturnClass()
@@ -299,7 +287,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * configured.
      *
      * @return bool
-     *
      * @since 2.2.4
      */
     public function hasReturnClass()
@@ -331,7 +318,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * function return type.
      *
      * @param ASTClassOrInterfaceReference $classReference Holder instance for the declared function return type.
-     *
      * @since  0.9.5
      */
     public function setReturnClassReference(ASTClassOrInterfaceReference $classReference): void
@@ -344,7 +330,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * this callable.
      *
      * @param ASTClassOrInterfaceReference $classReference A reference instance for a thrown exception.
-     *
      * @since  0.9.5
      */
     public function addExceptionClassReference(
@@ -384,7 +369,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * reference, otherwise the return value will be <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.9.5
      */
     public function returnsReference()
@@ -408,7 +392,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Returns an array with all declared static variables.
      *
      * @return array<string, mixed>
-     *
      * @since  0.9.6
      */
     public function getStaticVariables()
@@ -441,7 +424,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * will return <b>false</b>.
      *
      * @return bool
-     *
      * @since  0.10.0
      */
     public function isCached()

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -56,7 +56,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * The parent for this class node.
      *
      * @var ASTClassReference|null
-     *
      * @since 0.9.5
      */
     protected $parentClassReference = null;
@@ -89,7 +88,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * interface instance.
      *
      * @return array
-     *
      * @since  0.10.0
      */
     public function __sleep()
@@ -104,7 +102,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
      * @return ASTClass|null
-     *
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function getParentClass()
@@ -138,9 +135,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * and parent of this parent the second element and so on.
      *
      * @return ASTClass[]
-     *
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
-     *
      * @since  1.0.0
      */
     public function getParentClasses()
@@ -163,7 +158,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns a reference onto the parent class of this class node or <b>null</b>.
      *
      * @return ASTClassReference|null
-     *
      * @since  0.9.5
      */
     public function getParentClassReference()
@@ -175,7 +169,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Sets a reference onto the parent class of this class node.
      *
      * @param ASTClassReference $classReference Reference to the declared parent class.
-     *
      * @since  0.9.5
      */
     public function setParentClassReference(ASTClassReference $classReference): void
@@ -188,7 +181,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns a node iterator with all implemented interfaces.
      *
      * @return AbstractASTClassOrInterface[]|ASTArtifactList<AbstractASTClassOrInterface>
-     *
      * @since  0.9.5
      */
     public function getInterfaces()
@@ -200,7 +192,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns an array of references onto the interfaces of this class node.
      *
      * @return ASTClassOrInterfaceReference[]
-     *
      * @since  0.10.4
      */
     public function getInterfaceReferences()
@@ -251,9 +242,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * otherwise it returns <b>false</b>.
      *
      * @param string $name Name of the searched constant.
-     *
      * @return bool
-     *
      * @since  0.9.6
      */
     public function hasConstant($name)
@@ -269,7 +258,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * will return <b>false</b> when no constant for that name exists.
      *
      * @param string $name Name of the searched constant.
-     *
      * @since  0.9.6
      */
     public function getConstant($name): mixed
@@ -284,7 +272,6 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * Returns a list of all methods provided by this type or one of its parents.
      *
      * @return ASTMethod[]
-     *
      * @since  0.9.10
      */
     public function getAllMethods()

--- a/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\AST;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @see https://php.watch/versions/8.1/intersection-types
  */
 abstract class AbstractASTCombinationType extends ASTType

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\ASTVisitor\ASTVisitor;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 abstract class AbstractASTNode implements ASTNode
@@ -85,7 +83,6 @@ abstract class AbstractASTNode implements ASTNode
      * image in a colon seperated string.
      *
      * @var string
-     *
      * @since 0.10.4
      */
     protected $metadata = '::::';
@@ -108,7 +105,6 @@ abstract class AbstractASTNode implements ASTNode
      * array with those property names that should be serialized for this class.
      *
      * @return array
-     *
      * @since 0.10.0
      */
     public function __sleep()
@@ -139,7 +135,6 @@ abstract class AbstractASTNode implements ASTNode
      * @template T of array<string, mixed>|numeric-string
      *
      * @param T $data
-     *
      * @return T
      */
     public function accept(ASTVisitor $visitor, $data = [])
@@ -231,7 +226,6 @@ abstract class AbstractASTNode implements ASTNode
      * @param int $endLine
      * @param int $startColumn
      * @param int $endColumn
-     *
      * @since 0.9.10
      */
     public function configureLinesAndColumns(
@@ -250,9 +244,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns an integer value that was stored under the given index.
      *
      * @param int $index
-     *
      * @return int
-     *
      * @since 0.10.4
      */
     protected function getMetadataInteger($index)
@@ -266,7 +258,6 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param int $index
      * @param int $value
-     *
      * @since 0.10.4
      */
     protected function setMetadataInteger($index, $value): void
@@ -278,9 +269,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns a boolean value that was stored under the given index.
      *
      * @param int $index
-     *
      * @return bool
-     *
      * @since 0.10.4
      */
     protected function getMetadataBoolean($index)
@@ -292,9 +281,8 @@ abstract class AbstractASTNode implements ASTNode
      * Stores a boolean value under the given index in the internally used data
      * string.
      *
-     * @param int  $index
+     * @param int $index
      * @param bool $value
-     *
      * @since 0.10.4
      */
     protected function setMetadataBoolean($index, $value): void
@@ -306,9 +294,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the value that was stored under the given index.
      *
      * @param int $index
-     *
      * @return string
-     *
      * @since 0.10.4
      */
     protected function getMetadata($index)
@@ -321,9 +307,8 @@ abstract class AbstractASTNode implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int    $index
+     * @param int $index
      * @param string $value
-     *
      * @since 0.10.4
      */
     protected function setMetadata($index, $value): void
@@ -338,7 +323,6 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the total number of the used property bag.
      *
      * @return int
-     *
      * @since 0.10.4
      */
     protected function getMetadataSize()
@@ -350,9 +334,7 @@ abstract class AbstractASTNode implements ASTNode
      * Returns the node instance for the given index or throws an exception.
      *
      * @param int $index
-     *
      * @return ASTNode
-     *
      * @throws OutOfBoundsException When no node exists at the given index.
      */
     public function getChild($index)
@@ -387,7 +369,6 @@ abstract class AbstractASTNode implements ASTNode
      * @template T of ASTNode
      *
      * @param class-string<T> $targetType
-     *
      * @return T|null
      */
     public function getFirstChildOfType($targetType)
@@ -412,9 +393,8 @@ abstract class AbstractASTNode implements ASTNode
      * @template R of T
      *
      * @param class-string<T> $targetType Searched class or interface type.
-     * @param R[]             $results    Already found node instances. This parameter
-     *                                    is only for internal usage.
-     *
+     * @param R[] $results Already found node instances. This parameter
+     *                     is only for internal usage.
      * @return T[]
      */
     public function findChildrenOfType($targetType, array &$results = [])
@@ -462,7 +442,6 @@ abstract class AbstractASTNode implements ASTNode
      * of <b>$parentType</b>.
      *
      * @param string $parentType
-     *
      * @return ASTNode[]
      */
     public function getParentsOfType($parentType)

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -54,7 +53,6 @@ use PDepend\Util\Cache\CacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 abstract class AbstractASTType extends AbstractASTArtifact
@@ -115,7 +113,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * Temporary property that only holds methods during the parsing process.
      *
      * @var ASTMethod[]|null
-     *
      * @since 1.0.2
      */
     protected $methods = [];
@@ -392,7 +389,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * instance.
      *
      * @return bool
-     *
      * @since  1.0.6
      */
     abstract public function isSubtypeOf(AbstractASTType $type);
@@ -402,7 +398,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * that are imported through traits.
      *
      * @return ASTMethod[]
-     *
      * @since  1.0.0
      */
     protected function getTraitMethods()

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -79,11 +79,9 @@ interface ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
+     * @param string $method Name of the called method.
+     * @param array<int, mixed> $args Array with method argument.
      * @return array<string, mixed>|numeric-string
-     *
      * @since  0.9.12
      */
     public function __call($method, $args);
@@ -148,8 +146,7 @@ interface ASTVisitor
      * @template T of array<string, mixed>|numeric-string
      *
      * @param ASTNode $node
-     * @param T       $value
-     *
+     * @param T $value
      * @return T
      */
     public function visit($node, $value);

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -90,9 +90,8 @@ abstract class AbstractASTVisitor implements ASTVisitor
      * The return value of this method is the second input argument, modified
      * by the concrete visit method.
      *
-     * @param string            $method Name of the called method.
-     * @param array<int, mixed> $args   Array with method argument.
-     *
+     * @param string $method Name of the called method.
+     * @param array<int, mixed> $args Array with method argument.
      * @since  0.9.12
      */
     public function __call($method, $args)

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -177,7 +177,6 @@ interface Builder extends IteratorAggregate
      * Setter method for the currently used token cache.
      *
      * @return Builder<mixed>
-     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache);
@@ -195,9 +194,7 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return AbstractASTClassOrInterface
-     *
      * @since  0.9.5
      */
     public function getClassOrInterface($qualifiedName);
@@ -206,9 +203,7 @@ interface Builder extends IteratorAggregate
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     *
      * @return ASTClassOrInterfaceReference
-     *
      * @since  0.9.5
      */
     public function buildAstClassOrInterfaceReference($qualifiedName);
@@ -217,9 +212,7 @@ interface Builder extends IteratorAggregate
      * Builds a new php trait instance.
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait
-     *
      * @since  1.0.0
      */
     public function buildTrait($qualifiedName);
@@ -237,9 +230,7 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait
-     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName);
@@ -248,7 +239,6 @@ interface Builder extends IteratorAggregate
      * Builds a new code class instance.
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass
      */
     public function buildClass($qualifiedName);
@@ -266,9 +256,7 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass
-     *
      * @since  0.9.5
      */
     public function getClass($qualifiedName);
@@ -291,9 +279,7 @@ interface Builder extends IteratorAggregate
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     *
      * @return ASTClassReference
-     *
      * @since  0.9.5
      */
     public function buildAstClassReference($qualifiedName);
@@ -302,7 +288,6 @@ interface Builder extends IteratorAggregate
      * Builds a new new interface instance.
      *
      * @param string $qualifiedName
-     *
      * @return ASTInterface
      */
     public function buildInterface($qualifiedName);
@@ -320,9 +305,7 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
-     *
      * @return ASTInterface
-     *
      * @since  0.9.5
      */
     public function getInterface($qualifiedName);
@@ -331,7 +314,6 @@ interface Builder extends IteratorAggregate
      * Builds a new namespace instance.
      *
      * @param string $name
-     *
      * @return ASTNamespace
      */
     public function buildNamespace($name);
@@ -340,7 +322,6 @@ interface Builder extends IteratorAggregate
      * Builds a new method instance.
      *
      * @param string $name
-     *
      * @return ASTMethod
      */
     public function buildMethod($name);
@@ -349,7 +330,6 @@ interface Builder extends IteratorAggregate
      * Builds a new function instance.
      *
      * @param string $name
-     *
      * @return ASTFunction
      */
     public function buildFunction($name);
@@ -358,7 +338,6 @@ interface Builder extends IteratorAggregate
      * Builds a new self reference instance.
      *
      * @return ASTSelfReference
-     *
      * @since  0.9.6
      */
     public function buildAstSelfReference(AbstractASTClassOrInterface $type);
@@ -367,9 +346,7 @@ interface Builder extends IteratorAggregate
      * Builds a new parent reference instance.
      *
      * @param ASTClassOrInterfaceReference $reference The type instance that reference the concrete target of parent.
-     *
      * @return ASTParentReference
-     *
      * @since  0.9.6
      */
     public function buildAstParentReference(ASTClassOrInterfaceReference $reference);
@@ -378,7 +355,6 @@ interface Builder extends IteratorAggregate
      * Builds a new static reference instance.
      *
      * @return ASTStaticReference
-     *
      * @since  0.9.6
      */
     public function buildAstStaticReference(AbstractASTClassOrInterface $owner);
@@ -387,7 +363,6 @@ interface Builder extends IteratorAggregate
      * Builds a new field declaration node.
      *
      * @return ASTFieldDeclaration
-     *
      * @since  0.9.6
      */
     public function buildAstFieldDeclaration();
@@ -396,9 +371,7 @@ interface Builder extends IteratorAggregate
      * Builds a new variable declarator node.
      *
      * @param string $image The source image for the variable declarator.
-     *
      * @return ASTVariableDeclarator
-     *
      * @since  0.9.6
      */
     public function buildAstVariableDeclarator($image);
@@ -407,9 +380,7 @@ interface Builder extends IteratorAggregate
      * Builds a new constant node.
      *
      * @param string $image The source image for the constant.
-     *
      * @return ASTConstant
-     *
      * @since  0.9.6
      */
     public function buildAstConstant($image);
@@ -418,9 +389,7 @@ interface Builder extends IteratorAggregate
      * Builds a new variable node.
      *
      * @param string $image The source image for the variable.
-     *
      * @return ASTVariable
-     *
      * @since  0.9.6
      */
     public function buildAstVariable($image);
@@ -429,9 +398,7 @@ interface Builder extends IteratorAggregate
      * Builds a new variable variable node.
      *
      * @param string $image The source image for the variable variable.
-     *
      * @return ASTVariableVariable
-     *
      * @since  0.9.6
      */
     public function buildAstVariableVariable($image);
@@ -440,9 +407,7 @@ interface Builder extends IteratorAggregate
      * Builds a new compound variable node.
      *
      * @param string $image The source image for the compound variable.
-     *
      * @return ASTCompoundVariable
-     *
      * @since  0.9.6
      */
     public function buildAstCompoundVariable($image);
@@ -451,7 +416,6 @@ interface Builder extends IteratorAggregate
      * Builds a new compound expression node.
      *
      * @return ASTCompoundExpression
-     *
      * @since  0.9.6
      */
     public function buildAstCompoundExpression();
@@ -460,9 +424,7 @@ interface Builder extends IteratorAggregate
      * Builds a new static variable declaration node.
      *
      * @param string $image The source image for the static declaration.
-     *
      * @return ASTStaticVariableDeclaration
-     *
      * @since  0.9.6
      */
     public function buildAstStaticVariableDeclaration($image);
@@ -471,7 +433,6 @@ interface Builder extends IteratorAggregate
      * Builds a new closure node.
      *
      * @return ASTClosure
-     *
      * @since  0.9.12
      */
     public function buildAstClosure();
@@ -480,7 +441,6 @@ interface Builder extends IteratorAggregate
      * Builds a new formal parameters node.
      *
      * @return ASTFormalParameters
-     *
      * @since  0.9.6
      */
     public function buildAstFormalParameters();
@@ -489,7 +449,6 @@ interface Builder extends IteratorAggregate
      * Builds a new formal parameter node.
      *
      * @return ASTFormalParameter
-     *
      * @since  0.9.6
      */
     public function buildAstFormalParameter();
@@ -498,9 +457,7 @@ interface Builder extends IteratorAggregate
      * Builds a new expression node.
      *
      * @param string $image
-     *
      * @return ASTExpression
-     *
      * @since 0.9.8
      */
     public function buildAstExpression($image = null);
@@ -509,9 +466,7 @@ interface Builder extends IteratorAggregate
      * Builds a new assignment expression node.
      *
      * @param string $image The assignment operator.
-     *
      * @return ASTAssignmentExpression
-     *
      * @since  0.9.8
      */
     public function buildAstAssignmentExpression($image);
@@ -520,9 +475,7 @@ interface Builder extends IteratorAggregate
      * Builds a new allocation expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTAllocationExpression
-     *
      * @since  0.9.6
      */
     public function buildAstAllocationExpression($image);
@@ -531,9 +484,7 @@ interface Builder extends IteratorAggregate
      * Builds a new eval-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTEvalExpression
-     *
      * @since  0.9.12
      */
     public function buildAstEvalExpression($image);
@@ -542,9 +493,7 @@ interface Builder extends IteratorAggregate
      * Builds a new exit-expression instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTExitExpression
-     *
      * @since  0.9.12
      */
     public function buildAstExitExpression($image);
@@ -553,9 +502,7 @@ interface Builder extends IteratorAggregate
      * Builds a new clone-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTCloneExpression
-     *
      * @since  0.9.12
      */
     public function buildAstCloneExpression($image);
@@ -564,9 +511,7 @@ interface Builder extends IteratorAggregate
      * Builds a new list-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTListExpression
-     *
      * @since  0.9.12
      */
     public function buildAstListExpression($image);
@@ -575,7 +520,6 @@ interface Builder extends IteratorAggregate
      * Builds a new include- or include_once-expression.
      *
      * @return ASTIncludeExpression
-     *
      * @since  0.9.12
      */
     public function buildAstIncludeExpression();
@@ -584,7 +528,6 @@ interface Builder extends IteratorAggregate
      * Builds a new require- or require_once-expression.
      *
      * @return ASTRequireExpression
-     *
      * @since  0.9.12
      */
     public function buildAstRequireExpression();
@@ -593,7 +536,6 @@ interface Builder extends IteratorAggregate
      * Builds a new array-expression node.
      *
      * @return ASTArrayIndexExpression
-     *
      * @since  0.9.12
      */
     public function buildAstArrayIndexExpression();
@@ -608,7 +550,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTStringIndexExpression
-     *
      * @since  0.9.12
      */
     public function buildAstStringIndexExpression();
@@ -617,9 +558,7 @@ interface Builder extends IteratorAggregate
      * Builds a new instanceof-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTInstanceOfExpression
-     *
      * @since  0.9.6
      */
     public function buildAstInstanceOfExpression($image);
@@ -640,7 +579,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTIssetExpression
-     *
      * @since  0.9.12
      */
     public function buildAstIssetExpression();
@@ -655,7 +593,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTConditionalExpression
-     *
      * @since  0.9.8
      */
     public function buildAstConditionalExpression();
@@ -670,7 +607,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTPrintExpression
-     *
      * @since 2.3
      */
     public function buildAstPrintExpression();
@@ -679,7 +615,6 @@ interface Builder extends IteratorAggregate
      * Build a new shift left expression.
      *
      * @return ASTShiftLeftExpression
-     *
      * @since  1.0.1
      */
     public function buildAstShiftLeftExpression();
@@ -688,7 +623,6 @@ interface Builder extends IteratorAggregate
      * Build a new shift right expression.
      *
      * @return ASTShiftRightExpression
-     *
      * @since  1.0.1
      */
     public function buildAstShiftRightExpression();
@@ -697,7 +631,6 @@ interface Builder extends IteratorAggregate
      * Builds a new boolean and-expression.
      *
      * @return ASTBooleanAndExpression
-     *
      * @since  0.9.8
      */
     public function buildAstBooleanAndExpression();
@@ -706,7 +639,6 @@ interface Builder extends IteratorAggregate
      * Builds a new boolean or-expression.
      *
      * @return ASTBooleanOrExpression
-     *
      * @since  0.9.8
      */
     public function buildAstBooleanOrExpression();
@@ -715,7 +647,6 @@ interface Builder extends IteratorAggregate
      * Builds a new logical <b>and</b>-expression.
      *
      * @return ASTLogicalAndExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalAndExpression();
@@ -724,7 +655,6 @@ interface Builder extends IteratorAggregate
      * Builds a new logical <b>or</b>-expression.
      *
      * @return ASTLogicalOrExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalOrExpression();
@@ -733,7 +663,6 @@ interface Builder extends IteratorAggregate
      * Builds a new logical <b>xor</b>-expression.
      *
      * @return ASTLogicalXorExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalXorExpression();
@@ -742,7 +671,6 @@ interface Builder extends IteratorAggregate
      * Builds a new trait use-statement node.
      *
      * @return ASTTraitUseStatement
-     *
      * @since  1.0.0
      */
     public function buildAstTraitUseStatement();
@@ -751,7 +679,6 @@ interface Builder extends IteratorAggregate
      * Builds a new trait adaptation scope.
      *
      * @return ASTTraitAdaptation
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptation();
@@ -760,9 +687,7 @@ interface Builder extends IteratorAggregate
      * Builds a new trait adaptation alias statement.
      *
      * @param string $image The trait method name.
-     *
      * @return ASTTraitAdaptationAlias
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationAlias($image);
@@ -771,9 +696,7 @@ interface Builder extends IteratorAggregate
      * Builds a new trait adaptation precedence statement.
      *
      * @param string $image The trait method name.
-     *
      * @return ASTTraitAdaptationPrecedence
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationPrecedence($image);
@@ -782,9 +705,7 @@ interface Builder extends IteratorAggregate
      * Builds a new trait reference node.
      *
      * @param string $qualifiedName The full qualified trait name.
-     *
      * @return ASTTraitReference
-     *
      * @since  1.0.0
      */
     public function buildAstTraitReference($qualifiedName);
@@ -793,7 +714,6 @@ interface Builder extends IteratorAggregate
      * Builds a new switch-statement-node.
      *
      * @return ASTSwitchStatement
-     *
      * @since  0.9.8
      */
     public function buildAstSwitchStatement();
@@ -802,9 +722,7 @@ interface Builder extends IteratorAggregate
      * Builds a new switch-label node.
      *
      * @param string $image The source image of this label.
-     *
      * @return ASTSwitchLabel
-     *
      * @since  0.9.8
      */
     public function buildAstSwitchLabel($image);
@@ -813,9 +731,7 @@ interface Builder extends IteratorAggregate
      * Builds a new catch-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTCatchStatement
-     *
      * @since  0.9.8
      */
     public function buildAstCatchStatement($image);
@@ -824,7 +740,6 @@ interface Builder extends IteratorAggregate
      * Builds a new finally-statement node.
      *
      * @return ASTFinallyStatement
-     *
      * @since  2.0.0
      */
     public function buildAstFinallyStatement();
@@ -833,9 +748,7 @@ interface Builder extends IteratorAggregate
      * Builds a new if statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTIfStatement
-     *
      * @since  0.9.8
      */
     public function buildAstIfStatement($image);
@@ -844,9 +757,7 @@ interface Builder extends IteratorAggregate
      * Builds a new elseif-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTElseIfStatement
-     *
      * @since  0.9.8
      */
     public function buildAstElseIfStatement($image);
@@ -855,9 +766,7 @@ interface Builder extends IteratorAggregate
      * Builds a new for-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTForStatement
-     *
      * @since  0.9.8
      */
     public function buildAstForStatement($image);
@@ -872,7 +781,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTForInit
-     *
      * @since  0.9.8
      */
     public function buildAstForInit();
@@ -887,7 +795,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTForUpdate
-     *
      * @since  0.9.12
      */
     public function buildAstForUpdate();
@@ -896,9 +803,7 @@ interface Builder extends IteratorAggregate
      * Builds a new foreach-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTForeachStatement
-     *
      * @since  0.9.8
      */
     public function buildAstForeachStatement($image);
@@ -907,9 +812,7 @@ interface Builder extends IteratorAggregate
      * Builds a new while-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTWhileStatement
-     *
      * @since  0.9.8
      */
     public function buildAstWhileStatement($image);
@@ -918,9 +821,7 @@ interface Builder extends IteratorAggregate
      * Builds a new do/while-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTDoWhileStatement
-     *
      * @since  0.9.12
      */
     public function buildAstDoWhileStatement($image);
@@ -947,7 +848,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTDeclareStatement
-     *
      * @since  0.10.0
      */
     public function buildAstDeclareStatement();
@@ -974,9 +874,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTMemberPrimaryPrefix
-     *
      * @since  0.9.6
      */
     public function buildAstMemberPrimaryPrefix($image);
@@ -985,9 +883,7 @@ interface Builder extends IteratorAggregate
      * Builds a new identifier node.
      *
      * @param string $image The image of this identifier.
-     *
      * @return ASTIdentifier
-     *
      * @since  0.9.6
      */
     public function buildAstIdentifier($image);
@@ -1006,9 +902,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTFunctionPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstFunctionPostfix($image);
@@ -1027,9 +921,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTMethodPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstMethodPostfix($image);
@@ -1044,9 +936,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTConstantPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstConstantPostfix($image);
@@ -1065,9 +955,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTPropertyPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstPropertyPostfix($image);
@@ -1086,7 +974,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTClassFqnPostfix
-     *
      * @since  2.0.0
      */
     public function buildAstClassFqnPostfix();
@@ -1105,7 +992,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTArguments
-     *
      * @since  0.9.6
      */
     public function buildAstArguments();
@@ -1118,7 +1004,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTMatchArgument
-     *
      * @since  0.9.6
      */
     public function buildAstMatchArgument();
@@ -1133,7 +1018,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTMatchBlock
-     *
      * @since  2.9.0
      */
     public function buildAstMatchBlock();
@@ -1146,7 +1030,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTMatchEntry
-     *
      * @since  2.9.0
      */
     public function buildAstMatchEntry();
@@ -1159,9 +1042,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $name
-     *
      * @return ASTNamedArgument
-     *
      * @since  2.9.0
      */
     public function buildAstNamedArgument($name, ASTNode $value);
@@ -1170,7 +1051,6 @@ interface Builder extends IteratorAggregate
      * Builds a new array type node.
      *
      * @return ASTTypeArray
-     *
      * @since  0.9.6
      */
     public function buildAstTypeArray();
@@ -1179,7 +1059,6 @@ interface Builder extends IteratorAggregate
      * Builds a new node for the callable type.
      *
      * @return ASTTypeCallable
-     *
      * @since  1.0.0
      */
     public function buildAstTypeCallable();
@@ -1188,7 +1067,6 @@ interface Builder extends IteratorAggregate
      * Builds a new node for the iterable type.
      *
      * @return ASTTypeIterable
-     *
      * @since  2.5.1
      */
     public function buildAstTypeIterable();
@@ -1197,9 +1075,7 @@ interface Builder extends IteratorAggregate
      * Builds a new primitive type node.
      *
      * @param string $image
-     *
      * @return ASTScalarType
-     *
      * @since  0.9.6
      */
     public function buildAstScalarType($image);
@@ -1208,7 +1084,6 @@ interface Builder extends IteratorAggregate
      * Builds a new node for the union type.
      *
      * @return ASTUnionType
-     *
      * @since  2.9.0
      */
     public function buildAstUnionType();
@@ -1224,9 +1099,7 @@ interface Builder extends IteratorAggregate
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.
-     *
      * @return ASTLiteral
-     *
      * @since  0.9.6
      */
     public function buildAstLiteral($image);
@@ -1247,7 +1120,6 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @return ASTString
-     *
      * @since  0.9.10
      */
     public function buildAstString();
@@ -1256,7 +1128,6 @@ interface Builder extends IteratorAggregate
      * Builds a new php array node.
      *
      * @return ASTArray
-     *
      * @since  1.0.0
      */
     public function buildAstArray();
@@ -1265,7 +1136,6 @@ interface Builder extends IteratorAggregate
      * Builds a new array element node.
      *
      * @return ASTArrayElement
-     *
      * @since  1.0.0
      */
     public function buildAstArrayElement();
@@ -1274,7 +1144,6 @@ interface Builder extends IteratorAggregate
      * Builds a new heredoc node.
      *
      * @return ASTHeredoc
-     *
      * @since  0.9.12
      */
     public function buildAstHeredoc();
@@ -1292,9 +1161,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTConstantDefinition
-     *
      * @since  0.9.6
      */
     public function buildAstConstantDefinition($image);
@@ -1331,9 +1198,7 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTConstantDeclarator
-     *
      * @since  0.9.6
      */
     public function buildAstConstantDeclarator($image);
@@ -1342,9 +1207,7 @@ interface Builder extends IteratorAggregate
      * Builds a new comment node instance.
      *
      * @param string $cdata The comment text.
-     *
      * @return ASTComment
-     *
      * @since  0.9.8
      */
     public function buildAstComment($cdata);
@@ -1353,9 +1216,7 @@ interface Builder extends IteratorAggregate
      * Builds a new unary expression node instance.
      *
      * @param string $image The unary expression image/character.
-     *
      * @return ASTUnaryExpression
-     *
      * @since  0.9.11
      */
     public function buildAstUnaryExpression($image);
@@ -1364,9 +1225,7 @@ interface Builder extends IteratorAggregate
      * Builds a new cast-expression node instance.
      *
      * @param string $image The cast-expression image/character.
-     *
      * @return ASTCastExpression
-     *
      * @since  0.10.0
      */
     public function buildAstCastExpression($image);
@@ -1375,9 +1234,7 @@ interface Builder extends IteratorAggregate
      * Builds a new postfix-expression node instance.
      *
      * @param string $image The postfix-expression image/character.
-     *
      * @return ASTPostfixExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPostfixExpression($image);
@@ -1386,7 +1243,6 @@ interface Builder extends IteratorAggregate
      * Builds a new pre-increment-expression node instance.
      *
      * @return ASTPreIncrementExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPreIncrementExpression();
@@ -1395,7 +1251,6 @@ interface Builder extends IteratorAggregate
      * Builds a new pre-decrement-expression node instance.
      *
      * @return ASTPreDecrementExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPreDecrementExpression();
@@ -1404,7 +1259,6 @@ interface Builder extends IteratorAggregate
      * Builds a new function/method scope instance.
      *
      * @return ASTScope
-     *
      * @since  0.9.12
      */
     public function buildAstScope();
@@ -1413,7 +1267,6 @@ interface Builder extends IteratorAggregate
      * Builds a new statement instance.
      *
      * @return ASTStatement
-     *
      * @since  0.9.12
      */
     public function buildAstStatement();
@@ -1422,9 +1275,7 @@ interface Builder extends IteratorAggregate
      * Builds a new return-statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTReturnStatement
-     *
      * @since  0.9.12
      */
     public function buildAstReturnStatement($image);
@@ -1433,9 +1284,7 @@ interface Builder extends IteratorAggregate
      * Builds a new break-statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTBreakStatement
-     *
      * @since  0.9.12
      */
     public function buildAstBreakStatement($image);
@@ -1444,9 +1293,7 @@ interface Builder extends IteratorAggregate
      * Builds a new continue-statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTContinueStatement
-     *
      * @since  0.9.12
      */
     public function buildAstContinueStatement($image);
@@ -1455,7 +1302,6 @@ interface Builder extends IteratorAggregate
      * Builds a new scope-statement instance.
      *
      * @return ASTScopeStatement
-     *
      * @since  0.9.12
      */
     public function buildAstScopeStatement();
@@ -1464,9 +1310,7 @@ interface Builder extends IteratorAggregate
      * Builds a new try-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTTryStatement
-     *
      * @since  0.9.12
      */
     public function buildAstTryStatement($image);
@@ -1475,9 +1319,7 @@ interface Builder extends IteratorAggregate
      * Builds a new throw-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTThrowStatement
-     *
      * @since  0.9.12
      */
     public function buildAstThrowStatement($image);
@@ -1486,9 +1328,7 @@ interface Builder extends IteratorAggregate
      * Builds a new goto-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTGotoStatement
-     *
      * @since  0.9.12
      */
     public function buildAstGotoStatement($image);
@@ -1497,9 +1337,7 @@ interface Builder extends IteratorAggregate
      * Builds a new label-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTLabelStatement
-     *
      * @since  0.9.12
      */
     public function buildAstLabelStatement($image);
@@ -1508,7 +1346,6 @@ interface Builder extends IteratorAggregate
      * Builds a new global-statement instance.
      *
      * @return ASTGlobalStatement
-     *
      * @since  0.9.12
      */
     public function buildAstGlobalStatement();
@@ -1517,7 +1354,6 @@ interface Builder extends IteratorAggregate
      * Builds a new unset-statement instance.
      *
      * @return ASTUnsetStatement
-     *
      * @since  0.9.12
      */
     public function buildAstUnsetStatement();
@@ -1526,9 +1362,7 @@ interface Builder extends IteratorAggregate
      * Builds a new exit-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTEchoStatement
-     *
      * @since  0.9.12
      */
     public function buildAstEchoStatement($image);
@@ -1537,9 +1371,7 @@ interface Builder extends IteratorAggregate
      * Builds a new yield-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTYieldStatement
-     *
      * @since  $version$
      */
     public function buildAstYieldStatement($image);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -56,7 +55,6 @@ use PDepend\Source\AST\ASTTrait;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 interface BuilderContext
@@ -97,9 +95,7 @@ interface BuilderContext
      * Returns the trait instance for the given qualified name.
      *
      * @param string $qualifiedName Full qualified trait name.
-     *
      * @return ASTTrait
-     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName);
@@ -108,7 +104,6 @@ interface BuilderContext
      * Returns the class instance for the given qualified name.
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass
      */
     public function getClass($qualifiedName);
@@ -117,7 +112,6 @@ interface BuilderContext
      * Returns a class or an interface instance for the given qualified name.
      *
      * @param string $qualifiedName
-     *
      * @return AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -61,7 +60,6 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class GlobalBuilderContext implements BuilderContext
@@ -138,9 +136,7 @@ class GlobalBuilderContext implements BuilderContext
      * Returns the trait instance for the given qualified name.
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait
-     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName)
@@ -152,7 +148,6 @@ class GlobalBuilderContext implements BuilderContext
      * Returns the class instance for the given qualified name.
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass
      */
     public function getClass($qualifiedName)
@@ -164,7 +159,6 @@ class GlobalBuilderContext implements BuilderContext
      * Returns a class or an interface instance for the given qualified name.
      *
      * @param string $qualifiedName
-     *
      * @return AbstractASTClassOrInterface
      */
     public function getClassOrInterface($qualifiedName)

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -317,7 +317,6 @@ abstract class AbstractPHPParser
 
     /**
      * @var CacheDriver
-     *
      * @since 0.10.0
      */
     protected $cache;
@@ -376,7 +375,6 @@ abstract class AbstractPHPParser
      * Used identifier builder instance.
      *
      * @var IdBuilder
-     *
      * @since 0.9.12
      */
     private $idBuilder = null;
@@ -385,7 +383,6 @@ abstract class AbstractPHPParser
      * The maximum valid nesting level allowed.
      *
      * @var int
-     *
      * @since 0.9.12
      */
     private $maxNestingLevel = 1024;
@@ -428,7 +425,6 @@ abstract class AbstractPHPParser
      * Configures the maximum allowed nesting level.
      *
      * @param int $maxNestingLevel The maximum allowed nesting level.
-     *
      * @since 0.9.12
      */
     public function setMaxNestingLevel($maxNestingLevel): void
@@ -440,7 +436,6 @@ abstract class AbstractPHPParser
      * Returns the maximum allowed nesting/recursion level.
      *
      * @return int
-     *
      * @since 0.9.12
      */
     protected function getMaxNestingLevel()
@@ -547,7 +542,6 @@ abstract class AbstractPHPParser
      * Restores the parser environment back.
      *
      * @throws NoActiveScopeException
-     *
      * @since 0.9.12
      */
     protected function tearDownEnvironment(): void
@@ -560,8 +554,8 @@ abstract class AbstractPHPParser
     /**
      * Resets some object properties.
      *
-     * @param int  $modifiers Optional default modifiers.
-     * @param bool $echoing   True if current statement is echoing (such as after <?=).
+     * @param int $modifiers Optional default modifiers.
+     * @param bool $echoing True if current statement is echoing (such as after <?=).
      */
     protected function reset($modifiers = 0, $echoing = false): void
     {
@@ -576,9 +570,7 @@ abstract class AbstractPHPParser
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 1.1.1
      */
     abstract protected function isKeyword($tokenType);
@@ -588,7 +580,6 @@ abstract class AbstractPHPParser
      * token.
      *
      * @return string
-     *
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
@@ -608,9 +599,7 @@ abstract class AbstractPHPParser
      * name part.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 0.10.6
      */
     protected function isClassName($tokenType)
@@ -638,10 +627,8 @@ abstract class AbstractPHPParser
      * token stream, this method will throw an exception.
      *
      * @return string
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
-     *
      * @since 0.10.0
      */
     protected function parseFunctionName()
@@ -657,7 +644,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     private function isAllowedName($tokenType)
@@ -681,7 +667,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isConstantName($tokenType)
@@ -694,9 +679,7 @@ abstract class AbstractPHPParser
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -706,7 +689,6 @@ abstract class AbstractPHPParser
 
     /**
      * @return string
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */
@@ -723,7 +705,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isMethodName($tokenType)
@@ -735,7 +716,6 @@ abstract class AbstractPHPParser
      * Parses a trait declaration.
      *
      * @return ASTTrait
-     *
      * @since 1.0.0
      */
     private function parseTraitDeclaration()
@@ -795,7 +775,6 @@ abstract class AbstractPHPParser
      * interface instance.
      *
      * @return ASTInterface
-     *
      * @since 0.10.2
      */
     private function parseInterfaceSignature()
@@ -818,7 +797,6 @@ abstract class AbstractPHPParser
      * Parses an optional interface list of an interface declaration.
      *
      * @return ASTInterface
-     *
      * @since 0.10.2
      */
     private function parseOptionalExtendsList(ASTInterface $interface)
@@ -860,7 +838,6 @@ abstract class AbstractPHPParser
      * and an optional list of implemented interfaces.
      *
      * @return ASTClass
-     *
      * @since 1.0.0
      */
     protected function parseClassSignature()
@@ -950,9 +927,7 @@ abstract class AbstractPHPParser
      * @template T of ASTClass
      *
      * @param T $class
-     *
      * @return T
-     *
      * @since 1.0.0
      */
     protected function parseClassExtends(ASTClass $class)
@@ -1005,9 +980,7 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTClassOrInterface
      *
      * @param T $classOrInterface
-     *
      * @return T
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */
@@ -1120,9 +1093,7 @@ abstract class AbstractPHPParser
      * method.
      *
      * @param int $modifiers
-     *
      * @return ASTConstantDefinition|ASTFieldDeclaration|ASTMethod
-     *
      * @since 0.9.6
      */
     protected function parseMethodOrFieldDeclaration($modifiers = 0)
@@ -1187,9 +1158,7 @@ abstract class AbstractPHPParser
      *
      * @param int $tokenType
      * @param int $modifiers
-     *
      * @return ASTConstantDefinition|ASTFieldDeclaration
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseUnknownDeclaration($tokenType, $modifiers)
@@ -1215,7 +1184,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFieldDeclaration
-     *
      * @since 0.9.6
      */
     protected function parseFieldDeclaration()
@@ -1260,7 +1228,6 @@ abstract class AbstractPHPParser
      * closure.
      *
      * @return ASTCallable
-     *
      * @since 0.9.5
      */
     private function parseFunctionOrClosureDeclaration()
@@ -1301,7 +1268,6 @@ abstract class AbstractPHPParser
      * return <b>false</b>.
      *
      * @return bool
-     *
      * @since 0.9.8
      */
     protected function parseOptionalByReference()
@@ -1313,7 +1279,6 @@ abstract class AbstractPHPParser
      * Tests that the next available token is the returns by reference token.
      *
      * @return bool
-     *
      * @since 0.9.8
      */
     private function isNextTokenByReference()
@@ -1338,7 +1303,6 @@ abstract class AbstractPHPParser
      * Tests that the next available token is an opening parenthesis.
      *
      * @return bool
-     *
      * @since 0.9.10
      */
     private function isNextTokenFormalParameterList()
@@ -1351,7 +1315,6 @@ abstract class AbstractPHPParser
      * This method parses a function declaration.
      *
      * @return ASTFunction
-     *
      * @since 0.9.5
      */
     private function parseFunctionDeclaration()
@@ -1392,7 +1355,6 @@ abstract class AbstractPHPParser
      * This method parses a method declaration.
      *
      * @return ASTMethod
-     *
      * @since 0.9.5
      */
     private function parseMethodDeclaration()
@@ -1425,7 +1387,6 @@ abstract class AbstractPHPParser
      * This method parses a PHP 5.3 closure or lambda function.
      *
      * @return ASTClosure
-     *
      * @since 0.9.5
      */
     private function parseClosureDeclaration()
@@ -1471,7 +1432,6 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTCallable|ASTClosure
      *
      * @param T $callable
-     *
      * @return T
      */
     protected function parseCallableDeclarationAddition($callable)
@@ -1483,7 +1443,6 @@ abstract class AbstractPHPParser
      * Parses a trait use statement.
      *
      * @return ASTTraitUseStatement
-     *
      * @since 1.0.0
      */
     private function parseTraitUseStatement()
@@ -1510,7 +1469,6 @@ abstract class AbstractPHPParser
      * Parses a trait reference instance.
      *
      * @return ASTTraitReference
-     *
      * @since 1.0.0
      */
     private function parseTraitReference()
@@ -1530,7 +1488,6 @@ abstract class AbstractPHPParser
      * the terminating semicolon, when no adaptation list exists.
      *
      * @return ASTTraitUseStatement
-     *
      * @since 1.0.0
      */
     private function parseOptionalTraitAdaptation(ASTTraitUseStatement $useStatement)
@@ -1550,7 +1507,6 @@ abstract class AbstractPHPParser
      * Parses the adaptation expression of a trait use statement.
      *
      * @return ASTTraitAdaptation
-     *
      * @since 1.0.0
      */
     private function parseTraitAdaptation()
@@ -1597,7 +1553,6 @@ abstract class AbstractPHPParser
      * declaring trait.
      *
      * @return array<int, mixed>
-     *
      * @since 1.0.0
      */
     private function parseTraitMethodReference()
@@ -1628,9 +1583,7 @@ abstract class AbstractPHPParser
      * Parses a trait adaptation alias statement.
      *
      * @param array<int, mixed> $reference Parsed method reference array.
-     *
      * @return ASTTraitAdaptationAlias
-     *
      * @since 1.0.0
      */
     private function parseTraitAdaptationAliasStatement(array $reference)
@@ -1672,11 +1625,8 @@ abstract class AbstractPHPParser
      * Parses a trait adaptation precedence statement.
      *
      * @param array<int, mixed> $reference Parsed method reference array.
-     *
      * @return ASTTraitAdaptationPrecedence
-     *
      * @throws InvalidStateException
-     *
      * @since 1.0.0
      */
     private function parseTraitAdaptationPrecedenceStatement(array $reference)
@@ -1724,9 +1674,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTAllocationExpression
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseAllocationExpression()
@@ -1748,11 +1696,8 @@ abstract class AbstractPHPParser
      * @template T of ASTAllocationExpression
      *
      * @param T $allocation
-     *
      * @return T
-     *
      * @throws ParserException
-     *
      * @since 2.3
      */
     protected function parseAllocationExpressionTypeReference(ASTAllocationExpression $allocation)
@@ -1764,7 +1709,6 @@ abstract class AbstractPHPParser
      * Parse the instanciation for new keyword without arguments.
      *
      * @return ASTAllocationExpression
-     *
      * @throws ParserException
      */
     private function parseAllocationExpressionValue()
@@ -1799,7 +1743,6 @@ abstract class AbstractPHPParser
      * Parses a eval-expression node.
      *
      * @return ASTEvalExpression
-     *
      * @since 0.9.12
      */
     private function parseEvalExpression()
@@ -1817,7 +1760,6 @@ abstract class AbstractPHPParser
      * This method parses an exit-expression.
      *
      * @return ASTExitExpression
-     *
      * @since 0.9.12
      */
     private function parseExitExpression()
@@ -1838,7 +1780,6 @@ abstract class AbstractPHPParser
      * Parses a clone-expression node.
      *
      * @return ASTCloneExpression
-     *
      * @since 0.9.12
      */
     private function parseCloneExpression()
@@ -1855,7 +1796,7 @@ abstract class AbstractPHPParser
     /**
      * Throws an exception if the given token is not a valid list unpacking opening token for current PHP level.
      *
-     * @param int   $tokenType
+     * @param int $tokenType
      * @param Token $unexpectedToken
      */
     private function ensureTokenIsListUnpackingOpening($tokenType, $unexpectedToken = null): void
@@ -1879,7 +1820,6 @@ abstract class AbstractPHPParser
      * This method parses a single list-statement node.
      *
      * @return ASTListExpression
-     *
      * @since 0.9.12
      */
     private function parseListExpression()
@@ -1938,7 +1878,6 @@ abstract class AbstractPHPParser
      * Return true if the current node can be used as a list key.
      *
      * @param ASTNode|null $node
-     *
      * @return bool
      */
     protected function canBeListKey($node)
@@ -1977,7 +1916,6 @@ abstract class AbstractPHPParser
      * Parses a include-expression node.
      *
      * @return ASTIncludeExpression
-     *
      * @since 0.9.12
      */
     private function parseIncludeExpression()
@@ -1991,7 +1929,6 @@ abstract class AbstractPHPParser
      * Parses a include_once-expression node.
      *
      * @return ASTIncludeExpression
-     *
      * @since 0.9.12
      */
     private function parseIncludeOnceExpression()
@@ -2006,7 +1943,6 @@ abstract class AbstractPHPParser
      * Parses a require-expression node.
      *
      * @return ASTRequireExpression
-     *
      * @since 0.9.12
      */
     private function parseRequireExpression()
@@ -2020,7 +1956,6 @@ abstract class AbstractPHPParser
      * Parses a require_once-expression node.
      *
      * @return ASTRequireExpression
-     *
      * @since 0.9.12
      */
     private function parseRequireOnceExpression()
@@ -2037,11 +1972,9 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTExpression
      *
-     * @param T   $expr
+     * @param T $expr
      * @param int $type
-     *
      * @return T
-     *
      * @since 0.9.12
      */
     private function parseRequireOrIncludeExpression(ASTExpression $expr, $type)
@@ -2066,7 +1999,6 @@ abstract class AbstractPHPParser
      * Parses a cast-expression node.
      *
      * @return ASTCastExpression
-     *
      * @since 0.10.0
      */
     protected function parseCastExpression()
@@ -2089,9 +2021,7 @@ abstract class AbstractPHPParser
      * this can be a {@link ASTPostIncrementExpression} or {@link ASTPostfixExpression}.
      *
      * @param array<ASTNode> $expressions List of previous parsed expression nodes.
-     *
      * @return ASTExpression
-     *
      * @since 0.10.0
      */
     private function parseIncrementExpression(array &$expressions)
@@ -2107,9 +2037,7 @@ abstract class AbstractPHPParser
      * Parses a post increment-expression and adds the given child to that node.
      *
      * @param ASTNode $child The child expression node.
-     *
      * @return ASTPostfixExpression
-     *
      * @since 0.10.0
      */
     private function parsePostIncrementExpression(ASTNode $child)
@@ -2132,7 +2060,6 @@ abstract class AbstractPHPParser
      * Parses a pre increment-expression and adds the given child to that node.
      *
      * @return ASTPreIncrementExpression
-     *
      * @since 0.10.0
      */
     private function parsePreIncrementExpression()
@@ -2155,9 +2082,7 @@ abstract class AbstractPHPParser
      * this can be a {@link ASTPostDecrementExpression} or {@link ASTPostfixExpression}.
      *
      * @param array<ASTNode> $expressions List of previous parsed expression nodes.
-     *
      * @return ASTExpression
-     *
      * @since 0.10.0
      */
     private function parseDecrementExpression(array &$expressions)
@@ -2173,9 +2098,7 @@ abstract class AbstractPHPParser
      * Parses a post decrement-expression and adds the given child to that node.
      *
      * @param ASTNode $child The child expression node.
-     *
      * @return ASTPostfixExpression
-     *
      * @since 0.10.0
      */
     private function parsePostDecrementExpression(ASTNode $child)
@@ -2198,7 +2121,6 @@ abstract class AbstractPHPParser
      * Parses a pre decrement-expression and adds the given child to that node.
      *
      * @return ASTPreDecrementExpression
-     *
      * @since 0.10.0
      */
     private function parsePreDecrementExpression()
@@ -2236,9 +2158,7 @@ abstract class AbstractPHPParser
      * @template T of ASTNode
      *
      * @param T $node The parent/context node instance.
-     *
      * @return ASTIndexExpression|T
-     *
      * @since 0.9.12
      */
     protected function parseOptionalIndexExpression(ASTNode $node)
@@ -2261,13 +2181,11 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTExpression
      *
-     * @param ASTNode $node  The context source node.
-     * @param T       $expr  The concrete index expression.
-     * @param int     $open  The open token type.
-     * @param int     $close The close token type.
-     *
+     * @param ASTNode $node The context source node.
+     * @param T $expr The concrete index expression.
+     * @param int $open The open token type.
+     * @param int $close The close token type.
      * @return ASTIndexExpression|T
-     *
      * @since 0.9.12
      */
     private function parseIndexExpression(
@@ -2304,9 +2222,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The context source node.
-     *
      * @return ASTIndexExpression
-     *
      * @since 0.9.12
      */
     private function parseArrayIndexExpression(ASTNode $node)
@@ -2332,9 +2248,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The context source node.
-     *
      * @return ASTIndexExpression
-     *
      * @since 0.9.12
      */
     private function parseStringIndexExpression(ASTNode $node)
@@ -2354,7 +2268,6 @@ abstract class AbstractPHPParser
      * This method checks if the next available token starts an arguments node.
      *
      * @return bool
-     *
      * @since 0.9.8
      */
     protected function isNextTokenArguments()
@@ -2368,11 +2281,9 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTNode
      *
-     * @param T                      $node
+     * @param T $node
      * @param array<int, Token>|null $tokens
-     *
      * @return T
-     *
      * @since 0.9.8
      */
     protected function setNodePositionsAndReturn(ASTNode $node, ?array &$tokens = null)
@@ -2396,9 +2307,7 @@ abstract class AbstractPHPParser
      * Strips all trailing comments from the given token stream.
      *
      * @param Token[] $tokens Original token stream.
-     *
      * @return Token[]
-     *
      * @since 1.0.0
      */
     private function stripTrailingComments(array $tokens)
@@ -2438,7 +2347,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTInstanceOfExpression
-     *
      * @since 0.9.6
      */
     private function parseInstanceOfExpression()
@@ -2468,7 +2376,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTIssetExpression
-     *
      * @since 0.9.12
      */
     private function parseIssetExpression()
@@ -2504,7 +2411,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return ASTClassOrInterfaceReference
      */
     private function parseStandAloneExpressionTypeReference($tokenType)
@@ -2523,9 +2429,7 @@ abstract class AbstractPHPParser
 
     /**
      * @param bool $classRef
-     *
      * @return ASTNode
-     *
      * @throws ParserException
      */
     private function parseStandAloneExpressionType($classRef)
@@ -2555,11 +2459,9 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      *
-     * @param T    $expr
+     * @param T $expr
      * @param bool $classRef
-     *
      * @return T
-     *
      * @throws ParserException
      */
     protected function parseExpressionTypeReference(ASTNode $expr, $classRef)
@@ -2585,7 +2487,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTConditionalExpression
-     *
      * @since 0.9.8
      */
     protected function parseConditionalExpression()
@@ -2609,7 +2510,6 @@ abstract class AbstractPHPParser
      * This method parses a shift left expression node.
      *
      * @return ASTShiftLeftExpression
-     *
      * @since 1.0.1
      */
     protected function parseShiftLeftExpression()
@@ -2630,7 +2530,6 @@ abstract class AbstractPHPParser
      * This method parses a shift right expression node.
      *
      * @return ASTShiftRightExpression
-     *
      * @since 1.0.1
      */
     protected function parseShiftRightExpression()
@@ -2651,7 +2550,6 @@ abstract class AbstractPHPParser
      * This method parses a boolean and-expression.
      *
      * @return ASTBooleanAndExpression
-     *
      * @since 0.9.8
      */
     protected function parseBooleanAndExpression()
@@ -2672,7 +2570,6 @@ abstract class AbstractPHPParser
      * This method parses a boolean or-expression.
      *
      * @return ASTBooleanOrExpression
-     *
      * @since 0.9.8
      */
     protected function parseBooleanOrExpression()
@@ -2693,7 +2590,6 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>and</b>-expression.
      *
      * @return ASTLogicalAndExpression
-     *
      * @since 0.9.8
      */
     protected function parseLogicalAndExpression()
@@ -2714,7 +2610,6 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>or</b>-expression.
      *
      * @return ASTLogicalOrExpression
-     *
      * @since 0.9.8
      */
     protected function parseLogicalOrExpression()
@@ -2735,7 +2630,6 @@ abstract class AbstractPHPParser
      * This method parses a logical <b>xor</b>-expression.
      *
      * @return ASTLogicalXorExpression
-     *
      * @since 0.9.8
      */
     protected function parseLogicalXorExpression()
@@ -2756,9 +2650,7 @@ abstract class AbstractPHPParser
      * Parses a class or interface reference node.
      *
      * @param bool $classReference Force a class reference.
-     *
      * @return ASTClassOrInterfaceReference
-     *
      * @since 0.9.8
      */
     private function parseClassOrInterfaceReference($classReference)
@@ -2798,14 +2690,11 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      *
-     * @param T        $node
-     * @param int      $closeToken
+     * @param T $node
+     * @param int $closeToken
      * @param int|null $separatorToken
-     *
      * @return T
-     *
      * @throws TokenStreamEndException
-     *
      * @since 0.9.6
      */
     protected function parseBraceExpression(
@@ -2848,9 +2737,7 @@ abstract class AbstractPHPParser
      * @template T of ASTStatement
      *
      * @param T $stmt The owning statement.
-     *
      * @return T
-     *
      * @since 0.9.12
      */
     private function parseStatementBody(ASTStatement $stmt)
@@ -2872,9 +2759,7 @@ abstract class AbstractPHPParser
      * Parse a scope enclosed by curly braces.
      *
      * @return ASTScopeStatement
-     *
      * @throws ParserException
-     *
      * @since 0.9.12
      */
     private function parseRegularScope()
@@ -2895,7 +2780,6 @@ abstract class AbstractPHPParser
      * syntax for statements.
      *
      * @return ASTScopeStatement
-     *
      * @since 0.10.0
      */
     private function parseAlternativeScope()
@@ -2914,9 +2798,7 @@ abstract class AbstractPHPParser
      * instance.
      *
      * @return ASTScopeStatement
-     *
      * @throws ParserException
-     *
      * @since 0.10.0
      */
     private function parseScopeStatements()
@@ -2951,9 +2833,7 @@ abstract class AbstractPHPParser
      * method will return <b>false</b>.
      *
      * @param int $tokenType The token type identifier.
-     *
      * @return bool
-     *
      * @since 0.10.0
      */
     private function isAlternativeScopeTermination($tokenType)
@@ -2975,7 +2855,6 @@ abstract class AbstractPHPParser
      * Parses a series of tokens that represent an alternative scope termination.
      *
      * @param int $tokenType The token type identifier.
-     *
      * @since 0.10.0
      */
     private function parseAlternativeScopeTermination($tokenType): void
@@ -2997,9 +2876,7 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTNode
      *
      * @param T $exprList
-     *
      * @return T
-     *
      * @since 1.0.0
      */
     private function parseExpressionList(ASTNode $exprList)
@@ -3017,7 +2894,6 @@ abstract class AbstractPHPParser
      * Return true if children remain to be added, false else.
      *
      * @param AbstractASTNode $exprList
-     *
      * @return bool
      */
     protected function addChildToList(ASTNode $exprList, ASTNode $expr)
@@ -3045,9 +2921,7 @@ abstract class AbstractPHPParser
      * was found this method will throw an InvalidStateException.
      *
      * @return ASTNode
-     *
      * @throws ParserException
-     *
      * @since 1.0.1
      */
     private function parseExpression()
@@ -3069,9 +2943,7 @@ abstract class AbstractPHPParser
      * expression was found this method will return <b>null</b>.
      *
      * @return ASTNode|null
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseOptionalExpression()
@@ -3357,9 +3229,7 @@ abstract class AbstractPHPParser
      * expressions.
      *
      * @return ASTNode
-     *
      * @throws UnexpectedTokenException
-     *
      * @since 2.2
      */
     protected function parseOptionalExpressionForVersion()
@@ -3371,9 +3241,7 @@ abstract class AbstractPHPParser
      * Applies all reduce rules against the given expression list.
      *
      * @param ASTNode[] $expressions Unprepared input array with parsed expression nodes found in the source tree.
-     *
      * @return ASTNode[]
-     *
      * @since 0.10.0
      */
     protected function reduce(array $expressions)
@@ -3387,9 +3255,7 @@ abstract class AbstractPHPParser
      * @template T of ASTNode[]
      *
      * @param T $expressions Unprepared input array with parsed expression nodes found in the source tree.
-     *
      * @return T
-     *
      * @since 0.10.0
      */
     private function reduceUnaryExpression(array $expressions)
@@ -3418,9 +3284,7 @@ abstract class AbstractPHPParser
      * This method parses a switch statement.
      *
      * @return ASTSwitchStatement
-     *
      * @throws ParserException
-     *
      * @since 0.9.8
      */
     private function parseSwitchStatement()
@@ -3439,11 +3303,8 @@ abstract class AbstractPHPParser
      * Parses the body of a switch statement.
      *
      * @param ASTSwitchStatement $switch The parent switch stmt.
-     *
      * @return ASTSwitchStatement
-     *
      * @throws ParserException
-     *
      * @since 0.9.8
      */
     private function parseSwitchStatementBody(ASTSwitchStatement $switch)
@@ -3488,9 +3349,7 @@ abstract class AbstractPHPParser
      * This method parses a case label of a switch statement.
      *
      * @return ASTSwitchLabel
-     *
      * @throws ParserException
-     *
      * @since 0.9.8
      */
     private function parseSwitchLabel()
@@ -3516,7 +3375,6 @@ abstract class AbstractPHPParser
      * This method parses the default label of a switch statement.
      *
      * @return ASTSwitchLabel
-     *
      * @since 0.9.8
      */
     private function parseSwitchLabelDefault()
@@ -3543,9 +3401,7 @@ abstract class AbstractPHPParser
      * Parses the body of an switch label node.
      *
      * @param ASTSwitchLabel $label The context switch label.
-     *
      * @return ASTSwitchLabel
-     *
      * @throws ParserException
      */
     private function parseSwitchLabelBody(ASTSwitchLabel $label)
@@ -3594,7 +3450,6 @@ abstract class AbstractPHPParser
      * be a semicolon or a closing php tag.
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
-     *
      * @since 0.9.12
      */
     private function parseStatementTermination(array $allowedTerminationTokens = []): void
@@ -3617,9 +3472,7 @@ abstract class AbstractPHPParser
      * This method parses a try-statement + associated catch-statements.
      *
      * @return ASTTryStatement
-     *
      * @throws ParserException
-     *
      * @since 0.9.12
      */
     private function parseTryStatement()
@@ -3653,9 +3506,7 @@ abstract class AbstractPHPParser
      * This method parses a throw-statement.
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
-     *
      * @return ASTThrowStatement
-     *
      * @since 0.9.12
      */
     protected function parseThrowStatement(array $allowedTerminationTokens = [])
@@ -3675,7 +3526,6 @@ abstract class AbstractPHPParser
      * This method parses a goto-statement.
      *
      * @return ASTGotoStatement
-     *
      * @since 0.9.12
      */
     private function parseGotoStatement()
@@ -3697,7 +3547,6 @@ abstract class AbstractPHPParser
      * This method parses a label-statement.
      *
      * @return ASTLabelStatement
-     *
      * @since 0.9.12
      */
     private function parseLabelStatement()
@@ -3717,7 +3566,6 @@ abstract class AbstractPHPParser
      * This method parses a global-statement.
      *
      * @return ASTGlobalStatement
-     *
      * @since 0.9.12
      */
     private function parseGlobalStatement()
@@ -3737,7 +3585,6 @@ abstract class AbstractPHPParser
      * This method parses a unset-statement.
      *
      * @return ASTUnsetStatement
-     *
      * @since 0.9.12
      */
     private function parseUnsetStatement()
@@ -3764,7 +3611,6 @@ abstract class AbstractPHPParser
      * This method parses a catch-statement.
      *
      * @return ASTCatchStatement
-     *
      * @since 0.9.8
      */
     private function parseCatchStatement()
@@ -3821,7 +3667,6 @@ abstract class AbstractPHPParser
      * This method parses a finally-statement.
      *
      * @return ASTFinallyStatement
-     *
      * @since 2.0.0
      */
     private function parseFinallyStatement()
@@ -3841,7 +3686,6 @@ abstract class AbstractPHPParser
      * This method parses a single if-statement node.
      *
      * @return ASTIfStatement
-     *
      * @since 0.9.8
      */
     private function parseIfStatement()
@@ -3862,7 +3706,6 @@ abstract class AbstractPHPParser
      * This method parses a single elseif-statement node.
      *
      * @return ASTElseIfStatement
-     *
      * @since 0.9.8
      */
     private function parseElseIfStatement()
@@ -3883,9 +3726,7 @@ abstract class AbstractPHPParser
      * This method parses an optional else-, else+if- or elseif-statement.
      *
      * @param ASTStatement $stmt The owning if/elseif statement.
-     *
      * @return ASTStatement
-     *
      * @since 0.9.12
      */
     private function parseOptionalElseOrElseIfStatement(ASTStatement $stmt)
@@ -3913,9 +3754,7 @@ abstract class AbstractPHPParser
      * This method parses a single for-statement node.
      *
      * @return ASTForStatement
-     *
      * @throws ParserException
-     *
      * @since 0.9.8
      */
     private function parseForStatement()
@@ -3956,7 +3795,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTForInit|null
-     *
      * @since 0.9.8
      */
     private function parseForInit()
@@ -3979,9 +3817,7 @@ abstract class AbstractPHPParser
      * Parses the expression part of a for-statement.
      *
      * @return ASTNode|null
-     *
      * @throws ParserException
-     *
      * @since 0.9.12
      */
     private function parseForExpression()
@@ -3999,7 +3835,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTForUpdate|null
-     *
      * @since 0.9.12
      */
     private function parseForUpdate()
@@ -4021,9 +3856,7 @@ abstract class AbstractPHPParser
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 2.6.0
      */
     protected function isListUnpacking($tokenType = null)
@@ -4065,7 +3898,6 @@ abstract class AbstractPHPParser
      * This method parses a single foreach-statement node.
      *
      * @return ASTForeachStatement
-     *
      * @since 0.9.8
      */
     private function parseForeachStatement()
@@ -4099,7 +3931,6 @@ abstract class AbstractPHPParser
      * This method parses a single while-statement node.
      *
      * @return ASTWhileStatement
-     *
      * @since 0.9.8
      */
     private function parseWhileStatement()
@@ -4119,7 +3950,6 @@ abstract class AbstractPHPParser
      * This method parses a do/while-statement.
      *
      * @return ASTDoWhileStatement
-     *
      * @since 0.9.12
      */
     private function parseDoWhileStatement()
@@ -4162,7 +3992,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTDeclareStatement
-     *
      * @since 0.10.0
      */
     private function parseDeclareStatement()
@@ -4182,9 +4011,7 @@ abstract class AbstractPHPParser
      * consists of a string token and a static scalar.
      *
      * @param ASTDeclareStatement $stmt The declare statement that is the owner of this list.
-     *
      * @return ASTDeclareStatement
-     *
      * @since 0.10.0
      */
     private function parseDeclareList(ASTDeclareStatement $stmt)
@@ -4220,7 +4047,6 @@ abstract class AbstractPHPParser
      * This method builds a return statement from a given token.
      *
      * @return ASTReturnStatement
-     *
      * @since 2.7.0
      */
     protected function buildReturnStatement(Token $token)
@@ -4238,7 +4064,6 @@ abstract class AbstractPHPParser
      * This method parses a single return-statement node.
      *
      * @return ASTReturnStatement
-     *
      * @since 0.9.12
      */
     private function parseReturnStatement()
@@ -4258,7 +4083,6 @@ abstract class AbstractPHPParser
      * This method parses a break-statement node.
      *
      * @return ASTBreakStatement
-     *
      * @since 0.9.12
      */
     private function parseBreakStatement()
@@ -4279,7 +4103,6 @@ abstract class AbstractPHPParser
      * This method parses a continue-statement node.
      *
      * @return ASTContinueStatement
-     *
      * @since 0.9.12
      */
     private function parseContinueStatement()
@@ -4300,7 +4123,6 @@ abstract class AbstractPHPParser
      * This method parses a echo-statement node.
      *
      * @return ASTEchoStatement
-     *
      * @since 0.9.12
      */
     private function parseEchoStatement()
@@ -4326,7 +4148,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTNode
-     *
      * @since 1.0.0
      */
     protected function parseParenthesisExpressionOrPrimaryPrefix()
@@ -4340,7 +4161,6 @@ abstract class AbstractPHPParser
      * @template T of ASTExpression
      *
      * @param T $expr
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T
      */
     protected function parseParenthesisExpressionOrPrimaryPrefixForVersion(ASTExpression $expr)
@@ -4364,7 +4184,6 @@ abstract class AbstractPHPParser
 
     /**
      * @return Token
-     *
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
@@ -4378,7 +4197,6 @@ abstract class AbstractPHPParser
      * parenthesis
      *
      * @return ASTExpression
-     *
      * @since 0.9.8
      */
     protected function parseParenthesisExpression()
@@ -4431,9 +4249,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTNode
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     private function parseMemberPrefixOrFunctionPostfix()
@@ -4479,9 +4295,7 @@ abstract class AbstractPHPParser
      * @template T of ASTNode
      *
      * @param T $node The previously parsed node.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T The original input node or this node wrapped with a function postfix instance.
-     *
      * @since 1.0.0
      */
     private function parseOptionalFunctionPostfix(ASTNode $node)
@@ -4504,11 +4318,8 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node This node represents the function identifier. An identifier can be a static string,
      *                      a variable, a compound variable or any other valid php function identifier.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseFunctionPostfix(ASTNode $node)
@@ -4529,7 +4340,6 @@ abstract class AbstractPHPParser
      * property postfix expressions.
      *
      * @return ASTNode
-     *
      * @since 1.0.0
      */
     protected function parsePostfixIdentifier()
@@ -4556,11 +4366,8 @@ abstract class AbstractPHPParser
      * @param T $node This node represents primary prefix
      *                left expression. It will be the first child of the parsed member
      *                primary expression.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|T
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseOptionalMemberPrimaryPrefix(ASTNode $node)
@@ -4589,11 +4396,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The left node in the parsed member primary expression.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseMemberPrimaryPrefix(ASTNode $node)
@@ -4648,11 +4452,8 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node This node represents primary prefix left expression. It will
      *                      be the first child of the parsed member primary expression.
-     *
      * @return ASTNode
-     *
      * @throws ParserException
-     *
      * @since 1.0.1
      */
     private function parseOptionalStaticMemberPrimaryPrefix(ASTNode $node)
@@ -4690,11 +4491,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The left node in the parsed member primary expression.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseStaticMemberPrimaryPrefix(ASTNode $node)
@@ -4732,7 +4530,6 @@ abstract class AbstractPHPParser
      * will contain an identifier node as nested child.
      *
      * @return ASTNode
-     *
      * @since 0.9.6
      */
     private function parseMethodOrConstantPostfix()
@@ -4758,11 +4555,8 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node The identifier for the parsed postfix expression node. This node
      *                      will be the first child of the returned postfix node instance.
-     *
      * @return ASTNode
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     private function parseMethodOrPropertyPostfix(ASTNode $node)
@@ -4785,9 +4579,7 @@ abstract class AbstractPHPParser
      * Parses/Creates a property postfix node instance.
      *
      * @param ASTNode $node Node that represents the image of the property postfix node.
-     *
      * @return ASTPropertyPostfix
-     *
      * @since 0.10.2
      */
     private function parsePropertyPostfix(ASTNode $node)
@@ -4811,7 +4603,6 @@ abstract class AbstractPHPParser
      * Parses a full qualified class name postfix.
      *
      * @return ASTClassFqnPostfix
-     *
      * @since 2.0.0
      */
     protected function parseFullQualifiedClassNamePostfix()
@@ -4826,9 +4617,7 @@ abstract class AbstractPHPParser
      * return the image of the entire <b>$node</b>.
      *
      * @param ASTNode $node The context node that may be wrapped by multiple array or string index expressions.
-     *
      * @return string
-     *
      * @since 1.0.0
      */
     protected function extractPostfixImage(ASTNode $node)
@@ -4843,9 +4632,7 @@ abstract class AbstractPHPParser
      * Parses a method postfix node instance.
      *
      * @param ASTNode $node Node that represents the image of the method postfix node.
-     *
      * @return ASTFunctionPostfix|ASTIndexExpression|ASTMemberPrimaryPrefix|ASTMethodPostfix
-     *
      * @since 1.0.0
      */
     private function parseMethodPostfix(ASTNode $node)
@@ -4871,9 +4658,7 @@ abstract class AbstractPHPParser
      * This method parses the arguments passed to a function- or method-call.
      *
      * @return ASTArguments
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseArguments()
@@ -4891,9 +4676,7 @@ abstract class AbstractPHPParser
      * This method parses the tokens after arguments passed to a function- or method-call.
      *
      * @return ASTArguments
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseArgumentsParenthesesContent(ASTArguments $arguments)
@@ -4914,7 +4697,6 @@ abstract class AbstractPHPParser
      * @template T of ASTArguments
      *
      * @param T $arguments
-     *
      * @return T
      */
     protected function parseArgumentList(ASTArguments $arguments)
@@ -4928,7 +4710,6 @@ abstract class AbstractPHPParser
      * several php language constructs like, isset, empty, unset etc.
      *
      * @return ASTNode
-     *
      * @since 0.9.12
      */
     protected function parseVariableOrConstantOrPrimaryPrefix()
@@ -4967,9 +4748,7 @@ abstract class AbstractPHPParser
      * parenthesis.
      *
      * @return ASTNode
-     *
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     private function parseVariableOrFunctionPostfixOrMemberPrimaryPrefix()
@@ -5002,9 +4781,7 @@ abstract class AbstractPHPParser
      * Parses an assingment expression node.
      *
      * @param ASTNode $left The left part of the assignment expression that will be parsed by this method.
-     *
      * @return ASTAssignmentExpression
-     *
      * @since 0.9.12
      */
     protected function parseAssignmentExpression(ASTNode $left)
@@ -5035,12 +4812,9 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTStaticReference} node.
      *
      * @param Token $token The "static" keyword token.
-     *
      * @return ASTStaticReference
-     *
      * @throws ParserException
      * @throws InvalidStateException
-     *
      * @since 0.9.6
      */
     private function parseStaticReference(Token $token)
@@ -5071,12 +4845,9 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTSelfReference} node.
      *
      * @param Token $token The "self" keyword token.
-     *
      * @return ASTSelfReference
-     *
      * @throws ParserException
      * @throws InvalidStateException
-     *
      * @since 0.9.6
      */
     protected function parseSelfReference(Token $token)
@@ -5104,7 +4875,6 @@ abstract class AbstractPHPParser
      * Parses a simple PHP constant use and returns a corresponding node.
      *
      * @return ASTNode|null
-     *
      * @since 1.0.0
      */
     protected function parseConstant()
@@ -5138,10 +4908,8 @@ abstract class AbstractPHPParser
      * followed by a double colon token.
      *
      * @return ASTNode
-     *
      * @throws ParserException
      * @throws InvalidStateException
-     *
      * @since 0.9.6
      */
     private function parseConstantOrSelfMemberPrimaryPrefix()
@@ -5163,12 +4931,9 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTParentReference} node.
      *
      * @param Token $token The "self" keyword token.
-     *
      * @return ASTParentReference
-     *
      * @throws ParserException
      * @throws InvalidStateException
-     *
      * @since 0.9.6
      */
     private function parseParentReference(Token $token)
@@ -5216,10 +4981,8 @@ abstract class AbstractPHPParser
      * is followed by a double colon token.
      *
      * @return ASTNode
-     *
      * @throws ParserException
      * @throws InvalidStateException
-     *
      * @since 0.9.6
      */
     private function parseConstantOrParentMemberPrimaryPrefix()
@@ -5252,7 +5015,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTNode
-     *
      * @since 0.9.18
      */
     private function parseVariableOrMemberOptionalByReference()
@@ -5281,7 +5043,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTUnaryExpression
-     *
      * @since 0.9.18
      */
     private function parseVariableOrMemberByReference()
@@ -5301,9 +5062,7 @@ abstract class AbstractPHPParser
      * This method parses a simple PHP variable.
      *
      * @return ASTVariable
-     *
      * @throws UnexpectedTokenException
-     *
      * @since 0.9.6
      */
     private function parseVariable()
@@ -5327,11 +5086,9 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      *
-     * @param T    $node   The context parent node.
+     * @param T $node The context parent node.
      * @param bool $inCall
-     *
      * @return T The prepared entire node.
-     *
      * @since 0.9.12
      */
     private function parseVariableList(ASTNode $node, $inCall = false)
@@ -5381,10 +5138,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTCompoundVariable|ASTVariable|ASTVariableVariable
-     *
      * @throws ParserException
      * @throws UnexpectedTokenException
-     *
      * @since 0.9.6
      */
     protected function parseCompoundVariableOrVariableVariableOrVariable()
@@ -5399,7 +5154,6 @@ abstract class AbstractPHPParser
      * Parses a PHP compound variable or a simple literal node.
      *
      * @return ASTNode
-     *
      * @since 0.9.19
      */
     private function parseCompoundVariableOrLiteral()
@@ -5435,10 +5189,8 @@ abstract class AbstractPHPParser
      * compound-variable.
      *
      * @return ASTCompoundVariable|ASTVariableVariable
-     *
      * @throws ParserException
      * @throws UnexpectedTokenException
-     *
      * @since 0.9.6
      */
     private function parseCompoundVariableOrVariableVariable()
@@ -5480,9 +5232,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param Token $token The dollar token.
-     *
      * @return ASTCompoundVariable
-     *
      * @since 0.10.0
      */
     private function parseCompoundVariable(Token $token)
@@ -5512,7 +5262,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTNode
-     *
      * @since 0.9.10
      */
     private function parseCompoundExpressionOrLiteral()
@@ -5551,10 +5300,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTCompoundExpression
-     *
      * @throws ParserException
      * @throws ParserException
-     *
      * @since 0.9.6
      */
     protected function parseCompoundExpression()
@@ -5573,9 +5320,7 @@ abstract class AbstractPHPParser
      * function names.
      *
      * @param int $tokenType
-     *
      * @return ASTIdentifier
-     *
      * @since 0.9.12
      */
     protected function parseIdentifier($tokenType = Tokens::T_STRING)
@@ -5599,7 +5344,6 @@ abstract class AbstractPHPParser
      * in double quotes or surrounded by backticks.
      *
      * @return ASTNode
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseLiteralOrString()
@@ -5633,7 +5377,6 @@ abstract class AbstractPHPParser
      * Parses an integer value.
      *
      * @return ASTLiteral
-     *
      * @since 1.0.0
      */
     protected function parseIntegerNumber()
@@ -5655,9 +5398,7 @@ abstract class AbstractPHPParser
      * Parses an array structure.
      *
      * @param bool $static
-     *
      * @return ASTArray
-     *
      * @since 1.0.0
      */
     protected function doParseArray($static = false)
@@ -5677,7 +5418,6 @@ abstract class AbstractPHPParser
      * PHP version.
      *
      * @return bool
-     *
      * @since 1.0.0
      */
     abstract protected function isArrayStartDelimiter();
@@ -5686,9 +5426,7 @@ abstract class AbstractPHPParser
      * Parses a php array declaration.
      *
      * @param bool $static
-     *
      * @return ASTArray
-     *
      * @since 1.0.0
      */
     abstract protected function parseArray(ASTArray $array, $static = false);
@@ -5706,11 +5444,9 @@ abstract class AbstractPHPParser
     /**
      * Parses all elements in an array.
      *
-     * @param int  $endDelimiter
+     * @param int $endDelimiter
      * @param bool $static
-     *
      * @return ASTArray
-     *
      * @since 1.0.0
      */
     protected function parseArrayElements(ASTArray $array, $endDelimiter, $static = false)
@@ -5755,10 +5491,9 @@ abstract class AbstractPHPParser
      * Check if the given array/list is a value and so does not have consecutive commas in it,
      * or if it's a destructuring list and so check the syntax is valid in the current PHP level.
      *
-     * @param bool       $useSquaredBrackets
+     * @param bool $useSquaredBrackets
      * @param Token|null $openingToken
      * @param Token|null $consecutiveComma
-     *
      * @throws UnexpectedTokenException
      */
     protected function ensureArrayIsValid($useSquaredBrackets, $openingToken, $consecutiveComma): void
@@ -5779,7 +5514,6 @@ abstract class AbstractPHPParser
      * Parses a single match key.
      *
      * @return ASTNode
-     *
      * @since 2.9.0
      */
     protected function parseMatchEntryKey()
@@ -5805,7 +5539,6 @@ abstract class AbstractPHPParser
      * Parses a single match value expression.
      *
      * @return ASTNode
-     *
      * @since 2.9.0
      */
     protected function parseMatchEntryValue()
@@ -5823,7 +5556,6 @@ abstract class AbstractPHPParser
      * Parses a single match entry key-expression pair.
      *
      * @return ASTMatchEntry
-     *
      * @since 2.9.0
      */
     protected function parseMatchEntry()
@@ -5862,9 +5594,7 @@ abstract class AbstractPHPParser
      * reference or a key/value pair with a referenced value.
      *
      * @param bool $static
-     *
      * @return ASTArrayElement
-     *
      * @since 1.0.0
      */
     protected function parseArrayElement($static = false)
@@ -5909,7 +5639,6 @@ abstract class AbstractPHPParser
      * Parses a here- or nowdoc string instance.
      *
      * @return ASTHeredoc
-     *
      * @since 0.9.12
      */
     protected function parseHeredoc()
@@ -5930,9 +5659,7 @@ abstract class AbstractPHPParser
      * Parses a simple string sequence between two tokens of the same type.
      *
      * @param int $tokenType The start/stop token type.
-     *
      * @return string
-     *
      * @since 0.9.10
      */
     private function parseStringSequence($tokenType)
@@ -5964,11 +5691,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param int $delimiterType The start/stop token type.
-     *
      * @return ASTString
-     *
      * @throws UnexpectedTokenException
-     *
      * @since 0.9.10
      */
     private function parseString($delimiterType)
@@ -6002,10 +5726,8 @@ abstract class AbstractPHPParser
      * input string node.
      *
      * @param AbstractASTNode $node
-     * @param int             $stopToken
-     *
+     * @param int $stopToken
      * @return ASTNode
-     *
      * @since 0.9.12
      */
     private function parseStringExpressions(ASTNode $node, $stopToken)
@@ -6038,7 +5760,6 @@ abstract class AbstractPHPParser
      * This method parses an escaped sequence of literal tokens.
      *
      * @return ASTLiteral
-     *
      * @since 0.9.10
      */
     private function parseEscapedAstLiteralString()
@@ -6073,7 +5794,6 @@ abstract class AbstractPHPParser
      * properties.
      *
      * @return ASTLiteral
-     *
      * @since 0.9.10
      */
     protected function parseLiteral()
@@ -6097,7 +5817,6 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
-     *
      * @return ASTNode
      */
     protected function parseFormalParameterOrPrefix(ASTCallable $callable)
@@ -6110,9 +5829,7 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
-     *
      * @return ASTFormalParameters
-     *
      * @since 0.9.5
      */
     protected function parseFormalParameters(ASTCallable $callable)
@@ -6193,7 +5910,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     protected function parseFormalParameterOrTypeHintOrByReference()
@@ -6210,7 +5926,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return ASTFormalParameter
      */
     private function parseFormalParameterFromType($tokenType)
@@ -6248,7 +5963,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndArrayTypeHint()
@@ -6283,7 +5997,6 @@ abstract class AbstractPHPParser
      * Parses a type hint that is valid in the supported PHP version after the next token.
      *
      * @return ASTType|null
-     *
      * @since 2.9.2
      */
     private function parseOptionalTypeHint()
@@ -6303,7 +6016,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndTypeHint(ASTNode $typeHint)
@@ -6329,7 +6041,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndParentTypeHint()
@@ -6363,7 +6074,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndSelfTypeHint()
@@ -6390,7 +6100,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 2.9.2
      */
     private function parseFormalParameterAndStaticTypeHint()
@@ -6430,7 +6139,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     protected function parseFormalParameterOrByReference()
@@ -6452,7 +6160,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     private function parseFormalParameterAndByReference()
@@ -6477,7 +6184,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 0.9.6
      */
     protected function parseFormalParameter()
@@ -6493,9 +6199,7 @@ abstract class AbstractPHPParser
      * PHP version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 1.0.0
      */
     protected function isTypeHint($tokenType)
@@ -6515,7 +6219,6 @@ abstract class AbstractPHPParser
      * Parses a type hint that is valid in the supported PHP version.
      *
      * @return ASTType|null
-     *
      * @since 1.0.0
      */
     protected function parseTypeHint()
@@ -6537,7 +6240,6 @@ abstract class AbstractPHPParser
      * Extracts all dependencies from a callable body.
      *
      * @return ASTScope
-     *
      * @since 0.9.12
      */
     private function parseScope()
@@ -6567,10 +6269,8 @@ abstract class AbstractPHPParser
      * Parse a statement.
      *
      * @return ASTNode
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
-     *
      * @since 1.0.0
      */
     private function parseStatement()
@@ -6586,9 +6286,7 @@ abstract class AbstractPHPParser
      * Parses an optional statement or returns <b>null</b>.
      *
      * @return ASTNode|null
-     *
      * @throws ParserException
-     *
      * @since 0.9.8
      */
     private function parseOptionalStatement()
@@ -6728,7 +6426,6 @@ abstract class AbstractPHPParser
      * the next token.
      *
      * @return int
-     *
      * @since 0.9.12
      */
     private function parseNonePhpCode()
@@ -6758,7 +6455,6 @@ abstract class AbstractPHPParser
      * annotation.
      *
      * @return ASTComment
-     *
      * @since 0.9.8
      */
     private function parseCommentWithOptionalInlineClassOrInterfaceReference()
@@ -6789,9 +6485,7 @@ abstract class AbstractPHPParser
      * @template T of ASTClosure
      *
      * @param T $closure The context closure instance.
-     *
      * @return T
-     *
      * @since 1.0.0
      */
     protected function parseOptionalBoundVariables(
@@ -6812,9 +6506,7 @@ abstract class AbstractPHPParser
      * @template T of ASTClosure
      *
      * @param T $closure The parent closure instance.
-     *
      * @return T
-     *
      * @since 0.9.5
      */
     private function parseBoundVariables(ASTClosure $closure)
@@ -6873,9 +6565,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return string
-     *
      * @throws NoActiveScopeException
-     *
      * @link   http://php.net/manual/en/language.namespaces.importing.php
      */
     protected function parseQualifiedName()
@@ -6913,7 +6603,6 @@ abstract class AbstractPHPParser
      * identifier and returns the collected tokens as a string array.
      *
      * @return array<string>
-     *
      * @since 0.9.5
      */
     protected function parseQualifiedNameRaw()
@@ -6974,7 +6663,6 @@ abstract class AbstractPHPParser
      * Determines if the given image is a PHP 7 type hint.
      *
      * @param string $image
-     *
      * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
@@ -6985,7 +6673,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $previousElements
-     *
      * @return string
      */
     protected function parseQualifiedNameElement(array $previousElements)
@@ -6997,7 +6684,6 @@ abstract class AbstractPHPParser
      * This method parses a PHP 5.3 namespace declaration.
      *
      * @throws NoActiveScopeException
-     *
      * @since 0.9.5
      */
     private function parseNamespaceDeclaration(): void
@@ -7080,7 +6766,6 @@ abstract class AbstractPHPParser
      * short name and full qualified name to the use symbol table.
      *
      * @throws NoActiveScopeException
-     *
      * @since 0.9.5
      */
     protected function parseUseDeclaration(): void
@@ -7122,7 +6807,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $fragments
-     *
      * @return false|string
      */
     protected function parseNamespaceImage(array $fragments)
@@ -7153,7 +6837,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTConstantDefinition
-     *
      * @since 0.9.6
      */
     protected function parseConstantDefinition()
@@ -7189,7 +6872,6 @@ abstract class AbstractPHPParser
      * Constant cannot be typed before PHP 8.3.
      *
      * @return ASTConstantDeclarator
-     *
      * @since  1.16.0
      */
     protected function parseTypedConstantDeclarator()
@@ -7229,7 +6911,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTConstantDeclarator
-     *
      * @since 0.9.6
      */
     protected function parseConstantDeclarator()
@@ -7266,7 +6947,6 @@ abstract class AbstractPHPParser
      * values that were allowed in the oldest supported PHP version.
      *
      * @return ASTValue
-     *
      * @since 2.2.x
      */
     protected function parseConstantDeclaratorValue()
@@ -7312,10 +6992,8 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTNode
-     *
      * @throws ParserException
      * @throws UnexpectedTokenException
-     *
      * @since 0.9.6
      */
     private function parseStaticVariableDeclarationOrMemberPrimaryPrefix()
@@ -7372,9 +7050,7 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param Token $token Token with the "static" keyword.
-     *
      * @return ASTStaticVariableDeclaration
-     *
      * @since 0.9.6
      */
     private function parseStaticVariableDeclaration(Token $token)
@@ -7426,7 +7102,6 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @return ASTVariableDeclarator
-     *
      * @since 0.9.6
      */
     protected function parseVariableDeclarator()
@@ -7450,7 +7125,6 @@ abstract class AbstractPHPParser
      * Parse a default value after a parameter, static variable or constant declaration.
      *
      * @return ASTValue
-     *
      * @since 2.11.0
      */
     protected function parseVariableDefaultValue()
@@ -7463,7 +7137,6 @@ abstract class AbstractPHPParser
      * used as default value for a parameter or property declaration.
      *
      * @return ASTValue
-     *
      * @since 0.9.6
      */
     protected function parseStaticValueOrStaticArray()
@@ -7488,7 +7161,6 @@ abstract class AbstractPHPParser
      * parameter, property or constant declaration.
      *
      * @return ASTValue
-     *
      * @since 0.9.5
      */
     protected function parseStaticValue()
@@ -7616,7 +7288,6 @@ abstract class AbstractPHPParser
      * Parses additional static values that are valid in the supported php version.
      *
      * @return ASTValue
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
@@ -7628,7 +7299,6 @@ abstract class AbstractPHPParser
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
      * @return ASTClosure
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseLambdaFunctionDeclaration()
@@ -7641,9 +7311,7 @@ abstract class AbstractPHPParser
      * the PHP zend_language_parser.y definition.
      *
      * @param ASTNode $expr The context node instance.
-     *
      * @return bool
-     *
      * @since 0.10.0
      */
     private function isReadWriteVariable($expr)
@@ -7662,7 +7330,6 @@ abstract class AbstractPHPParser
      * parsed package annotation, when no namespace declaration was parsed.
      *
      * @param string $localName The local class or interface name.
-     *
      * @return string
      */
     private function createQualifiedTypeName($localName)
@@ -7675,7 +7342,6 @@ abstract class AbstractPHPParser
      * this method will return the name from the @package annotation.
      *
      * @return string
-     *
      * @since 0.9.8
      */
     private function getNamespaceOrPackageName()
@@ -7690,7 +7356,6 @@ abstract class AbstractPHPParser
      * Returns the currently active package or namespace.
      *
      * @return ASTNamespace
-     *
      * @since 1.0.0
      */
     private function getNamespaceOrPackage()
@@ -7705,7 +7370,6 @@ abstract class AbstractPHPParser
      * Extracts the @package information from the given comment.
      *
      * @param string $comment
-     *
      * @return string|null
      */
     private function parsePackageAnnotation($comment)
@@ -7768,7 +7432,6 @@ abstract class AbstractPHPParser
      * given comment block.
      *
      * @param string $comment The context doc comment block.
-     *
      * @return array<int, string>
      */
     private function parseThrowsAnnotations($comment)
@@ -7789,7 +7452,6 @@ abstract class AbstractPHPParser
      * it returns the found return type.
      *
      * @param string $comment A doc comment text.
-     *
      * @return string|null
      */
     private function parseReturnAnnotation($comment)
@@ -7816,7 +7478,6 @@ abstract class AbstractPHPParser
      * it returns the found property types.
      *
      * @param string $comment A doc comment text.
-     *
      * @return array<string>
      */
     private function parseVarAnnotation($comment)
@@ -7839,7 +7500,6 @@ abstract class AbstractPHPParser
      * type information exists.
      *
      * @return ASTType|null
-     *
      * @since 0.9.6
      */
     private function parseFieldDeclarationType()
@@ -7877,7 +7537,6 @@ abstract class AbstractPHPParser
      * matching type instance.
      *
      * @return ASTClassOrInterfaceReference|null
-     *
      * @since 0.9.6
      */
     private function parseFieldDeclarationClassOrInterfaceReference()
@@ -7900,7 +7559,6 @@ abstract class AbstractPHPParser
      *
      * @param bool $standalone Either yield is the statement (true), or nested in
      *                         an expression (false).
-     *
      * @return ASTYieldStatement
      */
     private function parseYield($standalone)
@@ -7974,9 +7632,7 @@ abstract class AbstractPHPParser
      * <b>$tokenType</b>.
      *
      * @param int $tokenType The next expected token type.
-     *
      * @return Token
-     *
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
@@ -8033,7 +7689,6 @@ abstract class AbstractPHPParser
      * null.
      *
      * @param Token|Tokenizer::T_*|null $token
-     *
      * @return TokenStreamEndException|UnexpectedTokenException
      */
     protected function getUnexpectedTokenException($token)
@@ -8057,7 +7712,6 @@ abstract class AbstractPHPParser
      *  $value = $falsableValue ?: throw new InvalidArgumentException();
      *
      * @return ASTThrowStatement
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseThrowExpression()
@@ -8070,7 +7724,6 @@ abstract class AbstractPHPParser
      *  enum Suit: string { case HEARTS = 'hearts'; }
      *
      * @return ASTEnum
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseEnumDeclaration()
@@ -8169,7 +7822,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param string $numberRepresentation integer number as it appears in the code, `0xfe4`, `1_000_000`
-     *
      * @return int
      */
     private function parseIntegerNumberImage($numberRepresentation)
@@ -8185,7 +7837,6 @@ abstract class AbstractPHPParser
 
     /**
      * @param string $numberRepresentation
-     *
      * @return float|int|string
      */
     private function getNumberFromImage($numberRepresentation)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -179,7 +179,6 @@ class PHPBuilder implements Builder
      * The internal used cache instance.
      *
      * @var CacheDriver
-     *
      * @since 0.10.0
      */
     protected $cache = null;
@@ -188,7 +187,6 @@ class PHPBuilder implements Builder
      * The ast builder context.
      *
      * @var BuilderContext
-     *
      * @since 0.10.0
      */
     protected $context = null;
@@ -212,7 +210,6 @@ class PHPBuilder implements Builder
      * This property holds all packages found during the parsing phase.
      *
      * @var ASTNamespace[]
-     *
      * @since 0.9.12
      */
     private $preparedNamespaces = null;
@@ -297,7 +294,6 @@ class PHPBuilder implements Builder
      * Setter method for the currently used token cache.
      *
      * @return $this
-     *
      * @since  0.10.0
      */
     public function setCache(CacheDriver $cache)
@@ -310,9 +306,7 @@ class PHPBuilder implements Builder
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     *
      * @return ASTClassOrInterfaceReference
-     *
      * @since  0.9.5
      */
     public function buildAstClassOrInterfaceReference($qualifiedName)
@@ -332,11 +326,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new code type reference instance, either Class or ClassOrInterface.
      *
-     * @param string $qualifiedName  The qualified name of the referenced type.
-     * @param bool   $classReference true if class reference only.
-     *
+     * @param string $qualifiedName The qualified name of the referenced type.
+     * @param bool $classReference true if class reference only.
      * @return ASTClassOrInterfaceReference
-     *
      * @since  0.9.5
      */
     public function buildAstNeededReference($qualifiedName, $classReference)
@@ -354,9 +346,7 @@ class PHPBuilder implements Builder
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return AbstractASTClassOrInterface
-     *
      * @since  0.9.5
      */
     public function getClassOrInterface($qualifiedName)
@@ -377,9 +367,7 @@ class PHPBuilder implements Builder
      * Builds a new php trait instance.
      *
      * @param string $qualifiedName The full qualified trait name.
-     *
      * @return ASTTrait
-     *
      * @since 1.0.0
      */
     public function buildTrait($qualifiedName)
@@ -400,9 +388,7 @@ class PHPBuilder implements Builder
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait
-     *
      * @since  1.0.0
      */
     public function getTrait($qualifiedName)
@@ -418,9 +404,7 @@ class PHPBuilder implements Builder
      * Builds a new trait reference node.
      *
      * @param string $qualifiedName The full qualified trait name.
-     *
      * @return ASTTraitReference
-     *
      * @since  1.0.0
      */
     public function buildAstTraitReference($qualifiedName)
@@ -459,7 +443,6 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $name The class name.
-     *
      * @return ASTClass The created class object.
      */
     public function buildClass($name)
@@ -480,9 +463,7 @@ class PHPBuilder implements Builder
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
-     *
      * @return ASTClass|ASTEnum
-     *
      * @since  0.9.5
      */
     public function getClass($qualifiedName)
@@ -507,9 +488,7 @@ class PHPBuilder implements Builder
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     *
      * @return ASTClassReference
-     *
      * @since  0.9.5
      */
     public function buildAstClassReference($qualifiedName)
@@ -555,7 +534,6 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $name The interface name.
-     *
      * @return ASTInterface
      */
     public function buildInterface($name)
@@ -576,9 +554,7 @@ class PHPBuilder implements Builder
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTInterface
-     *
      * @since  0.9.5
      */
     public function getInterface($qualifiedName)
@@ -594,7 +570,6 @@ class PHPBuilder implements Builder
      * Builds a new method instance.
      *
      * @param string $name
-     *
      * @return ASTMethod
      */
     public function buildMethod($name)
@@ -615,7 +590,6 @@ class PHPBuilder implements Builder
      * Builds a new package instance.
      *
      * @param string $name The package name.
-     *
      * @return ASTNamespace
      */
     public function buildNamespace($name)
@@ -635,7 +609,6 @@ class PHPBuilder implements Builder
      * Builds a new function instance.
      *
      * @param string $name The function name.
-     *
      * @return ASTFunction
      */
     public function buildFunction($name)
@@ -658,7 +631,6 @@ class PHPBuilder implements Builder
      * Builds a new self reference instance.
      *
      * @return ASTSelfReference
-     *
      * @since  0.9.6
      */
     public function buildAstSelfReference(AbstractASTClassOrInterface $type)
@@ -675,9 +647,7 @@ class PHPBuilder implements Builder
      *
      * @param ASTClassOrInterfaceReference $reference The type
      *                                                instance that reference the concrete target of parent.
-     *
      * @return ASTParentReference
-     *
      * @since  0.9.6
      */
     public function buildAstParentReference(ASTClassOrInterfaceReference $reference)
@@ -691,7 +661,6 @@ class PHPBuilder implements Builder
      * Builds a new static reference instance.
      *
      * @return ASTStaticReference
-     *
      * @since  0.9.6
      */
     public function buildAstStaticReference(AbstractASTClassOrInterface $owner)
@@ -705,7 +674,6 @@ class PHPBuilder implements Builder
      * Builds a new field declaration node.
      *
      * @return ASTFieldDeclaration
-     *
      * @since  0.9.6
      */
     public function buildAstFieldDeclaration()
@@ -717,9 +685,7 @@ class PHPBuilder implements Builder
      * Builds a new variable declarator node.
      *
      * @param string $image The source image for the variable declarator.
-     *
      * @return ASTVariableDeclarator
-     *
      * @since  0.9.6
      */
     public function buildAstVariableDeclarator($image)
@@ -731,9 +697,7 @@ class PHPBuilder implements Builder
      * Builds a new static variable declaration node.
      *
      * @param string $image The source image for the statuc declaration.
-     *
      * @return ASTStaticVariableDeclaration
-     *
      * @since  0.9.6
      */
     public function buildAstStaticVariableDeclaration($image)
@@ -745,9 +709,7 @@ class PHPBuilder implements Builder
      * Builds a new constant node.
      *
      * @param string $image The source image for the constant.
-     *
      * @return ASTConstant
-     *
      * @since  0.9.6
      */
     public function buildAstConstant($image)
@@ -759,9 +721,7 @@ class PHPBuilder implements Builder
      * Builds a new variable node.
      *
      * @param string $image The source image for the variable.
-     *
      * @return ASTVariable
-     *
      * @since  0.9.6
      */
     public function buildAstVariable($image)
@@ -773,9 +733,7 @@ class PHPBuilder implements Builder
      * Builds a new variable variable node.
      *
      * @param string $image The source image for the variable variable.
-     *
      * @return ASTVariableVariable
-     *
      * @since  0.9.6
      */
     public function buildAstVariableVariable($image)
@@ -787,9 +745,7 @@ class PHPBuilder implements Builder
      * Builds a new compound variable node.
      *
      * @param string $image The source image for the compound variable.
-     *
      * @return ASTCompoundVariable
-     *
      * @since  0.9.6
      */
     public function buildAstCompoundVariable($image)
@@ -801,7 +757,6 @@ class PHPBuilder implements Builder
      * Builds a new compound expression node.
      *
      * @return ASTCompoundExpression
-     *
      * @since  0.9.6
      */
     public function buildAstCompoundExpression()
@@ -813,7 +768,6 @@ class PHPBuilder implements Builder
      * Builds a new closure node.
      *
      * @return ASTClosure
-     *
      * @since  0.9.12
      */
     public function buildAstClosure()
@@ -825,7 +779,6 @@ class PHPBuilder implements Builder
      * Builds a new formal parameters node.
      *
      * @return ASTFormalParameters
-     *
      * @since  0.9.6
      */
     public function buildAstFormalParameters()
@@ -837,7 +790,6 @@ class PHPBuilder implements Builder
      * Builds a new formal parameter node.
      *
      * @return ASTFormalParameter
-     *
      * @since  0.9.6
      */
     public function buildAstFormalParameter()
@@ -849,9 +801,7 @@ class PHPBuilder implements Builder
      * Builds a new expression node.
      *
      * @param string $image
-     *
      * @return ASTExpression
-     *
      * @since 0.9.8
      */
     public function buildAstExpression($image = null)
@@ -863,9 +813,7 @@ class PHPBuilder implements Builder
      * Builds a new assignment expression node.
      *
      * @param string $image The assignment operator.
-     *
      * @return ASTAssignmentExpression
-     *
      * @since  0.9.8
      */
     public function buildAstAssignmentExpression($image)
@@ -877,9 +825,7 @@ class PHPBuilder implements Builder
      * Builds a new allocation expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTAllocationExpression
-     *
      * @since  0.9.6
      */
     public function buildAstAllocationExpression($image)
@@ -891,9 +837,7 @@ class PHPBuilder implements Builder
      * Builds a new eval-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTEvalExpression
-     *
      * @since  0.9.12
      */
     public function buildAstEvalExpression($image)
@@ -905,9 +849,7 @@ class PHPBuilder implements Builder
      * Builds a new exit-expression instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTExitExpression
-     *
      * @since  0.9.12
      */
     public function buildAstExitExpression($image)
@@ -919,9 +861,7 @@ class PHPBuilder implements Builder
      * Builds a new clone-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTCloneExpression
-     *
      * @since  0.9.12
      */
     public function buildAstCloneExpression($image)
@@ -933,9 +873,7 @@ class PHPBuilder implements Builder
      * Builds a new list-expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTListExpression
-     *
      * @since  0.9.12
      */
     public function buildAstListExpression($image)
@@ -947,7 +885,6 @@ class PHPBuilder implements Builder
      * Builds a new include- or include_once-expression.
      *
      * @return ASTIncludeExpression
-     *
      * @since  0.9.12
      */
     public function buildAstIncludeExpression()
@@ -959,7 +896,6 @@ class PHPBuilder implements Builder
      * Builds a new require- or require_once-expression.
      *
      * @return ASTRequireExpression
-     *
      * @since  0.9.12
      */
     public function buildAstRequireExpression()
@@ -971,7 +907,6 @@ class PHPBuilder implements Builder
      * Builds a new array-expression node.
      *
      * @return ASTArrayIndexExpression
-     *
      * @since  0.9.12
      */
     public function buildAstArrayIndexExpression()
@@ -989,7 +924,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTStringIndexExpression
-     *
      * @since  0.9.12
      */
     public function buildAstStringIndexExpression()
@@ -1001,7 +935,6 @@ class PHPBuilder implements Builder
      * Builds a new php array node.
      *
      * @return ASTArray
-     *
      * @since  1.0.0
      */
     public function buildAstArray()
@@ -1013,7 +946,6 @@ class PHPBuilder implements Builder
      * Builds a new array element node.
      *
      * @return ASTArrayElement
-     *
      * @since  1.0.0
      */
     public function buildAstArrayElement()
@@ -1026,9 +958,7 @@ class PHPBuilder implements Builder
      * Builds a new instanceof expression node.
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTInstanceOfExpression
-     *
      * @since  0.9.6
      */
     public function buildAstInstanceOfExpression($image)
@@ -1052,7 +982,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTIssetExpression
-     *
      * @since  0.9.12
      */
     public function buildAstIssetExpression()
@@ -1070,7 +999,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTConditionalExpression
-     *
      * @since  0.9.8
      */
     public function buildAstConditionalExpression()
@@ -1088,7 +1016,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTPrintExpression
-     *
      * @since 2.3
      */
     public function buildAstPrintExpression()
@@ -1100,7 +1027,6 @@ class PHPBuilder implements Builder
      * Build a new shift left expression.
      *
      * @return ASTShiftLeftExpression
-     *
      * @since  1.0.1
      */
     public function buildAstShiftLeftExpression()
@@ -1112,7 +1038,6 @@ class PHPBuilder implements Builder
      * Build a new shift right expression.
      *
      * @return ASTShiftRightExpression
-     *
      * @since  1.0.1
      */
     public function buildAstShiftRightExpression()
@@ -1124,7 +1049,6 @@ class PHPBuilder implements Builder
      * Builds a new boolean and-expression.
      *
      * @return ASTBooleanAndExpression
-     *
      * @since  0.9.8
      */
     public function buildAstBooleanAndExpression()
@@ -1136,7 +1060,6 @@ class PHPBuilder implements Builder
      * Builds a new boolean or-expression.
      *
      * @return ASTBooleanOrExpression
-     *
      * @since  0.9.8
      */
     public function buildAstBooleanOrExpression()
@@ -1148,7 +1071,6 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>and</b>-expression.
      *
      * @return ASTLogicalAndExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalAndExpression()
@@ -1160,7 +1082,6 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>or</b>-expression.
      *
      * @return ASTLogicalOrExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalOrExpression()
@@ -1172,7 +1093,6 @@ class PHPBuilder implements Builder
      * Builds a new logical <b>xor</b>-expression.
      *
      * @return ASTLogicalXorExpression
-     *
      * @since  0.9.8
      */
     public function buildAstLogicalXorExpression()
@@ -1184,7 +1104,6 @@ class PHPBuilder implements Builder
      * Builds a new trait use-statement node.
      *
      * @return ASTTraitUseStatement
-     *
      * @since  1.0.0
      */
     public function buildAstTraitUseStatement()
@@ -1196,7 +1115,6 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation scope
      *
      * @return ASTTraitAdaptation
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptation()
@@ -1208,9 +1126,7 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation alias statement.
      *
      * @param string $image The trait method name.
-     *
      * @return ASTTraitAdaptationAlias
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationAlias($image)
@@ -1222,9 +1138,7 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation precedence statement.
      *
      * @param string $image The trait method name.
-     *
      * @return ASTTraitAdaptationPrecedence
-     *
      * @since  1.0.0
      */
     public function buildAstTraitAdaptationPrecedence($image)
@@ -1236,7 +1150,6 @@ class PHPBuilder implements Builder
      * Builds a new switch-statement-node.
      *
      * @return ASTSwitchStatement
-     *
      * @since  0.9.8
      */
     public function buildAstSwitchStatement()
@@ -1248,9 +1161,7 @@ class PHPBuilder implements Builder
      * Builds a new switch-label node.
      *
      * @param string $image The source image of this label.
-     *
      * @return ASTSwitchLabel
-     *
      * @since  0.9.8
      */
     public function buildAstSwitchLabel($image)
@@ -1262,7 +1173,6 @@ class PHPBuilder implements Builder
      * Builds a new global-statement instance.
      *
      * @return ASTGlobalStatement
-     *
      * @since  0.9.12
      */
     public function buildAstGlobalStatement()
@@ -1274,7 +1184,6 @@ class PHPBuilder implements Builder
      * Builds a new unset-statement instance.
      *
      * @return ASTUnsetStatement
-     *
      * @since  0.9.12
      */
     public function buildAstUnsetStatement()
@@ -1286,9 +1195,7 @@ class PHPBuilder implements Builder
      * Builds a new catch-statement node.
      *
      * @param string $image
-     *
      * @return ASTCatchStatement
-     *
      * @since  0.9.8
      */
     public function buildAstCatchStatement($image)
@@ -1300,7 +1207,6 @@ class PHPBuilder implements Builder
      * Builds a new finally-statement node.
      *
      * @return ASTFinallyStatement
-     *
      * @since  2.0.0
      */
     public function buildAstFinallyStatement()
@@ -1312,9 +1218,7 @@ class PHPBuilder implements Builder
      * Builds a new if statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTIfStatement
-     *
      * @since  0.9.8
      */
     public function buildAstIfStatement($image)
@@ -1326,9 +1230,7 @@ class PHPBuilder implements Builder
      * Builds a new elseif statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTElseIfStatement
-     *
      * @since  0.9.8
      */
     public function buildAstElseIfStatement($image)
@@ -1340,9 +1242,7 @@ class PHPBuilder implements Builder
      * Builds a new for statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTForStatement
-     *
      * @since  0.9.8
      */
     public function buildAstForStatement($image)
@@ -1360,7 +1260,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTForInit
-     *
      * @since  0.9.8
      */
     public function buildAstForInit()
@@ -1378,7 +1277,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTForUpdate
-     *
      * @since  0.9.12
      */
     public function buildAstForUpdate()
@@ -1390,9 +1288,7 @@ class PHPBuilder implements Builder
      * Builds a new foreach-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTForeachStatement
-     *
      * @since  0.9.8
      */
     public function buildAstForeachStatement($image)
@@ -1404,9 +1300,7 @@ class PHPBuilder implements Builder
      * Builds a new while-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTWhileStatement
-     *
      * @since  0.9.8
      */
     public function buildAstWhileStatement($image)
@@ -1418,9 +1312,7 @@ class PHPBuilder implements Builder
      * Builds a new do/while-statement node.
      *
      * @param string $image The source image of this statement.
-     *
      * @return ASTDoWhileStatement
-     *
      * @since  0.9.12
      */
     public function buildAstDoWhileStatement($image)
@@ -1450,7 +1342,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTDeclareStatement
-     *
      * @since  0.10.0
      */
     public function buildAstDeclareStatement()
@@ -1480,9 +1371,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source image of this expression.
-     *
      * @return ASTMemberPrimaryPrefix
-     *
      * @since  0.9.6
      */
     public function buildAstMemberPrimaryPrefix($image)
@@ -1494,9 +1383,7 @@ class PHPBuilder implements Builder
      * Builds a new identifier node.
      *
      * @param string $image The image of this identifier.
-     *
      * @return ASTIdentifier
-     *
      * @since  0.9.6
      */
     public function buildAstIdentifier($image)
@@ -1518,9 +1405,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTFunctionPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstFunctionPostfix($image)
@@ -1542,9 +1427,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTMethodPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstMethodPostfix($image)
@@ -1562,9 +1445,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTConstantPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstConstantPostfix($image)
@@ -1586,9 +1467,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     *
      * @return ASTPropertyPostfix
-     *
      * @since  0.9.6
      */
     public function buildAstPropertyPostfix($image)
@@ -1610,7 +1489,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTClassFqnPostfix
-     *
      * @since  2.0.0
      */
     public function buildAstClassFqnPostfix()
@@ -1632,7 +1510,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTArguments
-     *
      * @since  0.9.6
      */
     public function buildAstArguments()
@@ -1648,7 +1525,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTMatchArgument
-     *
      * @since  0.9.6
      */
     public function buildAstMatchArgument()
@@ -1666,7 +1542,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTMatchBlock
-     *
      * @since  2.9.0
      */
     public function buildAstMatchBlock()
@@ -1682,7 +1557,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTMatchEntry
-     *
      * @since  2.9.0
      */
     public function buildAstMatchEntry()
@@ -1698,9 +1572,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $name
-     *
      * @return ASTNamedArgument
-     *
      * @since  2.9.0
      */
     public function buildAstNamedArgument($name, ASTNode $value)
@@ -1714,7 +1586,6 @@ class PHPBuilder implements Builder
      * Builds a new array type node.
      *
      * @return ASTTypeArray
-     *
      * @since  0.9.6
      */
     public function buildAstTypeArray()
@@ -1726,7 +1597,6 @@ class PHPBuilder implements Builder
      * Builds a new node for the callable type.
      *
      * @return ASTTypeCallable
-     *
      * @since  1.0.0
      */
     public function buildAstTypeCallable()
@@ -1738,7 +1608,6 @@ class PHPBuilder implements Builder
      * Builds a new node for the iterable type.
      *
      * @return ASTTypeIterable
-     *
      * @since  2.5.1
      */
     public function buildAstTypeIterable()
@@ -1750,9 +1619,7 @@ class PHPBuilder implements Builder
      * Builds a new primitive type node.
      *
      * @param string $image The source image for the primitive type.
-     *
      * @return ASTScalarType
-     *
      * @since  0.9.6
      */
     public function buildAstScalarType($image)
@@ -1764,7 +1631,6 @@ class PHPBuilder implements Builder
      * Builds a new node for the union type.
      *
      * @return ASTUnionType
-     *
      * @since  1.0.0
      */
     public function buildAstUnionType()
@@ -1786,9 +1652,7 @@ class PHPBuilder implements Builder
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.
-     *
      * @return ASTLiteral
-     *
      * @since  0.9.6
      */
     public function buildAstLiteral($image)
@@ -1812,7 +1676,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @return ASTString
-     *
      * @since  0.9.10
      */
     public function buildAstString()
@@ -1824,7 +1687,6 @@ class PHPBuilder implements Builder
      * Builds a new heredoc node.
      *
      * @return ASTHeredoc
-     *
      * @since  0.9.12
      */
     public function buildAstHeredoc()
@@ -1845,9 +1707,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTConstantDefinition
-     *
      * @since  0.9.6
      */
     public function buildAstConstantDefinition($image)
@@ -1887,9 +1747,7 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTConstantDeclarator
-     *
      * @since  0.9.6
      */
     public function buildAstConstantDeclarator($image)
@@ -1901,9 +1759,7 @@ class PHPBuilder implements Builder
      * Builds a new comment node instance.
      *
      * @param string $cdata The comment text.
-     *
      * @return ASTComment
-     *
      * @since  0.9.8
      */
     public function buildAstComment($cdata)
@@ -1915,9 +1771,7 @@ class PHPBuilder implements Builder
      * Builds a new unary expression node instance.
      *
      * @param string $image The unary expression image/character.
-     *
      * @return ASTUnaryExpression
-     *
      * @since  0.9.11
      */
     public function buildAstUnaryExpression($image)
@@ -1929,9 +1783,7 @@ class PHPBuilder implements Builder
      * Builds a new cast-expression node instance.
      *
      * @param string $image The cast-expression image/character.
-     *
      * @return ASTCastExpression
-     *
      * @since  0.10.0
      */
     public function buildAstCastExpression($image)
@@ -1943,9 +1795,7 @@ class PHPBuilder implements Builder
      * Builds a new postfix-expression node instance.
      *
      * @param string $image The postfix-expression image/character.
-     *
      * @return ASTPostfixExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPostfixExpression($image)
@@ -1957,7 +1807,6 @@ class PHPBuilder implements Builder
      * Builds a new pre-increment-expression node instance.
      *
      * @return ASTPreIncrementExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPreIncrementExpression()
@@ -1969,7 +1818,6 @@ class PHPBuilder implements Builder
      * Builds a new pre-decrement-expression node instance.
      *
      * @return ASTPreDecrementExpression
-     *
      * @since  0.10.0
      */
     public function buildAstPreDecrementExpression()
@@ -1981,7 +1829,6 @@ class PHPBuilder implements Builder
      * Builds a new function/method scope instance.
      *
      * @return ASTScope
-     *
      * @since  0.9.12
      */
     public function buildAstScope()
@@ -1993,7 +1840,6 @@ class PHPBuilder implements Builder
      * Builds a new statement instance.
      *
      * @return ASTStatement
-     *
      * @since  0.9.12
      */
     public function buildAstStatement()
@@ -2005,9 +1851,7 @@ class PHPBuilder implements Builder
      * Builds a new return statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTReturnStatement
-     *
      * @since  0.9.12
      */
     public function buildAstReturnStatement($image)
@@ -2019,9 +1863,7 @@ class PHPBuilder implements Builder
      * Builds a new break-statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTBreakStatement
-     *
      * @since  0.9.12
      */
     public function buildAstBreakStatement($image)
@@ -2033,9 +1875,7 @@ class PHPBuilder implements Builder
      * Builds a new continue-statement node instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTContinueStatement
-     *
      * @since  0.9.12
      */
     public function buildAstContinueStatement($image)
@@ -2047,7 +1887,6 @@ class PHPBuilder implements Builder
      * Builds a new scope-statement instance.
      *
      * @return ASTScopeStatement
-     *
      * @since  0.9.12
      */
     public function buildAstScopeStatement()
@@ -2059,9 +1898,7 @@ class PHPBuilder implements Builder
      * Builds a new try-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTTryStatement
-     *
      * @since  0.9.12
      */
     public function buildAstTryStatement($image)
@@ -2073,9 +1910,7 @@ class PHPBuilder implements Builder
      * Builds a new throw-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTThrowStatement
-     *
      * @since  0.9.12
      */
     public function buildAstThrowStatement($image)
@@ -2087,9 +1922,7 @@ class PHPBuilder implements Builder
      * Builds a new goto-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTGotoStatement
-     *
      * @since  0.9.12
      */
     public function buildAstGotoStatement($image)
@@ -2101,9 +1934,7 @@ class PHPBuilder implements Builder
      * Builds a new label-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTLabelStatement
-     *
      * @since  0.9.12
      */
     public function buildAstLabelStatement($image)
@@ -2115,9 +1946,7 @@ class PHPBuilder implements Builder
      * Builds a new exit-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTEchoStatement
-     *
      * @since  0.9.12
      */
     public function buildAstEchoStatement($image)
@@ -2129,9 +1958,7 @@ class PHPBuilder implements Builder
      * Builds a new yield-statement instance.
      *
      * @param string $image The source code image for this node.
-     *
      * @return ASTYieldStatement
-     *
      * @since  $version$
      */
     public function buildAstYieldStatement($image)
@@ -2169,7 +1996,6 @@ class PHPBuilder implements Builder
      * objects.
      *
      * @return ASTNamespace[]
-     *
      * @since  0.9.12
      */
     private function getPreparedNamespaces()
@@ -2211,9 +2037,7 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait
-     *
      * @since  0.9.5
      */
     protected function buildTraitInternal($qualifiedName)
@@ -2236,9 +2060,7 @@ class PHPBuilder implements Builder
      * matching instance or <b>null</b> if no match exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTTrait|null
-     *
      * @since  0.9.5
      */
     protected function findTrait($qualifiedName)
@@ -2288,9 +2110,7 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $qualifiedName
-     *
      * @return ASTInterface
-     *
      * @since  0.9.5
      */
     protected function buildInterfaceInternal($qualifiedName)
@@ -2313,9 +2133,7 @@ class PHPBuilder implements Builder
      * matching instance or <b>null</b> if no match exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTInterface|null
-     *
      * @since  0.9.5
      */
     protected function findInterface($qualifiedName)
@@ -2362,9 +2180,7 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass
-     *
      * @since  0.9.5
      */
     protected function buildClassInternal($qualifiedName)
@@ -2387,9 +2203,7 @@ class PHPBuilder implements Builder
      * matching instance or <b>null</b> if no match exists.
      *
      * @param string $qualifiedName
-     *
      * @return ASTClass|ASTEnum|null
-     *
      * @since  0.9.5
      */
     protected function findClass($qualifiedName)
@@ -2416,10 +2230,8 @@ class PHPBuilder implements Builder
      * @template T of AbstractASTType
      *
      * @param array<string, array<string, array<string, T>>> $instances
-     * @param string                                         $qualifiedName
-     *
+     * @param string $qualifiedName
      * @return T|null
-     *
      * @since  0.9.5
      */
     protected function findType(array $instances, $qualifiedName)
@@ -2483,7 +2295,6 @@ class PHPBuilder implements Builder
      *
      * @param array<string, array<string, array<string, T>>> $originalTypes The original types created during the parsing
      *                                                                      process.
-     *
      * @return array<string, array<string, array<string, T>>>
      */
     private function copyTypesWithPackage(array $originalTypes)
@@ -2569,9 +2380,8 @@ class PHPBuilder implements Builder
     /**
      * Builds an enum definition.
      *
-     * @param string         $name The enum name.
+     * @param string $name The enum name.
      * @param ?ASTScalarType $type The enum type ('string', 'int', or null if not backed).
-     *
      * @return ASTEnum The created class object.
      */
     public function buildEnum($name, ?ASTScalarType $type = null)
@@ -2589,9 +2399,8 @@ class PHPBuilder implements Builder
     /**
      * Builds an enum definition.
      *
-     * @param string   $name  The enum case name.
+     * @param string $name The enum case name.
      * @param ?ASTNode $value The enum case value if backed.
-     *
      * @return ASTEnumCase The created class object.
      */
     public function buildEnumCase($name, ?ASTNode $value = null)
@@ -2612,7 +2421,6 @@ class PHPBuilder implements Builder
      *
      * @param string $traitName
      * @param string $namespaceName
-     *
      * @since 1.0.0
      */
     protected function storeTrait($traitName, $namespaceName, ASTTrait $trait): void
@@ -2632,7 +2440,6 @@ class PHPBuilder implements Builder
      *
      * @param string $className
      * @param string $namespaceName
-     *
      * @since 0.9.5
      */
     protected function storeClass($className, $namespaceName, ASTClass $class): void
@@ -2652,7 +2459,6 @@ class PHPBuilder implements Builder
      *
      * @param string $enumName
      * @param string $namespaceName
-     *
      * @since 2.11.0
      */
     protected function storeEnum($enumName, $namespaceName, ASTEnum $enum): void
@@ -2672,7 +2478,6 @@ class PHPBuilder implements Builder
      *
      * @param string $interfaceName
      * @param string $namespaceName
-     *
      * @since 0.9.5
      */
     protected function storeInterface($interfaceName, $namespaceName, ASTInterface $interface): void
@@ -2692,9 +2497,7 @@ class PHPBuilder implements Builder
      * Checks that the parser is not frozen or a request is flagged as internal.
      *
      * @param bool $internal The new internal flag value.
-     *
      * @throws BadMethodCallException
-     *
      * @since  0.9.5
      */
     protected function checkBuilderState($internal = false): void
@@ -2712,7 +2515,6 @@ class PHPBuilder implements Builder
      * Returns <b>true</b> if the given package is the default package.
      *
      * @param string $namespaceName The package name.
-     *
      * @return bool
      */
     protected function isDefault($namespaceName)
@@ -2731,7 +2533,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $qualifiedName The qualified PHP 5.3 type identifier.
-     *
      * @return string
      */
     protected function extractTypeName($qualifiedName)
@@ -2761,7 +2562,6 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $qualifiedName The qualified PHP 5.3 class identifier.
-     *
      * @return string|null
      */
     protected function extractNamespaceName($qualifiedName)
@@ -2780,10 +2580,8 @@ class PHPBuilder implements Builder
      * @template T of ASTNode
      *
      * @param class-string<T> $className
-     * @param string          $image
-     *
+     * @param string $image
      * @return T
-     *
      * @since 0.9.12
      */
     private function buildAstNodeInstance($className, $image = null)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 
@@ -54,7 +53,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 class PHPParserGeneric extends PHPParserVersion83
@@ -64,9 +62,7 @@ class PHPParserGeneric extends PHPParserVersion83
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since  1.1.1
      */
     protected function isKeyword($tokenType)
@@ -84,9 +80,7 @@ class PHPParserGeneric extends PHPParserVersion83
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -117,11 +111,8 @@ class PHPParserGeneric extends PHPParserVersion83
      * Parses additional static values that are valid in the supported php version.
      *
      * @param ASTValue $value
-     *
      * @return ASTValue
-     *
      * @throws UnexpectedTokenException
-     *
      * @todo Handle shift left/right expressions in ASTValue
      */
     /*

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion72.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 
@@ -70,7 +69,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.4
  */
 abstract class PHPParserVersion72 extends AbstractPHPParser
@@ -97,9 +95,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 2.6.0
      */
     protected function isListUnpacking($tokenType = null)
@@ -191,7 +187,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Parses a scalar type hint or a callable type hint.
      *
      * @param string $image
-     *
      * @return ASTType|false
      */
     protected function parseScalarOrCallableTypeHint($image)
@@ -250,7 +245,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
     /**
      * @param int $tokenType
      * @param int $modifiers
-     *
      * @return int
      */
     private function getModifiersForConstantDefinition($tokenType, $modifiers)
@@ -276,7 +270,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Return true if the current node can be used as a list key.
      *
      * @param ASTExpression|null $node
-     *
      * @return bool
      */
     protected function canBeListKey($node)
@@ -287,7 +280,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isConstantName($tokenType)
@@ -369,7 +361,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isMethodName($tokenType)
@@ -384,7 +375,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
 
     /**
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isTypeHint($tokenType)
@@ -484,7 +474,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Tests if the given image is a PHP 7.0 type hint.
      *
      * @param string $image
-     *
      * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
@@ -507,7 +496,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Parse the type reference used in an allocation expression.
      *
      * @return ASTNode
-     *
      * @since 2.3
      */
     protected function parseAllocationExpressionTypeReference(ASTAllocationExpression $allocation)
@@ -522,7 +510,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * @template T of ASTAllocationExpression
      *
      * @param T $allocation
-     *
      * @return T|null
      */
     protected function parseAnonymousClassDeclaration(ASTAllocationExpression $allocation)
@@ -620,9 +607,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * expressions.
      *
      * @return ASTNode
-     *
      * @throws UnexpectedTokenException
-     *
      * @since 2.2
      */
     protected function parseOptionalExpressionForVersion()
@@ -663,7 +648,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * </code>
      *
      * @return ASTFormalParameter
-     *
      * @since 2.0.7
      */
     protected function parseFormalParameter()
@@ -750,7 +734,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
 
     /**
      * @param array<string> $previousElements
-     *
      * @return string|null
      */
     protected function parseQualifiedNameElement(array $previousElements)
@@ -770,7 +753,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Parses additional static values that are valid in the supported php version.
      *
      * @return ASTValue|null
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseStaticValueVersionSpecific(ASTValue $value)
@@ -1098,7 +1080,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * parseFullQualifiedClassNamePostfix() exists since 2.0.0 and have been customized for PHP 5.5 since 2.6.0.
      *
      * @return ASTClassFqnPostfix
-     *
      * @since 2.0.0
      */
     protected function parseFullQualifiedClassNamePostfix()
@@ -1117,9 +1098,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * name part.
      *
      * @param int $tokenType The type of a parsed token.
-     *
      * @return bool
-     *
      * @since  0.10.6
      */
     protected function isClassName($tokenType)
@@ -1141,9 +1120,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since 2.3
      */
     protected function isFunctionName($tokenType)
@@ -1165,7 +1142,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * version.
      *
      * @param int $tokenType
-     *
      * @return bool
      */
     protected function isKeyword($tokenType)
@@ -1186,7 +1162,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * PHP version.
      *
      * @return bool
-     *
      * @since 1.0.0
      */
     protected function isArrayStartDelimiter()
@@ -1204,9 +1179,7 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Parses a php array declaration.
      *
      * @param bool $static
-     *
      * @return ASTArray
-     *
      * @since 1.0.0
      */
     protected function parseArray(ASTArray $array, $static = false)
@@ -1235,7 +1208,6 @@ abstract class PHPParserVersion72 extends AbstractPHPParser
      * Parses an integer value.
      *
      * @return ASTLiteral
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseIntegerNumber()

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion73.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\Language\PHP;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.4
  */
 abstract class PHPParserVersion73 extends PHPParserVersion72

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion74.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.4
  */
 abstract class PHPParserVersion74 extends PHPParserVersion73

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion80.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.3
  */
 
@@ -66,7 +65,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.9
  */
 abstract class PHPParserVersion80 extends PHPParserVersion74
@@ -87,7 +85,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * name part.
      *
      * @param int $tokenType The type of a parsed token.
-     *
      * @return bool
      */
     protected function isClassName($tokenType)
@@ -132,7 +129,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
      * expressions.
      *
      * @return ASTNode
-     *
      * @throws UnexpectedTokenException
      */
     protected function parseOptionalExpressionForVersion()
@@ -347,7 +343,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
     /**
      * @param ASTType $firstType
-     *
      * @return ASTUnionType
      */
     protected function parseUnionTypeHint($firstType)
@@ -371,7 +366,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
     /**
      * @param ASTType $type
-     *
      * @return ASTType
      */
     protected function parseTypeHintCombination($type)
@@ -385,7 +379,6 @@ abstract class PHPParserVersion80 extends PHPParserVersion74
 
     /**
      * @param ASTNode $type
-     *
      * @return bool
      */
     protected function canNotBeStandAloneType($type)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11
  */
 
@@ -59,7 +58,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11
  */
 abstract class PHPParserVersion81 extends PHPParserVersion80
@@ -86,7 +84,6 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      * Tests if the given image is a PHP 8.1 type hint.
      *
      * @param string $image
-     *
      * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
@@ -127,7 +124,6 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
      * declaration.
      *
      * @return ASTValue
-     *
      * @since 2.11.0
      */
     protected function parseVariableDefaultValue()
@@ -163,7 +159,6 @@ abstract class PHPParserVersion81 extends PHPParserVersion80
 
     /**
      * @param ASTType $firstType
-     *
      * @return ASTIntersectionType
      */
     protected function parseIntersectionTypeHint($firstType)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11
  */
 
@@ -57,7 +56,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.12
  */
 abstract class PHPParserVersion82 extends PHPParserVersion81
@@ -83,7 +81,6 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
      * Tests if the given image is a PHP 8.2 type hint.
      *
      * @param string $image
-     *
      * @return bool
      */
     protected function isScalarOrCallableTypeHint($image)
@@ -106,7 +103,6 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
 
     /**
      * @return ASTType
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */
@@ -141,7 +137,6 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
 
     /**
      * @param ASTNode $type
-     *
      * @return bool
      */
     protected function canNotBeStandAloneType($type)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.11
  */
 
@@ -54,7 +53,6 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.12
  */
 abstract class PHPParserVersion83 extends PHPParserVersion82
@@ -63,10 +61,8 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
      * Parse a typed constant (PHP >= 8.3).
      *
      * @return ASTConstantDeclarator
-     *
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
-     *
      * @since  1.16.0
      */
     protected function parseTypedConstantDeclarator()
@@ -88,9 +84,7 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
 
     /**
      * @param int $tokenType
-     *
      * @return bool
-     *
      * @since  2.16.3
      */
     protected function isConstantName($tokenType)

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -727,7 +727,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the token type at the given position relatively to the current position.
      *
      * @param int $shift positive or negative to apply to the current index.
-     *
      * @return int
      */
     public function peekAt($shift)
@@ -752,7 +751,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * ignores all comments between the current and the next token.
      *
      * @return int|null
-     *
      * @since  0.9.12
      */
     public function peekNext()
@@ -794,7 +792,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * Split PHP 8 T_NAME(_FULLY)_QUALIFIED token into PHP 7 compatible tokens.
      *
      * @param array{int, string, int} $token
-     *
      * @return array<int, array<int, int|string>>
      */
     private function splitQualifiedNameToken($token)
@@ -826,8 +823,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * Split PHP 8 T_NAME_RELATIVE token into PHP 7 compatible tokens.
      *
      * @param array<int|string> $token
-     * @param string            $namespace
-     *
+     * @param string $namespace
      * @return array<int, array<int, int|string>>
      */
     private function splitRelativeNameToken($token, $namespace)
@@ -865,7 +861,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * parser implementation.
      *
      * @param array<array{int, string, int}|string> $tokens Unprepared array of php tokens.
-     *
      * @return array<array<int, int|string|null>|string>
      */
     private function substituteTokens(array $tokens)
@@ -1081,7 +1076,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * was no none php token.
      *
      * @param array<array<int, int|string>|string> $tokens Reference to the current token stream.
-     *
      * @return string|null
      */
     private function consumeNonePhpTokens(array &$tokens)
@@ -1113,7 +1107,6 @@ class PHPTokenizerInternal implements FullTokenizer
      * Generates a dummy/temp token for unknown string literals.
      *
      * @param string $token The unknown string token.
-     *
      * @return array<int, mixed>
      */
     private function generateUnknownToken($token)

--- a/src/main/php/PDepend/Source/Parser/InvalidStateException.php
+++ b/src/main/php/PDepend/Source/Parser/InvalidStateException.php
@@ -54,9 +54,9 @@ class InvalidStateException extends ParserException
     /**
      * Constructs a new invalid state exception.
      *
-     * @param int    $lineNumber Line number where the parser has stopped.
-     * @param string $fileName   The source file where this exception occurred.
-     * @param string $reason     Short description what has happened.
+     * @param int $lineNumber Line number where the parser has stopped.
+     * @param string $fileName The source file where this exception occurred.
+     * @param string $reason Short description what has happened.
      */
     public function __construct($lineNumber, $fileName, $reason)
     {

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -94,9 +94,8 @@ class SymbolTable
     /**
      * Adds a new value to the top most scope.
      *
-     * @param string $key   The key of this scope value.
-     * @param mixed  $value A new scope value.
-     *
+     * @param string $key The key of this scope value.
+     * @param mixed $value A new scope value.
      * @throws NoActiveScopeException
      */
     public function add($key, $value): void
@@ -122,9 +121,7 @@ class SymbolTable
      * value exists for the given key.
      *
      * @param string $key The key for a searched scope value.
-     *
      * @return string|null
-     *
      * @throws NoActiveScopeException
      */
     public function lookup($key)
@@ -153,7 +150,6 @@ class SymbolTable
      * <code>add()</code> and <code>lookup()</code> operations.
      *
      * @param string $key
-     *
      * @return string normalized key
      */
     private function normalizeKey($key)

--- a/src/main/php/PDepend/Source/Parser/TokenException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenException.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Source\Parser;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.10
  */
 class TokenException extends ParserException

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 
@@ -52,7 +51,6 @@ use PDepend\Source\Tokenizer\Token;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.6
  */
 class TokenStack
@@ -111,7 +109,6 @@ class TokenStack
      * This method will add a new token to the currently active token scope.
      *
      * @param Token $token The token to add.
-     *
      * @return Token
      */
     public function add(Token $token)

--- a/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
+++ b/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
@@ -56,7 +56,7 @@ class UnexpectedTokenException extends TokenException
     /**
      * Constructs a new unexpected token exception.
      *
-     * @param Token  $token    The last parsed token instance.
+     * @param Token $token The last parsed token instance.
      * @param string $fileName The file where the exception occurred.
      */
     public function __construct(Token $token, $fileName)

--- a/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
@@ -55,7 +55,6 @@ interface FullTokenizer extends Tokenizer
      * Returns the token type at the given position relatively to the current position.
      *
      * @param int $shift positive or negative to apply to the current index.
-     *
      * @return int
      */
     public function peekAt($shift);

--- a/src/main/php/PDepend/Source/Tokenizer/Token.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Token.php
@@ -95,12 +95,12 @@ class Token
     /**
      * Constructs a new source token.
      *
-     * @param int    $type        The token type identifier.
-     * @param string $image       The token image/textual representation.
-     * @param int    $startLine   The start line number for this token.
-     * @param int    $endLine     The end line number for this token.
-     * @param int    $startColumn The start column number for this token.
-     * @param int    $endColumn   The end column number for this token.
+     * @param int $type The token type identifier.
+     * @param string $image The token image/textual representation.
+     * @param int $startLine The start line number for this token.
+     * @param int $endLine The end line number for this token.
+     * @param int $startColumn The start column number for this token.
+     * @param int $endColumn The end column number for this token.
      */
     public function __construct($type, $image, $startLine, $endLine, $startColumn, $endColumn)
     {

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -88,7 +88,6 @@ interface Tokenizer
      * Returns the previous token or null if there is no one yet.
      *
      * @return Token|null
-     *
      * @since  2.6.0
      */
     public function prevToken();
@@ -97,7 +96,6 @@ interface Tokenizer
      * Returns the current token or null if there is no more.
      *
      * @return Token|null
-     *
      * @since  2.6.0
      */
     public function currentToken();
@@ -115,7 +113,6 @@ interface Tokenizer
      * ignores all comments between the current and the next token.
      *
      * @return int
-     *
      * @since  0.9.12
      */
     public function peekNext();

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -476,7 +476,6 @@ class Command
      * option.
      *
      * @return int
-     *
      * @throws Exception
      */
     protected function printLogOptions()
@@ -518,9 +517,7 @@ class Command
      * Prints the analyzer options.
      *
      * @param int $length Length of the longest option.
-     *
      * @return int
-     *
      * @throws Exception
      */
     protected function printAnalyzerOptions($length)
@@ -550,9 +547,9 @@ class Command
     /**
      * Prints a single option.
      *
-     * @param string $option  The option identifier.
+     * @param string $option The option identifier.
      * @param string $message The option help message.
-     * @param int    $length  The length of the longest option.
+     * @param int $length The length of the longest option.
      */
     private function printOption($option, $message, $length): void
     {
@@ -625,7 +622,6 @@ class Command
 
     /**
      * @param Exception|Throwable $exception
-     *
      * @return string
      */
     private function getErrorTrace($exception)

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -217,7 +217,7 @@ class Runner
     /**
      * Adds a logger or analyzer option.
      *
-     * @param string               $identifier
+     * @param string $identifier
      * @param array<string>|string $value
      */
     public function addOption($identifier, $value): void
@@ -239,7 +239,6 @@ class Runner
      * execution.
      *
      * @return int
-     *
      * @throws RuntimeException An exception with a readable error message and
      *                          an exit code.
      */

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Util\Cache;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 interface CacheDriver
@@ -68,7 +66,6 @@ interface CacheDriver
      * <em>store()</em>.
      *
      * @param string $type
-     *
      * @return CacheDriver
      */
     public function type($type);
@@ -80,8 +77,8 @@ interface CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param string $key  The cache key for the given data.
-     * @param mixed  $data Any data that should be cached.
+     * @param string $key The cache key for the given data.
+     * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function store($key, $data, $hash = null): void;
@@ -93,7 +90,7 @@ interface CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param string $key  The cache key for the given data.
+     * @param string $key The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null): mixed;

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -56,7 +55,6 @@ use RuntimeException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class CacheFactory
@@ -92,9 +90,7 @@ class CacheFactory
      * identifier.
      *
      * @param string $cacheKey The name/identifier for the cache instance.
-     *
      * @return CacheDriver
-     *
      * @throws InvalidArgumentException
      * @throws RandomException
      * @throws RuntimeException
@@ -111,9 +107,7 @@ class CacheFactory
      * Creates a cache instance based on the supplied configuration.
      *
      * @param string|null $cacheKey The name/identifier for the cache instance.
-     *
      * @return CacheDriver
-     *
      * @throws InvalidArgumentException If the configured cache driver is unknown.
      * @throws RandomException
      * @throws RuntimeException
@@ -138,12 +132,10 @@ class CacheFactory
     /**
      * Creates a new file system based cache instance.
      *
-     * @param string      $location Cache root directory.
-     * @param int         $ttl      Cache ttl
+     * @param string $location Cache root directory.
+     * @param int $ttl Cache ttl
      * @param string|null $cacheKey The name/identifier for the cache instance.
-     *
      * @return FileCacheDriver
-     *
      * @throws RuntimeException
      */
     protected function createFileCache($location, $ttl = self::DEFAULT_TTL, $cacheKey = null)
@@ -155,7 +147,6 @@ class CacheFactory
      * Creates an in memory cache instance.
      *
      * @return MemoryCacheDriver
-     *
      * @throws RandomException
      */
     protected function createMemoryCache()

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -54,7 +53,6 @@ use SplFileInfo;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class FileCacheDirectory
@@ -75,7 +73,6 @@ class FileCacheDirectory
      * Constructs a new cache directory helper instance.
      *
      * @param string $cacheDir The cache root directory.
-     *
      * @throws RuntimeException
      */
     public function __construct($cacheDir)
@@ -92,7 +89,6 @@ class FileCacheDirectory
      * full qualified path for that cache directory.
      *
      * @param string $key The cache for an entry.
-     *
      * @return string
      */
     public function createCacheDirectory($key)
@@ -106,7 +102,6 @@ class FileCacheDirectory
      * the full qualified path for that cache directory.
      *
      * @param string $key The cache for an entry.
-     *
      * @return string
      */
     protected function createOrReturnCacheDirectory($key)
@@ -122,7 +117,6 @@ class FileCacheDirectory
      * Ensures that the given <b>$cacheDir</b> really exists.
      *
      * @param string $cacheDir The cache root directory.
-     *
      * @return string
      */
     protected function ensureExists($cacheDir)
@@ -202,7 +196,6 @@ class FileCacheDirectory
      * Deletes all files and directories below the given <b>$cacheDir</b>.
      *
      * @param string $cacheDir A cache directory.
-     *
      * @throws RuntimeException
      */
     protected function flushDirectory($cacheDir): void
@@ -217,7 +210,6 @@ class FileCacheDirectory
      * it is a file, directory or symlink.
      *
      * @param DirectoryIterator $file
-     *
      * @throws RuntimeException
      */
     protected function flushEntry(SplFileInfo $file): void

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
@@ -70,7 +70,7 @@ class FileCacheGarbageCollector
 
     /**
      * @param string $cacheDir
-     * @param int    $ttl
+     * @param int $ttl
      */
     public function __construct($cacheDir, $ttl = self::DEFAULT_TTL)
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -58,7 +57,6 @@ use RuntimeException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class FileCacheDriver implements CacheDriver
@@ -95,7 +93,6 @@ class FileCacheDriver implements CacheDriver
      * Unique key for this cache instance.
      *
      * @var string
-     *
      * @since 1.0.0
      */
     private $cacheKey;
@@ -104,10 +101,9 @@ class FileCacheDriver implements CacheDriver
      * This method constructs a new file cache instance for the given root
      * directory.
      *
-     * @param string      $root     The cache root directory.
-     * @param int         $ttl      The cache TTL.
+     * @param string $root The cache root directory.
+     * @param int $ttl The cache TTL.
      * @param string|null $cacheKey Unique key for this cache instance.
-     *
      * @throws RuntimeException
      */
     public function __construct($root, $ttl = self::DEFAULT_TTL, $cacheKey = null)
@@ -129,7 +125,6 @@ class FileCacheDriver implements CacheDriver
      * <em>store()</em>.
      *
      * @param string $type The name or object type for the next storage method call.
-     *
      * @return $this
      */
     public function type($type)
@@ -145,8 +140,8 @@ class FileCacheDriver implements CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param string $key  The cache key for the given data.
-     * @param mixed  $data Any data that should be cached.
+     * @param string $key The cache key for the given data.
+     * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function store($key, $data, $hash = null): void
@@ -180,7 +175,7 @@ class FileCacheDriver implements CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param string $key  The cache key for the given data.
+     * @param string $key The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null): mixed
@@ -214,7 +209,6 @@ class FileCacheDriver implements CacheDriver
      * This method reads the raw data from the given <em>$file</em>.
      *
      * @param string $file The cache file name.
-     *
      * @return string
      */
     protected function read($file)
@@ -263,7 +257,6 @@ class FileCacheDriver implements CacheDriver
      * directory and the current entry type.
      *
      * @param string $key The cache key for the given data.
-     *
      * @return string
      */
     protected function getCacheFile($key)
@@ -284,7 +277,6 @@ class FileCacheDriver implements CacheDriver
      * extension.
      *
      * @param string $key The cache key for the given data.
-     *
      * @return string
      */
     protected function getCacheFileWithoutExtension($key)
@@ -301,7 +293,7 @@ class FileCacheDriver implements CacheDriver
      * Cleans old cache files.
      *
      * @param string $root
-     * @param int    $ttl
+     * @param int $ttl
      */
     protected function garbageCollect($root, $ttl): void
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -56,7 +55,6 @@ use Random\RandomException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 class MemoryCacheDriver implements CacheDriver
@@ -108,7 +106,6 @@ class MemoryCacheDriver implements CacheDriver
      * PHP's magic serialize sleep method.
      *
      * @return array
-     *
      * @since  1.0.2
      */
     public function __sleep()
@@ -137,7 +134,6 @@ class MemoryCacheDriver implements CacheDriver
      * <em>store()</em>.
      *
      * @param string $type The name or object type for the next storage method call.
-     *
      * @return $this
      */
     public function type($type)
@@ -153,8 +149,8 @@ class MemoryCacheDriver implements CacheDriver
      * hash and the supplied hash are not identical, that cache entry will be
      * removed and not returned.
      *
-     * @param string $key  The cache key for the given data.
-     * @param mixed  $data Any data that should be cached.
+     * @param string $key The cache key for the given data.
+     * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function store($key, $data, $hash = null): void
@@ -169,7 +165,7 @@ class MemoryCacheDriver implements CacheDriver
      * Then it returns the cached entry. Otherwise this method will return
      * <b>NULL</b>.
      *
-     * @param string $key  The cache key for the given data.
+     * @param string $key The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null): mixed
@@ -204,7 +200,6 @@ class MemoryCacheDriver implements CacheDriver
      * type, so that it is only valid for a single call.
      *
      * @param string $key The concrete object key.
-     *
      * @return string
      */
     protected function getCacheKey($key)

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -58,7 +58,6 @@ class Configuration
      * Simple object tree holding the concrete configuration values.
      *
      * @var stdClass
-     *
      * @since 0.10.0
      */
     protected $settings = null;
@@ -67,7 +66,6 @@ class Configuration
      * Constructs a new configuration instance with the given settings tree.
      *
      * @param stdClass $settings The concrete configuration values.
-     *
      * @since 0.10.0
      */
     public function __construct(stdClass $settings)
@@ -83,9 +81,7 @@ class Configuration
      * a matching entry exists. Otherwise this method will throw an exception.
      *
      * @param string $name Name of the requested configuration value.
-     *
      * @throws OutOfRangeException If no matching configuration value exists.
-     *
      * @since  0.10.0
      */
     public function __get($name): mixed
@@ -104,11 +100,9 @@ class Configuration
      * implementation of the magic set method always throws an exception, because
      * configuration settings are immutable.
      *
-     * @param string $name  Name of the write property.
-     * @param mixed  $value The new property value.
-     *
+     * @param string $name Name of the write property.
+     * @param mixed $value The new property value.
      * @throws OutOfRangeException Whenever this method is called.
-     *
      * @since  0.10.0
      */
     public function __set($name, $value): void
@@ -125,9 +119,7 @@ class Configuration
      * for the given <b>$name</b> exists.
      *
      * @param string $name Name of the requested property.
-     *
      * @return bool
-     *
      * @since  0.10.0
      */
     public function __isset($name)

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -137,7 +137,6 @@ class CloverReport implements Report
      * Returns the lines of the covered file.
      *
      * @param string $fileName The source file name.
-     *
      * @return array<bool>
      */
     private function getLines($fileName)

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -59,9 +59,7 @@ class Factory
      * path name.
      *
      * @param string $pathName Qualified path name of a coverage report file.
-     *
      * @return CloverReport
-     *
      * @throws RuntimeException When the given path name does not point to a
      *                          valid coverage file or onto an unsupported coverage format.
      */
@@ -79,9 +77,7 @@ class Factory
      * the given path name.
      *
      * @param string $pathName Qualified path name of a coverage report file.
-     *
      * @return SimpleXMLElement
-     *
      * @throws RuntimeException When the given path name does not point to a
      *                          valid xml file.
      */

--- a/src/main/php/PDepend/Util/FileUtil.php
+++ b/src/main/php/PDepend/Util/FileUtil.php
@@ -55,7 +55,6 @@ final class FileUtil
      * this method will return the system temp directory.
      *
      * @return string
-     *
      * @since  0.10.0
      */
     public static function getUserHomeDirOrSysTempDir()
@@ -83,7 +82,6 @@ final class FileUtil
      * Returns the home directory of the current user.
      *
      * @return string
-     *
      * @since  0.10.0
      */
     public static function getUserHomeDir()

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -56,7 +55,6 @@ use PDepend\Source\AST\ASTMethod;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 class IdBuilder
@@ -103,7 +101,6 @@ class IdBuilder
      * Generates an identifier for the given source item.
      *
      * @param string $prefix The item type identifier.
-     *
      * @return string
      */
     protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
@@ -134,7 +131,6 @@ class IdBuilder
      * Creates a base 36 hash for the given string.
      *
      * @param string $string The raw input identifier/string.
-     *
      * @return string
      */
     protected function hash($string)
@@ -146,9 +142,8 @@ class IdBuilder
      * Returns the node offset/occurence of the given <b>$string</b> within a
      * file.
      *
-     * @param string $file   The file identifier.
+     * @param string $file The file identifier.
      * @param string $string The node identifier.
-     *
      * @return string
      */
     protected function getOffsetInFile($file, $string)

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -59,9 +59,8 @@ class ImageConvert
     /**
      * Tries to converts the <b>$input</b> image into the <b>$output</b> format.
      *
-     * @param string $input  The input file.
+     * @param string $input The input file.
      * @param string $output The output file.
-     *
      * @throws ImagickException
      * @throws InvalidArgumentException
      */
@@ -140,7 +139,6 @@ class ImageConvert
      * file.
      *
      * @param string $input The input svg file.
-     *
      * @throws InvalidArgumentException
      */
     protected static function prepareSvg($input): void

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -55,9 +55,8 @@ final class MathUtil
      * This method will multiply the two given operands with the bcmath extension
      * when available, otherwise it will use the default mathematical operations.
      *
-     * @param numeric-string $left  The left arithmetic operand.
+     * @param numeric-string $left The left arithmetic operand.
      * @param numeric-string $right The right arithmetic operand.
-     *
      * @return numeric-string
      */
     public static function mul($left, $right)
@@ -72,9 +71,8 @@ final class MathUtil
      * This method will add the two given operands with the bcmath extension
      * when available, otherwise it will use the default mathematical operations.
      *
-     * @param string $left  The left arithmetic operand.
+     * @param string $left The left arithmetic operand.
      * @param string $right The right arithmetic operand.
-     *
      * @return numeric-string
      */
     public static function add($left, $right)

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -142,7 +142,6 @@ final class Type
      * and contain the name of the extension.
      *
      * @var array<string, string>
-     *
      * @since 0.9.10
      */
     private static $internalNamespaces = null;
@@ -242,9 +241,7 @@ final class Type
      * extension.
      *
      * @param string $typeName The type name.
-     *
      * @return bool
-     *
      * @throws ReflectionException
      */
     public static function isInternalType($typeName)
@@ -262,9 +259,7 @@ final class Type
      * exists, this method will return <b>null</b>.
      *
      * @param string $typeName The type name.
-     *
      * @return string|null
-     *
      * @throws ReflectionException
      */
     public static function getTypePackage($typeName)
@@ -283,7 +278,6 @@ final class Type
      * Returns an array with all package/extension names.
      *
      * @return array<string>
-     *
      * @throws ReflectionException
      */
     public static function getInternalNamespaces()
@@ -302,9 +296,7 @@ final class Type
      * php extension.
      *
      * @param string $packageName Name of a package.
-     *
      * @return bool
-     *
      * @throws ReflectionException
      */
     public static function isInternalPackage($packageName)
@@ -318,7 +310,6 @@ final class Type
      * the list of scalar/none-object types.
      *
      * @param string $image The type identifier.
-     *
      * @return bool
      */
     public static function isScalarType($image)
@@ -339,9 +330,7 @@ final class Type
      * the list of primitive types.
      *
      * @param string $image The type image.
-     *
      * @return bool
-     *
      * @since  0.9.6
      */
     public static function isPrimitiveType($image)
@@ -354,9 +343,7 @@ final class Type
      * image.
      *
      * @param string $image The found primitive type image.
-     *
      * @return string|null
-     *
      * @since  0.9.6
      */
     public static function getPrimitiveType($image)
@@ -381,9 +368,7 @@ final class Type
      * php array type.
      *
      * @param string $image The found type image.
-     *
      * @return bool
-     *
      * @since  0.9.6
      */
     public static function isArrayType($image)
@@ -397,7 +382,6 @@ final class Type
      * classes are collected in an internal data structure.
      *
      * @return array<string, string>
-     *
      * @throws ReflectionException
      */
     private static function initTypeToExtension()

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -49,14 +49,12 @@ namespace PDepend\Util;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 2.2.x
  */
 final class Utf8Util
 {
     /**
      * @param string $raw
-     *
      * @return string
      */
     public static function ensureEncoding($raw)

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -81,7 +81,6 @@ abstract class AbstractTestCase extends TestCase
      * The current working directory.
      *
      * @var string
-     *
      * @since 0.10.0
      */
     protected $workingDirectory = null;
@@ -127,7 +126,6 @@ abstract class AbstractTestCase extends TestCase
      * calling test case.
      *
      * @param string $directory Optional working directory.
-     *
      * @since 0.10.0
      */
     protected function changeWorkingDirectory($directory = null): void
@@ -144,7 +142,6 @@ abstract class AbstractTestCase extends TestCase
      * Returns the working directory for the currently executed test.
      *
      * @return string
-     *
      * @since 1.0.0
      */
     protected function getTestWorkingDirectory()
@@ -174,7 +171,6 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
-     *
      * @return ASTNode
      */
     protected function getFirstNodeOfTypeInFunction($testCase, $nodeType)
@@ -233,9 +229,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $nodeType The searched node class.
-     *
      * @return ASTNode
-     *
      * @since 1.0.0
      */
     protected function getFirstNodeOfTypeInTrait($nodeType)
@@ -249,7 +243,6 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
-     *
      * @return ASTNode
      */
     protected function getFirstNodeOfTypeInClass($testCase, $nodeType)
@@ -263,7 +256,6 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $testCase Name of the calling test case.
      * @param string $nodeType The searched node class.
-     *
      * @return ASTNode
      */
     protected function getFirstNodeOfTypeInInterface($testCase, $nodeType)
@@ -277,7 +269,6 @@ abstract class AbstractTestCase extends TestCase
      * test case.
      *
      * @return ASTTrait
-     *
      * @since 1.0.0
      */
     protected function getFirstTraitForTestCase()
@@ -389,9 +380,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Collects all children from a given node.
      *
-     * @param ASTNode $node   The current root node.
-     * @param array   $actual Previous filled list.
-     *
+     * @param ASTNode $node The current root node.
+     * @param array $actual Previous filled list.
      * @return array<string>
      */
     protected static function collectChildNodes(ASTNode $node, array $actual = [])
@@ -418,7 +408,6 @@ abstract class AbstractTestCase extends TestCase
      * Collects all children from a given node.
      *
      * @param ASTNode $node The current root node.
-     *
      * @return array
      */
     protected static function collectGraph(ASTNode $node)
@@ -437,8 +426,8 @@ abstract class AbstractTestCase extends TestCase
      * Tests that the given node and its children represent the expected ast
      * object graph.
      *
-     * @param ASTNode $node  The root node.
-     * @param array   $graph Expected class structure.
+     * @param ASTNode $node The root node.
+     * @param array $graph Expected class structure.
      */
     protected static function assertGraph(ASTNode $node, $graph): void
     {
@@ -450,9 +439,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a mocked class instance without calling the constructor.
      *
      * @param string $className Name of the class to mock.
-     *
      * @return stdClass
-     *
      * @since 0.10.0
      */
     protected function getMockWithoutConstructor($className)
@@ -494,7 +481,6 @@ abstract class AbstractTestCase extends TestCase
      * Creates a test configuration instance.
      *
      * @return Util\Configuration
-     *
      * @since 0.10.0
      */
     protected function createConfigurationFixture()
@@ -520,7 +506,6 @@ abstract class AbstractTestCase extends TestCase
      * with the calling test case.
      *
      * @return Engine
-     *
      * @since 0.10.0
      */
     protected function createEngineFixture()
@@ -540,7 +525,6 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * @param TextUI\Runner $runner
-     *
      * @return int
      */
     protected function silentRun($runner)
@@ -568,9 +552,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use class fixture.
      *
      * @param string $name Optional class name.
-     *
      * @return ASTClass
-     *
      * @since 1.0.2
      */
     protected function createClassFixture($name = null)
@@ -591,9 +573,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use interface fixture.
      *
      * @param string $name Optional interface name.
-     *
      * @return ASTInterface
-     *
      * @since 1.0.2
      */
     protected function createInterfaceFixture($name = null)
@@ -611,9 +591,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use trait fixture.
      *
      * @param string $name Optional trait name.
-     *
      * @return ASTTrait
-     *
      * @since 1.0.2
      */
     protected function createTraitFixture($name = null)
@@ -630,9 +608,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use function fixture.
      *
      * @param string $name Optional function name.
-     *
      * @return ASTFunction
-     *
      * @since 1.0.2
      */
     protected function createFunctionFixture($name = null)
@@ -651,9 +627,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use method fixture.
      *
      * @param string $name Optional method name.
-     *
      * @return ASTMethod
-     *
      * @since 1.0.2
      */
     protected function createMethodFixture($name = null)
@@ -671,9 +645,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a temporary resource for the given file name.
      *
      * @param string $fileName
-     *
      * @return string
-     *
      * @throws ErrorException
      */
     protected function createRunResourceURI($fileName = null)
@@ -685,9 +657,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a code uri for the given file name.
      *
      * @param string $fileName The code file name.
-     *
      * @return string
-     *
      * @throws ErrorException
      */
     protected static function createCodeResourceURI($fileName)
@@ -789,7 +759,6 @@ abstract class AbstractTestCase extends TestCase
      * Parses the test code associated with the calling test method.
      *
      * @param bool $ignoreAnnotations The parser should ignore annotations.
-     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     protected function parseCodeResourceForTest($ignoreAnnotations = false)
@@ -805,8 +774,7 @@ abstract class AbstractTestCase extends TestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -830,8 +798,7 @@ abstract class AbstractTestCase extends TestCase
      * and node builder implementations.
      *
      * @param string $fileOrDirectory
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseSource($fileOrDirectory, $ignoreAnnotations = false)
@@ -880,7 +847,6 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * @param \PDepend\Source\Builder\Builder<mixed> $builder
-     *
      * @return Source\Language\PHP\AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/ApplicationTest.php
+++ b/src/test/php/PDepend/ApplicationTest.php
@@ -49,7 +49,6 @@ use PDepend\Metrics\Analyzer\CrapIndexAnalyzer;
  * Test cases for the {@link \PDepend\Application} class.
  *
  * @covers \PDepend\Application
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -58,7 +58,6 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * calling test case.
      *
      * @return string
-     *
      * @since 0.10.0
      */
     protected function createSummaryXmlForCallingTest()
@@ -84,8 +83,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Parses the source of a test case file.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
@@ -100,7 +98,6 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Returns the source file for the given test case.
      *
      * @param string $testCase The qualified test case name.
-     *
      * @return string
      */
     protected function getSourceFileForTestCase($testCase)

--- a/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
+++ b/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link      http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
+++ b/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
  */
 
@@ -53,7 +52,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/9936901
  */
 
@@ -53,7 +52,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link https://www.pivotaltracker.com/story/show/9936901
  *
  * @ticket 9936901

--- a/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
+++ b/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
@@ -47,7 +47,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/182
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/18459091
  * @since 1.0.0
  */
@@ -55,7 +54,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link https://www.pivotaltracker.com/story/show/18459091
  * @since 1.0.0
  *

--- a/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
+++ b/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
@@ -49,7 +49,6 @@ use PDepend\Input\ExcludePathFilter;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/191
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -51,7 +51,6 @@ use SplFileInfo;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/164
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2016 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link    https://github.com/pdepend/pdepend/issues/247
  */
 
@@ -54,7 +53,6 @@ use PHPUnit_Framework_MockObject_MockObject;
  *
  * @copyright 2008-2016 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link    https://github.com/pdepend/pdepend/issues/247
  *
  * @ticket 247
@@ -109,7 +107,6 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
 
     /**
      * @param \PDepend\Source\Builder\Builder<mixed> $builder
-     *
      * @return PHPUnit_Framework_MockObject_MockObject
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/13405179
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link https://www.pivotaltracker.com/story/show/13405179
  *
  * @ticket 13405179
@@ -63,7 +61,6 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
      *
      * @param string $className Class name of a logger implementation.
      * @param string $extension Log file extension.
-     *
      * @dataProvider getLoggerClassNames
      */
     public function testLogFileIsCreatedForUnstructuredCode($className, $extension): void

--- a/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/17264279
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/17264279
  *
  * @ticket 17264279

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/21500611
  * @since 1.0.0
  */
@@ -52,7 +51,6 @@ use PDepend\Source\AST\ASTHeredoc;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link https://www.pivotaltracker.com/story/show/21500611
  * @since 1.0.0
  *

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/23905939
  * @since 0.10.8
  */
@@ -50,7 +49,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/23905939
  * @since 0.10.8
  *

--- a/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2011 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/23951621
  * @since 0.10.9
  */
@@ -50,7 +49,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2011 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @link https://www.pivotaltracker.com/story/show/23951621
  * @since 0.10.9
  *

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/8927377
  */
 
@@ -51,7 +50,6 @@ use PDepend\Source\AST\ASTPropertyPostfix;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://www.pivotaltracker.com/story/show/8927377
  *
  * @ticket 8927377

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -58,9 +58,8 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
      * This method tests that the parser handles reserved keywords in type
      * constant names correct.
      *
-     * @param string     $sourceFile   Name of the test file.
+     * @param string $sourceFile Name of the test file.
      * @param array<int> $constantName Name of the expected constant
-     *
      * @dataProvider dataProviderReservedKeywordAsTypeConstantName
      */
     public function testReservedKeywordAsTypeConstantName($sourceFile, $constantName): void

--- a/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
+++ b/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://github.com/pdepend/pdepend/issues/95
  * @link       https://github.com/pdepend/pdepend/issues/104
  * @since 1.1.1
@@ -51,7 +50,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://github.com/pdepend/pdepend/issues/95
  * @link       https://github.com/pdepend/pdepend/issues/104
  * @since 1.1.1

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -61,9 +61,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
      * This method tests that the parser does not substitute keyword tokens in
      * a class or object operator chain.
      *
-     * @param string     $sourceFile Name of the text file.
+     * @param string $sourceFile Name of the text file.
      * @param array<int> $tokenTypes List of all expected token types.
-     *
      * @dataProvider dataProviderTokenizerKeywordSubstitutionInOperatorChain
      */
     public function testTokenizerKeywordSubstitutionInOperatorChain($sourceFile, array $tokenTypes): void

--- a/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
+++ b/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://github.com/pdepend/pdepend/issues/100
  */
 
@@ -49,7 +48,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       https://github.com/pdepend/pdepend/issues/100
  *
  * @group regressiontest

--- a/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
+++ b/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
  */
@@ -53,7 +52,6 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
  *

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -51,7 +51,6 @@ use ReflectionMethod;
  *
  * @covers \PDepend\DependencyInjection\TreeBuilderFactory
  * @covers \PDepend\DependencyInjection\TreeBuilder
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -52,7 +52,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * @covers \PDepend\DependencyInjection\ExtensionManager
  * @covers \PDepend\DependencyInjection\Extension
  * @covers \PDepend\DependencyInjection\TreeBuilder
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test cases for the {@link \PDepend\Application} class.
  *
  * @covers \PDepend\DependencyInjection\TreeBuilder
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTNamespace;
  * Test case for \PDepend\Engine facade.
  *
  * @covers \PDepend\Engine
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Input/CompositeFilterTest.php
+++ b/src/test/php/PDepend/Input/CompositeFilterTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the composite filter.
  *
  * @covers \PDepend\Input\CompositeFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -50,7 +50,6 @@ use RecursiveIteratorIterator;
  * Test case for the exclude path filter.
  *
  * @covers \PDepend\Input\ExcludePathFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -192,7 +191,6 @@ class ExcludePathFilterTest extends AbstractTestCase
      * path filter.
      *
      * @param array<string> $excludes The filtered patterns
-     *
      * @return array<string>
      */
     protected function createFilteredFileList(array $excludes)

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -50,7 +50,6 @@ use RecursiveIteratorIterator;
  * Test case for the file extension filter.
  *
  * @covers \PDepend\Input\ExtensionFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -92,7 +91,6 @@ class ExtensionFilterTest extends AbstractTestCase
      * filter.
      *
      * @param array<string> $includes The file extensions
-     *
      * @return array<string>
      */
     protected function createFilteredFileList(array $includes)

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -53,7 +53,6 @@ use SplFileInfo;
  * Test case for the php file filter iterator.
  *
  * @covers \PDepend\Input\Iterator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -164,7 +163,6 @@ class IteratorTest extends AbstractTestCase
      * Creates an array of file names that were returned by the input iterator.
      *
      * @param array<string> $extensions The accepted file extension.
-     *
      * @return array<string>
      */
     protected function createFilteredFileList(array $extensions)

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -124,7 +124,6 @@ class BuilderParserCacheTest extends AbstractTestCase
      * Parses the given test file and then returns the builder instance.
      *
      * @param string $file Relative path to a test file for the calling test.
-     *
      * @return \PDepend\Source\Builder\Builder
      */
     protected function parseSourceAndReturnBuilder($file)

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -68,7 +68,6 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * Parses the source for the calling test case.
      *
      * @param string $testCase
-     *
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     protected function parseTestCase($testCase = null)
@@ -84,8 +83,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)

--- a/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -50,7 +50,6 @@ use PDepend\Source\Tokenizer\Tokens;
  * Test case for issue #638, php 8.2 readonly allows double class modifiers.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -46,7 +46,6 @@ namespace PDepend\Issues;
  * Test case for issue #87. Handling of dependencies declared in inline comments.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -47,7 +47,6 @@ namespace PDepend\Issues;
  * primitive property and parameter types.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -58,9 +57,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
     /**
      * Tests that the parser sets the expected primitive type information.
      *
-     * @param string $actual   The actual used type identifier.
+     * @param string $actual The actual used type identifier.
      * @param string $expected The expected primitive type image.
-     *
      * @dataProvider dataProviderParserSetsExpectedPrimitivePropertyType
      */
     public function testParserSetsExpectedPrimitivePropertyType($actual, $expected): void

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -46,7 +46,6 @@ namespace PDepend\Issues;
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -293,9 +292,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser expands a local name within the signature of a
      * namespace class or interface correct.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInTypeSignature
      */
     public function testParserResolvesQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
@@ -314,9 +312,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser expands a local name within the body of a
      * namespaced function correct.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInFunction
      */
     public function testParserResolvesQualifiedTypeNameInFunction($fileName, $namespaceName): void
@@ -340,9 +337,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser does not expand a qualified name within the
      * signature of a namespaced class or interface correct.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInTypeSignature
      */
     public function testParserKeepsQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
@@ -361,9 +357,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser does not expand a qualified name within the body of
      * a namespaced function correct.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInFunction
      */
     public function testParserKeepsQualifiedTypeNameInFunction($fileName, $namespaceName): void
@@ -382,9 +377,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax
      */
     public function testParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax($fileName, $namespaceName): void
@@ -403,9 +397,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax
      */
     public function testParserResolvesNamespaceKeywordInFunctionSemicolonSyntax($fileName, $namespaceName): void
@@ -424,9 +417,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax
      */
     public function testParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax($fileName, $namespaceName): void
@@ -445,9 +437,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
-     * @param string $fileName      Name of the test file.
+     * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     *
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax
      */
     public function testParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax($fileName, $namespaceName): void

--- a/src/test/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/src/test/php/PDepend/Issues/NewClassInstanceTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTStatement;
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -48,7 +48,6 @@ use PDepend\Input\ExtensionFilter;
  * Test case for the catch error ticket #61.
  *
  * @covers \PDepend\Engine
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -46,7 +46,6 @@ namespace PDepend\Issues;
  * Test case for parameter related ticker #32.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTNode;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTParameter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
+++ b/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
@@ -52,7 +52,6 @@ use PDepend\Source\Tokenizer\Tokens;
  * http://tracker.pdepend.org/pdepend/issue_tracker/issue/79
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -58,8 +58,7 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\AbstractMetricsTestCase;
  * Tests the for the package metrics visitor.
  *
  * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -53,7 +53,6 @@ use RuntimeException;
  * Test case for the class level analyzer.
  *
  * @covers \PDepend\Metrics\Analyzer\ClassLevelAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -427,7 +426,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTrait
      *
      * @return array
-     *
      * @since 1.0.6
      */
     public function testGetNodeMetricsForTrait()
@@ -443,7 +441,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTraitReturnsExpectedMetricSet
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -460,7 +457,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct IMPL values.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -474,7 +470,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the calculated Class Interface Size(CSI) is correct.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -488,7 +483,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the calculated Class SiZe(CSZ) metric is correct.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -502,7 +496,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateNpmMetricForClassWithPublicMethod
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -516,7 +509,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct VARS metric
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -530,7 +522,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct VARSi metric
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -544,7 +535,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct VARSnp metric
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -558,7 +548,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct WMC metric.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -572,7 +561,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct WMCi metric.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -586,7 +574,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the correct WMCnp metric.
      *
      * @param array $metrics Calculated class metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -601,7 +588,6 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * returns all measured metrics.
      *
      * @return array<string, mixed>
-     *
      * @since 1.0.6
      */
     private function calculateTraitMetrics()

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the method strategy.
  *
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the code rank property strategy.
  *
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the code rank property strategy.
  *
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTClass;
  * Test case for the code metric analyzer class.
  *
  * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\AbstractMetricsTestCase;
  * Test case for the coupling analyzer.
  *
  * @covers \PDepend\Metrics\Analyzer\CouplingAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -502,7 +501,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTrait
      *
      * @return array
-     *
      * @since 1.0.6
      */
     public function testGetNodeMetricsForTrait()
@@ -517,7 +515,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetNodeMetricsForTraitReturnsExpectedMetricSet
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -531,7 +528,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateCEMetricForTrait
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -545,7 +541,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateCBOMetricForTrait
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -559,7 +554,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateCAMetricForTrait
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetNodeMetricsForTrait
@@ -573,7 +567,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetProjectMetricsForTrait
      *
      * @return array
-     *
      * @since 1.0.6
      */
     public function testGetProjectMetricsForTrait()
@@ -591,7 +584,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testGetProjectMetricsForTraitReturnsExpectedMetricSet
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetProjectMetricsForTrait
@@ -605,7 +597,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateCallsMetricForTrait
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetProjectMetricsForTrait
@@ -619,7 +610,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * testCalculateFanoutMetricForTrait
      *
      * @param array $metrics Calculated coupling metrics.
-     *
      * @since 1.0.6
      *
      * @depends testGetProjectMetricsForTrait
@@ -634,7 +624,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * returns all measured metrics.
      *
      * @return array<string, mixed>
-     *
      * @since 1.0.6
      */
     private function calculateTraitMetrics()
@@ -651,9 +640,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * Tests that the analyzer calculates the expected call count.
      *
      * @param string $testCase File with test source.
-     * @param int    $calls    Number of expected calls.
-     * @param int    $fanout   Expected fanout value.
-     *
+     * @param int $calls Number of expected calls.
+     * @param int $fanout Expected fanout value.
      * @dataProvider dataProviderAnalyzerCalculatesExpectedCallCount
      */
     public function testAnalyzerCalculatesExpectedCallCount(
@@ -672,9 +660,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * the calculated project metrics.
      *
      * @param string $testCase Optional name of the calling test case.
-     *
      * @return array<string, mixed>
-     *
      * @since 0.10.2
      */
     private function calculateProjectMetrics($testCase = null)

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\AbstractMetricsTestCase;
  * Test cases for the {@link  \PDepend\Metrics\Analyzer\CrapIndexAnalyzer} class.
  *
  * @covers \PDepend\Metrics\Analyzer\CrapIndexAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -150,9 +149,9 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the crap index algorithm implementation.
      *
-     * @param string $testCase  Name of the calling test case.
-     * @param int    $ccn       The entire cyclomatic complexity number.
-     * @param int    $crapIndex The expected crap index.
+     * @param string $testCase Name of the calling test case.
+     * @param int $ccn The entire cyclomatic complexity number.
+     * @param int $crapIndex The expected crap index.
      */
     private function doTestCrapIndexCalculation($testCase, $ccn, $crapIndex): void
     {
@@ -164,8 +163,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      * Calculates the crap index.
      *
      * @param string $testCase Name of the calling test case.
-     * @param int    $ccn      The entire cyclomatic complexity number.
-     *
+     * @param int $ccn The entire cyclomatic complexity number.
      * @return array
      */
     private function calculateCrapIndex($testCase, $ccn)
@@ -216,7 +214,6 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      * Creates a mocked instance of the cyclomatic complexity analyzer.
      *
      * @param int $ccn
-     *
      * @return CyclomaticComplexityAnalyzer
      */
     private function createCyclomaticComplexityAnalyzerMock($ccn = 42)

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -50,7 +50,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Metrics\AbstractCachingAnalyzer
  * @covers \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
@@ -60,7 +59,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
-     *
      * @since 1.0.0
      */
     private $cache;
@@ -344,7 +342,6 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Returns a pre configured ccn analyzer.
      *
      * @return CyclomaticComplexityAnalyzer
-     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\AbstractMetricsTestCase;
  * Tests the for the package metrics visitor.
  *
  * @covers \PDepend\Metrics\Analyzer\DependencyAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -50,7 +50,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Metrics\AbstractCachingAnalyzer
  * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
- *
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
@@ -60,7 +59,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
-     *
      * @since 1.0.0
      */
     private $cache;
@@ -292,7 +290,6 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
      * Returns a pre configured ccn analyzer.
      *
      * @return HalsteadAnalyzer
-     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTClass;
  * Test case for the hierarchy analyzer.
  *
  * @covers \PDepend\Metrics\Analyzer\HierarchyAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -51,7 +51,6 @@ use PDepend\Source\AST\ASTClass;
  * Test case for the inheritance analyzer.
  *
  * @covers \PDepend\Metrics\Analyzer\InheritanceAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
@@ -283,7 +282,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
      * calculated metric value.
      *
      * @param string $testCase Name of the calling test case.
-     * @param string $metric   Name of the searched metric.
+     * @param string $metric Name of the searched metric.
      */
     private function getCalculatedMetric($testCase, $metric): mixed
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -50,7 +50,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Metrics\AbstractCachingAnalyzer
  * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
- *
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
@@ -60,7 +59,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
-     *
      * @since 1.0.0
      */
     private $cache;
@@ -195,7 +193,6 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
      * Returns a pre configured ccn analyzer.
      *
      * @return MaintainabilityIndexAnalyzer
-     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -51,7 +51,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Metrics\AbstractCachingAnalyzer
  * @covers \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *
@@ -61,7 +60,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
-     *
      * @since 1.0.0
      */
     private $cache;
@@ -162,7 +160,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * testNPathComplexityForSiblingExpressions
      *
      * @since 0.9.12
-     *
      * @todo What happens with boolean/logical expressions within the body of
      *       any other statement/expression?
      */
@@ -450,7 +447,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * associated with the calling test case.
      *
      * @return int
-     *
      * @since 0.9.12
      */
     private function calculateFunctionMetric()
@@ -465,7 +461,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * the first function found in the test case source file.
      *
      * @return \PDepend\Source\AST\ASTFunction
-     *
      * @since 0.9.12
      */
     private function getFirstFunctionForTestCaseInternal()
@@ -481,7 +476,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * associated with the calling test case.
      *
      * @return int
-     *
      * @since 0.9.12
      */
     private function calculateMethodMetric()
@@ -496,7 +490,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * the first method found in the test case source file.
      *
      * @return \PDepend\Source\AST\ASTMethod
-     *
      * @since 0.9.12
      */
     private function getFirstMethodForTestCaseInternal()
@@ -513,7 +506,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Calculates the NPath complexity for the given callable instance.
      *
      * @return string
-     *
      * @since 0.9.12
      */
     private function calculateNPathComplexity(AbstractASTCallable $callable)
@@ -529,7 +521,6 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Creates a ready to use npath complexity analyzer.
      *
      * @return NPathComplexityAnalyzer
-     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -50,7 +50,6 @@ use PDepend\Source\AST\ASTNamespace;
  * Test case for the node count analyzer.
  *
  * @covers \PDepend\Metrics\Analyzer\NodeCountAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -51,7 +51,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Metrics\AbstractCachingAnalyzer
  * @covers \PDepend\Metrics\Analyzer\NodeLocAnalyzer
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -61,7 +60,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * @var \PDepend\Util\Cache\CacheDriver
-     *
      * @since 1.0.0
      */
     private $cache;
@@ -645,7 +643,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
      * the calling test case and returns the metric value for <b>$name</b>.
      *
      * @param string $name The name of the requested metric.
-     *
      * @since 0.10.2
      */
     private function calculateFunctionMetric($name): mixed
@@ -666,7 +663,6 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
      * Creates a ready to use node loc analyzer.
      *
      * @return NodeLocAnalyzer
-     *
      * @since 1.0.0
      */
     private function createAnalyzer()

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -49,7 +49,6 @@ use PDepend\Report\DummyAnalyzer;
  * Test case for the {@link \PDepend\Metrics\AnalyzerIterator} class.
  *
  * @covers \PDepend\Metrics\AnalyzerIterator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -59,7 +59,6 @@ class ParserRegressionTest extends AbstractTestCase
      * Tests that the parser handles the given source file.
      *
      * @param string $pathName Name of the file to parse.
-     *
      * @dataProvider dataProviderSourceFiles
      */
     public function testParserHandlesSourceFileWithoutException($pathName): void

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -55,7 +55,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * Test case implementation for the PDepend code parser.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the xml summary log.
  *
  * @covers \PDepend\Report\Dependencies\Xml
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -124,7 +124,6 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
-     *
      * @return bool
      */
     public function log(\PDepend\Metrics\Analyzer $analyzer)

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -132,7 +132,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      * state based disabling/enabling.
      *
      * @return bool
-     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -144,7 +143,6 @@ class DummyAnalyzer implements AnalyzerNodeAware, AnalyzerProjectAware
      * Set global options
      *
      * @param array<string, mixed> $options
-     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -54,7 +54,6 @@ use PDepend\Source\AST\ASTArtifactList;
  * Test case for the jdepend chart logger.
  *
  * @covers \PDepend\Report\Jdepend\Chart
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -320,9 +319,8 @@ class ChartTest extends AbstractTestCase
     }
 
     /**
-     * @param bool   $userDefined
+     * @param bool $userDefined
      * @param string $packageName
-     *
      * @return \PDepend\Source\AST\ASTNamespace
      */
     private function createPackage($userDefined, $packageName)

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -50,7 +50,6 @@ use PDepend\Report\DummyAnalyzer;
  * Test case for the jdepend xml logger.
  *
  * @covers \PDepend\Report\Jdepend\Xml
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -143,7 +142,6 @@ class XmlTest extends AbstractTestCase
      * Normalizes the file references within the expected result document.
      *
      * @param string $fileName File name of the expected result document.
-     *
      * @return string The prepared xml document
      */
     protected function getNormalizedPathXml($fileName)

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -50,7 +50,6 @@ use PDepend\Report\DummyAnalyzer;
  * Test case for the overview pyramid logger.
  *
  * @covers \PDepend\Report\Overview\Pyramid
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -73,7 +73,7 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * Constructs a new analyzer dummy instance.
      *
      * @param array<string, mixed> $projectMetrics Dummy project metrics.
-     * @param array<string, array> $nodeMetrics    Dummy node metrics.
+     * @param array<string, array> $nodeMetrics Dummy node metrics.
      */
     public function __construct(array $projectMetrics = [], array $nodeMetrics = [])
     {
@@ -111,7 +111,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * state based disabling/enabling.
      *
      * @return bool
-     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -143,7 +142,6 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      * Set global options
      *
      * @param array<string, mixed> $options
-     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -101,7 +101,6 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * state based disabling/enabling.
      *
      * @return bool
-     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -126,7 +125,6 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      * Set global options
      *
      * @param array<string, mixed> $options
-     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -100,7 +100,6 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
      * state based disabling/enabling.
      *
      * @return bool
-     *
      * @since 0.9.10
      */
     public function isEnabled()
@@ -122,7 +121,6 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
      * Set global options
      *
      * @param array<string, mixed> $options
-     *
      * @since 2.0.1
      */
     public function setOptions(array $options = []): void

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTArtifactList;
  * Test case for the xml summary log.
  *
  * @covers \PDepend\Report\Summary\Xml
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -239,7 +238,6 @@ class XmlTest extends AbstractTestCase
     /**
      * @param string $fixture
      * @param string $expectation
-     *
      * @dataProvider dataProviderNodeAware
      */
     public function testNodeAwareAnalyzer($fixture, $expectation): void

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTAllocationExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -129,7 +128,6 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
      * Returns a test allocation expression.
      *
      * @param string $testCase The calling test case.
-     *
      * @return ASTAllocationExpression
      */
     private function getFirstAllocationExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -50,7 +50,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
  * @covers \PDepend\Source\AST\ASTAnonymousClass
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTArguments
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTArrayElement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -48,7 +48,6 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIndexExpression
  * @covers \PDepend\Source\AST\ASTArrayIndexExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTArray
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -50,7 +50,6 @@ use PDepend\AbstractTestCase;
  * Test case the node iterator.
  *
  * @covers \PDepend\Source\AST\ASTArtifactList
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Source\AST\AbstractASTArtifact} class.
  *
  * @covers \PDepend\Source\AST\AbstractASTArtifact
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTAssignmentExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -273,7 +272,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
      * testVariableAssignmentExpression
      *
      * @return ASTAssignmentExpression
-     *
      * @since 1.0.1
      */
     public function testVariableAssignmentExpression()
@@ -336,7 +334,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
      * testStaticPropertyAssignmentExpression
      *
      * @return ASTAssignmentExpression
-     *
      * @since 1.0.1
      */
     public function testStaticPropertyAssignmentExpression()
@@ -399,7 +396,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
      * testObjectPropertyAssignmentExpression
      *
      * @return ASTAssignmentExpression
-     *
      * @since 1.0.1
      */
     public function testObjectPropertyAssignmentExpression()
@@ -462,7 +458,6 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
      * testChainedPropertyAssignmentExpression
      *
      * @return ASTAssignmentExpression
-     *
      * @since 1.0.1
      */
     public function testChainedPropertyAssignmentExpression()

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTBooleanAndExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTBooleanAndExpression
      */
     private function getFirstBooleanAndExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTBooleanOrExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTBooleanOrExpression
      */
     private function getFirstBooleanOrExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTBreakStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTBreakStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTBreakStatement
      */
     private function getFirstBreakStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\Tokenizer\Token;
  * Test case for the {@link \PDepend\Source\AST\AbstractASTCallable} class.
  *
  * @covers \PDepend\Source\AST\AbstractASTCallable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -256,7 +255,6 @@ class ASTCallableTest extends AbstractTestCase
      * method.
      *
      * @return AbstractASTCallable
-     *
      * @since 0.10.0
      */
     protected function getFirstCallableForTest()

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTCastExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -292,7 +291,6 @@ class ASTCastExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTCastExpression
      */
     private function getFirstCastExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTCatchStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -144,7 +143,6 @@ class ASTCatchStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTCatchStatement
      */
     private function getFirstCatchStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -53,7 +53,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClassFqnPostfix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
@@ -321,7 +320,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClassOrInterfaceReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -244,7 +243,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTClassOrInterfaceReference
      */
     private function getFirstReferenceInFunction($testCase)
@@ -259,7 +257,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      * Returns the first reference node for the currently executed test case.
      *
      * @return ASTClassOrInterfaceReference
-     *
      * @since 0.10.5
      */
     private function getFirstReferenceInClass()
@@ -274,7 +271,6 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      * Returns the first reference node for the currently executed test case.
      *
      * @return ASTClassOrInterfaceReference
-     *
      * @since 0.10.5
      */
     private function getFirstReferenceInInterface()

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClassReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -187,7 +186,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTClassReference
      */
     private function getFirstReferenceInFunction($testCase)
@@ -202,7 +200,6 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      * Returns the first reference node for the currently executed test case.
      *
      * @return ASTClassReference
-     *
      * @since 0.10.5
      */
     private function getFirstReferenceInClass()

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -56,7 +56,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\AST\AbstractASTClassOrInterface
  * @covers \PDepend\Source\AST\AbstractASTType
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -338,7 +337,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      * testGetAllMethodsWithMethodCollisionThrowsExpectedException
      *
      * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
-     *
      * @since 1.0.0
      *
      * @group issue-154

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTCloneExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTCloneExpression
      */
     private function getFirstCloneExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTClosure
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTComment
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -167,7 +166,6 @@ class ASTCommentTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTComment
      */
     private function getFirstCommentInClass($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the code file class.
  *
  * @covers \PDepend\Source\AST\ASTCompilationUnit
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTCompoundExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTCompoundExpression
      */
     private function getFirstExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTCompoundVariable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -155,7 +154,6 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTCompoundVariable
      */
     private function getFirstVariableInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTConditionalExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTConditionalExpression
      */
     private function getFirstConditionalExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -105,7 +104,6 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
      * testConstantDeclarator
      *
      * @return ASTConstantDeclarator
-     *
      * @since 1.0.2
      */
     public function testConstantDeclarator()

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTConstantDefinition
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -60,7 +59,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * valid combinations of modifiers.
      *
      * @param int $modifiers Combinations of valid modifiers.
-     *
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
     public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
@@ -76,7 +74,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * invalid modifier or modifier combination was set.
      *
      * @param int $modifiers Combinations of invalid modifiers.
-     *
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void
@@ -187,7 +184,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinition
      *
      * @return ASTConstantDefinition
-     *
      * @since 1.0.2
      */
     public function testConstantDefinition()
@@ -250,7 +246,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclarators
      *
      * @return ASTConstantDefinition
-     *
      * @since 1.0.2
      */
     public function testConstantDefinitionWithDeclarators()
@@ -265,7 +260,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedStartLine
      *
      * @param ASTConstantDefinition $constant
-     *
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
@@ -279,7 +273,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedStartColumn
      *
      * @param ASTConstantDefinition $constant
-     *
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
@@ -293,7 +286,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedEndLine
      *
      * @param ASTConstantDefinition $constant
-     *
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
@@ -307,7 +299,6 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedEndColumn
      *
      * @param ASTConstantDefinition $constant
-     *
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTConstantPostfix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -113,7 +112,6 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTConstantPostfix
      */
     private function getFirstConstantPostfixInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTConstant
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -122,7 +121,6 @@ class ASTConstantTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTConstant
      */
     private function getFirstConstantInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTContinueStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTContinueStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTContinueStatement
      */
     private function getFirstContinueStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTDeclareStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  *
  * @group unittest
@@ -206,7 +203,6 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTDeclareStatement
      */
     private function getFirstDeclareStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTDoWhileStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -131,7 +130,6 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTDoWhileStatement
      */
     private function getFirstDoWhileStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTEchoStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTEchoStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTEchoStatement
      */
     private function getFirstEchoStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTElseIfStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -203,7 +202,6 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTElseIfStatement
      */
     private function getFirstElseIfStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -53,7 +53,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForInit
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTEvalExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTEvalExpression
      */
     private function getFirstEvalExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTExitExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCode
      *
      * @return ASTExitExpression
-     *
      * @since 1.0.1
      */
     public function testExitExpressionWithExitCode()
@@ -74,7 +72,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedStartLine
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
@@ -88,7 +85,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedEndLine
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
@@ -102,7 +98,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedStartColumn
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
@@ -116,7 +111,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedEndColumn
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
@@ -130,7 +124,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgs
      *
      * @return ASTExitExpression
-     *
      * @since 1.0.1
      */
     public function testExitExpressionWithEmptyArgs()
@@ -145,7 +138,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedStartLine
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
@@ -159,7 +151,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedEndLine
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
@@ -173,7 +164,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedStartColumn
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
@@ -187,7 +177,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedEndColumn
      *
      * @param ASTExitExpression $expr
-     *
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
@@ -201,7 +190,6 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithoutArgs
      *
      * @return ASTExitExpression
-     *
      * @since 1.0.1
      */
     public function testExitExpressionWithoutArgs()

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -122,7 +121,6 @@ class ASTExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTExpression
      */
     private function getFirstExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTFieldDeclaration
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -118,7 +117,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * valid combinations of modifiers.
      *
      * @param int $modifiers Combinations of valid modifiers.
-     *
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
     public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
@@ -133,7 +131,6 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * invalid modifier or modifier combination was set.
      *
      * @param int $modifiers Combinations of invalid modifiers.
-     *
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTFinallyStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -140,7 +139,6 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTFinallyStatement
      */
     private function getFirstFinallyStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForInit
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTForInitTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTForInit
      */
     private function getFirstForInitInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -320,7 +319,6 @@ class ASTForStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTForStatement
      */
     private function getFirstForStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForUpdate
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTForUpdateTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTForUpdate
      */
     private function getFirstForUpdateInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForeachStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -293,7 +292,6 @@ class ASTForeachStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTForeachStatement
      */
     private function getFirstForeachStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTFormalParameter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTFormalParameters
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  *
  * @group unittest
@@ -99,7 +96,6 @@ class ASTFormalParametersTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTFormalParameters
      */
     private function getFirstFormalParametersInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -48,7 +48,6 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTInvocation
  * @covers \PDepend\Source\AST\ASTFunctionPostfix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -51,7 +51,6 @@ use PDepend\Source\Tokenizer\Token;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\AbstractASTCallable
  * @covers \PDepend\Source\AST\ASTFunction
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTGlobalStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTGlobalStatement
      */
     private function getFirstGlobalStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTGotoStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTGotoStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTGotoStatement
      */
     private function getFirstGotoStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTHeredoc
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIdentifier
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTIdentifierTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTIdentifier
      */
     private function getFirstIdentifierInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIfStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -312,7 +311,6 @@ class ASTIfStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTIfStatement
      */
     private function getFirstIfStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIncludeExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  *
  * @group unittest
@@ -170,7 +167,6 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTIncludeExpression
      */
     private function getFirstIncludeExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTInstanceOfExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -157,7 +156,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * Tests the instanceof expression object graph.
      *
      * @param object $parent The parent ast node.
-     * @param string $image  The expected type image.
+     * @param string $image The expected type image.
      */
     protected function assertInstanceOfGraphStatic($parent, $image): void
     {
@@ -172,7 +171,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * Tests the instanceof expression object graph.
      *
      * @param object $parent The parent ast node.
-     * @param string $image  The expected type image.
+     * @param string $image The expected type image.
      */
     protected function assertInstanceOfGraphProperty($parent, $image): void
     {
@@ -187,8 +186,8 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * Tests the instanceof expression object graph.
      *
      * @param object $parent The parent ast node.
-     * @param string $image  The expected type image.
-     * @param string $type   The expected class or interface type.
+     * @param string $image The expected type image.
+     * @param string $type The expected class or interface type.
      */
     protected function assertInstanceOfGraph($parent, $image, $type): void
     {

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -53,7 +53,6 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @covers \PDepend\Source\AST\AbstractASTType
  * @covers \PDepend\Source\AST\ASTInterface
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIssetExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  *
  * @group unittest
@@ -129,7 +126,6 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTIssetExpression
      */
     private function getFirstIssetExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLabelStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTLabelStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTLabelStatement
      */
     private function getFirstLabelStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTListExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpression
      *
      * @return ASTListExpression
-     *
      * @since 1.0.2
      */
     public function testListExpression()
@@ -122,7 +120,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedList
      *
      * @return ASTListExpression
-     *
      * @since 1.0.2
      */
     public function testListExpressionWithNestedList()
@@ -137,7 +134,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedStartLine
      *
      * @param ASTListExpression $expr
-     *
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
@@ -151,7 +147,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedStartColumn
      *
      * @param ASTListExpression $expr
-     *
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
@@ -165,7 +160,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedEndLine
      *
      * @param ASTListExpression $expr
-     *
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
@@ -179,7 +173,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedEndColumn
      *
      * @param ASTListExpression $expr
-     *
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
@@ -356,7 +349,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithKeys
      *
      * @return ASTListExpression
-     *
      * @since 1.0.2
      */
     public function testListExpressionWithKeys()
@@ -371,7 +363,6 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithKeysAndNestedList
      *
      * @return ASTListExpression
-     *
      * @since 1.0.2
      */
     public function testListExpressionWithKeysAndNestedList()

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLiteral
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -155,7 +154,6 @@ class ASTLiteralTest extends ASTNodeTestCase
      * testLiteralWithZeroBinaryIntegerValue
      *
      * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
-     *
      * @since 1.0.0
      */
     public function testLiteralWithZeroBinaryIntegerValue(): void
@@ -190,7 +188,6 @@ class ASTLiteralTest extends ASTNodeTestCase
      * testLiteralWithNonZeroBinaryIntegerValue
      *
      * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
-     *
      * @since 1.0.0
      */
     public function testLiteralWithNonZeroBinaryIntegerValue(): void
@@ -203,7 +200,6 @@ class ASTLiteralTest extends ASTNodeTestCase
      * testLiteralWithZeroFloatValue
      *
      * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
-     *
      * @since 2.16.0
      */
     public function testLiteralWithZeroFloatValue(): void

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLogicalAndExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  *
  * @group unittest
@@ -99,7 +96,6 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTLogicalAndExpression
      */
     private function getFirstLogicalAndExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLogicalOrExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.8
  *
  * @group unittest
@@ -99,7 +96,6 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTLogicalOrExpression
      */
     private function getFirstLogicalOrExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTLogicalXorExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -95,7 +94,6 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTLogicalXorExpression
      */
     private function getFirstLogicalXorExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTMemberPrimaryPrefix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -48,7 +48,6 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTInvocation
  * @covers \PDepend\Source\AST\ASTMethodPostfix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -676,7 +675,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInFunction($testCase)
@@ -691,7 +689,6 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -51,7 +51,6 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\AbstractASTCallable
  * @covers \PDepend\Source\AST\ASTMethod
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\ASTVisitor\StubASTVisitor;
  * Test case implementation for the \PDepend\Source\AST\ASTNamespace class.
  *
  * @covers \PDepend\Source\AST\ASTNamespace
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -50,7 +50,6 @@ use ReflectionClass;
  * Abstract test case for classes derived {@link \PDepend\Source\AST\ASTNode}ö
  *
  * @covers \PDepend\Source\AST\AbstractASTNode
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -725,8 +724,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the code parameter class.
  *
  * @covers \PDepend\Source\AST\ASTParameter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -205,7 +204,6 @@ class ASTParameterTest extends AbstractTestCase
      * calling test method.
      *
      * @return ASTMethod
-     *
      * @since 1.0.0
      */
     private function getFirstMethodInClass()

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTParentReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -188,7 +187,6 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTParentReference
      */
     private function getFirstParentReferenceInClass($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPostfixExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -324,7 +323,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPostfixExpression
      */
     private function getFirstPostfixExpressionInClass($testCase)
@@ -339,7 +337,6 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPostfixExpression
      */
     private function getFirstPostfixExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPreDecrementExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -179,7 +178,6 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPreDecrementExpression
      */
     private function getFirstPreDecrementExpressionInClass($testCase)
@@ -194,7 +192,6 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPreDecrementExpression
      */
     private function getFirstPreDecrementExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -48,7 +48,6 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\AST\ASTPreIncrementExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -193,7 +192,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPreIncrementExpression
      */
     private function getFirstPreIncrementExpressionInClass($testCase)
@@ -208,7 +206,6 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTPreIncrementExpression
      */
     private function getFirstPreIncrementExpressionInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPrintExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -53,7 +53,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTPropertyPostfix
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
@@ -413,7 +412,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInFunction($testCase)
@@ -428,7 +426,6 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTMemberPrimaryPrefix
      */
     private function getFirstMemberPrimaryPrefixInClass($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the code property class.
  *
  * @covers \PDepend\Source\AST\ASTProperty
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTRequireExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  *
  * @group unittest
@@ -98,7 +95,6 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
      * testRequireExpression
      *
      * @return ASTRequireExpression
-     *
      * @since 1.0.2
      */
     public function testRequireExpression()
@@ -161,7 +157,6 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
      * testRequireExpressionWithParenthesis
      *
      * @return ASTRequireExpression
-     *
      * @since 1.0.2
      */
     public function testRequireExpressionWithParenthesis()

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTReturnStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTReturnStatementTest extends ASTNodeTestCase
      * testReturnStatement
      *
      * @return ASTReturnStatement
-     *
      * @since 1.0.2
      */
     public function testReturnStatement()

--- a/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTScalarType
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTScopeStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testParserHandlesInlineScopeStatement
      *
      * @return ASTScopeStatement
-     *
      * @since 1.0.0
      */
     public function testParserHandlesInlineScopeStatement()
@@ -74,9 +72,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedStartLine
      *
      * @param ASTScopeStatement $stmt
-     *
      * @return ASTScopeStatement
-     *
      * @since 1.0.0
      *
      * @depends testParserHandlesInlineScopeStatement
@@ -92,9 +88,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedStartColumn
      *
      * @param ASTScopeStatement $stmt
-     *
      * @return ASTScopeStatement
-     *
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartLine
@@ -110,9 +104,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedEndLine
      *
      * @param ASTScopeStatement $stmt
-     *
      * @return ASTScopeStatement
-     *
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartColumn
@@ -128,9 +120,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedEndColumn
      *
      * @param ASTScopeStatement $stmt
-     *
      * @return ASTScopeStatement
-     *
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedEndLine
@@ -144,7 +134,6 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testScopeStatement
      *
      * @return ASTScopeStatement
-     *
      * @since 1.0.2
      */
     public function testScopeStatement()
@@ -207,7 +196,6 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testScopeStatementWithAlternative
      *
      * @return ASTScopeStatement
-     *
      * @since 1.0.2
      */
     public function testScopeStatementWithAlternative()

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTScope
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTScopeTest extends ASTNodeTestCase
      * testScope
      *
      * @return ASTScope
-     *
      * @since 1.0.2
      */
     public function testScope()

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTSelfReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -148,7 +147,6 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      * testSelfReference
      *
      * @return ASTSelfReference
-     *
      * @since 1.0.2
      */
     public function testSelfReference()

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTShiftLeftExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTShiftRightExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.1
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTStatementTest extends ASTNodeTestCase
      * testStatement
      *
      * @return ASTStatement
-     *
      * @since 1.0.2
      */
     public function testStatement()
@@ -122,7 +120,6 @@ class ASTStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTStatement
      */
     private function getFirstStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTStaticReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -158,7 +157,6 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
      * testStaticReference
      *
      * @return ASTStaticReference
-     *
      * @since 1.0.2
      */
     public function testStaticReference()

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTStaticVariableDeclaration
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
      * testStaticVariableDeclaration
      *
      * @return ASTStringIndexExpression
-     *
      * @since 1.0.2
      */
     public function testStaticVariableDeclaration()

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -50,10 +49,8 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTIndexExpression
  * @covers \PDepend\Source\AST\ASTStringIndexExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  *
  * @group unittest
@@ -64,7 +61,6 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
      * testStringIndexExpression
      *
      * @return ASTStringIndexExpression
-     *
      * @since 1.0.2
      */
     public function testStringIndexExpression()

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTString
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -244,7 +243,6 @@ class ASTStringTest extends ASTNodeTestCase
      * Returns a test member primary prefix.
      *
      * @param string $testCase The calling test case.
-     *
      * @return ASTString
      */
     private function getFirstStringInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTSwitchLabel
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -96,7 +95,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabel
      *
      * @return ASTSwitchLabel
-     *
      * @since 1.0.2
      */
     public function testSwitchLabel()
@@ -188,7 +186,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCode
      *
      * @return ASTSwitchLabel
-     *
      * @since 2.1.0
      */
     public function testSwitchLabelWithNestedNonePhpCode()
@@ -251,7 +248,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelDefault
      *
      * @return ASTSwitchLabel
-     *
      * @since 1.0.2
      */
     public function testSwitchLabelDefault()
@@ -342,7 +338,6 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCode
      *
      * @return ASTSwitchLabel
-     *
      * @since 2.1.0
      */
     public function testSwitchLabelDefaultWithNestedNonePhpCode()

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTSwitchStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -82,7 +81,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatement
      *
      * @return ASTSwitchStatement
-     *
      * @since 1.0.2
      */
     public function testSwitchStatement()
@@ -181,7 +179,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithAlternativeScope
      *
      * @return ASTSwitchStatement
-     *
      * @since 1.0.2
      */
     public function testSwitchStatementWithAlternativeScope()
@@ -253,7 +250,6 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithNestedNonePhpCode
      *
      * @return ASTSwitch
-     *
      * @since 2.1.0
      */
     public function testSwitchStatementWithNestedNonePhpCode()

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTThrowStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTThrowStatementTest extends ASTNodeTestCase
      * testThrowStatement
      *
      * @return ASTThrowStatement
-     *
      * @since 1.0.2
      */
     public function testThrowStatement()

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptationAlias
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -141,7 +138,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
      * testTraitAdaptationAlias
      *
      * @return ASTTraitAdaptationAlias
-     *
      * @since 1.0.2
      */
     public function testTraitAdaptationAlias()
@@ -217,7 +213,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
      * testTraitReference
      *
      * @return ASTTraitReference
-     *
      * @since 1.0.2
      */
     public function testTraitReference()

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptationPrecedence
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -87,7 +84,6 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
      * testTraitAdaptationPrecedence
      *
      * @return ASTTraitAdaptationPrecedence
-     *
      * @since 1.0.2
      */
     public function testTraitAdaptationPrecedence()
@@ -163,7 +159,6 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
      * testTraitReference
      *
      * @return ASTTraitReference
-     *
      * @since 1.0.2
      */
     public function testTraitReference()

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitAdaptation
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -63,7 +60,6 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
      * testTraitAdaptation
      *
      * @return ASTTraitAdaptation
-     *
      * @since 1.0.2
      */
     public function testTraitAdaptation()

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -51,10 +50,8 @@ use PDepend\Source\Builder\BuilderContext;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitReference
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -80,7 +77,6 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
      * testTraitReference
      *
      * @return ASTTraitReference
-     *
      * @since 1.0.2
      */
     public function testTraitReference()

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
   * @since 1.0.0
  */
 
@@ -50,10 +49,8 @@ namespace PDepend\Source\AST;
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTrait
  * @covers \PDepend\Source\AST\AbstractASTType
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -52,10 +51,8 @@ use ReflectionMethod;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTraitUseStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -384,7 +381,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      * testTraitUseStatement
      *
      * @return ASTTraitUseStatement
-     *
      * @since 1.0.2
      */
     public function testTraitUseStatement()
@@ -447,7 +443,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      * testTraitUseStatementInTrait
      *
      * @return ASTTraitUseStatement
-     *
      * @since 1.0.2
      */
     public function testTraitUseStatementInTrait()

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTryStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTTryStatementTest extends ASTNodeTestCase
      * testTryStatement
      *
      * @return ASTTryStatement
-     *
      * @since 1.0.2
      */
     public function testTryStatement()

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTypeArray
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTTypeArrayTest extends ASTNodeTestCase
      * testArrayType
      *
      * @return ASTTypeArray
-     *
      * @since 1.0.2
      */
     public function testArrayType()

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -49,10 +48,8 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTypeCallable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest
@@ -71,7 +68,6 @@ class ASTTypeCallableTest extends ASTNodeTestCase
      * testCallableType
      *
      * @return ASTTypeCallable
-     *
      * @since 1.0.2
      */
     public function testCallableType()

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTTypeIterable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTTypeIterableTest extends ASTNodeTestCase
      * testIterableType
      *
      * @return ASTTypeIterable
-     *
      * @since 2.5.1
      */
     public function testIterableType()

--- a/src/test/php/PDepend/Source/AST/ASTTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeTest.php
@@ -46,7 +46,6 @@ namespace PDepend\Source\AST;
  * Test case for the {@link \PDepend\Source\AST\ASTType} class.
  *
  * @covers \PDepend\Source\AST\ASTType
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTUnaryExpression
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
      * testUnaryExpression
      *
      * @return ASTUnaryExpression
-     *
      * @since 1.0.2
      */
     public function testUnaryExpression()

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTUnsetStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
      * testUnsetStatement
      *
      * @return ASTUnsetStatement
-     *
      * @since 1.0.2
      */
     public function testUnsetStatement()
@@ -122,7 +120,6 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTUnsetStatement
      */
     private function getFirstUnsetStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/ASTValueTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTValueTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
   * @since 0.10.2
  */
 
@@ -50,10 +49,8 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Source\AST\ASTValue} class.
  *
  * @covers \PDepend\Source\AST\ASTValue
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTVariableDeclarator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -96,7 +95,6 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
      * testVariableDeclarator
      *
      * @return ASTVariableDeclarator
-     *
      * @since 1.0.2
      */
     public function testVariableDeclarator()

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTVariable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -94,7 +93,6 @@ class ASTVariableTest extends ASTNodeTestCase
      * testVariable
      *
      * @return ASTVariable
-     *
      * @since 1.0.2
      */
     public function testVariable()

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTVariableVariable
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -59,7 +58,6 @@ class ASTVariableVariableTest extends ASTNodeTestCase
      * testVariableVariable
      *
      * @return ASTVariableVariable
-     *
      * @since 1.0.2
      */
     public function testVariableVariable()

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTWhileStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -86,7 +85,6 @@ class ASTWhileStatementTest extends ASTNodeTestCase
      * testWhileStatement
      *
      * @return ASTWhileStatement
-     *
      * @since 1.0.2
      */
     public function testWhileStatement()
@@ -149,7 +147,6 @@ class ASTWhileStatementTest extends ASTNodeTestCase
      * testWhileStatementWithAlternativeScope
      *
      * @return ASTWhileStatement
-     *
      * @since 1.0.2
      */
     public function testWhileStatementWithAlternativeScope()

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -47,7 +47,6 @@ namespace PDepend\Source\AST;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\AST\ASTForeachStatement
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -230,7 +229,6 @@ class ASTYieldStatementTest extends ASTNodeTestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $testCase Name of the calling test case.
-     *
      * @return ASTYieldStatement
      */
     private function getFirstYieldStatementInFunction($testCase)

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Base test case for abstract item implementations.
  *
  * @covers \PDepend\Source\AST\AbstractASTArtifact
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -74,8 +73,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      * and node builder implementations.
      *
      * @param string $testCase
-     * @param bool   $ignoreAnnotations
-     *
+     * @param bool $ignoreAnnotations
      * @return \PDepend\Source\AST\ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -52,10 +51,8 @@ use PDepend\Source\AST\ASTClass;
  * class.
  *
  * @covers \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -57,10 +56,8 @@ use PDepend\Source\AST\ASTTrait;
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter} class.
  *
  * @covers \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
@@ -53,7 +53,6 @@ use PDepend\Source\AST\ASTNamespace;
  * class.
  *
  * @covers \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
   * @since 1.0.0
  */
 
@@ -51,10 +50,8 @@ use PDepend\AbstractTestCase;
  * class.
  *
  * @covers \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -50,7 +50,6 @@ use PDepend\Source\AST\ASTTrait;
  * Test case for the default visit listener implementation.
  *
  * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -52,7 +52,6 @@ use PDepend\Source\AST\ASTTrait;
  * Test case for the default visitor implementation.
  *
  * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -79,7 +79,6 @@ class StubASTVisitor implements ASTVisitor
      * The last visited trait instance.
      *
      * @var ASTTrait
-     *
      * @since 1.0.0
      */
     public $trait;
@@ -144,10 +143,8 @@ class StubASTVisitor implements ASTVisitor
      * by the concrete visit method.
      *
      * @param string $method Name of the called method.
-     * @param array  $args   Array with method argument.
-     *
+     * @param array $args Array with method argument.
      * @return array
-     *
      * @since 0.9.12
      */
     public function __call($method, $args)

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -53,7 +53,6 @@ use PDepend\Source\AST\ASTTrait;
  * class.
  *
  * @covers \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -45,7 +45,6 @@ use PDepend\Source\AST\ASTMethod;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -45,7 +45,6 @@ use PDepend\Source\AST\ASTFormalParameters;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ExplicitOctalNotationTest.php
@@ -44,7 +44,6 @@ use InvalidArgumentException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -45,7 +45,6 @@ use PDepend\Source\AST\ASTReturnStatement;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTVariable;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -46,7 +46,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
@@ -47,7 +47,6 @@ use PDepend\Util\Cache\CacheDriver;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
@@ -45,7 +45,6 @@ use PDepend\Source\AST\ASTReturnStatement;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTParameter;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -45,7 +45,6 @@ use PDepend\Source\AST\ASTConstantDeclarator;
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -44,7 +44,6 @@ use PDepend\Source\AST\State;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -44,7 +44,6 @@ use PDepend\Source\AST\ASTMethodPostfix;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -50,7 +50,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -47,7 +47,6 @@ use PDepend\Util\Cache\CacheDriver;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -44,7 +44,6 @@ use PDepend\Source\AST\State;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -47,7 +47,6 @@ use PDepend\Source\AST\ASTParameter;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -50,7 +50,6 @@ use PDepend\Source\AST\ASTPropertyPostfix;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -47,7 +47,6 @@ use PDepend\Util\Cache\CacheDriver;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -48,7 +48,6 @@ use PDepend\Source\AST\ASTScalarType;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -42,7 +42,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 /**
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -46,7 +46,6 @@ use PDepend\Source\AST\ASTScope;
 /**
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -47,7 +47,6 @@ use PDepend\Util\Cache\CacheDriver;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -53,7 +53,6 @@ use PDepend\Source\AST\ASTValue;
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -54,7 +54,6 @@ use PDepend\Source\AST\ASTValue;
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @covers \PDepend\Source\AST\ASTConstantDeclarator
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\ASTFunction;
  * Test case implementation for the default node builder implementation.
  *
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 
@@ -50,10 +49,8 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 
@@ -51,7 +50,6 @@ use PDepend\AbstractTestCase;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since     0.9.20
  */
 
@@ -53,7 +52,6 @@ use PDepend\Source\AST\ASTNamespace;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
- *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since     0.9.20
  */
 
@@ -51,7 +50,6 @@ use PDepend\AbstractTestCase;
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
- *
  * @copyright 2008-2013 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion72Test.php
@@ -65,7 +65,6 @@ use ReflectionMethod;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion72} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion72
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
@@ -57,7 +57,6 @@ use PDepend\Util\Cache\CacheDriver;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion73} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion73
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -63,7 +63,6 @@ use PDepend\Util\Cache\CacheDriver;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion74} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion74
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -51,7 +51,6 @@ use PDepend\Util\Cache\CacheDriver;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserVersion80} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -50,7 +50,6 @@ use PDepend\Source\Tokenizer\Tokens;
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPTokenizerInternal} class.
  *
  * @covers \PDepend\Source\Language\PHP\PHPTokenizerInternal
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  */
 
@@ -50,10 +49,8 @@ use PDepend\Source\AST\ASTAllocationExpression;
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  *
  * @group unittest
@@ -257,7 +254,6 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
      * with the calling test method.
      *
      * @return ASTAllocationExpression
-     *
      * @since 1.0.1
      */
     private function getFirstAllocationInClass()

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  */
 
@@ -48,10 +47,8 @@ namespace PDepend\Source\Parser;
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  */
 
@@ -50,10 +49,8 @@ use PDepend\Source\AST\ASTFormalParameter;
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.2
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
+++ b/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 
@@ -51,7 +50,6 @@ use PDepend\AbstractTestCase;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.20
  */
 abstract class AbstractParserTestCase extends AbstractTestCase

--- a/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.5
  */
 
@@ -48,10 +47,8 @@ namespace PDepend\Source\Parser;
  * Test case for the namespace resolving in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.5
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -50,10 +49,8 @@ use PDepend\Source\Tokenizer\Token;
  * Test case for the {@link \PDepend\Source\Parser\TokenStack} class.
  *
  * @covers \PDepend\Source\Parser\TokenStack
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  */
 
@@ -48,10 +47,8 @@ namespace PDepend\Source\Parser;
  * Tests for unstructured code handling in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 1.0.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
+++ b/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Source\Tokenizer\Token} class.
  *
  * @covers \PDepend\Source\Tokenizer\Token
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -52,7 +52,6 @@ use ReflectionClass;
  * Test case for the text ui command.
  *
  * @covers \PDepend\TextUI\Command
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -301,7 +300,6 @@ class CommandTest extends AbstractTestCase
      * Executes the command class and returns an array with namespace statistics.
      *
      * @param string $pathName
-     *
      * @return array
      */
     private function runCommandAndReturnStatistics(array $argv, $pathName)
@@ -567,7 +565,7 @@ class CommandTest extends AbstractTestCase
     /**
      * Tests the help output with an optional prolog text.
      *
-     * @param string $actual     The cli output.
+     * @param string $actual The cli output.
      * @param string $prologText Optional prolog text.
      */
     protected function assertHelpOutput($actual, $prologText = ''): void
@@ -592,7 +590,6 @@ class CommandTest extends AbstractTestCase
      * an array <b>array($exitCode, $output)</b>.
      *
      * @param ?array $argv The cli parameters.
-     *
      * @return array<mixed>
      */
     private function executeCommand(?array $argv = null)

--- a/src/test/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/src/test/php/PDepend/TextUI/ResultPrinterTest.php
@@ -53,7 +53,6 @@ use PDepend\Source\Language\PHP\PHPTokenizerInternal;
  * Test case for the default text ui result printer.
  *
  * @covers \PDepend\TextUI\ResultPrinter
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -54,7 +54,6 @@ use Symfony\Component\DependencyInjection\Container;
  * Test case for the text ui runner.
  *
  * @covers \PDepend\TextUI\Runner
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -311,9 +310,8 @@ class RunnerTest extends AbstractTestCase
     /**
      * Executes the runner class and returns an array with namespace statistics.
      *
-     * @param Runner $runner   The runner instance.
-     * @param        $pathName The source path.
-     *
+     * @param Runner $runner The runner instance.
+     * @param $pathName The source path.
      * @return array
      */
     private function runRunnerAndReturnStatistics(Runner $runner, $pathName)

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Util\Cache\CacheFactory} class.
  *
  * @covers \PDepend\Util\Cache\CacheFactory
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -51,10 +50,8 @@ use PDepend\Util\Cache\CacheDriver;
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheDirectory} class.
  *
  * @covers \PDepend\Util\Cache\Driver\File\FileCacheDirectory
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector} class.
  *
  * @covers \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -49,7 +49,6 @@ use RuntimeException;
  * Test case for the {@link \PDepend\Util\Cache\Driver\FileCacheDriver} class.
  *
  * @covers \PDepend\Util\Cache\Driver\FileCacheDriver
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -48,7 +48,6 @@ use PDepend\Util\Cache\AbstractDriverTestCase;
  * Test case for the {@link \PDepend\Util\Cache\Driver\MemoryCacheDriver} class.
  *
  * @covers \PDepend\Util\Cache\Driver\MemoryCacheDriver
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Util/ConfigurationTest.php
+++ b/src/test/php/PDepend/Util/ConfigurationTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.10.0
  */
 
@@ -52,10 +51,8 @@ use stdClass;
  * Test case for the {@link \PDepend\Util\Configuration} class.
  *
  * @covers \PDepend\Util\Configuration
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @since 0.10.0
  *
  * @group unittest

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Util\Coverage\CloverReport} class.
  *
  * @covers \PDepend\Util\Coverage\CloverReport
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *
@@ -180,10 +179,9 @@ class CloverReportTest extends AbstractTestCase
     /**
      * Creates a mocked method instance.
      *
-     * @param string $name      Name of the mock method.
-     * @param int    $startLine
-     * @param int    $endLine
-     *
+     * @param string $name Name of the mock method.
+     * @param int $startLine
+     * @param int $endLine
      * @return \PDepend\Source\AST\ASTMethod
      */
     private function createMethodMock($name, $startLine = 1, $endLine = 4)

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -49,7 +49,6 @@ use RuntimeException;
  * Test case for the {@link \PDepend\Util\Coverage\Factory} class.
  *
  * @covers \PDepend\Util\Coverage\Factory
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for the {@link \PDepend\Util\FileUtil} class.
  *
  * @covers \PDepend\Util\FileUtil
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -38,7 +38,6 @@
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
  * @since 0.9.12
  */
 
@@ -55,10 +54,8 @@ use PDepend\Source\AST\ASTMethod;
  * Test case for the {@link \PDepend\Util\IdBuilder} class.
  *
  * @covers \PDepend\Util\IdBuilder
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
  * @since 0.9.12
  *
  * @group unittest

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -49,7 +49,6 @@ use stdClass;
  * Test case for the image convert utility class.
  *
  * @covers \PDepend\Util\ImageConvert
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  *

--- a/src/test/php/PDepend/Util/TypeTest.php
+++ b/src/test/php/PDepend/Util/TypeTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for type utility class.
  *
  * @covers \PDepend\Util\Type
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *

--- a/src/test/php/PDepend/Util/Utf8UtilTest.php
+++ b/src/test/php/PDepend/Util/Utf8UtilTest.php
@@ -48,7 +48,6 @@ use PDepend\AbstractTestCase;
  * Test case for type utility class.
  *
  * @covers \PDepend\Util\Utf8Util
- *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  *


### PR DESCRIPTION
Type: documentation update  
Breaking change: no

Would prefer not to drop this, but with some of the other style configs coming down the wire I can be ok with it.