### PR TITLE
Use native type for nulled property

### DIFF
--- a/scripts/update-version.php
+++ b/scripts/update-version.php
@@ -53,34 +53,28 @@ class CacheVersionUpdater
 {
     /**
      * The source directory.
-     *
-     * @var string
      */
-    private $rootDirectory = null;
+    private string $rootDirectory;
 
     /**
      * The source sub directories that we will process.
      *
-     * @var array(string)
+     * @var array<int, string>
      */
-    private $localPaths = [
+    private array $localPaths = [
         '/Source',
         '/Metrics',
     ];
 
     /**
      * The target file, where this script will persist the new cache version.
-     *
-     * @var string
      */
-    private $targetFile = '/Util/Cache/CacheDriver.php';
+    private string $targetFile = '/Util/Cache/CacheDriver.php';
 
     /**
      * Regular expression used to replace a previous cache version.
-     *
-     * @var string
      */
-    private $targetRegexp = '(@version:[a-f0-9]{32}:@)';
+    private string $targetRegexp = '(@version:[a-f0-9]{32}:@)';
 
     /**
      * Constructs a new cache version updater instance.

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -89,45 +89,42 @@ class Engine
     /**
      * The system configuration.
      *
-     * @var Configuration
      * @since 0.10.0
      */
-    protected $configuration = null;
+    protected Configuration $configuration;
 
     /**
      * Prefix for PHP streams.
-     *
-     * @var string
      */
-    protected $phpStreamPrefix = 'php://';
+    protected string $phpStreamPrefix = 'php://';
 
     /**
      * List of source directories.
      *
      * @var array<string>
      */
-    private $directories = [];
+    private array $directories = [];
 
     /**
      * List of source code file names.
      *
      * @var array<string>
      */
-    private $files = [];
+    private array $files = [];
 
     /**
      * The used code node builder.
      *
-     * @var PHPBuilder<ASTNamespace>|null
+     * @var PHPBuilder<ASTNamespace>
      */
-    private $builder = null;
+    private PHPBuilder $builder;
 
     /**
      * Generated {@link ASTNamespace} objects.
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    private $namespaces = null;
+    private ASTArtifactList $namespaces;
 
     /**
      * List of all registered {@link ReportGenerator} instances.
@@ -138,17 +135,13 @@ class Engine
 
     /**
      * A composite filter for input files.
-     *
-     * @var CompositeFilter
      */
-    private $fileFilter = null;
+    private CompositeFilter $fileFilter;
 
     /**
      * A filter for namespace.
-     *
-     * @var ArtifactFilter
      */
-    private $codeFilter = null;
+    private ArtifactFilter $codeFilter;
 
     /**
      * Should the parse ignore doc comment annotations?
@@ -362,7 +355,7 @@ class Engine
      */
     public function countClasses()
     {
-        if ($this->namespaces === null) {
+        if (!isset($this->namespaces)) {
             $msg = 'countClasses() doesn\'t work before the source was analyzed.';
             throw new RuntimeException($msg);
         }
@@ -393,7 +386,7 @@ class Engine
      */
     public function countNamespaces()
     {
-        if ($this->namespaces === null) {
+        if (!isset($this->namespaces)) {
             $msg = 'countNamespaces() doesn\'t work before the source was analyzed.';
             throw new RuntimeException($msg);
         }
@@ -417,7 +410,7 @@ class Engine
      */
     public function getNamespace($name)
     {
-        if ($this->namespaces === null) {
+        if (!isset($this->namespaces)) {
             $msg = 'getNamespace() doesn\'t work before the source was analyzed.';
             throw new RuntimeException($msg);
         }
@@ -437,7 +430,7 @@ class Engine
      */
     public function getNamespaces()
     {
-        if ($this->namespaces === null) {
+        if (!isset($this->namespaces)) {
             $msg = 'getNamespaces() doesn\'t work before the source was analyzed.';
             throw new RuntimeException($msg);
         }

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -55,18 +55,15 @@ class Iterator extends FilterIterator
 {
     /**
      * The associated filter object.
-     *
-     * @var Filter
      */
-    protected $filter = null;
+    protected Filter $filter;
 
     /**
      * Optional root path for the files.
      *
-     * @var string|null
      * @since 0.10.0
      */
-    protected $rootPath = null;
+    protected ?string $rootPath;
 
     /**
      * Constructs a new file filter iterator.

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -66,7 +66,7 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      *
      * @var array<string, mixed>
      */
-    protected $metrics = null;
+    protected array $metrics;
 
     /**
      * Metrics restored from the cache. This property is only used temporary.

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -68,7 +68,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * @var array<string, AbstractASTClassOrInterface>
      */
-    private $nodeSet = [];
+    private array $nodeSet = [];
 
     /**
      * @var array<string, array<string, array<int, string>>>
@@ -80,28 +80,28 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      *
      * @var array<string, array<string, int>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * Nodes in which the current analyzed class is used.
      *
      * @var array<string, array<int, AbstractASTClassOrInterface>>
      */
-    private $efferentNodes = [];
+    private array $efferentNodes = [];
 
     /**
      * Nodes that is used by the current analyzed class.
      *
      * @var array<string, array<int, AbstractASTClassOrInterface>>
      */
-    private $afferentNodes = [];
+    private array $afferentNodes = [];
 
     /**
      * Processes all {@link ASTNamespace} code nodes.
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->fireStartAnalyzer();
 
             $this->nodeRelations = [];

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -105,23 +105,21 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      *
      * @var array<string, array<string, int>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * The internal used cyclomatic complexity analyzer.
-     *
-     * @var CyclomaticComplexityAnalyzer
      */
-    private $cyclomaticAnalyzer = null;
+    private CyclomaticComplexityAnalyzer $cyclomaticAnalyzer;
 
     /**
      * Processes all {@link ASTNamespace} code nodes.
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             // First check for the require cc analyzer
-            if ($this->cyclomaticAnalyzer === null) {
+            if (!isset($this->cyclomaticAnalyzer)) {
                 throw new RuntimeException('Missing required CC analyzer.');
             }
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -81,7 +81,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      *
      * @var array<string, array<string, float>>
      */
-    private $metrics = null;
+    private array $metrics;
 
     /**
      * The coverage report instance representing the supplied coverage report
@@ -146,7 +146,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      */
     public function analyze($namespaces): void
     {
-        if ($this->isEnabled() && $this->metrics === null) {
+        if ($this->isEnabled() && !isset($this->metrics)) {
             $this->doAnalyze($namespaces);
         }
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -89,7 +89,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      */
     public function analyze($namespaces): void
     {
-        if ($this->metrics === null) {
+        if (!isset($this->metrics)) {
             $this->loadCache();
             $this->fireStartAnalyzer();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HalsteadAnalyzer.php
@@ -81,7 +81,7 @@ class HalsteadAnalyzer extends AbstractCachingAnalyzer implements AnalyzerNodeAw
      */
     public function analyze($namespaces): void
     {
-        if ($this->metrics === null) {
+        if (!isset($this->metrics)) {
             $this->loadCache();
             $this->fireStartAnalyzer();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzer.php
@@ -111,7 +111,7 @@ class MaintainabilityIndexAnalyzer extends AbstractCachingAnalyzer implements An
         $this->analyzersLOC->setCache($this->getCache());
         $this->analyzersLOC->analyze($namespaces);
 
-        if ($this->metrics === null) {
+        if (!isset($this->metrics)) {
             $this->loadCache();
             $this->fireStartAnalyzer();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -85,7 +85,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      */
     public function analyze($namespaces): void
     {
-        if ($this->metrics === null) {
+        if (!isset($this->metrics)) {
             $this->loadCache();
             $this->fireStartAnalyzer();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -98,7 +98,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      *
      * @var array<string, array<string, int>>
      */
-    protected $metrics = null;
+    protected array $metrics;
 
     /**
      * Collected project metrics.
@@ -179,7 +179,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      */
     public function analyze($namespaces): void
     {
-        if ($this->metrics === null) {
+        if (!isset($this->metrics)) {
             $this->loadCache();
             $this->fireStartAnalyzer();
 

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -70,15 +70,6 @@ final class CollectionArtifactFilter implements ArtifactFilter
     private $filter = null;
 
     /**
-     * Constructs a new static filter.
-     *
-     * @access private
-     */
-    public function __construct()
-    {
-    }
-
-    /**
      * Singleton method for this filter class.
      *
      * @return CollectionArtifactFilter

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -71,10 +71,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
 
     /**
      * The source file name/path.
-     *
-     * @var string|null
      */
-    protected $fileName = null;
+    protected ?string $fileName = null;
 
     /**
      * The comment for this type.
@@ -82,22 +80,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * @var string|null
      */
     protected $comment = null;
-
-    /**
-     * The files start line. This property must always have the value <em>1</em>.
-     *
-     * @var int
-     * @since 0.10.0
-     */
-    protected $startLine = 0;
-
-    /**
-     * The files end line.
-     *
-     * @var int
-     * @since 0.10.0
-     */
-    protected $endLine = 0;
 
     /**
      * List of classes, interfaces and functions that parsed from this file.

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -51,13 +51,6 @@ namespace PDepend\Source\AST;
 class ASTNamespace extends AbstractASTArtifact
 {
     /**
-     * The unique identifier for this function.
-     *
-     * @var string
-     */
-    protected $id = null;
-
-    /**
      * List of all {@link AbstractASTClassOrInterface}
      * objects for this namespace.
      *

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -86,17 +86,13 @@ class ASTParameter extends AbstractASTArtifact
 
     /**
      * The wrapped formal parameter instance.
-     *
-     * @var ASTFormalParameter
      */
-    private $formalParameter = null;
+    private ASTFormalParameter $formalParameter;
 
     /**
      * The wrapped variable declarator instance.
-     *
-     * @var ASTVariableDeclarator
      */
-    private $variableDeclarator = null;
+    private ?ASTVariableDeclarator $variableDeclarator;
 
     /**
      * Constructs a new parameter instance for the given AST node.

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -60,10 +60,8 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
 
     /**
      * The wrapped reference node.
-     *
-     * @var ASTClassOrInterfaceReference
      */
-    protected $reference = null;
+    protected ASTClassOrInterfaceReference $reference;
 
     /**
      * Constructs a new type holder instance.

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -60,18 +60,16 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * The wrapped field declaration instance.
      *
-     * @var ASTFieldDeclaration
      * @since 0.9.6
      */
-    private $fieldDeclaration = null;
+    private ASTFieldDeclaration $fieldDeclaration;
 
     /**
      * The wrapped variable declarator instance.
      *
-     * @var ASTVariableDeclarator
      * @since 0.9.6
      */
-    private $variableDeclarator = null;
+    private ASTVariableDeclarator $variableDeclarator;
 
     /**
      * Constructs a new item for the given field declaration and variable

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -69,19 +69,16 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * The line number where the item declaration starts.
-     *
-     * @var int
      */
-    protected $startLine = 0;
+    protected int $startLine = 0;
 
     /**
      * The line number where the item declaration ends.
-     *
-     * @var int
      */
-    protected $endLine = 0;
+    protected int $endLine = 0;
 
     protected int $startColumn = 0;
+
     protected int $endColumn = 0;
 
     /**
@@ -184,7 +181,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      */
     public function setCompilationUnit(ASTCompilationUnit $compilationUnit): void
     {
-        if ($this->compilationUnit === null || $this->compilationUnit->getName() === null) {
+        if ($this->compilationUnit?->getName() === null) {
             $this->compilationUnit = $compilationUnit;
         }
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -97,24 +97,6 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     protected $nodes = [];
 
     /**
-     * The start line number of the method or function declaration.
-     *
-     * @var int
-     * @since 0.9.12
-     */
-    protected $startLine = 0;
-
-    /**
-     * The end line number of the method or function declaration.
-     *
-     * @var int
-     * @since 0.9.12
-     */
-    protected $endLine = 0;
-
-    /**
-     * List of method/function parameters.
-     *
      * @var ASTParameter[]|null
      */
     private $parameters = null;

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -82,10 +82,9 @@ abstract class AbstractASTNode implements ASTNode
      * contains the start, end line, and the start, end column and the node
      * image in a colon seperated string.
      *
-     * @var string
      * @since 0.10.4
      */
-    protected $metadata = '::::';
+    protected string $metadata = '::::';
 
     /**
      * Constructs a new ast node instance.

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -296,10 +296,8 @@ abstract class AbstractPHPParser
 
     /**
      * The symbol table used to handle PHP 5.3 use statements.
-     *
-     * @var SymbolTable
      */
-    protected $useSymbolTable;
+    protected SymbolTable $useSymbolTable;
 
     /**
      * The actually parsed class or interface instance.
@@ -310,23 +308,18 @@ abstract class AbstractPHPParser
 
     /**
      * Stack with all active token scopes.
-     *
-     * @var TokenStack
      */
-    protected $tokenStack;
+    protected TokenStack $tokenStack;
 
     /**
-     * @var CacheDriver
      * @since 0.10.0
      */
-    protected $cache;
+    protected CacheDriver $cache;
 
     /**
      * The used code tokenizer.
-     *
-     * @var Tokenizer
      */
-    protected $tokenizer;
+    protected Tokenizer $tokenizer;
 
     /**
      * The name of the last detected namespace.
@@ -374,10 +367,9 @@ abstract class AbstractPHPParser
     /**
      * Used identifier builder instance.
      *
-     * @var IdBuilder
      * @since 0.9.12
      */
-    private $idBuilder = null;
+    private IdBuilder $idBuilder;
 
     /**
      * The maximum valid nesting level allowed.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -186,25 +186,20 @@ class PHPBuilder implements Builder
     /**
      * The ast builder context.
      *
-     * @var BuilderContext
      * @since 0.10.0
      */
-    protected $context = null;
+    protected BuilderContext $context;
 
     /**
      * Default package which contains all functions and classes with an unknown
      * scope.
-     *
-     * @var ASTNamespace
      */
-    protected $defaultPackage = null;
+    protected ASTNamespace $defaultPackage;
 
     /**
      * Default source file that acts as a dummy.
-     *
-     * @var ASTCompilationUnit
      */
-    protected $defaultCompilationUnit = null;
+    protected ASTCompilationUnit $defaultCompilationUnit;
 
     /**
      * This property holds all packages found during the parsing phase.
@@ -240,7 +235,7 @@ class PHPBuilder implements Builder
      *
      * @var ASTNamespace[]
      */
-    private $namespaces = [];
+    private array $namespaces = [];
 
     /**
      * Internal status flag used to check that a build request is internal.

--- a/src/main/php/PDepend/Source/Tokenizer/Token.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Token.php
@@ -52,45 +52,33 @@ class Token
 {
     /**
      * The token type identifier.
-     *
-     * @var int
      */
-    public $type = null;
+    public int $type;
 
     /**
      * The token image/textual representation.
-     *
-     * @var string
      */
-    public $image = null;
+    public string $image;
 
     /**
      * The start line number for this token.
-     *
-     * @var int
      */
-    public $startLine = null;
+    public int $startLine;
 
     /**
      * The end line number for this token.
-     *
-     * @var int
      */
-    public $endLine = null;
+    public int $endLine;
 
     /**
      * The start column number for this token.
-     *
-     * @var int
      */
-    public $startColumn = null;
+    public int $startColumn;
 
     /**
      * The end column number for this token.
-     *
-     * @var int
      */
-    public $endColumn = null;
+    public int $endColumn;
 
     /**
      * Constructs a new source token.

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -73,26 +73,21 @@ class Command
      *
      * @var array<string, mixed>
      */
-    private $options = [];
+    private array $options = [];
 
     /**
      * The directories/files to be analyzed
      *
      * @var array<int, string>
      */
-    private $source = [];
+    private array $source = [];
 
     /**
      * The used text ui runner.
-     *
-     * @var Runner
      */
-    private $runner = null;
+    private Runner $runner;
 
-    /**
-     * @var Application
-     */
-    private $application;
+    private Application $application;
 
     /**
      * Performs the main cli process and returns the exit code.

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -63,17 +63,15 @@ class CacheFactory
 
     /**
      * The system configuration.
-     *
-     * @var Configuration
      */
-    protected $configuration = null;
+    protected Configuration $configuration;
 
     /**
      * Singleton property that holds existing cache instances.
      *
      * @var CacheDriver[]
      */
-    protected $caches = [];
+    protected array $caches = [];
 
     /**
      * Constructs a new cache factory instance for the given configuration.

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -64,10 +64,8 @@ class FileCacheDirectory
 
     /**
      * The cache root directory.
-     *
-     * @var string
      */
-    protected $cacheDir = null;
+    protected string $cacheDir;
 
     /**
      * Constructs a new cache directory helper instance.

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -80,17 +80,15 @@ class MemoryCacheDriver implements CacheDriver
 
     /**
      * Unique identifier within the same cache instance.
-     *
-     * @var string
      */
-    protected $staticId = null;
+    protected string $staticId;
 
     /**
      * Global stack, mainly used during testing.
      *
      * @var array<string, array<string, array<int, mixed>>>
      */
-    protected static $staticCache = [];
+    protected static array $staticCache = [];
 
     /**
      * Instantiates a new in memory cache instance.

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -57,10 +57,9 @@ class Configuration
     /**
      * Simple object tree holding the concrete configuration values.
      *
-     * @var stdClass
      * @since 0.10.0
      */
-    protected $settings = null;
+    protected stdClass $settings;
 
     /**
      * Constructs a new configuration instance with the given settings tree.

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -80,10 +80,9 @@ abstract class AbstractTestCase extends TestCase
     /**
      * The current working directory.
      *
-     * @var string
      * @since 0.10.0
      */
-    protected $workingDirectory = null;
+    protected ?string $workingDirectory = null;
 
     /**
      * Removes temporary test contents.

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -60,24 +60,18 @@ class BuilderParserCacheTest extends AbstractTestCase
 {
     /**
      * The temporary cache directory.
-     *
-     * @var string
      */
-    protected $cacheDir = null;
+    protected string $cacheDir;
 
     /**
      * TTL for files in cache directory
-     *
-     * @var int
      */
-    protected $cacheTtl = null;
+    protected int $cacheTtl = FileCacheDriver::DEFAULT_TTL;
 
     /**
      * The temporary cache file.
-     *
-     * @var string
      */
-    protected $testFile = null;
+    protected string $testFile;
 
     /**
      * Creates temporary test resources.
@@ -88,7 +82,6 @@ class BuilderParserCacheTest extends AbstractTestCase
 
         $this->cacheDir = $this->createRunResourceURI('cacheDir');
         unlink($this->cacheDir);
-        $this->cacheTtl = FileCacheDriver::DEFAULT_TTL;
         $this->testFile = $this->createRunResourceURI('testFile');
     }
 

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\Builder\Builder;
 
 /**
  * Tests the for the package metrics visitor.
@@ -57,10 +58,8 @@ class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * The used node builder.
-     *
-     * @var \PDepend\Source\Builder\Builder
      */
-    protected $builder = null;
+    protected Builder $builder;
 
     /**
      * Input test data.

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -81,10 +81,8 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * The code rank analyzer.
-     *
-     * @var CodeRankAnalyzer
      */
-    private $analyzer = null;
+    private CodeRankAnalyzer $analyzer;
 
     /**
      * testCodeRankOfSimpleInheritanceExample

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\Builder\Builder;
 
 /**
  * Tests the for the package metrics visitor.
@@ -57,17 +58,15 @@ class DependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
      * The used node builder.
-     *
-     * @var \PDepend\Source\Builder\Builder
      */
-    protected $builder = null;
+    protected Builder $builder;
 
     /**
      * Input test data.
      *
      * @var array<string, array>
      */
-    private $input = [
+    private array $input = [
         '+global' => [
             'tc' => 0,
             'cc' => 0,

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Report\Dependencies;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for the xml summary log.
@@ -58,16 +60,14 @@ class XmlTest extends AbstractTestCase
     /**
      * Test code structure.
      *
-     * @var \PDepend\Source\AST\ASTNamespace[]
+     * @var ASTArtifactList<ASTNamespace>
      */
-    protected $namespaces = null;
+    protected ASTArtifactList $namespaces;
 
     /**
      * The temporary file name for the logger result.
-     *
-     * @var string
      */
-    protected $resultFile = null;
+    protected string $resultFile;
 
     /**
      * Creates the package structure from a test source file.

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -56,27 +56,18 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
 {
     /**
      * The output file name.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * The logger input data.
      *
      * @var array<string, mixed>
      */
-    private $input = [
+    private array $input = [
         'code' => null,
         'analyzers' => [],
     ];
-
-    /**
-     * Constructs a new logger for the given output file.
-     */
-    public function __construct()
-    {
-    }
 
     /**
      * Sets the output log file.
@@ -137,7 +128,7 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      */
     public function close(): void
     {
-        if ($this->logFile) {
+        if (isset($this->logFile)) {
             file_put_contents($this->logFile, serialize($this->input));
         }
     }

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -63,10 +63,8 @@ class ChartTest extends AbstractTestCase
 {
     /**
      * Temporary output file.
-     *
-     * @var string
      */
-    private $outputFile = null;
+    private string $outputFile;
 
     /**
      * setUp()

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -45,6 +45,7 @@ namespace PDepend\Report\Jdepend;
 use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
+use PDepend\Source\AST\ASTArtifactList;
 
 /**
  * Test case for the jdepend xml logger.
@@ -59,24 +60,18 @@ class XmlTest extends AbstractTestCase
 {
     /**
      * Test code structure.
-     *
-     * @var \PDepend\Source\AST\ASTArtifactList
      */
-    protected $packages = null;
+    protected ASTArtifactList $packages;
 
     /**
      * Test dependency analyzer.
-     *
-     * @var DependencyAnalyzer
      */
-    protected $analyzer = null;
+    protected DependencyAnalyzer $analyzer;
 
     /**
      * The temporary file name for the logger result.
-     *
-     * @var string
      */
-    protected $resultFile = null;
+    protected string $resultFile;
 
     /**
      * Creates the package structure from a test source file.

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -60,14 +60,14 @@ class AnalyzerNodeAndProjectAwareDummy implements AnalyzerNodeAware, AnalyzerPro
      *
      * @var array<string, mixed>
      */
-    protected $projectMetrics = null;
+    protected array $projectMetrics;
 
     /**
      * Dummy node metrics.
      *
      * @var array<string, array>
      */
-    protected $nodeMetrics = null;
+    protected array $nodeMetrics;
 
     /**
      * Constructs a new analyzer dummy instance.

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -59,7 +59,7 @@ class AnalyzerNodeAwareDummy implements AnalyzerNodeAware
      *
      * @var array<string, array>
      */
-    protected $nodeMetrics = null;
+    protected array $nodeMetrics;
 
     /**
      * Constructs a new analyzer dummy instance.

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -58,7 +58,7 @@ class AnalyzerProjectAwareDummy implements AnalyzerProjectAware
      *
      * @var array<string, mixed>
      */
-    protected $projectMetrics = null;
+    protected array $projectMetrics;
 
     /**
      * Constructs a new analyzer dummy instance.

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -44,6 +44,7 @@ namespace PDepend\Report\Summary;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for the xml summary log.
@@ -59,16 +60,14 @@ class XmlTest extends AbstractTestCase
     /**
      * Test code structure.
      *
-     * @var \PDepend\Source\AST\ASTNamespace[]
+     * @var ASTArtifactList<ASTNamespace>
      */
-    protected $namespaces = null;
+    protected ASTArtifactList $namespaces;
 
     /**
      * The temporary file name for the logger result.
-     *
-     * @var string
      */
-    protected $resultFile = null;
+    protected string $resultFile;
 
     /**
      * Creates the package structure from a test source file.

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -56,10 +56,8 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 {
     /**
      * The mocked reference instance.
-     *
-     * @var ASTClassOrInterfaceReference
      */
-    protected $referenceMock = null;
+    protected ASTClassOrInterfaceReference $referenceMock;
 
     /**
      * testGetTypeDelegatesCallToInjectedReferenceObject

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -60,17 +60,13 @@ class FileCacheDirectoryTest extends AbstractTestCase
 {
     /**
      * Temporary cache directory.
-     *
-     * @var string
      */
-    protected $cacheDir = null;
+    protected string $cacheDir;
 
     /**
      * File with the cache version information.
-     *
-     * @var string
      */
-    protected $versionFile = null;
+    protected string $versionFile;
 
     /**
      * Initializes a temporary working directory.

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -57,17 +57,13 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
 {
     /**
      * Temporary cache directory.
-     *
-     * @var string
      */
-    protected $cacheDir;
+    protected string $cacheDir;
 
     /**
      * Cache TTL
-     *
-     * @var int
      */
-    protected $cacheTtl = null;
+    protected int $cacheTtl = FileCacheGarbageCollector::DEFAULT_TTL;
 
     /**
      * Initializes a temporary working directory.
@@ -79,7 +75,6 @@ class FileCacheGarbageCollectorTest extends AbstractTestCase
         $tmp = $this->createRunResourceURI('cache');
         unlink($tmp);
         $this->cacheDir = $tmp . '/';
-        $this->cacheTtl = FileCacheGarbageCollector::DEFAULT_TTL;
         mkdir($this->cacheDir);
     }
 

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -58,17 +58,13 @@ class FileCacheDriverTest extends AbstractDriverTestCase
 {
     /**
      * Temporary cache directory.
-     *
-     * @var string
      */
-    protected $cacheDir = null;
+    protected string $cacheDir;
 
     /**
      * Cache TTL
-     *
-     * @var int
      */
-    protected $cacheTtl = null;
+    protected int $cacheTtl = FileCacheDriver::DEFAULT_TTL;
 
     /**
      * Initializes a temporary working directory.
@@ -79,7 +75,6 @@ class FileCacheDriverTest extends AbstractDriverTestCase
 
         $this->cacheDir = $this->createRunResourceURI('cache');
         unlink($this->cacheDir);
-        $this->cacheTtl = FileCacheDriver::DEFAULT_TTL;
     }
 
     /**


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

To address https://github.com/pdepend/pdepend/pull/801#discussion_r1592485865 this PR start the process of figuring out when a property should be nullable or simple uninitialized. I also removed a few redundant overwrites in the process.