### PR TITLE
Handle some null cases

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -191,9 +191,13 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      */
     public function visitConditionalExpression($node, $data)
     {
+        $npath = '0';
+
         // Calculate the complexity of the condition
-        $parent = $node->getParent()->getChild(0);
-        $npath = $this->sumComplexity($parent);
+        $parent = $node->getParent();
+        if ($parent) {
+            $npath = $this->sumComplexity($parent->getChild(0));
+        }
 
         // New PHP 5.3 ifsetor-operator $x ?: $y
         if (count($node->getChildren()) === 1) {

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -204,7 +204,7 @@ class Pyramid implements FileAwareGenerator
             preg_match('/fill:(#[^;"]+)/', $color->getAttribute('style'), $match);
 
             $style = $rect->getAttribute('style');
-            $style = preg_replace('/fill:#[^;"]+/', "fill:{$match[1]}", $style);
+            $style = preg_replace('/fill:#[^;"]+/', "fill:{$match[1]}", $style) ?? $style;
             $rect->setAttribute('style', $style);
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -94,6 +94,8 @@ class PackageArtifactFilter implements ArtifactFilter
             $namespace = $node->getNamespace()->getName();
         } elseif ($node instanceof ASTNamespace) {
             $namespace = $node->getName();
+        } else {
+            return false;
         }
 
         return (preg_match($this->pattern, $namespace) === 0);

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -62,11 +62,6 @@ class ASTCompilationUnit extends AbstractASTArtifact
     protected CacheDriver $cache;
 
     /**
-     * The unique identifier for this function.
-     */
-    protected ?string $id = null;
-
-    /**
      * The source file name/path.
      */
     protected ?string $fileName = null;
@@ -182,18 +177,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      */
     public function getId()
     {
-        return $this->id;
-    }
-
-    /**
-     * Sets the unique identifier for this file instance.
-     *
-     * @param string $id Identifier for this file.
-     * @since  0.9.12
-     */
-    public function setId($id): void
-    {
-        $this->id = $id;
+        return $this->id ?? null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -201,7 +201,7 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the source file where this method was declared.
      *
-     * @return ASTCompilationUnit
+     * @return ?ASTCompilationUnit
      * @throws ASTCompilationUnitNotFoundException When no parent was set.
      * @since  0.10.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -88,16 +88,6 @@ class ASTNamespace extends AbstractASTArtifact
     }
 
     /**
-     * Returns a id for this code node.
-     *
-     * @return string
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
      * Returns <b>true</b> when at least one artifact <b>function</b> or a
      * <b>class/method</b> is user defined. Otherwise this method will return
      * <b>false</b>.

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -175,7 +175,7 @@ interface ASTNode
     /**
      * Sets the raw doc comment for this node.
      *
-     * @param string $comment The doc comment block for this node.
+     * @param ?string $comment The doc comment block for this node.
      */
     public function setComment($comment): void;
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -367,7 +367,7 @@ class ASTParameter extends AbstractASTArtifact
      */
     public function getDefaultValue(): mixed
     {
-        $value = $this->variableDeclarator->getValue();
+        $value = $this->variableDeclarator?->getValue();
 
         return $value === null ? null : $value->getValue();
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -63,7 +63,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * The unique identifier for this function.
      */
-    protected ?string $id = null;
+    protected string $id;
 
     /**
      * The line number where the item declaration starts.
@@ -143,7 +143,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      */
     public function getId()
     {
-        if ($this->id === null) {
+        if (!isset($this->id)) {
             $this->id = md5(uniqid('', true));
         }
         return $this->id;
@@ -266,7 +266,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Sets the raw doc comment for this node.
      *
-     * @param string $comment
+     * @param ?string $comment
      */
     public function setComment($comment): void
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -408,7 +408,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      */
     public function isCached()
     {
-        return $this->compilationUnit->isCached();
+        return $this->compilationUnit?->isCached() ?? false;
     }
 
     /**
@@ -424,16 +424,18 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
             ASTFormalParameters::class,
         );
 
-        $formalParameters = $formalParameters->findChildrenOfType(
-            ASTFormalParameter::class,
-        );
+        if ($formalParameters) {
+            $formalParameters = $formalParameters->findChildrenOfType(
+                ASTFormalParameter::class,
+            );
 
-        foreach ($formalParameters as $formalParameter) {
-            $parameter = new ASTParameter($formalParameter);
-            $parameter->setDeclaringFunction($this);
-            $parameter->setPosition(count($parameters));
+            foreach ($formalParameters as $formalParameter) {
+                $parameter = new ASTParameter($formalParameter);
+                $parameter->setDeclaringFunction($this);
+                $parameter->setPosition(count($parameters));
 
-            $parameters[] = $parameter;
+                $parameters[] = $parameter;
+            }
         }
 
         $optional = true;

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -369,7 +369,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
 
         foreach ($declarators as $declarator) {
             $image = $declarator->getImage();
-            $value = $declarator->getValue()->getValue();
+            $value = $declarator->getValue()?->getValue();
 
             $this->constants[$image] = $value;
         }

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -144,11 +144,11 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Sets the image for this ast node.
      *
-     * @param string $image
+     * @param ?string $image
      */
     public function setImage($image): void
     {
-        $this->setMetadata(4, $image);
+        $this->setMetadata(4, $image ?? '');
     }
 
     /**
@@ -475,7 +475,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Sets the raw doc comment for this node.
      *
-     * @param string $comment The doc comment block for this node.
+     * @param ?string $comment The doc comment block for this node.
      */
     public function setComment($comment): void
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -359,7 +359,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function isCached()
     {
-        return $this->compilationUnit->isCached();
+        return $this->compilationUnit?->isCached() ?? false;
     }
 
     /**

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -130,7 +130,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartClass($class);
 
-        $class->getCompilationUnit()->accept($this);
+        $class->getCompilationUnit()?->accept($this);
 
         foreach ($class->getProperties() as $property) {
             $property->accept($this);
@@ -149,7 +149,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartEnum($enum);
 
-        $enum->getCompilationUnit()->accept($this);
+        $enum->getCompilationUnit()?->accept($this);
 
         foreach ($enum->getProperties() as $property) {
             $property->accept($this);
@@ -170,7 +170,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartTrait($trait);
 
-        $trait->getCompilationUnit()->accept($this);
+        $trait->getCompilationUnit()?->accept($this);
 
         foreach ($trait->getMethods() as $method) {
             $method->accept($this);
@@ -195,7 +195,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartFunction($function);
 
-        $function->getCompilationUnit()->accept($this);
+        $function->getCompilationUnit()?->accept($this);
 
         foreach ($function->getParameters() as $parameter) {
             $parameter->accept($this);
@@ -211,7 +211,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
     {
         $this->fireStartInterface($interface);
 
-        $interface->getCompilationUnit()->accept($this);
+        $interface->getCompilationUnit()?->accept($this);
 
         foreach ($interface->getMethods() as $method) {
             $method->accept($this);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -8640,7 +8640,7 @@ abstract class AbstractPHPParser
     protected function getUnexpectedTokenException($token)
     {
         if ($token instanceof Token) {
-            return new UnexpectedTokenException($token, $this->tokenizer->getSourceFile());
+            return new UnexpectedTokenException($token, $this->tokenizer->getSourceFile() ?? 'unknown');
         }
 
         return new TokenStreamEndException($this->tokenizer);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2040,7 +2040,7 @@ class PHPBuilder implements Builder
 
         $trait = $this->buildTrait($qualifiedName);
         $trait->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName) ?? self::DEFAULT_NAMESPACE),
         );
 
         $this->restoreTrait($trait);
@@ -2113,7 +2113,7 @@ class PHPBuilder implements Builder
 
         $interface = $this->buildInterface($qualifiedName);
         $interface->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName) ?? self::DEFAULT_NAMESPACE),
         );
 
         $this->restoreInterface($interface);
@@ -2183,7 +2183,7 @@ class PHPBuilder implements Builder
 
         $class = $this->buildClass($qualifiedName);
         $class->setNamespace(
-            $this->buildNamespace($this->extractNamespaceName($qualifiedName)),
+            $this->buildNamespace($this->extractNamespaceName($qualifiedName) ?? self::DEFAULT_NAMESPACE),
         );
 
         $this->restoreClass($class);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -130,7 +130,7 @@ class PHPParserGeneric extends PHPParserVersion83
             default:
                 throw new UnexpectedTokenException(
                     $this->tokenizer->next(),
-                    $this->tokenizer->getSourceFile()
+                    $this->tokenizer->getSourceFile() ?? 'unknown'
                 );
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion81.php
@@ -169,6 +169,7 @@ abstract class PHPParserVersion81 extends AbstractPHPParser
         while ($this->tokenizer->peekNext() !== Tokens::T_VARIABLE && $this->addTokenToStackIfType(Tokens::T_BITWISE_AND)) {
             $types[] = $this->parseSingleTypeHint();
         }
+        $types = array_filter($types);
 
         $intersectionType = $this->builder->buildAstIntersectionType();
         foreach ($types as $type) {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -102,7 +102,7 @@ abstract class PHPParserVersion82 extends PHPParserVersion81
     }
 
     /**
-     * @return ASTType
+     * @return ?ASTType
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -660,7 +660,7 @@ class PHPTokenizerInternal implements FullTokenizer
     {
         $this->tokenize();
 
-        if ($this->index > 0 && $this->index < $this->count - 1) {
+        if ($this->index > 0 && $this->index < $this->count - 1 && $this->tokens) {
             return $this->tokens[$this->index - 1];
         }
 
@@ -676,7 +676,7 @@ class PHPTokenizerInternal implements FullTokenizer
     {
         $this->tokenize();
 
-        if ($this->index < $this->count - 1) {
+        if ($this->index < $this->count - 1 && $this->tokens) {
             return $this->tokens[$this->index];
         }
 
@@ -693,7 +693,7 @@ class PHPTokenizerInternal implements FullTokenizer
     {
         $this->tokenize();
 
-        if ($this->index < $this->count) {
+        if ($this->index < $this->count && $this->tokens) {
             return $this->tokens[$this->index++];
         }
 
@@ -776,7 +776,7 @@ class PHPTokenizerInternal implements FullTokenizer
     {
         $this->tokenize();
 
-        if ($this->index > 1) {
+        if ($this->index > 1 && $this->tokens) {
             return $this->tokens[$this->index - 2]->type;
         }
         return self::T_BOF;

--- a/src/main/php/PDepend/Source/Parser/MissingValueException.php
+++ b/src/main/php/PDepend/Source/Parser/MissingValueException.php
@@ -68,7 +68,7 @@ class MissingValueException extends ParserException
             'Missing default value on line: %d, col: %d, file: %s.',
             $token->startLine,
             $token->startColumn,
-            $tokenizer->getSourceFile(),
+            $tokenizer->getSourceFile() ?? 'unknown',
         );
 
         parent::__construct($message);

--- a/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
@@ -61,7 +61,7 @@ class TokenStreamEndException extends TokenException
         parent::__construct(
             sprintf(
                 'Unexpected end of token stream in file: %s.',
-                $tokenizer->getSourceFile(),
+                $tokenizer->getSourceFile() ?? 'unknown',
             ),
         );
     }

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -144,7 +144,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
 
         $parts = explode('\\', $analyzer::class);
 
-        $name = preg_replace('(Analyzer$)', '', end($parts));
+        $name = end($parts);
+        $name = preg_replace('(Analyzer$)', '', $name) ?? $name;
         $name = preg_replace('/([a-zA-Z])([a-z])(?=[A-Z])/', '$1$2 ', $name);
 
         echo "Calculating {$name} metrics:\n";

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -92,7 +92,7 @@ class FileCacheDriver implements CacheDriver
     /**
      * Unique key for this cache instance.
      *
-     * @var string
+     * @var ?string
      * @since 1.0.0
      */
     private $cacheKey;
@@ -109,7 +109,7 @@ class FileCacheDriver implements CacheDriver
     public function __construct($root, $ttl = self::DEFAULT_TTL, $cacheKey = null)
     {
         $this->directory = new FileCacheDirectory($root);
-        $this->version = preg_replace('(^(\d+\.\d+).*)', '\\1', PHP_VERSION);
+        $this->version = preg_replace('(^(\d+\.\d+).*)', '\\1', PHP_VERSION) ?? PHP_VERSION;
 
         $this->cacheKey = $cacheKey;
 
@@ -176,7 +176,7 @@ class FileCacheDriver implements CacheDriver
      * <b>NULL</b>.
      *
      * @param string $key The cache key for the given data.
-     * @param string $hash Optional hash that will be used for verification.
+     * @param ?string $hash Optional hash that will be used for verification.
      */
     public function restore($key, $hash = null): mixed
     {
@@ -192,14 +192,14 @@ class FileCacheDriver implements CacheDriver
      * to stored hash value. If both hashes are equal this method returns the
      * cached entry. Otherwise this method returns <b>NULL</b>.
      *
-     * @param string $file The cache file name.
-     * @param string $hash The verification hash.
+     * @param string  $file The cache file name.
+     * @param ?string $hash The verification hash.
      */
     protected function restoreFile($file, $hash): mixed
     {
         // unserialize() throws E_NOTICE when data is corrupt
         $data = @unserialize($this->read($file));
-        if ($data !== false && $data['hash'] === $hash) {
+        if ($data !== false && ($hash === null || $data['hash'] === $hash)) {
             return $data['data'];
         }
         return null;

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -107,7 +107,7 @@ class CloverReport implements Report
      */
     public function getCoverage(AbstractASTArtifact $artifact)
     {
-        $lines = $this->getLines($artifact->getCompilationUnit()->getFileName());
+        $lines = $this->getLines($artifact->getCompilationUnit()?->getFileName() ?? 'default');
 
         $startLine = $artifact->getStartLine();
         $endLine = $artifact->getEndLine();

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -71,7 +71,7 @@ class IdBuilder
      */
     public function forFile(ASTCompilationUnit $compilationUnit)
     {
-        return $this->hash($compilationUnit->getFileName());
+        return $this->hash($compilationUnit->getFileName() ?? 'default');
     }
 
     /**
@@ -105,7 +105,7 @@ class IdBuilder
      */
     protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
     {
-        $fileHash = $artifact->getCompilationUnit()->getId();
+        $fileHash = $artifact->getCompilationUnit()?->getId() ?? 'default';
         $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getName()));
 
         $offset = $this->getOffsetInFile($fileHash, $itemHash);
@@ -120,11 +120,14 @@ class IdBuilder
      */
     public function forMethod(ASTMethod $method)
     {
-        return sprintf(
-            '%s-%s',
-            $method->getParent()->getId(),
-            $this->hash(strtolower($method->getName())),
-        );
+        $hash = $this->hash(strtolower($method->getName()));
+
+        $parent = $method->getParent();
+        if (!$parent) {
+            return $hash;
+        }
+
+        return $parent->getId() . '-' . $hash;
     }
 
     /**

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -161,7 +161,7 @@ class ImageConvert
             $fontReplace = 'font-family:' . strtr($fontFamily, ';:', '  ');
             $fontPattern = '/font-family:\s*Arial/';
 
-            $svg = preg_replace($fontPattern, $fontReplace, $svg);
+            $svg = preg_replace($fontPattern, $fontReplace, $svg) ?? $svg;
         }
 
         // Check for font size
@@ -180,7 +180,7 @@ class ImageConvert
                 $fontReplace = 'font-size:' . ($fontSize + $resize);
                 $fontPattern = "/font-size:\s*{$fontSize}/";
 
-                $svg = preg_replace($fontPattern, $fontReplace, $svg);
+                $svg = preg_replace($fontPattern, $fontReplace, $svg) ?? $svg;
             }
         }
 


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: no

Document nullable types and handle various edge cases related to them. This is this solves PHPStan level 8 issues and gets us ready to apply native type hints.