### PR TITLE
Sync parent relationship

### DIFF
--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -151,6 +151,19 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     }
 
     /**
+     * The magic wakeup method will be called by PHP's runtime environment when
+     * a previously serialized object gets unserialized. This implementation of
+     * the wakeup method restores the dependencies between an ast node and the
+     * node's children.
+     */
+    public function __wakeup(): void
+    {
+        foreach ($this->nodes as $node) {
+            $node->setParent($this);
+        }
+    }
+
+    /**
      * Setter method for the currently used token cache, where this callable
      * instance can store the associated tokens.
      *
@@ -176,6 +189,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     public function addChild(ASTNode $node): void
     {
         $this->nodes[] = $node;
+        $node->setParent($this);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -170,6 +170,10 @@ abstract class AbstractASTType extends AbstractASTArtifact
     public function __wakeup(): void
     {
         $this->methods = null;
+
+        foreach ($this->nodes as $node) {
+            $node->setParent($this);
+        }
     }
 
     /**
@@ -203,6 +207,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     public function addChild(ASTNode $node): void
     {
         $this->nodes[] = $node;
+        $node->setParent($this);
     }
 
     /**


### PR DESCRIPTION
Type: feature  
Breaking change: no

As a follow up to https://github.com/pdepend/pdepend/pull/754 this makes it so that the parent relation is also set when applicable.
This lets us navigate the tree in both directions which can be useful when trying to determine a nodes relation. Like when PHPMD tries to determine if a variable is part of an inner function or the current scope.