### PR TITLE
Import classes and use ::class instead of strings and FQNs

### DIFF
--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -77,7 +77,7 @@ class PdependExtension extends SymfonyExtension
                 if (!isset($config['class'])) {
                     continue;
                 }
-                if (!is_a($config['class'], 'PDepend\DependencyInjection\Extension', true)) {
+                if (!is_a($config['class'], Extension::class, true)) {
                     throw new RuntimeException(
                         sprintf('Class "%s" is not a valid Extension', $config['class']),
                     );

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -147,7 +147,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      */
     public function getRequiredAnalyzers()
     {
-        return ['PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer'];
+        return [CyclomaticComplexityAnalyzer::class];
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -80,9 +80,9 @@ class StrategyFactory
      * @var array<string, class-string<CodeRankStrategyI>>
      */
     private $validStrategies = [
-        self::STRATEGY_INHERITANCE => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\InheritanceStrategy',
-        self::STRATEGY_METHOD => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\MethodStrategy',
-        self::STRATEGY_PROPERTY => 'PDepend\\Metrics\\Analyzer\\CodeRankAnalyzer\\PropertyStrategy',
+        self::STRATEGY_INHERITANCE => InheritanceStrategy::class,
+        self::STRATEGY_METHOD => MethodStrategy::class,
+        self::STRATEGY_PROPERTY => PropertyStrategy::class,
     ];
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -119,7 +119,7 @@ class CohesionAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
         $this->fireStartMethod($method);
 
         $prefixes = $method->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
         foreach ($prefixes as $prefix) {
             $variable = $prefix->getChild(0);

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -52,6 +52,8 @@ use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTInvocation;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTProperty;
@@ -403,12 +405,12 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      */
     private function countCalls(AbstractASTCallable $callable): void
     {
-        $invocations = $callable->findChildrenOfType('PDepend\\Source\\AST\\ASTInvocation');
+        $invocations = $callable->findChildrenOfType(ASTInvocation::class);
 
         $invoked = [];
 
         foreach ($invocations as $invocation) {
-            $parents = $invocation->getParentsOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix');
+            $parents = $invocation->getParentsOfType(ASTMemberPrimaryPrefix::class);
 
             $image = '';
             foreach ($parents as $parent) {

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -128,7 +128,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      */
     public function getRequiredAnalyzers()
     {
-        return ['PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer'];
+        return [CyclomaticComplexityAnalyzer::class];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -127,9 +127,9 @@ class ASTClass extends AbstractASTClassOrInterface
         if ($this->properties === null) {
             $this->properties = [];
 
-            $declarations = $this->findChildrenOfType('PDepend\\Source\\AST\\ASTFieldDeclaration');
+            $declarations = $this->findChildrenOfType(ASTFieldDeclaration::class);
             foreach ($declarations as $declaration) {
-                $declarators = $declaration->findChildrenOfType('PDepend\\Source\\AST\\ASTVariableDeclarator');
+                $declarators = $declaration->findChildrenOfType(ASTVariableDeclarator::class);
 
                 foreach ($declarators as $declarator) {
                     $property = new ASTProperty($declaration, $declarator);

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -164,7 +164,7 @@ class ASTEnum extends AbstractASTClassOrInterface
     public function getCases()
     {
         return new ASTArtifactList(
-            $this->findChildrenOfType('PDepend\\Source\\AST\\ASTEnumCase'),
+            $this->findChildrenOfType(ASTEnumCase::class),
         );
     }
 

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -142,7 +142,7 @@ class ASTNamespace extends AbstractASTArtifact
      */
     public function getTraits()
     {
-        return $this->getTypesOfType('PDepend\\Source\\AST\\ASTTrait');
+        return $this->getTypesOfType(ASTTrait::class);
     }
 
     /**
@@ -153,7 +153,7 @@ class ASTNamespace extends AbstractASTArtifact
      */
     public function getClasses()
     {
-        return $this->getTypesOfType('PDepend\\Source\\AST\\ASTClass');
+        return $this->getTypesOfType(ASTClass::class);
     }
 
     /**
@@ -164,7 +164,7 @@ class ASTNamespace extends AbstractASTArtifact
      */
     public function getEnums()
     {
-        return $this->getTypesOfType('PDepend\\Source\\AST\\ASTEnum');
+        return $this->getTypesOfType(ASTEnum::class);
     }
 
     /**
@@ -175,7 +175,7 @@ class ASTNamespace extends AbstractASTArtifact
      */
     public function getInterfaces()
     {
-        return $this->getTypesOfType('PDepend\\Source\\AST\\ASTInterface');
+        return $this->getTypesOfType(ASTInterface::class);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -101,7 +101,7 @@ class ASTParameter extends AbstractASTArtifact
     {
         $this->formalParameter = $formalParameter;
         $this->variableDeclarator = $formalParameter->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator',
+            ASTVariableDeclarator::class,
         );
 
         $this->id = spl_object_hash($this);
@@ -253,7 +253,7 @@ class ASTParameter extends AbstractASTArtifact
     public function getClass()
     {
         $classReference = $this->formalParameter->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
+            ASTClassOrInterfaceReference::class,
         );
         if ($classReference === null) {
             return null;

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -194,7 +194,7 @@ class ASTProperty extends AbstractASTArtifact
     public function isArray()
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType',
+            ASTType::class,
         );
         if ($typeNode === null) {
             return false;
@@ -212,7 +212,7 @@ class ASTProperty extends AbstractASTArtifact
     public function isScalar()
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType',
+            ASTType::class,
         );
         if ($typeNode === null) {
             return false;
@@ -230,7 +230,7 @@ class ASTProperty extends AbstractASTArtifact
     public function getClass()
     {
         $reference = $this->fieldDeclaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
+            ASTClassOrInterfaceReference::class,
         );
         if ($reference === null) {
             return null;

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -90,7 +90,7 @@ class ASTTraitUseStatement extends ASTStatement
         $methodName = strtolower($method->getName());
         $methodParent = $method->getParent();
 
-        $precedences = $this->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence');
+        $precedences = $this->findChildrenOfType(ASTTraitAdaptationPrecedence::class);
 
         foreach ($precedences as $precedence) {
             if (strtolower($precedence->getImage()) !== $methodName) {
@@ -196,6 +196,6 @@ class ASTTraitUseStatement extends ASTStatement
      */
     private function getAliases()
     {
-        return $this->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationAlias');
+        return $this->findChildrenOfType(ASTTraitAdaptationAlias::class);
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -240,7 +240,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     {
         return new ASTClassOrInterfaceReferenceIterator(
             $this->findChildrenOfType(
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
+                ASTClassOrInterfaceReference::class,
             ),
         );
     }
@@ -381,11 +381,11 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         $staticVariables = [];
 
         $declarations = $this->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTStaticVariableDeclaration',
+            ASTStaticVariableDeclaration::class,
         );
         foreach ($declarations as $declaration) {
             $variables = $declaration->findChildrenOfType(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                ASTVariableDeclarator::class,
             );
             foreach ($variables as $variable) {
                 $image = $variable->getImage();
@@ -423,11 +423,11 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         $parameters = [];
 
         $formalParameters = $this->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameters',
+            ASTFormalParameters::class,
         );
 
         $formalParameters = $formalParameters->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter',
+            ASTFormalParameter::class,
         );
 
         foreach ($formalParameters as $formalParameter) {

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -395,10 +395,10 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
             );
         }
 
-        $definitions = $this->findChildrenOfType('PDepend\\Source\\AST\\ASTConstantDefinition');
+        $definitions = $this->findChildrenOfType(ASTConstantDefinition::class);
 
         foreach ($definitions as $definition) {
-            $declarators = $definition->findChildrenOfType('PDepend\\Source\\AST\\ASTConstantDeclarator');
+            $declarators = $definition->findChildrenOfType(ASTConstantDeclarator::class);
 
             foreach ($declarators as $declarator) {
                 $image = $declarator->getImage();

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -406,12 +406,12 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
         /** @var ASTTraitUseStatement[] */
         $uses = $this->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement',
+            ASTTraitUseStatement::class,
         );
 
         foreach ($uses as $use) {
             $priorMethods = [];
-            $precedences = $use->findChildrenOfType('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence');
+            $precedences = $use->findChildrenOfType(ASTTraitAdaptationPrecedence::class);
 
             foreach ($precedences as $precedence) {
                 $priorMethods[strtolower($precedence->getImage())] = true;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -474,7 +474,7 @@ class PHPBuilder implements Builder
      */
     public function buildAnonymousClass()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTAnonymousClass')
+        return $this->buildAstNodeInstance(ASTAnonymousClass::class)
             ->setCache($this->cache)
             ->setContext($this->context);
     }
@@ -673,7 +673,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstFieldDeclaration()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTFieldDeclaration');
+        return $this->buildAstNodeInstance(ASTFieldDeclaration::class);
     }
 
     /**
@@ -685,7 +685,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstVariableDeclarator($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTVariableDeclarator', $image);
+        return $this->buildAstNodeInstance(ASTVariableDeclarator::class, $image);
     }
 
     /**
@@ -697,7 +697,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstStaticVariableDeclaration($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTStaticVariableDeclaration', $image);
+        return $this->buildAstNodeInstance(ASTStaticVariableDeclaration::class, $image);
     }
 
     /**
@@ -709,7 +709,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstConstant($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTConstant', $image);
+        return $this->buildAstNodeInstance(ASTConstant::class, $image);
     }
 
     /**
@@ -721,7 +721,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstVariable($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTVariable', $image);
+        return $this->buildAstNodeInstance(ASTVariable::class, $image);
     }
 
     /**
@@ -733,7 +733,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstVariableVariable($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTVariableVariable', $image);
+        return $this->buildAstNodeInstance(ASTVariableVariable::class, $image);
     }
 
     /**
@@ -745,7 +745,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstCompoundVariable($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTCompoundVariable', $image);
+        return $this->buildAstNodeInstance(ASTCompoundVariable::class, $image);
     }
 
     /**
@@ -756,7 +756,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstCompoundExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTCompoundExpression');
+        return $this->buildAstNodeInstance(ASTCompoundExpression::class);
     }
 
     /**
@@ -767,7 +767,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstClosure()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTClosure');
+        return $this->buildAstNodeInstance(ASTClosure::class);
     }
 
     /**
@@ -778,7 +778,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstFormalParameters()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTFormalParameters');
+        return $this->buildAstNodeInstance(ASTFormalParameters::class);
     }
 
     /**
@@ -789,7 +789,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstFormalParameter()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTFormalParameter');
+        return $this->buildAstNodeInstance(ASTFormalParameter::class);
     }
 
     /**
@@ -801,7 +801,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstExpression($image = null)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTExpression', $image);
+        return $this->buildAstNodeInstance(ASTExpression::class, $image);
     }
 
     /**
@@ -813,7 +813,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstAssignmentExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTAssignmentExpression', $image);
+        return $this->buildAstNodeInstance(ASTAssignmentExpression::class, $image);
     }
 
     /**
@@ -825,7 +825,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstAllocationExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTAllocationExpression', $image);
+        return $this->buildAstNodeInstance(ASTAllocationExpression::class, $image);
     }
 
     /**
@@ -837,7 +837,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstEvalExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTEvalExpression', $image);
+        return $this->buildAstNodeInstance(ASTEvalExpression::class, $image);
     }
 
     /**
@@ -849,7 +849,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstExitExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTExitExpression', $image);
+        return $this->buildAstNodeInstance(ASTExitExpression::class, $image);
     }
 
     /**
@@ -861,7 +861,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstCloneExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTCloneExpression', $image);
+        return $this->buildAstNodeInstance(ASTCloneExpression::class, $image);
     }
 
     /**
@@ -873,7 +873,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstListExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTListExpression', $image);
+        return $this->buildAstNodeInstance(ASTListExpression::class, $image);
     }
 
     /**
@@ -884,7 +884,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstIncludeExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIncludeExpression');
+        return $this->buildAstNodeInstance(ASTIncludeExpression::class);
     }
 
     /**
@@ -895,7 +895,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstRequireExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTRequireExpression');
+        return $this->buildAstNodeInstance(ASTRequireExpression::class);
     }
 
     /**
@@ -906,7 +906,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstArrayIndexExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTArrayIndexExpression');
+        return $this->buildAstNodeInstance(ASTArrayIndexExpression::class);
     }
 
     /**
@@ -923,7 +923,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstStringIndexExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTStringIndexExpression');
+        return $this->buildAstNodeInstance(ASTStringIndexExpression::class);
     }
 
     /**
@@ -934,7 +934,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstArray()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTArray');
+        return $this->buildAstNodeInstance(ASTArray::class);
     }
 
     /**
@@ -945,7 +945,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstArrayElement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTArrayElement');
+        return $this->buildAstNodeInstance(ASTArrayElement::class);
     }
 
 
@@ -958,7 +958,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstInstanceOfExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTInstanceOfExpression', $image);
+        return $this->buildAstNodeInstance(ASTInstanceOfExpression::class, $image);
     }
 
     /**
@@ -981,7 +981,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstIssetExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIssetExpression');
+        return $this->buildAstNodeInstance(ASTIssetExpression::class);
     }
 
     /**
@@ -998,7 +998,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstConditionalExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTConditionalExpression', '?');
+        return $this->buildAstNodeInstance(ASTConditionalExpression::class, '?');
     }
 
     /**
@@ -1015,7 +1015,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstPrintExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTPrintExpression', 'print');
+        return $this->buildAstNodeInstance(ASTPrintExpression::class, 'print');
     }
 
     /**
@@ -1026,7 +1026,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstShiftLeftExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTShiftLeftExpression');
+        return $this->buildAstNodeInstance(ASTShiftLeftExpression::class);
     }
 
     /**
@@ -1037,7 +1037,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstShiftRightExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTShiftRightExpression');
+        return $this->buildAstNodeInstance(ASTShiftRightExpression::class);
     }
 
     /**
@@ -1048,7 +1048,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstBooleanAndExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTBooleanAndExpression', '&&');
+        return $this->buildAstNodeInstance(ASTBooleanAndExpression::class, '&&');
     }
 
     /**
@@ -1059,7 +1059,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstBooleanOrExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTBooleanOrExpression', '||');
+        return $this->buildAstNodeInstance(ASTBooleanOrExpression::class, '||');
     }
 
     /**
@@ -1070,7 +1070,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstLogicalAndExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTLogicalAndExpression', 'and');
+        return $this->buildAstNodeInstance(ASTLogicalAndExpression::class, 'and');
     }
 
     /**
@@ -1081,7 +1081,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstLogicalOrExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTLogicalOrExpression', 'or');
+        return $this->buildAstNodeInstance(ASTLogicalOrExpression::class, 'or');
     }
 
     /**
@@ -1092,7 +1092,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstLogicalXorExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTLogicalXorExpression', 'xor');
+        return $this->buildAstNodeInstance(ASTLogicalXorExpression::class, 'xor');
     }
 
     /**
@@ -1103,7 +1103,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTraitUseStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTraitUseStatement');
+        return $this->buildAstNodeInstance(ASTTraitUseStatement::class);
     }
 
     /**
@@ -1114,7 +1114,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTraitAdaptation()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTraitAdaptation');
+        return $this->buildAstNodeInstance(ASTTraitAdaptation::class);
     }
 
     /**
@@ -1126,7 +1126,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTraitAdaptationAlias($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTraitAdaptationAlias', $image);
+        return $this->buildAstNodeInstance(ASTTraitAdaptationAlias::class, $image);
     }
 
     /**
@@ -1138,7 +1138,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTraitAdaptationPrecedence($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence', $image);
+        return $this->buildAstNodeInstance(ASTTraitAdaptationPrecedence::class, $image);
     }
 
     /**
@@ -1149,7 +1149,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstSwitchStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTSwitchStatement');
+        return $this->buildAstNodeInstance(ASTSwitchStatement::class);
     }
 
     /**
@@ -1161,7 +1161,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstSwitchLabel($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTSwitchLabel', $image);
+        return $this->buildAstNodeInstance(ASTSwitchLabel::class, $image);
     }
 
     /**
@@ -1172,7 +1172,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstGlobalStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTGlobalStatement');
+        return $this->buildAstNodeInstance(ASTGlobalStatement::class);
     }
 
     /**
@@ -1183,7 +1183,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstUnsetStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTUnsetStatement');
+        return $this->buildAstNodeInstance(ASTUnsetStatement::class);
     }
 
     /**
@@ -1195,7 +1195,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstCatchStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTCatchStatement', $image);
+        return $this->buildAstNodeInstance(ASTCatchStatement::class, $image);
     }
 
     /**
@@ -1206,7 +1206,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstFinallyStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTFinallyStatement', 'finally');
+        return $this->buildAstNodeInstance(ASTFinallyStatement::class, 'finally');
     }
 
     /**
@@ -1218,7 +1218,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstIfStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIfStatement', $image);
+        return $this->buildAstNodeInstance(ASTIfStatement::class, $image);
     }
 
     /**
@@ -1230,7 +1230,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstElseIfStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTElseIfStatement', $image);
+        return $this->buildAstNodeInstance(ASTElseIfStatement::class, $image);
     }
 
     /**
@@ -1242,7 +1242,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstForStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTForStatement', $image);
+        return $this->buildAstNodeInstance(ASTForStatement::class, $image);
     }
 
     /**
@@ -1259,7 +1259,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstForInit()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTForInit');
+        return $this->buildAstNodeInstance(ASTForInit::class);
     }
 
     /**
@@ -1276,7 +1276,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstForUpdate()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTForUpdate');
+        return $this->buildAstNodeInstance(ASTForUpdate::class);
     }
 
     /**
@@ -1288,7 +1288,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstForeachStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTForeachStatement', $image);
+        return $this->buildAstNodeInstance(ASTForeachStatement::class, $image);
     }
 
     /**
@@ -1300,7 +1300,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstWhileStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTWhileStatement', $image);
+        return $this->buildAstNodeInstance(ASTWhileStatement::class, $image);
     }
 
     /**
@@ -1312,7 +1312,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstDoWhileStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTDoWhileStatement', $image);
+        return $this->buildAstNodeInstance(ASTDoWhileStatement::class, $image);
     }
 
     /**
@@ -1341,7 +1341,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstDeclareStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTDeclareStatement');
+        return $this->buildAstNodeInstance(ASTDeclareStatement::class);
     }
 
     /**
@@ -1371,7 +1371,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstMemberPrimaryPrefix($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $image);
+        return $this->buildAstNodeInstance(ASTMemberPrimaryPrefix::class, $image);
     }
 
     /**
@@ -1383,7 +1383,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstIdentifier($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIdentifier', $image);
+        return $this->buildAstNodeInstance(ASTIdentifier::class, $image);
     }
 
     /**
@@ -1405,7 +1405,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstFunctionPostfix($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTFunctionPostfix', $image);
+        return $this->buildAstNodeInstance(ASTFunctionPostfix::class, $image);
     }
 
     /**
@@ -1427,7 +1427,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstMethodPostfix($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMethodPostfix', $image);
+        return $this->buildAstNodeInstance(ASTMethodPostfix::class, $image);
     }
 
     /**
@@ -1445,7 +1445,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstConstantPostfix($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTConstantPostfix', $image);
+        return $this->buildAstNodeInstance(ASTConstantPostfix::class, $image);
     }
 
     /**
@@ -1467,7 +1467,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstPropertyPostfix($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTPropertyPostfix', $image);
+        return $this->buildAstNodeInstance(ASTPropertyPostfix::class, $image);
     }
 
     /**
@@ -1488,7 +1488,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstClassFqnPostfix()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTClassFqnPostfix', 'class');
+        return $this->buildAstNodeInstance(ASTClassFqnPostfix::class, 'class');
     }
 
     /**
@@ -1509,7 +1509,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstArguments()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTArguments');
+        return $this->buildAstNodeInstance(ASTArguments::class);
     }
 
     /**
@@ -1524,7 +1524,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstMatchArgument()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchArgument');
+        return $this->buildAstNodeInstance(ASTMatchArgument::class);
     }
 
     /**
@@ -1541,7 +1541,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstMatchBlock()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchBlock');
+        return $this->buildAstNodeInstance(ASTMatchBlock::class);
     }
 
     /**
@@ -1556,7 +1556,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstMatchEntry()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTMatchEntry');
+        return $this->buildAstNodeInstance(ASTMatchEntry::class);
     }
 
     /**
@@ -1585,7 +1585,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTypeArray()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTypeArray');
+        return $this->buildAstNodeInstance(ASTTypeArray::class);
     }
 
     /**
@@ -1596,7 +1596,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTypeCallable()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTypeCallable');
+        return $this->buildAstNodeInstance(ASTTypeCallable::class);
     }
 
     /**
@@ -1607,7 +1607,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTypeIterable()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTypeIterable');
+        return $this->buildAstNodeInstance(ASTTypeIterable::class);
     }
 
     /**
@@ -1619,7 +1619,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstScalarType($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTScalarType', $image);
+        return $this->buildAstNodeInstance(ASTScalarType::class, $image);
     }
 
     /**
@@ -1630,7 +1630,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstUnionType()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTUnionType');
+        return $this->buildAstNodeInstance(ASTUnionType::class);
     }
 
     /**
@@ -1640,7 +1640,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstIntersectionType()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTIntersectionType');
+        return $this->buildAstNodeInstance(ASTIntersectionType::class);
     }
 
     /**
@@ -1652,7 +1652,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstLiteral($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTLiteral', $image);
+        return $this->buildAstNodeInstance(ASTLiteral::class, $image);
     }
 
     /**
@@ -1675,7 +1675,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstString()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTString');
+        return $this->buildAstNodeInstance(ASTString::class);
     }
 
     /**
@@ -1686,7 +1686,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstHeredoc()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTHeredoc');
+        return $this->buildAstNodeInstance(ASTHeredoc::class);
     }
 
     /**
@@ -1707,7 +1707,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstConstantDefinition($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTConstantDefinition', $image);
+        return $this->buildAstNodeInstance(ASTConstantDefinition::class, $image);
     }
 
     /**
@@ -1747,7 +1747,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstConstantDeclarator($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTConstantDeclarator', $image);
+        return $this->buildAstNodeInstance(ASTConstantDeclarator::class, $image);
     }
 
     /**
@@ -1759,7 +1759,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstComment($cdata)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTComment', $cdata);
+        return $this->buildAstNodeInstance(ASTComment::class, $cdata);
     }
 
     /**
@@ -1771,7 +1771,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstUnaryExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTUnaryExpression', $image);
+        return $this->buildAstNodeInstance(ASTUnaryExpression::class, $image);
     }
 
     /**
@@ -1783,7 +1783,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstCastExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTCastExpression', $image);
+        return $this->buildAstNodeInstance(ASTCastExpression::class, $image);
     }
 
     /**
@@ -1795,7 +1795,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstPostfixExpression($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTPostfixExpression', $image);
+        return $this->buildAstNodeInstance(ASTPostfixExpression::class, $image);
     }
 
     /**
@@ -1806,7 +1806,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstPreIncrementExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTPreIncrementExpression');
+        return $this->buildAstNodeInstance(ASTPreIncrementExpression::class);
     }
 
     /**
@@ -1817,7 +1817,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstPreDecrementExpression()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTPreDecrementExpression');
+        return $this->buildAstNodeInstance(ASTPreDecrementExpression::class);
     }
 
     /**
@@ -1828,7 +1828,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstScope()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTScope');
+        return $this->buildAstNodeInstance(ASTScope::class);
     }
 
     /**
@@ -1839,7 +1839,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTStatement');
+        return $this->buildAstNodeInstance(ASTStatement::class);
     }
 
     /**
@@ -1851,7 +1851,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstReturnStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTReturnStatement', $image);
+        return $this->buildAstNodeInstance(ASTReturnStatement::class, $image);
     }
 
     /**
@@ -1863,7 +1863,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstBreakStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTBreakStatement', $image);
+        return $this->buildAstNodeInstance(ASTBreakStatement::class, $image);
     }
 
     /**
@@ -1875,7 +1875,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstContinueStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTContinueStatement', $image);
+        return $this->buildAstNodeInstance(ASTContinueStatement::class, $image);
     }
 
     /**
@@ -1886,7 +1886,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstScopeStatement()
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTScopeStatement');
+        return $this->buildAstNodeInstance(ASTScopeStatement::class);
     }
 
     /**
@@ -1898,7 +1898,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstTryStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTTryStatement', $image);
+        return $this->buildAstNodeInstance(ASTTryStatement::class, $image);
     }
 
     /**
@@ -1910,7 +1910,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstThrowStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTThrowStatement', $image);
+        return $this->buildAstNodeInstance(ASTThrowStatement::class, $image);
     }
 
     /**
@@ -1922,7 +1922,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstGotoStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTGotoStatement', $image);
+        return $this->buildAstNodeInstance(ASTGotoStatement::class, $image);
     }
 
     /**
@@ -1934,7 +1934,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstLabelStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTLabelStatement', $image);
+        return $this->buildAstNodeInstance(ASTLabelStatement::class, $image);
     }
 
     /**
@@ -1946,7 +1946,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstEchoStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTEchoStatement', $image);
+        return $this->buildAstNodeInstance(ASTEchoStatement::class, $image);
     }
 
     /**
@@ -1958,7 +1958,7 @@ class PHPBuilder implements Builder
      */
     public function buildAstYieldStatement($image)
     {
-        return $this->buildAstNodeInstance('\\PDepend\\Source\\AST\\ASTYieldStatement', $image);
+        return $this->buildAstNodeInstance(ASTYieldStatement::class, $image);
     }
 
     /**

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -49,16 +49,22 @@ use Exception;
 use Imagick;
 use PDepend\Input\ExcludePathFilter;
 use PDepend\Input\Iterator;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClosure;
 use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -193,7 +199,7 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @return Source\AST\ASTClosure
+     * @return ASTClosure
      */
     protected function getFirstClosureForTestCase()
     {
@@ -201,7 +207,7 @@ abstract class AbstractTestCase extends TestCase
             ->current()
             ->getFunctions()
             ->current()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTClosure');
+            ->getFirstChildOfType(ASTClosure::class);
     }
 
     /**
@@ -342,7 +348,7 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
      *
-     * @return Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     protected function getFirstTypeForTestCase()
     {
@@ -366,13 +372,13 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @return Source\AST\ASTFormalParameter
+     * @return ASTFormalParameter
      */
     protected function getFirstFormalParameterForTestCase()
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType(
-                'PDepend\\Source\\AST\\ASTFormalParameter'
+                ASTFormalParameter::class
             );
     }
 
@@ -494,7 +500,7 @@ abstract class AbstractTestCase extends TestCase
      */
     protected function createCacheFixture()
     {
-        $cache = $this->getMockBuilder('\\PDepend\\Util\\Cache\\CacheDriver')
+        $cache = $this->getMockBuilder(CacheDriver::class)
             ->getMock();
 
         return $cache;
@@ -561,7 +567,7 @@ abstract class AbstractTestCase extends TestCase
         $class = new ASTClass($name);
         $class->setCompilationUnit(new ASTCompilationUnit($GLOBALS['argv'][0]));
         $class->setCache(new MemoryCacheDriver());
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $class->setContext($context);
 
@@ -758,7 +764,7 @@ abstract class AbstractTestCase extends TestCase
      * Parses the test code associated with the calling test method.
      *
      * @param bool $ignoreAnnotations The parser should ignore annotations.
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     protected function parseCodeResourceForTest($ignoreAnnotations = false)
     {
@@ -774,7 +780,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
@@ -798,7 +804,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $fileOrDirectory
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseSource($fileOrDirectory, $ignoreAnnotations = false)
     {
@@ -845,8 +851,8 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder
-     * @return Source\Language\PHP\AbstractPHPParser
+     * @param Builder<mixed> $builder
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/ApplicationTest.php
+++ b/src/test/php/PDepend/ApplicationTest.php
@@ -44,6 +44,10 @@ namespace PDepend;
 
 use InvalidArgumentException;
 use PDepend\Metrics\Analyzer\CrapIndexAnalyzer;
+use PDepend\Metrics\AnalyzerFactory;
+use PDepend\Report\ReportGeneratorFactory;
+use PDepend\TextUI\Runner;
+use PDepend\Util\Configuration;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
@@ -61,21 +65,21 @@ class ApplicationTest extends AbstractTestCase
         $application = $this->createTestApplication();
         $runner = $application->getRunner();
 
-        $this->assertInstanceOf('PDepend\\TextUI\\Runner', $runner);
+        $this->assertInstanceOf(Runner::class, $runner);
     }
 
     public function testAnalyzerFactory(): void
     {
         $application = $this->createTestApplication();
 
-        $this->assertInstanceOf('PDepend\\Metrics\\AnalyzerFactory', $application->getAnalyzerFactory());
+        $this->assertInstanceOf(AnalyzerFactory::class, $application->getAnalyzerFactory());
     }
 
     public function testReportGeneratorFactory(): void
     {
         $application = $this->createTestApplication();
 
-        $this->assertInstanceOf('PDepend\\Report\\ReportGeneratorFactory', $application->getReportGeneratorFactory());
+        $this->assertInstanceOf(ReportGeneratorFactory::class, $application->getReportGeneratorFactory());
     }
 
     public function testBinCanReadInput(): void
@@ -109,7 +113,7 @@ class ApplicationTest extends AbstractTestCase
         $application = $this->createTestApplication();
         $config = $application->getConfiguration();
 
-        $this->assertInstanceOf('PDepend\\Util\\Configuration', $config);
+        $this->assertInstanceOf(Configuration::class, $config);
     }
 
     public function testGetEngine(): void
@@ -117,7 +121,7 @@ class ApplicationTest extends AbstractTestCase
         $application = $this->createTestApplication();
         $config = $application->getEngine();
 
-        $this->assertInstanceOf('PDepend\\Engine', $config);
+        $this->assertInstanceOf(Engine::class, $config);
     }
 
     public function testGetAvailableLoggerOptions(): void

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -44,6 +44,7 @@ namespace PDepend\Bugs;
 
 use PDepend\AbstractTestCase;
 use PDepend\Report\Summary\Xml;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Abstract test case for the "Bugs" package.
@@ -84,7 +85,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case related to bug 70.
  *
@@ -90,7 +92,7 @@ class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
      */
     public function testParserThrowsExceptionForInvalidBoundClosureVariableBug70(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }

--- a/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTString;
+
 /**
  * Test case for ticket #114.
  *
@@ -120,7 +123,7 @@ class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
             ->getMethods()
             ->current();
 
-        $string = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $string->getChild(1));
+        $string = $method->getFirstChildOfType(ASTString::class);
+        $this->assertInstanceOf(ASTLiteral::class, $string->getChild(1));
     }
 }

--- a/src/test/php/PDepend/Bugs/ConflictingImportTest.php
+++ b/src/test/php/PDepend/Bugs/ConflictingImportTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\DependencyInjection\Extension;
+use PDepend\DependencyInjection\PdependExtension;
 use ReflectionClass;
 
 class ConflictingImportTest extends AbstractRegressionTestCase
@@ -49,7 +51,7 @@ class ConflictingImportTest extends AbstractRegressionTestCase
     public function testSymfonyExtension(): void
     {
         // force compilation of both conflicting files
-        new ReflectionClass('PDepend\DependencyInjection\Extension');
-        new ReflectionClass('PDepend\DependencyInjection\PdependExtension');
+        new ReflectionClass(Extension::class);
+        new ReflectionClass(PdependExtension::class);
     }
 }

--- a/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+
 /**
  * Test case for bug #152.
  *
@@ -69,7 +71,7 @@ class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestC
      */
     public function testClassNotResultsInEndlessLoopWhileCallingGetParentClass2(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -47,6 +47,8 @@ namespace PDepend\Bugs;
 use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer;
 use PDepend\Metrics\Analyzer\InheritanceAnalyzer;
+use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PDepend\TextUI\Command;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -78,7 +80,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
      */
     public function testClassLevelAnalyzerNotRunsEndlessForTwoLevelClassHierarchy(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         set_time_limit(5);
 
@@ -96,7 +98,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
      */
     public function testClassLevelAnalyzerNotRunsEndlessForDeepClassHierarchy(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         set_time_limit(5);
 
@@ -146,7 +148,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
      */
     public function testInheritanceAnalyzerNotRunsEndlessForTwoLevelClassHierarchy(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         set_time_limit(5);
 
@@ -159,7 +161,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
      */
     public function testInheritanceAnalyzerNotRunsEndlessForDeepClassHierarchy(): void
     {
-        $this->expectException(\PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException::class);
+        $this->expectException(ASTClassOrInterfaceRecursiveInheritanceException::class);
 
         set_time_limit(5);
 
@@ -205,7 +207,7 @@ class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 
         ob_start();
 
-        $command = new \PDepend\TextUI\Command();
+        $command = new Command();
         $command->run();
 
         $output = ob_get_clean();

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -43,6 +43,7 @@
 namespace PDepend\Bugs;
 
 use ArrayIterator;
+use PDepend\Input\Filter;
 use PDepend\Input\Iterator;
 use SplFileInfo;
 
@@ -62,7 +63,7 @@ class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegress
      */
     public function testIteratorOnlyPassesLocalPathToFilter(): void
     {
-        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+        $filter = $this->getMockBuilder(Filter::class)
             ->getMock();
         $filter->expects($this->once())
             ->method('accept')

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
@@ -69,7 +71,7 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
         $method = $this->getFirstClassMethodForTestCase();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTConstant') as $reference) {
+        foreach ($method->findChildrenOfType(ASTConstant::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 
@@ -91,7 +93,7 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
         $method = $this->getFirstClassMethodForTestCase();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTFunctionPostfix') as $reference) {
+        foreach ($method->findChildrenOfType(ASTFunctionPostfix::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 
@@ -106,7 +108,7 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
     }
 
     /**
-     * @param \PDepend\Source\Builder\Builder<mixed> $builder
+     * @param Builder<mixed> $builder
      * @return PHPUnit_Framework_MockObject_MockObject
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -43,6 +43,11 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Report\Jdepend\Chart;
+use PDepend\Report\Jdepend\Xml as JdependXml;
+use PDepend\Report\Overview\Pyramid;
+use PDepend\Report\Summary\Xml as SummaryXml;
+
 /**
  * Test case for bug #13405179.
  *
@@ -86,10 +91,10 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
     public static function getLoggerClassNames()
     {
         return [
-            ['PDepend\\Report\\Jdepend\\Chart', 'svg'],
-            ['PDepend\\Report\\Jdepend\\Xml', 'xml'],
-            ['PDepend\\Report\\Overview\\Pyramid', 'svg'],
-            ['PDepend\\Report\\Summary\\Xml', 'xml'],
+            [Chart::class, 'svg'],
+            [JdependXml::class, 'xml'],
+            [Pyramid::class, 'svg'],
+            [SummaryXml::class, 'xml'],
         ];
     }
 }

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\Parser\InvalidStateException;
+
 /**
  * Test case for the parent keyword type hint bug no #87.
  *
@@ -77,7 +79,7 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
     public function testParserThrowsExpectedExceptionForParentTypeHintInFunction(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\InvalidStateException'
+            InvalidStateException::class
         );
         $this->expectExceptionMessage(
             'The keyword "parent" was used as type hint but the parameter ' .
@@ -93,7 +95,7 @@ class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestC
     public function testParserThrowsExpectedExceptionForParentTypeHintWithRootClass(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\InvalidStateException'
+            InvalidStateException::class
         );
         $this->expectExceptionMessage(
             'The keyword "parent" was used as type hint but the ' .

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -111,6 +111,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
             ->current()
             ->getClasses()
             ->current()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTHeredoc');
+            ->getFirstChildOfType(ASTHeredoc::class);
     }
 }

--- a/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -44,6 +44,9 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTInterface;
+
 /**
  * Test case for bug #23951621.
  *
@@ -64,7 +67,7 @@ class ParserBug23951621Test extends AbstractRegressionTestCase
     public function testParserHandlesHeredocAsPropertyDefaultValue(): void
     {
         $class = $this->getFirstClassForTestCase();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClass', $class);
+        $this->assertInstanceOf(ASTClass::class, $class);
     }
 
     /**
@@ -73,7 +76,7 @@ class ParserBug23951621Test extends AbstractRegressionTestCase
     public function testParserHandlesHeredocAsParameterDefaultValue(): void
     {
         $class = $this->getFirstClassForTestCase();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClass', $class);
+        $this->assertInstanceOf(ASTClass::class, $class);
     }
 
     /**
@@ -82,6 +85,6 @@ class ParserBug23951621Test extends AbstractRegressionTestCase
     public function testParserHandlesHeredocAsClassConstantValue(): void
     {
         $interface = $this->getFirstInterfaceForTestCase();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTInterface', $interface);
+        $this->assertInstanceOf(ASTInterface::class, $interface);
     }
 }

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -105,6 +105,6 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
             ->current()
             ->getClasses()
             ->current()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTPropertyPostfix');
+            ->getFirstChildOfType(ASTPropertyPostfix::class);
     }
 }

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -45,6 +45,7 @@ namespace PDepend\DependencyInjection;
 use PDepend\AbstractTestCase;
 use PDepend\TestExtension;
 use ReflectionMethod;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
@@ -63,17 +64,17 @@ class ConfigurationTest extends AbstractTestCase
         $config = new Configuration([new TestExtension()]);
 
         $this->assertInstanceOf(
-            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            TreeBuilder::class,
             $config->getConfigTreeBuilder()
         );
 
         $method = new ReflectionMethod(
-            'PDepend\\DependencyInjection\\Configuration',
+            Configuration::class,
             'getConfigTreeBuilder'
         );
 
         $this->assertSame(
-            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            TreeBuilder::class,
             $method->getReturnType()->getName()
         );
     }

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\DependencyInjection;
 
 use PDepend\AbstractTestCase;
+use PDepend\TestExtension;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -82,7 +83,7 @@ class ExtensionManagerTest extends AbstractTestCase
         $message = null;
 
         try {
-            $extensionManager->activateExtension('PDepend\\DependencyInjection\\ExtensionManager');
+            $extensionManager->activateExtension(ExtensionManager::class);
         } catch (RuntimeException $exception) {
             $message = $exception->getMessage();
         }
@@ -93,14 +94,14 @@ class ExtensionManagerTest extends AbstractTestCase
         );
         $this->assertSame([], $extensionManager->getActivatedExtensions());
 
-        $extensionManager->activateExtension('PDepend\\TestExtension');
+        $extensionManager->activateExtension(TestExtension::class);
         $extensions = $extensionManager->getActivatedExtensions();
 
         $this->assertSame(['test'], array_keys($extensions));
 
         $extension = $extensions['test'];
 
-        $this->assertInstanceOf('PDepend\\TestExtension', $extension);
+        $this->assertInstanceOf(TestExtension::class, $extension);
         $this->assertSame([], $extension->getCompilerPasses());
 
         $container = new ContainerBuilder();

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\DependencyInjection;
 
 use PDepend\AbstractTestCase;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder as SymfonyTreeBuilder;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
@@ -60,12 +62,12 @@ class TreeBuilderTest extends AbstractTestCase
         $treeBuilder = new TreeBuilder();
 
         $this->assertInstanceOf(
-            'Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition',
+            ArrayNodeDefinition::class,
             $treeBuilder->getRootNode()
         );
 
         $this->assertInstanceOf(
-            'Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder',
+            SymfonyTreeBuilder::class,
             $treeBuilder->getTreeBuilder()
         );
     }

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -243,7 +243,7 @@ class EngineTest extends AbstractTestCase
             'package3',
         ];
 
-        $className = '\\PDepend\\Source\\AST\\ASTNamespace';
+        $className = ASTNamespace::class;
 
         foreach ($namespaces as $namespace) {
             $this->assertInstanceOf($className, $engine->getNamespace($namespace));

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -111,7 +111,7 @@ class IteratorTest extends AbstractTestCase
      */
     public function testIteratorPassesLocalPathToFilterWhenRootIsPresent(): void
     {
-        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+        $filter = $this->getMockBuilder(Filter::class)
             ->getMock();
         $filter->expects($this->once())
             ->method('accept')
@@ -132,7 +132,7 @@ class IteratorTest extends AbstractTestCase
     {
         $files = new ArrayIterator([new SplFileInfo(__FILE__)]);
 
-        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+        $filter = $this->getMockBuilder(Filter::class)
             ->getMock();
         $filter->expects($this->once())
             ->method('accept')
@@ -149,7 +149,7 @@ class IteratorTest extends AbstractTestCase
     {
         $files = new ArrayIterator([new SplFileInfo(__FILE__)]);
 
-        $filter = $this->getMockBuilder('\\PDepend\\Input\\Filter')
+        $filter = $this->getMockBuilder(Filter::class)
             ->getMock();
         $filter->expects($this->once())
             ->method('accept')

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Integration;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -117,7 +118,7 @@ class BuilderParserCacheTest extends AbstractTestCase
      * Parses the given test file and then returns the builder instance.
      *
      * @param string $file Relative path to a test file for the calling test.
-     * @return \PDepend\Source\Builder\Builder
+     * @return Builder
      */
     protected function parseSourceAndReturnBuilder($file)
     {

--- a/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Integration;
 
 use PDepend\AbstractTestCase;
+use PDepend\Input\ExcludePathFilter;
 
 /**
  * Tests the integration of the {@link \PDepend\Engine} class and the
@@ -68,7 +69,7 @@ class DependExcludePathFilterTest extends AbstractTestCase
         $pdepend = $this->createEngineFixture();
         $pdepend->addFile($this->createCodeResourceUriForTest() . '/Integration/FilteredClass.php');
         $pdepend->addFileFilter(
-            new \PDepend\Input\ExcludePathFilter([$pattern])
+            new ExcludePathFilter([$pattern])
         );
 
         $this->assertCount(0, $pdepend->analyze());
@@ -88,7 +89,7 @@ class DependExcludePathFilterTest extends AbstractTestCase
         $pdepend = $this->createEngineFixture();
         $pdepend->addDirectory($directory);
         $pdepend->addFileFilter(
-            new \PDepend\Input\ExcludePathFilter([$pattern])
+            new ExcludePathFilter([$pattern])
         );
 
         $this->assertCount(0, $pdepend->analyze());
@@ -111,7 +112,7 @@ class DependExcludePathFilterTest extends AbstractTestCase
         $pdepend = $this->createEngineFixture();
         $pdepend->addDirectory($directory);
         $pdepend->addFileFilter(
-            new \PDepend\Input\ExcludePathFilter([$pattern])
+            new ExcludePathFilter([$pattern])
         );
 
         $this->assertCount(
@@ -138,7 +139,7 @@ class DependExcludePathFilterTest extends AbstractTestCase
         $pdepend = $this->createEngineFixture();
         $pdepend->addDirectory($directory);
         $pdepend->addFileFilter(
-            new \PDepend\Input\ExcludePathFilter([$pattern])
+            new ExcludePathFilter([$pattern])
         );
 
         $this->assertCount(1, $pdepend->analyze());

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -44,6 +44,8 @@ namespace PDepend\Issues;
 
 use ErrorException;
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTParameter;
 
 /**
  * Abstract base class for issue tests.
@@ -56,7 +58,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
     /**
      * Returns the parameters of the first function in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTParameter[]
+     * @return ASTParameter[]
      */
     protected function getParametersOfFirstFunction()
     {
@@ -68,7 +70,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * Parses the source for the calling test case.
      *
      * @param string $testCase
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     protected function parseTestCase($testCase = null)
     {
@@ -84,7 +86,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -43,6 +43,7 @@
 namespace PDepend\Issues;
 
 use PDepend\Source\AST\State;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -222,7 +223,7 @@ class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
      */
     public function testAbstractFinalReadonlyClass(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->getFirstClassForTestCase();
     }

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTType;
+
 /**
  * Test case for issue #84, where the object model should keep information about
  * primitive property and parameter types.
@@ -67,8 +70,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
             ->current()
             ->getClasses()
             ->current()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFieldDeclaration')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+            ->getFirstChildOfType(ASTFieldDeclaration::class)
+            ->getFirstChildOfType(ASTType::class);
 
         $this->assertEquals($expected, $type->getImage());
     }
@@ -79,8 +82,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
     public function testParserSetsExpectedArrayPropertyType(): void
     {
         $type = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFieldDeclaration')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+            ->getFirstChildOfType(ASTFieldDeclaration::class)
+            ->getFirstChildOfType(ASTType::class);
 
         $this->assertTrue($type->isArray());
     }
@@ -91,8 +94,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
     public function testParserSetsExpectedArrayWithParenthesisPropertyType(): void
     {
         $type = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFieldDeclaration')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+            ->getFirstChildOfType(ASTFieldDeclaration::class)
+            ->getFirstChildOfType(ASTType::class);
 
         $this->assertTrue($type->isArray());
     }

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
@@ -106,7 +108,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     public function testParserThrowsExpectedExceptionWhenUseDeclarationContextEndsOnBackslash(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: as, line: 2, col: 19, file: '
@@ -162,7 +164,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     public function testParserThrowsExpectedExceptionForNamespaceDeclarationWithoutIdentifierAndSemicolonSyntax(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: ;, line: 2, col: 18, file: '
@@ -178,7 +180,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     public function testParserThrowsExpectedExceptionForLeadingBackslashInIdentifier(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: {, line: 2, col: 13, file: '

--- a/src/test/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/src/test/php/PDepend/Issues/NewClassInstanceTest.php
@@ -42,7 +42,11 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTStatement;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
@@ -78,13 +82,13 @@ class NewClassInstanceTest extends AbstractFeatureTestCase
             $children = $statement->getChildren();
 
             $self->assertCount(1, $children);
-            $self->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $children[0]);
+            $self->assertInstanceOf(ASTAssignmentExpression::class, $children[0]);
 
             $children = $children[0]->getChildren();
             $self->assertCount(2, $children);
-            $self->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+            $self->assertInstanceOf(ASTVariable::class, $children[0]);
             $self->assertMatchesRegularExpression('/^\$object\d+$/', $children[0]->getImage());
-            $self->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $children[1]);
+            $self->assertInstanceOf(ASTAllocationExpression::class, $children[1]);
             $children = $children[1]->getChildren();
             $self->assertCount(1, $children);
 
@@ -92,13 +96,13 @@ class NewClassInstanceTest extends AbstractFeatureTestCase
         }, array_slice($instructions, 1, 3));
 
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $expressions[0]);
+        $this->assertInstanceOf(ASTVariable::class, $expressions[0]);
         $this->assertEquals('$class', $expressions[0]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $expressions[1]);
+        $this->assertInstanceOf(ASTVariable::class, $expressions[1]);
         $this->assertEquals('$class', $expressions[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $expressions[2]);
+        $this->assertInstanceOf(ASTLiteral::class, $expressions[2]);
         $this->assertEquals("'stdClass'", $expressions[2]->getImage());
     }
 }

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -43,6 +43,8 @@
 namespace PDepend\Issues;
 
 use PDepend\Input\ExtensionFilter;
+use PDepend\Report\Dummy\Logger;
+use PDepend\TextUI\Command;
 
 /**
  * Test case for the catch error ticket #61.
@@ -64,7 +66,7 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
         $pdepend = $this->createEngineFixture();
         $pdepend->addDirectory($this->createCodeResourceUriForTest());
         $pdepend->addFileFilter(new ExtensionFilter(['php']));
-        $pdepend->addReportGenerator(new \PDepend\Report\Dummy\Logger());
+        $pdepend->addReportGenerator(new Logger());
         $pdepend->analyze();
 
         $exceptions = $pdepend->getExceptions();
@@ -166,7 +168,7 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      */
     protected function runTextUICommand()
     {
-        $command = new \PDepend\TextUI\Command();
+        $command = new Command();
 
         ob_start();
         $exitCode = $command->run();

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\AST\ASTParameter;
+
 /**
  * Test case for parameter related ticker #32.
  *
@@ -146,7 +148,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
     /**
      * Returns the parameters of the first method in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTParameter[]
+     * @return ASTParameter[]
      */
     private function getParametersOfFirstMethod()
     {

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -42,7 +42,13 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\Parser\MissingValueException;
+use PDepend\Source\Parser\TokenStreamEndException;
 
 /**
  * Test case for the Reflection API compatibility ticket #67.
@@ -571,7 +577,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
      */
     public function testParserThrowsExpectedExceptionForMissingDefaultValue(): void
     {
-        $this->expectException(\PDepend\Source\Parser\MissingValueException::class);
+        $this->expectException(MissingValueException::class);
 
         $this->parseTestCase();
     }
@@ -584,7 +590,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
      */
     public function testParserThrowsExpectedExceptionWhenReachesEofWhileParsingDefaultValue(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->parseTestCase();
     }
@@ -592,7 +598,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Returns the first interface in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTInterface
+     * @return ASTInterface
      */
     private function getFirstInterface()
     {
@@ -605,7 +611,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Returns the first class in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTClass
+     * @return ASTClass
      */
     private function getFirstClass()
     {
@@ -618,7 +624,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Returns the first method in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     private function getFirstMethod()
     {
@@ -633,7 +639,7 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Returns the first function in the test case file.
      *
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return ASTFunction
      */
     private function getFirstFunction()
     {

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -44,6 +44,7 @@ namespace PDepend\Metrics;
 
 use Exception;
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Abstract base class for tests of the metrics package.
@@ -59,7 +60,7 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -94,7 +94,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
     {
         $analyzer = new ClassLevelAnalyzer();
         $this->assertEquals(
-            ['PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer'],
+            [CyclomaticComplexityAnalyzer::class],
             $analyzer->getRequiredAnalyzers()
         );
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for the method strategy.
@@ -90,7 +92,7 @@ class MethodStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassA',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend_CodeRank_ClassB'] => [
                 'in' => [
@@ -101,7 +103,7 @@ class MethodStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassB',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend_CodeRank_ClassC'] => [
                 'in' => [
@@ -113,7 +115,7 @@ class MethodStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassB'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassC',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend::CodeRankA'] => [
                 'in' => [
@@ -125,7 +127,7 @@ class MethodStrategyTest extends AbstractTestCase
                     $idMap['PDepend::CodeRankB'],
                 ],
                 'name' => 'PDepend::CodeRankA',
-                'type' => 'PDepend\\Source\\AST\\ASTNamespace',
+                'type' => ASTNamespace::class,
             ],
             $idMap['PDepend::CodeRankB'] => [
                 'in' => [
@@ -137,7 +139,7 @@ class MethodStrategyTest extends AbstractTestCase
                     $idMap['PDepend::CodeRankA'],
                 ],
                 'name' => 'PDepend::CodeRankB',
-                'type' => 'PDepend\\Source\\AST\\ASTNamespace',
+                'type' => ASTNamespace::class,
             ],
         ];
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for the code rank property strategy.
@@ -90,7 +92,7 @@ class PropertyStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassC'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassA',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend_CodeRank_ClassB'] => [
                 'in' => [
@@ -101,7 +103,7 @@ class PropertyStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassA'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassB',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend_CodeRank_ClassC'] => [
                 'in' => [
@@ -113,7 +115,7 @@ class PropertyStrategyTest extends AbstractTestCase
                     $idMap['PDepend_CodeRank_ClassB'],
                 ],
                 'name' => 'PDepend_CodeRank_ClassC',
-                'type' => 'PDepend\\Source\\AST\\ASTClass',
+                'type' => ASTClass::class,
             ],
             $idMap['PDepend::CodeRankA'] => [
                 'in' => [
@@ -125,7 +127,7 @@ class PropertyStrategyTest extends AbstractTestCase
                     $idMap['PDepend::CodeRankB'],
                 ],
                 'name' => 'PDepend::CodeRankA',
-                'type' => 'PDepend\\Source\\AST\\ASTNamespace',
+                'type' => ASTNamespace::class,
             ],
             $idMap['PDepend::CodeRankB'] => [
                 'in' => [
@@ -137,7 +139,7 @@ class PropertyStrategyTest extends AbstractTestCase
                     $idMap['PDepend::CodeRankA'],
                 ],
                 'name' => 'PDepend::CodeRankB',
-                'type' => 'PDepend\\Source\\AST\\ASTNamespace',
+                'type' => ASTNamespace::class,
             ],
         ];
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\AST\ASTArtifact;
 
 /**
  * Test case for the coupling analyzer.
@@ -60,7 +61,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      */
     public function testGetNodeMetricsReturnsAnEmptyArrayByDefault(): void
     {
-        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+        $astArtifact = $this->getMockBuilder(ASTArtifact::class)
             ->getMock();
 
         $analyzer = new CouplingAnalyzer();

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -62,7 +62,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     {
         $analyzer = new CrapIndexAnalyzer();
         $actual = $analyzer->getRequiredAnalyzers();
-        $expected = ['PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer'];
+        $expected = [CyclomaticComplexityAnalyzer::class];
 
         $this->assertEquals($expected, $actual);
     }
@@ -218,7 +218,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      */
     private function createCyclomaticComplexityAnalyzerMock($ccn = 42)
     {
-        $mock = $this->getMockBuilder('PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer')
+        $mock = $this->getMockBuilder(CyclomaticComplexityAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getCCN2')

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\AST\ASTArtifact;
+use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -58,7 +60,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      * @since 1.0.0
      */
     private $cache;
@@ -79,7 +81,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     public function testGetCCNReturnsZeroForUnknownNode(): void
     {
         $analyzer = $this->createAnalyzer();
-        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+        $astArtifact = $this->getMockBuilder(ASTArtifact::class)
             ->getMock();
         $this->assertEquals(0, $analyzer->getCcn($astArtifact));
     }
@@ -90,7 +92,7 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     public function testGetCCN2ReturnsZeroForUnknownNode(): void
     {
         $analyzer = $this->createAnalyzer();
-        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+        $astArtifact = $this->getMockBuilder(ASTArtifact::class)
             ->getMock();
         $this->assertEquals(0, $analyzer->getCcn2($astArtifact));
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\AST\ASTArtifact;
+use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -58,7 +60,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      * @since 1.0.0
      */
     private $cache;
@@ -79,7 +81,7 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     public function testGetNodeMetricsReturnsNothingForUnknownNode(): void
     {
         $analyzer = $this->createAnalyzer();
-        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+        $astArtifact = $this->getMockBuilder(ASTArtifact::class)
             ->getMock();
         $this->assertEquals([], $analyzer->getNodeMetrics($astArtifact));
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Source\AST\ASTArtifact;
+use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -58,7 +60,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      * @since 1.0.0
      */
     private $cache;
@@ -79,7 +81,7 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     public function testGetNodeMetricsReturnsNothingForUnknownNode(): void
     {
         $analyzer = $this->createAnalyzer();
-        $astArtifact = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifact')
+        $astArtifact = $this->getMockBuilder(ASTArtifact::class)
             ->getMock();
         $this->assertEquals([], $analyzer->getNodeMetrics($astArtifact));
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -44,6 +44,9 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\AbstractASTCallable;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -59,7 +62,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      * @since 1.0.0
      */
     private $cache;
@@ -460,7 +463,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Parses the source code associated with the calling test case and returns
      * the first function found in the test case source file.
      *
-     * @return \PDepend\Source\AST\ASTFunction
+     * @return ASTFunction
      * @since 0.9.12
      */
     private function getFirstFunctionForTestCaseInternal()
@@ -489,7 +492,7 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Parses the source code associated with the calling test case and returns
      * the first method found in the test case source file.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      * @since 0.9.12
      */
     private function getFirstMethodForTestCaseInternal()

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -44,6 +44,7 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
 /**
@@ -59,7 +60,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
-     * @var \PDepend\Util\Cache\CacheDriver
+     * @var CacheDriver
      * @since 1.0.0
      */
     private $cache;

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -43,13 +43,28 @@
 namespace PDepend;
 
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\State;
+use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
+use PDepend\Source\Parser\MissingValueException;
+use PDepend\Source\Parser\TokenStreamEndException;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use RuntimeException;
 
 /**
  * Test case implementation for the PDepend code parser.
@@ -89,7 +104,7 @@ class ParserTest extends AbstractTestCase
             'pkg1' => true,
             'pkg2' => true,
             'pkg3' => true,
-            Source\Builder\Builder::DEFAULT_NAMESPACE => true,
+            Builder::DEFAULT_NAMESPACE => true,
         ];
 
         $tmp = $this->parseCodeResourceForTest();
@@ -131,7 +146,7 @@ class ParserTest extends AbstractTestCase
     {
         $sourceFile = $this->createCodeResourceUriForTest();
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\TokenStreamEndException'
+            TokenStreamEndException::class
         );
         $this->expectExceptionMessage(
             "Unexpected end of token stream in file: {$sourceFile}."
@@ -147,7 +162,7 @@ class ParserTest extends AbstractTestCase
     public function testParserWithUnclosedFunctionFail(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\TokenStreamEndException'
+            TokenStreamEndException::class
         );
         $this->expectExceptionMessage(
             'Unexpected end of token stream in file: '
@@ -163,7 +178,7 @@ class ParserTest extends AbstractTestCase
     public function testParserWithInvalidFunction1Fail(): void
     {
         $this->expectException(
-            '\\RuntimeException'
+            RuntimeException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: (, line: 3, col: 23, file: '
@@ -179,7 +194,7 @@ class ParserTest extends AbstractTestCase
     public function testParserWithInvalidFunction2Fail(): void
     {
         $this->expectException(
-            '\\RuntimeException'
+            RuntimeException::class
         );
         $this->expectExceptionMessage(
             "Unexpected token: Bar, line: 3, col: 18, file: "
@@ -484,7 +499,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser sets the correct function return type.
      *
-     * @return \PDepend\Source\AST\ASTFunction[]
+     * @return ASTFunction[]
      */
     public function testParserSetsCorrectFunctionReturnType()
     {
@@ -497,7 +512,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTFunction[] $functions
+     * @param ASTFunction[] $functions
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
@@ -516,7 +531,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTFunction[] $functions
+     * @param ASTFunction[] $functions
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
@@ -535,7 +550,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTFunction[] $functions
+     * @param ASTFunction[] $functions
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
@@ -906,7 +921,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser supports sub packages.
      *
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function testParserSetsFileLevelFunctionPackage()
     {
@@ -918,7 +933,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
@@ -929,7 +944,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
@@ -940,7 +955,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
@@ -952,7 +967,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
@@ -964,7 +979,7 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
-     * @param \PDepend\Source\AST\ASTNamespace[] $namespaces
+     * @param ASTNamespace[] $namespaces
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
@@ -1052,7 +1067,7 @@ class ParserTest extends AbstractTestCase
             ->getMethods()
             ->current();
 
-        $foreach = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTForeachStatement');
+        $foreach = $method->getFirstChildOfType(ASTForeachStatement::class);
         $this->assertNotNull($foreach);
     }
 
@@ -1063,7 +1078,7 @@ class ParserTest extends AbstractTestCase
     public function testParserThrowsUnexpectedTokenExceptionForBrokenParameterArrayDefaultValue(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: {, line: 2, col: 29, file: '
@@ -1079,7 +1094,7 @@ class ParserTest extends AbstractTestCase
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInParameterDefaultValue(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: &, line: 2, col: 27, file: '
@@ -1095,7 +1110,7 @@ class ParserTest extends AbstractTestCase
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInClassBody(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: ;, line: 4, col: 5, file: '
@@ -1111,7 +1126,7 @@ class ParserTest extends AbstractTestCase
     public function testParserThrowsUnexpectedTokenExceptionForInvalidTokenInMethodDeclaration(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: &, line: 4, col: 12, file: '
@@ -1129,7 +1144,7 @@ class ParserTest extends AbstractTestCase
         $parameters = $this->getFirstClassMethodForTestCase()->getParameters();
 
         $this->assertTrue($parameters[0]->isDefaultValueAvailable());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParentReference', $parameters[0]->getDefaultValue());
+        $this->assertInstanceOf(ASTParentReference::class, $parameters[0]->getDefaultValue());
         $this->assertSame('parent', $parameters[0]->getDefaultValue()->getImage());
     }
 
@@ -1217,7 +1232,7 @@ class ParserTest extends AbstractTestCase
      */
     public function testParserThrowsExpectedExceptionWhenDefaultStaticDefaultValueNotExists(): void
     {
-        $this->expectException(Source\Parser\MissingValueException::class);
+        $this->expectException(MissingValueException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -1240,7 +1255,7 @@ class ParserTest extends AbstractTestCase
             ->getFunctions()
             ->current();
 
-        $string = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
+        $string = $function->getFirstChildOfType(ASTString::class);
         $image = $string->getChild(0)->getImage();
 
         $this->assertEquals('\$foobar', $image);
@@ -1256,7 +1271,7 @@ class ParserTest extends AbstractTestCase
             ->getFunctions()
             ->current();
 
-        $string = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
+        $string = $function->getFirstChildOfType(ASTString::class);
         $image = $string->getChild(0)->getImage();
 
         $this->assertEquals('\\\\\"', $image);
@@ -1272,10 +1287,10 @@ class ParserTest extends AbstractTestCase
             ->getFunctions()
             ->current();
 
-        $string = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
+        $string = $function->getFirstChildOfType(ASTString::class);
         $variable = $string->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
+        $this->assertInstanceOf(ASTVariable::class, $variable);
     }
 
     /**
@@ -1288,10 +1303,10 @@ class ParserTest extends AbstractTestCase
             ->getFunctions()
             ->current();
 
-        $string = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
+        $string = $function->getFirstChildOfType(ASTString::class);
         $variable = $string->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
+        $this->assertInstanceOf(ASTVariable::class, $variable);
     }
 
     /**
@@ -1306,8 +1321,8 @@ class ParserTest extends AbstractTestCase
             ->getMethods()
             ->current();
 
-        $string = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTString');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $string->getChild(1));
+        $string = $method->getFirstChildOfType(ASTString::class);
+        $this->assertInstanceOf(ASTLiteral::class, $string->getChild(1));
     }
 
     /**
@@ -1315,7 +1330,7 @@ class ParserTest extends AbstractTestCase
      */
     public function testParserStopsProcessingWhenCacheContainsValidResult(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
 
         $tokenizer = new PHPTokenizerInternal();
@@ -1397,7 +1412,7 @@ class ParserTest extends AbstractTestCase
      */
     public function testParseExpressionUntilThrowsExceptionForUnclosedStatement(): void
     {
-        $this->expectException(Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -1421,7 +1436,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns an interface instance from the mixed code test file.
      *
-     * @return Source\AST\ASTInterface
+     * @return ASTInterface
      */
     protected function getInterfaceForTest()
     {
@@ -1433,7 +1448,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns the methods of an interface from the mixed code test file.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     protected function getInterfaceMethodsForTest()
     {
@@ -1448,7 +1463,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns a class instance from the mixed code test file.
      *
-     * @return Source\AST\ASTClass
+     * @return ASTClass
      */
     protected function getClassForTest()
     {
@@ -1459,7 +1474,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns the methods of a class from the mixed code test file.
      *
-     * @return \PDepend\Source\AST\ASTMethod[]
+     * @return ASTMethod[]
      */
     protected function getClassMethodsForTest()
     {

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -43,6 +43,10 @@
 namespace PDepend\Report\Dependencies;
 
 use PDepend\AbstractTestCase;
+use PDepend\Metrics\Analyzer\ClassDependencyAnalyzer;
+use PDepend\Metrics\AnalyzerNodeAware;
+use PDepend\Report\NoLogOutputException;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
@@ -110,7 +114,7 @@ class XmlTest extends AbstractTestCase
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
         $this->expectException(
-            '\\PDepend\\Report\\NoLogOutputException'
+            NoLogOutputException::class
         );
         $this->expectExceptionMessage(
             "The log target is not configured for 'PDepend\\Report\\Dependencies\\Xml'."
@@ -125,7 +129,7 @@ class XmlTest extends AbstractTestCase
      */
     public function testLogMethodReturnsFalseForWrongAnalyzer(): void
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerNodeAware')
+        $analyzer = $this->getMockBuilder(AnalyzerNodeAware::class)
             ->getMock();
 
         $logger = new Xml();
@@ -139,7 +143,7 @@ class XmlTest extends AbstractTestCase
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeClassDepenendecyAnalyzer(): void
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer')
+        $analyzer = $this->getMockBuilder(ClassDependencyAnalyzer::class)
             ->getMock();
 
         $logger = new Xml();
@@ -177,7 +181,7 @@ class XmlTest extends AbstractTestCase
     {
         $this->namespaces = self::parseCodeResourceForTest();
 
-        $type = $this->getMockBuilder('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface')
+        $type = $this->getMockBuilder(AbstractASTClassOrInterface::class)
             ->disableOriginalConstructor()
             ->getMock();
         $type
@@ -189,7 +193,7 @@ class XmlTest extends AbstractTestCase
             ->method('getNamespaceName')
             ->will($this->returnValue('namespace'));
 
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\ClassDependencyAnalyzer')
+        $analyzer = $this->getMockBuilder(ClassDependencyAnalyzer::class)
             ->getMock();
         $analyzer
             ->expects($this->any())

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -42,6 +42,7 @@
 
 namespace PDepend\Report\Dummy;
 
+use PDepend\Metrics\Analyzer;
 use PDepend\Report\CodeAwareGenerator;
 use PDepend\Report\FileAwareGenerator;
 use PDepend\Source\AST\ASTArtifactList;
@@ -114,10 +115,10 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      * Adds an analyzer to log. If this logger accepts the given analyzer it
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
-     * @param \PDepend\Metrics\Analyzer $analyzer The analyzer to log.
+     * @param Analyzer $analyzer The analyzer to log.
      * @return bool
      */
-    public function log(\PDepend\Metrics\Analyzer $analyzer)
+    public function log(Analyzer $analyzer)
     {
         $this->input['analyzers'][] = $analyzer;
         return true;

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -47,8 +47,10 @@ use DOMXPath;
 use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
+use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTNamespace;
 
 /**
  * Test case for the jdepend chart logger.
@@ -106,7 +108,7 @@ class ChartTest extends AbstractTestCase
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
-        $this->expectException(\PDepend\Report\NoLogOutputException::class);
+        $this->expectException(NoLogOutputException::class);
 
         $logger = new Chart();
         $logger->close();
@@ -207,7 +209,7 @@ class ChartTest extends AbstractTestCase
     {
         $nodes = $this->createPackages(true, true);
 
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\DependencyAnalyzer')
+        $analyzer = $this->getMockBuilder(DependencyAnalyzer::class)
             ->getMock();
         $analyzer->expects($this->atLeastOnce())
             ->method('getStats')
@@ -302,7 +304,7 @@ class ChartTest extends AbstractTestCase
     }
 
     /**
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     private function createPackages()
     {
@@ -319,11 +321,11 @@ class ChartTest extends AbstractTestCase
     /**
      * @param bool $userDefined
      * @param string $packageName
-     * @return \PDepend\Source\AST\ASTNamespace
+     * @return ASTNamespace
      */
     private function createPackage($userDefined, $packageName)
     {
-        $packageA = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTNamespace')
+        $packageA = $this->getMockBuilder(ASTNamespace::class)
             ->onlyMethods(['isUserDefined'])
             ->setConstructorArgs([$packageName])
             ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTNamespace')

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -45,6 +45,7 @@ namespace PDepend\Report\Jdepend;
 use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
+use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 
 /**
@@ -112,7 +113,7 @@ class XmlTest extends AbstractTestCase
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
         $this->expectException(
-            '\\PDepend\\Report\\NoLogOutputException'
+            NoLogOutputException::class
         );
         $this->expectExceptionMessage(
             "The log target is not configured for 'PDepend\\Report\\Jdepend\\Xml'."

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -43,8 +43,15 @@
 namespace PDepend\Report\Overview;
 
 use DOMDocument;
+use DOMElement;
 use PDepend\AbstractTestCase;
+use PDepend\Metrics\Analyzer\CouplingAnalyzer;
+use PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer;
+use PDepend\Metrics\Analyzer\InheritanceAnalyzer;
+use PDepend\Metrics\Analyzer\NodeCountAnalyzer;
+use PDepend\Metrics\Analyzer\NodeLocAnalyzer;
 use PDepend\Report\DummyAnalyzer;
+use PDepend\Report\NoLogOutputException;
 
 /**
  * Test case for the overview pyramid logger.
@@ -84,7 +91,7 @@ class PyramidTest extends AbstractTestCase
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
         $this->expectException(
-            '\\PDepend\\Report\\NoLogOutputException'
+            NoLogOutputException::class
         );
         $this->expectExceptionMessage(
             "The log target is not configured for 'PDepend\\Report\\Overview\\Pyramid'."
@@ -253,7 +260,7 @@ class PyramidTest extends AbstractTestCase
         // TODO: Replace this loop assertion
         foreach ($expected as $name => $value) {
             $elem = $svg->getElementById("pdepend.{$name}");
-            $this->assertInstanceOf('\\DOMElement', $elem);
+            $this->assertInstanceOf(DOMElement::class, $elem);
             $this->assertEqualsWithDelta($value, $elem->nodeValue, 0.01);
         }
 
@@ -262,7 +269,7 @@ class PyramidTest extends AbstractTestCase
 
     private function createCouplingAnalyzer()
     {
-        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\CouplingAnalyzer')
+        $mock = $this->getMockBuilder(CouplingAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
@@ -278,7 +285,7 @@ class PyramidTest extends AbstractTestCase
 
     private function createComplexityAnalyzer()
     {
-        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\CyclomaticComplexityAnalyzer')
+        $mock = $this->getMockBuilder(CyclomaticComplexityAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
@@ -293,7 +300,7 @@ class PyramidTest extends AbstractTestCase
 
     private function createInheritanceAnalyzer()
     {
-        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\InheritanceAnalyzer')
+        $mock = $this->getMockBuilder(InheritanceAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
@@ -309,7 +316,7 @@ class PyramidTest extends AbstractTestCase
 
     private function createNodeCountAnalyzer()
     {
-        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\NodeCountAnalyzer')
+        $mock = $this->getMockBuilder(NodeCountAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')
@@ -327,7 +334,7 @@ class PyramidTest extends AbstractTestCase
 
     private function createNodeLocAnalyzer()
     {
-        $mock = $this->getMockBuilder('\\PDepend\\Metrics\\Analyzer\\NodeLocAnalyzer')
+        $mock = $this->getMockBuilder(NodeLocAnalyzer::class)
             ->getMock();
         $mock->expects($this->any())
             ->method('getProjectMetrics')

--- a/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
+++ b/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Report;
 
 use PDepend\AbstractTestCase;
+use PDepend\Application;
 
 /**
  * Test case for the logger factory.
@@ -54,7 +55,7 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
 {
     private function createReportGeneratorFactory()
     {
-        $application = new \PDepend\Application();
+        $application = new Application();
 
         return $application->getReportGeneratorFactory();
     }
@@ -68,7 +69,7 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
         $factory = $this->createReportGeneratorFactory();
         $generator = $factory->createGenerator('summary-xml', 'pdepend.xml');
 
-        $this->assertInstanceOf('PDepend\\Report\\Summary\\Xml', $generator);
+        $this->assertInstanceOf(Summary\Xml::class, $generator);
     }
 
     /**
@@ -81,7 +82,7 @@ class ReportGeneratorFactoryTest extends AbstractTestCase
         $generator1 = $factory->createGenerator('summary-xml', 'pdepend1.xml');
         $generator2 = $factory->createGenerator('summary-xml', 'pdepend2.xml');
 
-        $this->assertInstanceOf('PDepend\\Report\\Summary\\Xml', $generator1);
+        $this->assertInstanceOf(Summary\Xml::class, $generator1);
         $this->assertSame($generator1, $generator2);
     }
 

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -43,6 +43,9 @@
 namespace PDepend\Report\Summary;
 
 use PDepend\AbstractTestCase;
+use PDepend\Metrics\AnalyzerNodeAware;
+use PDepend\Metrics\AnalyzerProjectAware;
+use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
@@ -122,7 +125,7 @@ class XmlTest extends AbstractTestCase
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
         $this->expectException(
-            '\\PDepend\\Report\\NoLogOutputException'
+            NoLogOutputException::class
         );
         $this->expectExceptionMessage(
             "The log target is not configured for 'PDepend\\Report\\Summary\\Xml'."
@@ -137,7 +140,7 @@ class XmlTest extends AbstractTestCase
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeProjectAware(): void
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerProjectAware')
+        $analyzer = $this->getMockBuilder(AnalyzerProjectAware::class)
             ->getMock();
 
         $logger = new Xml();
@@ -151,7 +154,7 @@ class XmlTest extends AbstractTestCase
      */
     public function testLogMethodReturnsTrueForAnalyzerOfTypeNodeAware(): void
     {
-        $analyzer = $this->getMockBuilder('\\PDepend\\Metrics\\AnalyzerNodeAware')
+        $analyzer = $this->getMockBuilder(AnalyzerNodeAware::class)
             ->getMock();
 
         $logger = new Xml();

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -60,7 +60,7 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
     public function testAllocationExpressionWithoutArguments(): void
     {
         $expr = $this->getFirstAllocationExpressionInFunction(__METHOD__);
-        $args = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTArguments');
+        $args = $expr->findChildrenOfType(ASTArguments::class);
 
         $this->assertCount(0, $args);
     }
@@ -71,7 +71,7 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
     public function testAllocationExpressionWithArguments(): void
     {
         $expr = $this->getFirstAllocationExpressionInFunction(__METHOD__);
-        $args = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTArguments');
+        $args = $expr->findChildrenOfType(ASTArguments::class);
 
         $this->assertCount(1, $args);
     }
@@ -83,7 +83,7 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
     public function testAllocationExpressionWithNestedArguments(): void
     {
         $expr = $this->getFirstAllocationExpressionInFunction(__METHOD__);
-        $arg = $expr->getFirstChildOfType('PDepend\\Source\\AST\\ASTArguments');
+        $arg = $expr->getFirstChildOfType(ASTArguments::class);
 
         $this->assertEquals($expr, $arg->getParent());
     }
@@ -134,7 +134,7 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTAllocationExpression'
+            ASTAllocationExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -117,6 +117,6 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
     private function getFirstAnonymousClassInFunction()
     {
         return $this->getFirstFunctionForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTAnonymousClass');
+            ->getFirstChildOfType(ASTAnonymousClass::class);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -65,11 +65,11 @@ class ASTArgumentsTest extends ASTNodeTestCase
         $this->assertGraph(
             $arguments,
             [
-                'PDepend\\Source\\AST\\ASTConstant' . ' (__CLASS__)',
-                'PDepend\\Source\\AST\\ASTLiteral' . ' ("run")',
-                'PDepend\\Source\\AST\\ASTArray' . ' ()', [
-                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTVariable' . ' ($count)']],
+                ASTConstant::class . ' (__CLASS__)',
+                ASTLiteral::class . ' ("run")',
+                ASTArray::class . ' ()', [
+                    ASTArrayElement::class . ' ()', [
+                        ASTVariable::class . ' ($count)']],
             ]
         );
     }
@@ -131,7 +131,7 @@ class ASTArgumentsTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -76,7 +76,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)',
+                ASTVariable::class . ' ($foo)',
             ]
         );
     }
@@ -101,7 +101,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($foo)',
+                ASTVariable::class . ' ($foo)',
             ]
         );
     }
@@ -127,8 +127,8 @@ class ASTArrayElementTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)',
+                ASTVariable::class . ' ($key)',
+                ASTVariable::class . ' ($value)',
             ]
         );
     }
@@ -154,8 +154,8 @@ class ASTArrayElementTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($key)',
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($value)',
+                ASTVariable::class . ' ($key)',
+                ASTVariable::class . ' ($value)',
             ]
         );
     }
@@ -200,21 +200,21 @@ class ASTArrayElementTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstArrayElementInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTLiteral' . ' ("bar")',
-                'PDepend\\Source\\AST\\ASTArray' . ' ()', [
-                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                            'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']],
-                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)',
-                        'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                            'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']],
-                    'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTArray' . ' ()', [
-                            'PDepend\\Source\\AST\\ASTArrayElement' . ' ()', [
-                                'PDepend\\Source\\AST\\ASTLiteral' . ' ("foo")',
-                                'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                                    'PDepend\\Source\\AST\\ASTClassReference' . ' (Object)']]]],
+                ASTLiteral::class . ' ("bar")',
+                ASTArray::class . ' ()', [
+                    ASTArrayElement::class . ' ()', [
+                        ASTAllocationExpression::class . ' (new)', [
+                            ASTClassReference::class . ' (Object)']],
+                    ASTArrayElement::class . ' ()', [
+                        ASTLiteral::class . ' (23)',
+                        ASTAllocationExpression::class . ' (new)', [
+                            ASTClassReference::class . ' (Object)']],
+                    ASTArrayElement::class . ' ()', [
+                        ASTArray::class . ' ()', [
+                            ASTArrayElement::class . ' ()', [
+                                ASTLiteral::class . ' ("foo")',
+                                ASTAllocationExpression::class . ' (new)', [
+                                    ASTClassReference::class . ' (Object)']]]],
                 ],
             ]
         );
@@ -301,7 +301,7 @@ class ASTArrayElementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArrayElement'
+            ASTArrayElement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -79,10 +79,10 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -111,10 +111,10 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTFunctionPostfix::class,
+                ASTVariable::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -145,12 +145,12 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -181,12 +181,12 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTVariable::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -217,12 +217,12 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -253,12 +253,12 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTMethodPostfix::class,
+                ASTVariable::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -275,8 +275,8 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTVariable::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -293,8 +293,8 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTIdentifier::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -311,12 +311,12 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstArrayIndexExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral',
-                'PDepend\\Source\\AST\\ASTLiteral',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTArrayIndexExpression::class,
+                ASTArrayIndexExpression::class,
+                ASTVariable::class,
+                ASTLiteral::class,
+                ASTLiteral::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -366,7 +366,7 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression'
+            ASTArrayIndexExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -143,7 +143,7 @@ class ASTArrayTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArray'
+            ASTArray::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -147,7 +147,7 @@ class ASTArtifactTest extends AbstractTestCase
     protected function getItemMock()
     {
         return $this->getAbstractClassMock(
-            'PDepend\\Source\\AST\\AbstractASTArtifact',
+            AbstractASTArtifact::class,
             [__CLASS__]
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -62,12 +62,12 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstAssignmentExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTVariable::class,
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -80,11 +80,11 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstAssignmentExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTVariable::class,
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -97,13 +97,13 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstAssignmentExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTVariable::class,
+                ASTMemberPrimaryPrefix::class,
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTPropertyPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -116,8 +116,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstAssignmentExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTVariable::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -130,8 +130,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstAssignmentExpressionInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTVariable::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -277,7 +277,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     public function testVariableAssignmentExpression()
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
+        $this->assertInstanceOf(ASTAssignmentExpression::class, $expr);
 
         return $expr;
     }
@@ -339,7 +339,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     public function testStaticPropertyAssignmentExpression()
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
+        $this->assertInstanceOf(ASTAssignmentExpression::class, $expr);
 
         return $expr;
     }
@@ -401,7 +401,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     public function testObjectPropertyAssignmentExpression()
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
+        $this->assertInstanceOf(ASTAssignmentExpression::class, $expr);
 
         return $expr;
     }
@@ -463,7 +463,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     public function testChainedPropertyAssignmentExpression()
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $expr);
+        $this->assertInstanceOf(ASTAssignmentExpression::class, $expr);
 
         return $expr;
     }
@@ -525,7 +525,7 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTAssignmentExpression'
+            ASTAssignmentExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -100,7 +100,7 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTBooleanAndExpression'
+            ASTBooleanAndExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -100,7 +100,7 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTBooleanOrExpression'
+            ASTBooleanOrExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -100,7 +100,7 @@ class ASTBreakStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTBreakStatement'
+            ASTBreakStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -89,7 +89,7 @@ class ASTCallableTest extends AbstractTestCase
     public function testGetParametersReturnsArrayWithObjectsOfTypeParameter(): void
     {
         $parameters = $this->getFirstCallableForTest()->getParameters();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParameter', $parameters[0]);
+        $this->assertInstanceOf(ASTParameter::class, $parameters[0]);
     }
 
     /**
@@ -270,7 +270,7 @@ class ASTCallableTest extends AbstractTestCase
     protected function getCallableMock()
     {
         return $this->getAbstractClassMock(
-            'PDepend\\Source\\AST\\AbstractASTCallable',
+            AbstractASTCallable::class,
             [__CLASS__]
         );
     }

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -243,10 +243,10 @@ class ASTCastExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTCastExpression',
-                'PDepend\\Source\\AST\\ASTCastExpression',
-                'PDepend\\Source\\AST\\ASTCastExpression',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTCastExpression::class,
+                ASTCastExpression::class,
+                ASTCastExpression::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -297,7 +297,7 @@ class ASTCastExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTCastExpression'
+            ASTCastExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -96,7 +96,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     public function testCatchStatementVariableHasExpectedStartLine(): void
     {
         $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+            ->getFirstChildOfType(ASTVariable::class);
         $this->assertEquals(8, $variable->getStartLine());
     }
 
@@ -106,7 +106,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     public function testCatchStatementVariableHasExpectedStartColumn(): void
     {
         $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+            ->getFirstChildOfType(ASTVariable::class);
         $this->assertEquals(9, $variable->getStartColumn());
     }
 
@@ -116,7 +116,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     public function testCatchStatementVariableHasExpectedEndLine(): void
     {
         $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+            ->getFirstChildOfType(ASTVariable::class);
         $this->assertEquals(8, $variable->getStartLine());
     }
 
@@ -126,7 +126,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     public function testCatchStatementVariableHasExpectedEndColumn(): void
     {
         $variable = $this->getFirstCatchStatementInFunction(__METHOD__)
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+            ->getFirstChildOfType(ASTVariable::class);
         $this->assertEquals(10, $variable->getEndColumn());
     }
 
@@ -136,7 +136,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     public function testThirdChildOfCatchStatementIsScopeStatement(): void
     {
         $stmt = $this->getFirstCatchStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(2));
     }
 
     /**
@@ -149,7 +149,7 @@ class ASTCatchStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTCatchStatement'
+            ASTCatchStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -75,8 +75,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
-                'PDepend\\Source\\AST\\ASTStaticReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
+                ASTStaticReference::class,
+                ASTClassFqnPostfix::class,
             ]
         );
     }
@@ -98,8 +98,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
-                'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
+                ASTSelfReference::class,
+                ASTClassFqnPostfix::class,
             ]
         );
     }
@@ -112,8 +112,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
-                'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
+                ASTParentReference::class,
+                ASTClassFqnPostfix::class,
             ]
         );
     }
@@ -126,8 +126,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInClass(__METHOD__),
             [
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTClassFqnPostfix',
+                ASTClassOrInterfaceReference::class,
+                ASTClassFqnPostfix::class,
             ]
         );
     }
@@ -146,17 +146,17 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         /** @var ASTFieldDeclaration $fieldDeclaration */
         $fieldDeclaration = $this->getFirstClassForTestCase(__METHOD__)->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFieldDeclaration', $fieldDeclaration);
+        $this->assertInstanceOf(ASTFieldDeclaration::class, $fieldDeclaration);
 
         /** @var ASTVariableDeclarator $variableDeclarator */
         $variableDeclarator = $fieldDeclaration->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         $this->assertTrue($variableDeclarator->getValue()->isValueAvailable());
 
         /** @var ASTClassOrInterfaceReference $classReference */
         $classReference = $variableDeclarator->getValue()->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $classReference);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $classReference);
 
         $this->assertSame('\\Iterator', $classReference->getImage());
     }
@@ -175,17 +175,17 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         /** @var ASTFieldDeclaration $fieldDeclaration */
         $fieldDeclaration = $this->getFirstClassForTestCase(__METHOD__)->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFieldDeclaration', $fieldDeclaration);
+        $this->assertInstanceOf(ASTFieldDeclaration::class, $fieldDeclaration);
 
         /** @var ASTVariableDeclarator $variableDeclarator */
         $variableDeclarator = $fieldDeclaration->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         $this->assertTrue($variableDeclarator->getValue()->isValueAvailable());
 
         /** @var ASTSelfReference $classReference */
         $classReference = $variableDeclarator->getValue()->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $classReference);
+        $this->assertInstanceOf(ASTSelfReference::class, $classReference);
 
         $this->assertSame('self', $classReference->getImage());
     }
@@ -197,11 +197,11 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTParameter[] $parameters */
+        /** @var ASTParameter[] $parameters */
         $parameters = $this->getFirstClassMethodForTestCase(__METHOD__)->getParameters();
         $this->assertCount(1, $parameters);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParameter', $parameters[0]);
+        $this->assertInstanceOf(ASTParameter::class, $parameters[0]);
 
         $this->assertSame('testClassFqnPostfixAsParameterInitializer', $parameters[0]->getDefaultValue()->getImage());
     }
@@ -213,11 +213,11 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     {
         $this->assertNotNull($this->parseCodeResourceForTest());
 
-        /** @var \PDepend\Source\AST\ASTParameter[] $parameters */
+        /** @var ASTParameter[] $parameters */
         $parameters = $this->getFirstClassMethodForTestCase(__METHOD__)->getParameters();
         $this->assertCount(1, $parameters);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParameter', $parameters[0]);
+        $this->assertInstanceOf(ASTParameter::class, $parameters[0]);
 
         $this->assertSame('self', $parameters[0]->getDefaultValue()->getImage());
     }
@@ -232,12 +232,12 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         /** @var ASTConstantDefinition $constantDefinition */
         $constantDefinition = $this->getFirstClassForTestCase()->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constantDefinition);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constantDefinition);
 
         /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $constantDeclarator);
+        $this->assertInstanceOf(ASTConstantDeclarator::class, $constantDeclarator);
     }
 
     /**
@@ -250,12 +250,12 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
         /** @var ASTConstantDefinition $constantDefinition */
         $constantDefinition = $this->getFirstClassForTestCase()->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constantDefinition);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constantDefinition);
 
         /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $constantDeclarator);
+        $this->assertInstanceOf(ASTConstantDeclarator::class, $constantDeclarator);
     }
 
     /**
@@ -313,7 +313,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTClassFqnPostfix'
+            ASTClassFqnPostfix::class
         );
     }
     /**
@@ -326,7 +326,7 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -249,7 +249,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
     }
 
@@ -263,7 +263,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
     }
 
@@ -277,7 +277,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInInterface(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
     }
 
@@ -301,7 +301,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      */
     protected function getBuilderContextMock()
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         return $context;

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -192,7 +192,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTClassReference'
+            ASTClassReference::class
         );
     }
 
@@ -206,7 +206,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTClassReference'
+            ASTClassReference::class
         );
     }
 
@@ -230,7 +230,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      */
     protected function getBuilderContextMock()
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         return $context;

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -47,6 +47,7 @@ use InvalidArgumentException;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -134,7 +135,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $methods = $class->getAllMethods();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTrait',
+            ASTTrait::class,
             $methods['foo']->getParent()
         );
     }
@@ -150,7 +151,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $methods = $class->getAllMethods();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTrait',
+            ASTTrait::class,
             $methods['foo']->getParent()
         );
     }
@@ -166,7 +167,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $methods = $class->getAllMethods();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTClass',
+            ASTClass::class,
             $methods['foo']->getParent()
         );
     }
@@ -541,14 +542,14 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->never())
@@ -568,20 +569,20 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node3 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node3->expects($this->once())
@@ -601,14 +602,14 @@ class ASTClassTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
@@ -633,10 +634,10 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $params = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            ASTFormalParameter::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $params);
+        $this->assertInstanceOf(ASTFormalParameter::class, $params);
     }
 
     /**
@@ -646,7 +647,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $params = $class->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            ASTFormalParameter::class
         );
 
         $this->assertCount(4, $params);
@@ -659,7 +660,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $params = $class->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+            ASTVariableDeclarator::class
         );
 
         $this->assertCount(2, $params);
@@ -1449,7 +1450,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $method = new ASTMethod(__FUNCTION__);
         $class->addMethod($method);
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $class->setContext($context);
 
@@ -1467,11 +1468,11 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     {
         $class = new ASTClass(__CLASS__);
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $context->expects($this->once())
             ->method('registerClass')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTClass'));
+            ->with($this->isInstanceOf(ASTClass::class));
 
         $class->setContext($context)->__wakeup();
     }
@@ -1487,7 +1488,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $class->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $class->setCache(new MemoryCacheDriver());
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $class->setContext($context);
 

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -100,7 +100,7 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTCloneExpression'
+            ASTCloneExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -107,7 +107,7 @@ class ASTClosureTest extends ASTNodeTestCase
     public function testParserHandlesPureClosureStatementWithoutAssignment(): void
     {
         $closure = $this->getFirstClosureInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClosure', $closure);
+        $this->assertInstanceOf(ASTClosure::class, $closure);
     }
 
     /**
@@ -263,7 +263,7 @@ class ASTClosureTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTClosure'
+            ASTClosure::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -172,7 +172,7 @@ class ASTCommentTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTComment'
+            ASTComment::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code file class.
@@ -160,11 +161,11 @@ class ASTCompilationUnitTest extends AbstractTestCase
      */
     public function testAcceptInvokesVisitFileOnGivenVisitor(): void
     {
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('visitCompilationUnit')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTCompilationUnit'));
+            ->with($this->isInstanceOf(ASTCompilationUnit::class));
 
         $file = new ASTCompilationUnit(null);
         $file->accept($visitor);
@@ -213,13 +214,13 @@ class ASTCompilationUnitTest extends AbstractTestCase
      */
     public function testMagicWakeupMethodInvokesSetSourceFileOnChildNodes(): void
     {
-        $node = $this->getMockBuilder('PDepend\\Source\\AST\\ASTClass')
+        $node = $this->getMockBuilder(ASTClass::class)
             ->onlyMethods(['setCompilationUnit'])
             ->setConstructorArgs([__CLASS__])
             ->getMock();
         $node->expects($this->once())
             ->method('setCompilationUnit')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTCompilationUnit'));
+            ->with($this->isInstanceOf(ASTCompilationUnit::class));
 
         $compilationUnit = new ASTCompilationUnit(__FILE__);
         $compilationUnit->addChild($node);

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -100,7 +100,7 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTCompoundExpression'
+            ASTCompoundExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\TokenStreamEndException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCompoundVariable} class.
  *
@@ -62,7 +64,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
         $variable = $this->getFirstVariableInFunction(__METHOD__);
 
         $string = $variable->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTString', $string);
+        $this->assertInstanceOf(ASTString::class, $string);
     }
 
     /**
@@ -84,7 +86,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
         $variable = $this->getFirstVariableInFunction(__METHOD__);
 
         $string = $variable->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTString', $string);
+        $this->assertInstanceOf(ASTString::class, $string);
     }
 
     /**
@@ -94,11 +96,11 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
     {
         $variable = $this->getFirstVariableInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTMemberPrimaryPrefix::class,
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($variable, $expected);
@@ -109,7 +111,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
      */
     public function testUnclosedCompoundVariableThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -160,7 +162,7 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTCompoundVariable'
+            ASTCompoundVariable::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -100,7 +100,7 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTConditionalExpression'
+            ASTConditionalExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -77,7 +77,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     public function testParserInjectsValueObjectIntoConstantDeclarator(): void
     {
         $declarator = $this->getFirstConstantDeclaratorInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $declarator->getValue());
+        $this->assertInstanceOf(ASTValue::class, $declarator->getValue());
     }
 
     /**
@@ -109,7 +109,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     public function testConstantDeclarator()
     {
         $declarator = $this->getFirstConstantDeclaratorInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $declarator);
+        $this->assertInstanceOf(ASTConstantDeclarator::class, $declarator);
 
         return $declarator;
     }
@@ -171,7 +171,7 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTConstantDeclarator'
+            ASTConstantDeclarator::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -189,7 +189,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     public function testConstantDefinition()
     {
         $constant = $this->getFirstConstantDefinitionInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constant);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constant);
 
         return $constant;
     }
@@ -251,7 +251,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     public function testConstantDefinitionWithDeclarators()
     {
         $constant = $this->getFirstConstantDefinitionInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constant);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constant);
 
         return $constant;
     }
@@ -337,7 +337,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTConstantDefinition'
+            ASTConstantDefinition::class
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -69,7 +69,7 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
     public function testConstantPostfixStructureForStaticAccessOnVariable(): void
     {
         $postfix = $this->getFirstConstantPostfixInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $postfix->getChild(0));
+        $this->assertInstanceOf(ASTIdentifier::class, $postfix->getChild(0));
     }
 
     /**
@@ -118,7 +118,7 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTConstantPostfix'
+            ASTConstantPostfix::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -127,7 +127,7 @@ class ASTConstantTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTConstant'
+            ASTConstant::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -100,7 +100,7 @@ class ASTContinueStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTContinueStatement'
+            ASTContinueStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -209,7 +209,7 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTDeclareStatement'
+            ASTDeclareStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -69,7 +69,7 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
     public function testFirstChildOfDoWhileStatementIsInstanceOfScopeStatement(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(0));
     }
 
     /**
@@ -78,7 +78,7 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
     public function testSecondChildOfDoWhileStatementIsInstanceOfExpression(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -123,7 +123,7 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
     public function testDoWhileStatementWithoutScopeStatementChild(): void
     {
         $stmt = $this->getFirstDoWhileStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIfStatement', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTIfStatement::class, $stmt->getChild(0));
     }
 
     /**
@@ -136,7 +136,7 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTDoWhileStatement'
+            ASTDoWhileStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -100,7 +100,7 @@ class ASTEchoStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTEchoStatement'
+            ASTEchoStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -105,7 +105,7 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
     public function testFirstChildOfElseIfStatementIsInstanceOfExpression(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(0));
     }
 
     /**
@@ -114,7 +114,7 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
     public function testSecondChildOfElseIfStatementIsInstanceOfScopeStatement(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(1));
     }
 
     /**
@@ -159,7 +159,7 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
     public function testElseIfStatementWithoutScopeStatementBody(): void
     {
         $stmt = $this->getFirstElseIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForeachStatement', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTForeachStatement::class, $stmt->getChild(1));
     }
 
     /**
@@ -208,7 +208,7 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTElseIfStatement'
+            ASTElseIfStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -71,9 +71,9 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
         /** @var ASTEnum $enum */
         $deserializedEnum = unserialize($serializedClass);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $deserializedEnum);
+        $this->assertInstanceOf(ASTEnum::class, $deserializedEnum);
         $this->assertSame('test', $deserializedEnum->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $deserializedEnum->getType());
+        $this->assertInstanceOf(ASTScalarType::class, $deserializedEnum->getType());
         $this->assertSame('string', $deserializedEnum->getType()->getImage());
     }
 
@@ -100,9 +100,9 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
         }
 
         $this->assertSame([
-            'PDepend\Source\AST\ASTEnum' => ['test'],
-            'PDepend\Source\AST\ASTClass' => ['test'],
-            'PDepend\Source\AST\ASTNamespace' => ['+global', '+global'],
+            ASTEnum::class => ['test'],
+            ASTClass::class => ['test'],
+            ASTNamespace::class => ['+global', '+global'],
         ], $nodes);
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -100,7 +100,7 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTEvalExpression'
+            ASTEvalExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -63,7 +63,7 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     public function testExitExpressionWithExitCode()
     {
         $expr = $this->getFirstExitExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
+        $this->assertInstanceOf(ASTExitExpression::class, $expr);
 
         return $expr;
     }
@@ -129,7 +129,7 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     public function testExitExpressionWithEmptyArgs()
     {
         $expr = $this->getFirstExitExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
+        $this->assertInstanceOf(ASTExitExpression::class, $expr);
 
         return $expr;
     }
@@ -195,7 +195,7 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     public function testExitExpressionWithoutArgs()
     {
         $expr = $this->getFirstExitExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExitExpression', $expr);
+        $this->assertInstanceOf(ASTExitExpression::class, $expr);
 
         return $expr;
     }
@@ -257,7 +257,7 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTExitExpression'
+            ASTExitExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -70,12 +70,12 @@ class ASTExpressionTest extends ASTNodeTestCase
     {
         $expr = $this->getFirstExpressionInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTBooleanAndExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTBooleanOrExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTExpression::class,
+            ASTVariable::class,
+            ASTBooleanAndExpression::class,
+            ASTVariable::class,
+            ASTBooleanOrExpression::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($expr, $expected);
@@ -127,7 +127,7 @@ class ASTExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTExpression'
+            ASTExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use Java\Style;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFieldDeclaration} class.
  *
@@ -77,10 +79,10 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
             ->current();
 
         $declaration = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFieldDeclaration'
+            ASTFieldDeclaration::class
         );
         $reference = $declaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
         $this->assertNull($reference);
     }
@@ -94,7 +96,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
     {
         $declaration = $this->getFirstFieldDeclarationInClass();
         $reference = $declaration->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
 
         $type = $reference->getType();
@@ -109,7 +111,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      */
     public function testNamespaceForJavaStyleArrayNotation(AbstractASTClassOrInterface $type): void
     {
-        $this->assertEquals('Java\\Style', $type->getNamespaceName());
+        $this->assertEquals(Style::class, $type->getNamespaceName());
     }
 
     /**
@@ -289,7 +291,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFieldDeclaration'
+            ASTFieldDeclaration::class
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -132,7 +132,7 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
     public function testChildOfFinallyStatementIsScopeStatement(): void
     {
         $stmt = $this->getFirstFinallyStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(0));
     }
 
     /**
@@ -145,7 +145,7 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTFinallyStatement'
+            ASTFinallyStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -100,7 +100,7 @@ class ASTForInitTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTForInit'
+            ASTForInit::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -132,7 +132,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testFirstChildOfForStatementIsInstanceOfForInit(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForInit', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTForInit::class, $stmt->getChild(0));
     }
 
     /**
@@ -141,7 +141,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testFirstChildOfForStatementCanBeLeftBlank(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(0));
     }
 
 
@@ -159,7 +159,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testSecondChildOfForStatementIsInstanceOfExpression(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -168,7 +168,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testSecondChildOfForStatementCanBeLeftBlank(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForUpdate', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTForUpdate::class, $stmt->getChild(1));
     }
 
     /**
@@ -177,7 +177,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testThirdChildOfForStatementIsInstanceOfForUpdate(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForUpdate', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTForUpdate::class, $stmt->getChild(2));
     }
 
     /**
@@ -186,7 +186,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testThirdChildOfForStatementCanBeLeftBlank(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(2));
     }
 
     /**
@@ -195,7 +195,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testFourthChildOfForStatementIsInstanceOfScopeStatement(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(3));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(3));
     }
 
     /**
@@ -204,7 +204,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     public function testFourthChildOfForStatementIsInstanceOfStatement(): void
     {
         $stmt = $this->getFirstForStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStatement', $stmt->getChild(3));
+        $this->assertInstanceOf(ASTStatement::class, $stmt->getChild(3));
     }
 
     /**
@@ -325,7 +325,7 @@ class ASTForStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTForStatement'
+            ASTForStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -100,7 +100,7 @@ class ASTForUpdateTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTForUpdate'
+            ASTForUpdate::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForeachStatement} class.
  *
@@ -60,7 +62,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testThirdChildOfForeachStatementIsASTScopeStatement(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(2));
     }
 
     /**
@@ -105,7 +107,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementContainsExpressionAsFirstChild(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(0));
     }
 
     /**
@@ -114,7 +116,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithoutKeyAndWithValue(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTVariable::class, $stmt->getChild(1));
     }
 
     /**
@@ -123,7 +125,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithoutKeyAndWithValueByReference(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTUnaryExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -132,7 +134,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithKeyAndValue(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTVariable::class, $stmt->getChild(2));
     }
 
     /**
@@ -141,7 +143,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithKeyAndValueByReference(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTUnaryExpression::class, $stmt->getChild(2));
     }
 
     /**
@@ -150,7 +152,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithObjectPropertyByReference(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTUnaryExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -159,7 +161,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithKeyAndObjectPropertyByReference(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTUnaryExpression::class, $stmt->getChild(2));
     }
 
     /**
@@ -168,7 +170,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithObjectPropertyAsKey(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $stmt->getChild(1));
     }
 
     /**
@@ -177,7 +179,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithObjectPropertyAsValue(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $stmt->getChild(1));
     }
 
     /**
@@ -186,7 +188,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithObjectPropertyAsKeyAndValue(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $stmt->getChild(1));
     }
 
     /**
@@ -194,7 +196,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
      */
     public function testForeachStatementThrowsExpectedExceptionForKeyByReference(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->getFirstForeachStatementInFunction(__METHOD__);
     }
@@ -258,7 +260,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithList(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTListExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -267,7 +269,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithKeyAndList(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTListExpression::class, $stmt->getChild(2));
     }
 
     /**
@@ -276,7 +278,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithShortList(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTListExpression::class, $stmt->getChild(1));
     }
 
     /**
@@ -285,7 +287,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     public function testForeachStatementWithKeyAndShortList(): void
     {
         $stmt = $this->getFirstForeachStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTListExpression::class, $stmt->getChild(2));
     }
 
     /**
@@ -298,7 +300,7 @@ class ASTForeachStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTForeachStatement'
+            ASTForeachStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use OutOfBoundsException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFormalParameter} class.
  *
@@ -85,7 +87,7 @@ class ASTFormalParameterTest extends ASTNodeTestCase
         $parameter = new ASTFormalParameter();
         $parameter->addChild(new ASTVariableDeclarator());
 
-        $this->expectException('\\OutOfBoundsException');
+        $this->expectException(OutOfBoundsException::class);
 
         $parameter->getType();
     }
@@ -202,7 +204,7 @@ class ASTFormalParameterTest extends ASTNodeTestCase
     public function testFormalParameterWithArrayTypeHint(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTypeArray',
+            ASTTypeArray::class,
             $this->getFirstFormalParameterInFunction()->getChild(0)
         );
     }
@@ -271,7 +273,7 @@ class ASTFormalParameterTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            ASTFormalParameter::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -102,7 +102,7 @@ class ASTFormalParametersTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTFormalParameters'
+            ASTFormalParameters::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -92,9 +92,9 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTIdentifier::class,
+            ASTArguments::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -107,8 +107,8 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -121,10 +121,10 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
-            'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTConstant',
+            ASTCompoundVariable::class,
+            ASTConstant::class,
+            ASTArguments::class,
+            ASTConstant::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -137,12 +137,12 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTArrayIndexExpression::class,
+            ASTArrayIndexExpression::class,
+            ASTVariable::class,
+            ASTVariable::class,
+            ASTLiteral::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -155,9 +155,9 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTIdentifier::class,
+            ASTArguments::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -170,9 +170,9 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTIdentifier::class,
+            ASTArguments::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -185,13 +185,13 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstFunctionPostfixInFunction();
         $expected = [
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTMemberPrimaryPrefix::class,
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTIdentifier::class,
+            ASTLiteral::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -252,7 +252,7 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFunctionPostfix'
+            ASTFunctionPostfix::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 
 /**
@@ -179,7 +180,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
      */
     public function testSetNamespaceNotEstablishesBackReference(): void
     {
-        $namespace = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNamespace')
+        $namespace = $this->getMockBuilder(ASTNamespace::class)
             ->setConstructorArgs([__FUNCTION__])
             ->getMock();
         $namespace->expects($this->never())
@@ -330,14 +331,14 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->never())
@@ -357,20 +358,20 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node3 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node3->expects($this->once())
@@ -390,14 +391,14 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
@@ -417,14 +418,14 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
      */
     public function testFindChildrenOfTypeReturnsExpectedResult(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue([]));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
@@ -592,7 +593,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $function = new ASTFunction(__FUNCTION__);
         $function->setCompilationUnit(new ASTCompilationUnit(__FILE__));
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $function->setContext($context);
 

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -100,7 +100,7 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTGlobalStatement'
+            ASTGlobalStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -100,7 +100,7 @@ class ASTGotoStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTGotoStatement'
+            ASTGotoStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -62,7 +62,7 @@ class ASTHeredocTest extends ASTNodeTestCase
     public function testHeredocAsArrayInitializeValue(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTLiteral::class,
             $this->getFirstHeredocInClass()->getChild(0)
         );
     }
@@ -112,7 +112,7 @@ class ASTHeredocTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTHeredoc'
+            ASTHeredoc::class
         );
     }
 
@@ -125,7 +125,7 @@ class ASTHeredocTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTHeredoc'
+            ASTHeredoc::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -100,7 +100,7 @@ class ASTIdentifierTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTIdentifier'
+            ASTIdentifier::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIfStatement} class.
  *
@@ -105,7 +107,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
     public function testFirstChildOfIfStatementIsInstanceOfExpression(): void
     {
         $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(0));
     }
 
     /**
@@ -114,7 +116,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
     public function testSecondChildOfIfStatementIsInstanceOfScopeStatement(): void
     {
         $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(1));
     }
 
     /**
@@ -122,7 +124,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
      */
     public function testParserThrowsExpectedExceptionWhenIfStatementHasNoBody(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->getFirstIfStatementInFunction(__METHOD__);
     }
@@ -295,7 +297,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
     public function testThirdChildOfIfStatementIsInstanceOfScopeStatementForElse(): void
     {
         $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(2));
     }
 
     /**
@@ -304,7 +306,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
     public function testThirdChildOfIfStatementIsInstanceOfIfStatementForElseIf(): void
     {
         $stmt = $this->getFirstIfStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIfStatement', $stmt->getChild(2));
+        $this->assertInstanceOf(ASTIfStatement::class, $stmt->getChild(2));
     }
 
     /**
@@ -317,7 +319,7 @@ class ASTIfStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTIfStatement'
+            ASTIfStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -173,7 +173,7 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTIncludeExpression'
+            ASTIncludeExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -163,7 +163,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
         $this->assertInstanceOfGraph(
             $parent,
             $image,
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'
+            ASTClassOrInterfaceReference::class
         );
     }
 
@@ -178,7 +178,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
         $this->assertInstanceOfGraph(
             $parent,
             $image,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 
@@ -192,7 +192,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
     protected function assertInstanceOfGraph($parent, $image, $type): void
     {
         $instanceOf = $parent->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTInstanceOfExpression'
+            ASTInstanceOfExpression::class
         );
 
         $reference = $instanceOf->getChild(0);

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Source\AST;
 
 use BadMethodCallException;
+use PDepend\Source\ASTVisitor\ASTVisitor;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 
@@ -65,14 +67,14 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->never())
@@ -92,20 +94,20 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node3 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node3->expects($this->once())
@@ -125,14 +127,14 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Mock_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
@@ -315,8 +317,8 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->current();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFormalParameter',
-            $class->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter')
+            ASTFormalParameter::class,
+            $class->getFirstChildOfType(ASTFormalParameter::class)
         );
     }
 
@@ -331,7 +333,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->current();
 
         $parameters = $class->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            ASTFormalParameter::class
         );
         $this->assertCount(4, $parameters);
     }
@@ -346,7 +348,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
         $interface = $this->createItem();
 
-        $reference = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTClassReference')
+        $reference = $this->getMockBuilder(ASTClassReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $interface->setParentClassReference($reference);
@@ -795,11 +797,11 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
     {
         $interface = $this->createItem();
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $context->expects($this->once())
             ->method('registerInterface')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
+            ->with($this->isInstanceOf(ASTInterface::class));
 
         $interface->setContext($context)->__wakeup();
     }
@@ -809,11 +811,11 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
      */
     public function testAcceptInvokesVisitInterfaceOnGivenVisitor(): void
     {
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('visitInterface')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
+            ->with($this->isInstanceOf(ASTInterface::class));
 
         $interface = $this->createItem();
         $interface->accept($visitor);
@@ -830,7 +832,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $interface->setCompilationUnit(new ASTCompilationUnit(__FILE__));
         $interface->setCache(new MemoryCacheDriver());
 
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $interface->setContext($context);
 

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -62,7 +62,7 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
     public function testIssetExpressionGraphWithMultipleVariables(): void
     {
         $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
-        $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable');
+        $vars = $expr->findChildrenOfType(ASTVariable::class);
         $this->assertCount(3, $vars);
     }
 
@@ -72,7 +72,7 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
     public function testIssetExpressionGraphWithStaticProperty(): void
     {
         $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
-        $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix');
+        $vars = $expr->findChildrenOfType(ASTMemberPrimaryPrefix::class);
         $this->assertCount(1, $vars);
     }
 
@@ -82,7 +82,7 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
     public function testIssetExpressionGraphWithArrayProperty(): void
     {
         $expr = $this->getFirstIssetExpressionInFunction(__METHOD__);
-        $vars = $expr->findChildrenOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix');
+        $vars = $expr->findChildrenOfType(ASTMemberPrimaryPrefix::class);
         $this->assertCount(1, $vars);
     }
 
@@ -132,7 +132,7 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTIssetExpression'
+            ASTIssetExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -100,7 +100,7 @@ class ASTLabelStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTLabelStatement'
+            ASTLabelStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTListExpression} class.
  *
@@ -63,7 +65,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     public function testListExpression()
     {
         $expr = $this->getFirstListExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+        $this->assertInstanceOf(ASTListExpression::class, $expr);
 
         return $expr;
     }
@@ -125,7 +127,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     public function testListExpressionWithNestedList()
     {
         $expr = $this->getFirstListExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+        $this->assertInstanceOf(ASTListExpression::class, $expr);
 
         return $expr;
     }
@@ -240,7 +242,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         $expr = $this->getFirstListExpressionInFunction();
         $var = $expr->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableVariable', $var);
+        $this->assertInstanceOf(ASTVariableVariable::class, $var);
     }
 
     /**
@@ -250,10 +252,10 @@ class ASTListExpressionTest extends ASTNodeTestCase
     {
         $parameters = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFormalParameters'
+            ASTFormalParameters::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $parameters);
+        $this->assertInstanceOf(ASTFormalParameters::class, $parameters);
     }
 
     /**
@@ -263,10 +265,10 @@ class ASTListExpressionTest extends ASTNodeTestCase
     {
         $parameters = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFormalParameters'
+            ASTFormalParameters::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $parameters);
+        $this->assertInstanceOf(ASTFormalParameters::class, $parameters);
     }
 
     /**
@@ -275,7 +277,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     public function testListExpressionWithArrayAndEmptySlot(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: ,, line: 4, col: 18, file: '
@@ -292,7 +294,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         /** @var ASTArray $expr */
         $array = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArray'
+            ASTArray::class
         );
         $this->assertCount(1, $array->getChildren());
         $this->assertSame('$b', $array->getChild(0)->getChild(0)->getImage());
@@ -306,7 +308,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         /** @var ASTScalarType $type */
         $type = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\Source\AST\ASTScalarType'
+            ASTScalarType::class
         );
 
         $this->assertSame('void', $type->getImage());
@@ -320,7 +322,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         $expr = $this->getFirstListExpressionInFunction();
         $var = $expr->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundVariable', $var);
+        $this->assertInstanceOf(ASTCompoundVariable::class, $var);
     }
 
     /**
@@ -331,7 +333,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         $expr = $this->getFirstListExpressionInFunction();
         $var = $expr->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArrayIndexExpression', $var);
+        $this->assertInstanceOf(ASTArrayIndexExpression::class, $var);
     }
 
     /**
@@ -342,7 +344,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
         $expr = $this->getFirstListExpressionInFunction();
         $var = $expr->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $var);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $var);
     }
 
     /**
@@ -354,7 +356,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     public function testListExpressionWithKeys()
     {
         $expr = $this->getFirstListExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+        $this->assertInstanceOf(ASTListExpression::class, $expr);
 
         return $expr;
     }
@@ -368,7 +370,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     public function testListExpressionWithKeysAndNestedList()
     {
         $expr = $this->getFirstListExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTListExpression', $expr);
+        $this->assertInstanceOf(ASTListExpression::class, $expr);
 
         return $expr;
     }
@@ -382,7 +384,7 @@ class ASTListExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTListExpression'
+            ASTListExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\TokenStreamEndException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLiteral} class.
  *
@@ -228,7 +230,7 @@ class ASTLiteralTest extends ASTNodeTestCase
      */
     public function testUnclosedDoubleQuoteStringResultsInExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -252,7 +254,7 @@ class ASTLiteralTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTLiteral'
+            ASTLiteral::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -102,7 +102,7 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTLogicalAndExpression'
+            ASTLogicalAndExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -102,7 +102,7 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTLogicalOrExpression'
+            ASTLogicalOrExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -100,7 +100,7 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTLogicalXorExpression'
+            ASTLogicalXorExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -96,18 +96,18 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($object)',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (plots)', [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (plots)',
-                            'PDepend\\Source\\AST\\ASTLiteral' . ' (0)']],
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (coords)', [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
-                            'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()', [
-                                'PDepend\\Source\\AST\\ASTIdentifier' . ' (coords)',
-                                'PDepend\\Source\\AST\\ASTLiteral' . ' (0)'],
-                            'PDepend\\Source\\AST\\ASTVariable' . ' ($i)']]],
+                ASTVariable::class . ' ($object)',
+                ASTMemberPrimaryPrefix::class . ' (->)', [
+                    ASTPropertyPostfix::class . ' (plots)', [
+                        ASTArrayIndexExpression::class . ' ()', [
+                            ASTIdentifier::class . ' (plots)',
+                            ASTLiteral::class . ' (0)']],
+                    ASTPropertyPostfix::class . ' (coords)', [
+                        ASTArrayIndexExpression::class . ' ()', [
+                            ASTArrayIndexExpression::class . ' ()', [
+                                ASTIdentifier::class . ' (coords)',
+                                ASTLiteral::class . ' (0)'],
+                            ASTVariable::class . ' ($i)']]],
             ]
         );
     }
@@ -135,9 +135,9 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTConstantPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTVariable::class,
+                ASTConstantPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -166,9 +166,9 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -199,11 +199,11 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -234,11 +234,11 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTVariable::class,
+                ASTArguments::class,
+                ASTLiteral::class,
             ]
         );
     }
@@ -268,12 +268,12 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',
+                ASTAllocationExpression::class . ' (new)', [
+                    ASTClassReference::class . ' (MyClass)',
+                    ASTArguments::class . ' ()'],
+                ASTMethodPostfix::class . ' (foo)', [
+                    ASTIdentifier::class . ' (foo)',
+                    ASTArguments::class . ' ()',
                 ]]
         );
     }
@@ -306,15 +306,15 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)'],
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
-                        'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
-                    'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
-                        'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
+                ASTAllocationExpression::class . ' (new)', [
+                    ASTClassReference::class . ' (MyClass)'],
+                ASTMemberPrimaryPrefix::class . ' (->)', [
+                    ASTMethodPostfix::class . ' (foo)', [
+                        ASTIdentifier::class . ' (foo)',
+                        ASTArguments::class . ' ()'],
+                    ASTMethodPostfix::class . ' (bar)', [
+                        ASTIdentifier::class . ' (bar)',
+                        ASTArguments::class . ' ()']],
             ]
         );
     }
@@ -343,11 +343,11 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
-                'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
+                ASTAllocationExpression::class . ' (new)', [
+                    ASTClassReference::class . ' (MyClass)',
+                    ASTArguments::class . ' ()'],
+                ASTPropertyPostfix::class . ' (foo)', [
+                    ASTIdentifier::class . ' (foo)'],
             ]
         );
     }
@@ -378,13 +378,13 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTAllocationExpression' . ' (new)', [
-                    'PDepend\\Source\\AST\\ASTClassReference' . ' (MyClass)'],
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (bar)', [
-                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)']],
+                ASTAllocationExpression::class . ' (new)', [
+                    ASTClassReference::class . ' (MyClass)'],
+                ASTMemberPrimaryPrefix::class . ' (->)', [
+                    ASTPropertyPostfix::class . ' (foo)', [
+                        ASTIdentifier::class . ' (foo)'],
+                    ASTPropertyPostfix::class . ' (bar)', [
+                        ASTIdentifier::class . ' (bar)']],
             ]
         );
     }
@@ -402,9 +402,9 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -433,9 +433,9 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -453,10 +453,10 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -488,12 +488,12 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $prefix,
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($object)',
-                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' ($method)', [
-                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()', [
-                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)',
-                        'PDepend\\Source\\AST\\ASTLiteral' . ' (42)']],
+                ASTVariable::class . ' ($object)',
+                ASTMethodPostfix::class . ' ($method)', [
+                    ASTVariable::class . ' ($method)',
+                    ASTArguments::class . ' ()', [
+                        ASTLiteral::class . ' (23)',
+                        ASTLiteral::class . ' (42)']],
             ]
         );
     }
@@ -526,14 +526,14 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTLiteral',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTArrayIndexExpression::class,
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTLiteral::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -551,17 +551,17 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariable' . ' ($obj)',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',     [
-                    'PDepend\\Source\\AST\\ASTPropertyPostfix' . ' (foo)',  [
-                        'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)'],
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)', [
-                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
-                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']]],
+                ASTVariable::class . ' ($obj)',
+                ASTMemberPrimaryPrefix::class . ' (->)',     [
+                    ASTPropertyPostfix::class . ' (foo)',  [
+                        ASTIdentifier::class . ' (foo)'],
+                    ASTMemberPrimaryPrefix::class . ' (->)', [
+                        ASTMethodPostfix::class . ' (bar)', [
+                            ASTIdentifier::class . ' (bar)',
+                            ASTArguments::class . ' ()'],
+                        ASTMethodPostfix::class . ' (baz)', [
+                            ASTIdentifier::class . ' (baz)',
+                            ASTArguments::class . ' ()']]],
             ]
         );
     }
@@ -579,21 +579,21 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTFunctionPostfix' . ' (foo)', [
-                                'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
-                                'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
-                                    'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']],
-                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                ASTArrayIndexExpression::class . ' ()',    [
+                    ASTMemberPrimaryPrefix::class . ' (->)',  [
+                        ASTArrayIndexExpression::class . ' ()',    [
+                            ASTFunctionPostfix::class . ' (foo)', [
+                                ASTIdentifier::class . ' (foo)',
+                                ASTArguments::class . ' ()',    [
+                                    ASTLiteral::class . ' (23)']],
+                            ASTLiteral::class . ' (42)'],
+                        ASTMethodPostfix::class . ' (bar)', [
+                            ASTIdentifier::class . ' (bar)',
+                            ASTArguments::class . ' ()']],
+                    ASTLiteral::class . ' (17)'],
+                ASTMethodPostfix::class . ' (baz)', [
+                    ASTIdentifier::class . ' (baz)',
+                    ASTArguments::class . ' ()'],
             ]
         );
     }
@@ -611,23 +611,23 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (::)', [
-                                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference' . ' (Clazz)',
-                                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
-                                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
-                                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
-                                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']]],
-                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                ASTArrayIndexExpression::class . ' ()',    [
+                    ASTMemberPrimaryPrefix::class . ' (->)',  [
+                        ASTArrayIndexExpression::class . ' ()',    [
+                            ASTMemberPrimaryPrefix::class . ' (::)', [
+                                ASTClassOrInterfaceReference::class . ' (Clazz)',
+                                ASTMethodPostfix::class . ' (foo)', [
+                                    ASTIdentifier::class . ' (foo)',
+                                    ASTArguments::class . ' ()',    [
+                                        ASTLiteral::class . ' (23)']]],
+                            ASTLiteral::class . ' (42)'],
+                        ASTMethodPostfix::class . ' (bar)', [
+                            ASTIdentifier::class . ' (bar)',
+                            ASTArguments::class . ' ()']],
+                    ASTLiteral::class . ' (17)'],
+                ASTMethodPostfix::class . ' (baz)', [
+                    ASTIdentifier::class . ' (baz)',
+                    ASTArguments::class . ' ()'],
             ]
         );
     }
@@ -645,23 +645,23 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMemberPrimaryPrefixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                    'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (->)',  [
-                        'PDepend\\Source\\AST\\ASTArrayIndexExpression' . ' ()',    [
-                            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix' . ' (::)', [
-                                'PDepend\\Source\\AST\\ASTVariable' . ' ($class)',
-                                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (foo)', [
-                                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (foo)',
-                                    'PDepend\\Source\\AST\\ASTArguments' . ' ()',    [
-                                        'PDepend\\Source\\AST\\ASTLiteral' . ' (23)']]],
-                            'PDepend\\Source\\AST\\ASTLiteral' . ' (42)'],
-                        'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (bar)', [
-                            'PDepend\\Source\\AST\\ASTIdentifier' . ' (bar)',
-                            'PDepend\\Source\\AST\\ASTArguments' . ' ()']],
-                    'PDepend\\Source\\AST\\ASTLiteral' . ' (17)'],
-                'PDepend\\Source\\AST\\ASTMethodPostfix' . ' (baz)', [
-                    'PDepend\\Source\\AST\\ASTIdentifier' . ' (baz)',
-                    'PDepend\\Source\\AST\\ASTArguments' . ' ()'],
+                ASTArrayIndexExpression::class . ' ()',    [
+                    ASTMemberPrimaryPrefix::class . ' (->)',  [
+                        ASTArrayIndexExpression::class . ' ()',    [
+                            ASTMemberPrimaryPrefix::class . ' (::)', [
+                                ASTVariable::class . ' ($class)',
+                                ASTMethodPostfix::class . ' (foo)', [
+                                    ASTIdentifier::class . ' (foo)',
+                                    ASTArguments::class . ' ()',    [
+                                        ASTLiteral::class . ' (23)']]],
+                            ASTLiteral::class . ' (42)'],
+                        ASTMethodPostfix::class . ' (bar)', [
+                            ASTIdentifier::class . ' (bar)',
+                            ASTArguments::class . ' ()']],
+                    ASTLiteral::class . ' (17)'],
+                ASTMethodPostfix::class . ' (baz)', [
+                    ASTIdentifier::class . ' (baz)',
+                    ASTArguments::class . ' ()'],
             ]
         );
     }
@@ -747,7 +747,7 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -122,10 +122,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -138,12 +138,12 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $postfix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTVariable::class,
+            ASTLiteral::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($postfix, $expected);
@@ -172,9 +172,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", [
-                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments' . " ()",
+                ASTCompoundExpression::class . " ()", [
+                    ASTLiteral::class . " ('method')"],
+                ASTArguments::class . " ()",
             ]
         );
     }
@@ -202,9 +202,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", [
-                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments' . " ()",
+                ASTCompoundVariable::class . " ($)", [
+                    ASTLiteral::class . " ('method')"],
+                ASTArguments::class . " ()",
             ]
         );
     }
@@ -232,9 +232,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', [
-                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)'],
-                'PDepend\\Source\\AST\\ASTArguments' . ' ()',
+                ASTVariableVariable::class . ' ($)', [
+                    ASTVariable::class . ' ($method)'],
+                ASTArguments::class . ' ()',
             ]
         );
     }
@@ -262,9 +262,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTCompoundExpression' . " ()", [
-                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments' . " ()",
+                ASTCompoundExpression::class . " ()", [
+                    ASTLiteral::class . " ('method')"],
+                ASTArguments::class . " ()",
             ]
         );
     }
@@ -292,9 +292,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTCompoundVariable' . " ($)", [
-                    'PDepend\\Source\\AST\\ASTLiteral' . " ('method')"],
-                'PDepend\\Source\\AST\\ASTArguments' . " ()",
+                ASTCompoundVariable::class . " ($)", [
+                    ASTLiteral::class . " ('method')"],
+                ASTArguments::class . " ()",
             ]
         );
     }
@@ -322,9 +322,9 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $this->assertGraph(
             $this->getFirstMethodPostfixInFunction(),
             [
-                'PDepend\\Source\\AST\\ASTVariableVariable' . ' ($)', [
-                    'PDepend\\Source\\AST\\ASTVariable' . ' ($method)'],
-                'PDepend\\Source\\AST\\ASTArguments' . ' ()',
+                ASTVariableVariable::class . ' ($)', [
+                    ASTVariable::class . ' ($method)'],
+                ASTArguments::class . ' ()',
             ]
         );
     }
@@ -408,10 +408,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -424,10 +424,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -440,11 +440,11 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariableVariable',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTVariableVariable::class,
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -457,11 +457,11 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
-            'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTCompoundVariable::class,
+            ASTConstant::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -474,10 +474,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -490,10 +490,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -506,11 +506,11 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariableVariable',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTVariableVariable::class,
+            ASTVariable::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -523,11 +523,11 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
-            'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTCompoundVariable::class,
+            ASTConstant::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -541,12 +541,12 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
 
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTVariableVariable',
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
-            'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMethodPostfix::class,
+            ASTVariableVariable::class,
+            ASTCompoundVariable::class,
+            ASTConstant::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -559,14 +559,14 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTClassOrInterfaceReference::class,
+            ASTMemberPrimaryPrefix::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -579,10 +579,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -595,10 +595,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTSelfReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTSelfReference::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -611,10 +611,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTParentReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTParentReference::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -627,10 +627,10 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTStaticReference',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTStaticReference::class,
+            ASTMethodPostfix::class,
+            ASTIdentifier::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -647,12 +647,12 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTVariable::class,
+            ASTMethodPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTVariable::class,
+            ASTLiteral::class,
+            ASTArguments::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -667,7 +667,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTMethodPostfix'
+            ASTMethodPostfix::class
         );
     }
 
@@ -681,7 +681,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 
@@ -695,7 +695,7 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -499,14 +499,14 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->never())
@@ -526,20 +526,20 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node3 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node3 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node3->expects($this->once())
@@ -559,14 +559,14 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNull(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('getFirstChildOfType')
             ->will($this->returnValue(null));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())
@@ -588,14 +588,14 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
      */
     public function testFindChildrenOfTypeReturnsExpectedResult(): void
     {
-        $node1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node1 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->once())
             ->method('findChildrenOfType')
             ->will($this->returnValue([]));
 
-        $node2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTNode')
+        $node2 = $this->getMockBuilder(ASTNode::class)
             ->setMockClassName('Class_' . __FUNCTION__ . '_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->once())

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -76,7 +76,7 @@ class ASTNamespaceTest extends AbstractTestCase
         $namespace = new ASTNamespace('package1');
         $types = $namespace->getTypes();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $types);
+        $this->assertInstanceOf(ASTArtifactList::class, $types);
     }
 
     /**
@@ -263,7 +263,7 @@ class ASTNamespaceTest extends AbstractTestCase
         $namespace = new ASTNamespace('package1');
         $functions = $namespace->getFunctions();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $functions);
+        $this->assertInstanceOf(ASTArtifactList::class, $functions);
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -44,6 +44,7 @@ namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
 use PDepend\AbstractTestCase;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 use ReflectionClass;
 
 /**
@@ -166,7 +167,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
         $node = $this->createNodeInstance();
         $this->assertSame(
             [],
-            $node->getParentsOfType('PDepend\\Source\\AST\\ASTScope')
+            $node->getParentsOfType(ASTScope::class)
         );
     }
 
@@ -177,10 +178,10 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetParentsOfTypeReturnsExpectedParentNodes(): void
     {
-        $parent0 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
-        $parent1 = $this->getAbstractClassMock('PDepend\\Source\\AST\\AbstractASTNode');
-        $parent2 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
-        $parent3 = $this->getAbstractClassMock('PDepend\\Source\\AST\\AbstractASTNode');
+        $parent0 = $this->getAbstractClassMock(ASTScope::class);
+        $parent1 = $this->getAbstractClassMock(AbstractASTNode::class);
+        $parent2 = $this->getAbstractClassMock(ASTScope::class);
+        $parent3 = $this->getAbstractClassMock(AbstractASTNode::class);
 
         $node = $this->createNodeInstance();
 
@@ -191,7 +192,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             [$parent0, $parent2],
-            $node->getParentsOfType('PDepend\\Source\\AST\\ASTScope')
+            $node->getParentsOfType(ASTScope::class)
         );
     }
 
@@ -260,7 +261,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         $this->assertNull(
             $this->getNodeMock()->getFirstChildOfType(
-                'PDepend\\Source\\AST\\ASTArguments'
+                ASTArguments::class
             )
         );
     }
@@ -273,7 +274,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testGetFirstChildOfTypeReturnsFirstMatchingChild(): void
     {
         $child0 = $this->getAbstractClassMock(
-            'PDepend\\Source\\AST\\ASTIndexExpression'
+            ASTIndexExpression::class
         );
 
         $node = $this->getNodeMock();
@@ -281,7 +282,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             $child0,
-            $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTIndexExpression')
+            $node->getFirstChildOfType(ASTIndexExpression::class)
         );
     }
 
@@ -293,10 +294,10 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testGetFirstChildOfTypeReturnsFirstMatchingChildRecursive(): void
     {
         $child0 = $this->getAbstractClassMock(
-            'PDepend\\Source\\AST\\ASTIndexExpression'
+            ASTIndexExpression::class
         );
         $child1 = $this->getAbstractClassMock(
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
 
         $node = $this->getNodeMock();
@@ -305,7 +306,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             $child1,
-            $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTArguments')
+            $node->getFirstChildOfType(ASTArguments::class)
         );
     }
 
@@ -319,7 +320,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
         $node = $this->getNodeMock();
         $this->assertSame(
             [],
-            $node->findChildrenOfType('PDepend\\Source\\AST\\ASTNode')
+            $node->findChildrenOfType(ASTNode::class)
         );
     }
 
@@ -331,7 +332,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testFindChildrenOfTypeReturnsDirectChild(): void
     {
         $child0 = $this->getNodeMock();
-        $child1 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
+        $child1 = $this->getAbstractClassMock(ASTScope::class);
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -339,7 +340,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             [$child1],
-            $node->findChildrenOfType('PDepend\\Source\\AST\\ASTScope')
+            $node->findChildrenOfType(ASTScope::class)
         );
     }
 
@@ -351,7 +352,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testFindChildrenOfTypeReturnsIndirectChild(): void
     {
         $child0 = $this->getNodeMock();
-        $child1 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
+        $child1 = $this->getAbstractClassMock(ASTScope::class);
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -359,7 +360,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             [$child1],
-            $node->findChildrenOfType('PDepend\\Source\\AST\\ASTScope')
+            $node->findChildrenOfType(ASTScope::class)
         );
     }
 
@@ -370,9 +371,9 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testFindChildrenOfTypeReturnsDirectAndIndirectChild(): void
     {
-        $child0 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
-        $child1 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
-        $child2 = $this->getAbstractClassMock('PDepend\\Source\\AST\\ASTScope');
+        $child0 = $this->getAbstractClassMock(ASTScope::class);
+        $child1 = $this->getAbstractClassMock(ASTScope::class);
+        $child2 = $this->getAbstractClassMock(ASTScope::class);
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -381,7 +382,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $this->assertSame(
             [$child0, $child1, $child2],
-            $node->findChildrenOfType('PDepend\\Source\\AST\\ASTScope')
+            $node->findChildrenOfType(ASTScope::class)
         );
     }
 
@@ -551,7 +552,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     private function getNodeMock()
     {
-        return $this->getAbstractClassMock('PDepend\\Source\\AST\\AbstractASTNode');
+        return $this->getAbstractClassMock(AbstractASTNode::class);
     }
 
     /**
@@ -559,9 +560,9 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testPrependChildAddsChildAtFirstPosition(): void
     {
-        $child1 = $this->getMockBuilder('PDepend\\Source\\AST\\AbstractASTNode')
+        $child1 = $this->getMockBuilder(AbstractASTNode::class)
             ->getMock();
-        $child2 = $this->getMockBuilder('PDepend\\Source\\AST\\AbstractASTNode')
+        $child2 = $this->getMockBuilder(AbstractASTNode::class)
             ->getMock();
 
         $parent = $this->createNodeInstance();
@@ -578,7 +579,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         $methodName = 'visit' . substr(get_class($this), 22, -4);
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('__call')
@@ -595,7 +596,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         $methodName = 'visit' . substr(get_class($this), 22, -4);
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('__call')
@@ -611,7 +612,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedFirstMatch(): void
     {
-        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+        $node2 = $this->getMockBuilder(AbstractASTNode::class)
             ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
             ->getMock();
         $node2->expects($this->never())
@@ -630,13 +631,13 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetFirstChildOfTypeReturnsTheExpectedNestedMatch(): void
     {
-        $node1 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+        $node1 = $this->getMockBuilder(AbstractASTNode::class)
             ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
             ->getMock();
         $node1->expects($this->never())
             ->method('getFirstChildOfType');
 
-        $node3 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+        $node3 = $this->getMockBuilder(AbstractASTNode::class)
             ->setMockClassName('PDepend_Source_AST_ASTNode_' . md5(microtime()))
             ->getMock();
         $node3->expects($this->once())
@@ -657,7 +658,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         $name = 'PDepend_Source_AST_ASTNode_' . md5(microtime());
 
-        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+        $node2 = $this->getMockBuilder(AbstractASTNode::class)
             ->setMockClassName($name)
             ->getMock();
         $node2->expects($this->once())
@@ -677,7 +678,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         $name = 'PDepend_Source_AST_ASTNode_' . md5(microtime());
 
-        $node2 = $this->getMockBuilder('\PDepend\Source\AST\AbstractASTNode')
+        $node2 = $this->getMockBuilder(AbstractASTNode::class)
             ->setMockClassName($name)
             ->getMock();
         $node2->expects($this->once())
@@ -725,7 +726,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code parameter class.
@@ -221,13 +222,13 @@ class ASTParameterTest extends AbstractTestCase
      */
     public function testAcceptInvokesVisitParameterOnSuppliedVisitor(): void
     {
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('visitParameter')
-            ->with($this->isInstanceOf('\\PDepend\\Source\\AST\\ASTParameter'));
+            ->with($this->isInstanceOf(ASTParameter::class));
 
-        $formalParameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTFormalParameter')
+        $formalParameter = $this->getMockBuilder(ASTFormalParameter::class)
             ->getMock();
         $parameter = new ASTParameter($formalParameter);
         $parameter->accept($visitor);

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\InvalidStateException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTParentReference} class.
  *
@@ -95,7 +97,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      */
     public function testParentReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -105,7 +107,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      */
     public function testParentReferenceInClassWithoutParentThrowsException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -115,7 +117,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      */
     public function testParentReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -174,7 +176,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
      */
     protected function createNodeInstance()
     {
-        $this->referenceMock = $this->getMockBuilder('\PDepend\Source\AST\ASTClassOrInterfaceReference')
+        $this->referenceMock = $this->getMockBuilder(ASTClassOrInterfaceReference::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -191,7 +193,7 @@ class ASTParentReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTParentReference'
+            ASTParentReference::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -63,10 +63,10 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -80,10 +80,10 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTSelfReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -97,10 +97,10 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTParentReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -114,10 +114,10 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -131,10 +131,10 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -148,9 +148,9 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTVariableVariable',
-                'PDepend\\Source\\AST\\ASTVariableVariable',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTVariableVariable::class,
+                ASTVariableVariable::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -164,8 +164,8 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTCompoundVariable',
-                'PDepend\\Source\\AST\\ASTConstant',
+                ASTCompoundVariable::class,
+                ASTConstant::class,
             ]
         );
     }
@@ -179,12 +179,12 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -198,11 +198,11 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -216,13 +216,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTPostfixExpression',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTPostfixExpression::class,
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTArrayIndexExpression::class,
+                ASTIdentifier::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -272,13 +272,13 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTPostfixExpression',
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTPostfixExpression::class,
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTArrayIndexExpression::class,
+                ASTIdentifier::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -329,7 +329,7 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPostfixExpression'
+            ASTPostfixExpression::class
         );
     }
 
@@ -343,7 +343,7 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPostfixExpression'
+            ASTPostfixExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -63,10 +63,10 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -80,10 +80,10 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTSelfReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -97,10 +97,10 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTParentReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -114,9 +114,9 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -130,10 +130,10 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -184,7 +184,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPreDecrementExpression'
+            ASTPreDecrementExpression::class
         );
     }
 
@@ -198,7 +198,7 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPreDecrementExpression'
+            ASTPreDecrementExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -64,10 +64,10 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -81,10 +81,10 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTSelfReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -98,10 +98,10 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTParentReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -115,9 +115,9 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTFunctionPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTFunctionPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -131,10 +131,10 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $this->assertGraphEquals(
             $expr,
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -147,7 +147,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
         $exprs = $this->getFirstClassForTestCase()
             ->getMethods()
             ->current()
-            ->findChildrenOfType('PDepend\\Source\\AST\\ASTPreIncrementExpression');
+            ->findChildrenOfType(ASTPreIncrementExpression::class);
 
         $this->assertCount(2, $exprs);
     }
@@ -198,7 +198,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPreIncrementExpression'
+            ASTPreIncrementExpression::class
         );
     }
 
@@ -212,7 +212,7 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTPreIncrementExpression'
+            ASTPreIncrementExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -60,7 +60,7 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     public function testSimplePrintExpression()
     {
         $print = $this->getFirstPrintInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTPrintExpression', $print);
+        $this->assertInstanceOf(ASTPrintExpression::class, $print);
 
         return $print;
     }
@@ -103,6 +103,6 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
     private function getFirstPrintInFunction()
     {
         return $this->getFirstFunctionForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTPrintExpression');
+            ->getFirstChildOfType(ASTPrintExpression::class);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\InvalidStateException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPropertyPostfix} class.
  *
@@ -105,11 +107,11 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTVariable::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -126,11 +128,11 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTIdentifier::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -143,9 +145,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTIdentifier',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTIdentifier::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -158,9 +160,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -173,10 +175,10 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariableVariable',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTVariableVariable::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -189,13 +191,13 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTConstant',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTCompoundVariable::class,
+            ASTExpression::class,
+            ASTConstant::class,
+            ASTExpression::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -208,10 +210,10 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTCompoundExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTCompoundExpression::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -224,9 +226,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTClassOrInterfaceReference::class,
+            ASTPropertyPostfix::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -239,9 +241,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInFunction(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -254,9 +256,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTSelfReference',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTSelfReference::class,
+            ASTPropertyPostfix::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -269,9 +271,9 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTParentReference',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTParentReference::class,
+            ASTPropertyPostfix::class,
+            ASTVariable::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -288,11 +290,11 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTIdentifier',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTVariable::class,
+            ASTPropertyPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTIdentifier::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -309,11 +311,11 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         $prefix = $this->getFirstMemberPrimaryPrefixInClass(__METHOD__);
         $expected = [
-            'PDepend\\Source\\AST\\ASTSelfReference',
-            'PDepend\\Source\\AST\\ASTPropertyPostfix',
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTSelfReference::class,
+            ASTPropertyPostfix::class,
+            ASTArrayIndexExpression::class,
+            ASTVariable::class,
+            ASTLiteral::class,
         ];
 
         $this->assertGraphEquals($prefix, $expected);
@@ -324,7 +326,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      */
     public function testPropertyPostfixSelfVariableInFunctionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -334,7 +336,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      */
     public function testPropertyPostfixParentVariableInFunctionThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -344,7 +346,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
      */
     public function testPropertyPostfixParentVariableInClassWithoutParentThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -404,7 +406,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTPropertyPostfix'
+            ASTPropertyPostfix::class
         );
     }
 
@@ -418,7 +420,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 
@@ -432,7 +434,7 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $testCase,
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix'
+            ASTMemberPrimaryPrefix::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\ASTVisitor\ASTVisitor;
 
 /**
  * Test case for the code property class.
@@ -134,7 +135,7 @@ class ASTPropertyTest extends AbstractTestCase
      */
     public function testGetCompilationUnitReturnsNullByDefault(): void
     {
-        $property = $this->getMockWithoutConstructor('PDepend\\Source\\AST\\ASTProperty');
+        $property = $this->getMockWithoutConstructor(ASTProperty::class);
         $this->assertNull($property->getCompilationUnit());
     }
 
@@ -145,7 +146,7 @@ class ASTPropertyTest extends AbstractTestCase
     {
         $compilationUnit = new ASTCompilationUnit(__FILE__);
 
-        $property = $this->getMockWithoutConstructor('PDepend\\Source\\AST\\ASTProperty');
+        $property = $this->getMockWithoutConstructor(ASTProperty::class);
         $property->setCompilationUnit($compilationUnit);
 
         $this->assertSame($compilationUnit, $property->getCompilationUnit());
@@ -400,12 +401,12 @@ class ASTPropertyTest extends AbstractTestCase
      */
     public function testAcceptCallsVisitorMethodVisitProperty(): void
     {
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects($this->once())
             ->method('visitProperty');
 
-        $property = $this->getMockBuilder('PDepend\\Source\\AST\\ASTProperty')
+        $property = $this->getMockBuilder(ASTProperty::class)
             ->onlyMethods(['__construct'])
             ->disableOriginalConstructor()
             ->setMockClassName(substr('package_' . md5(microtime()), 0, 18) . '_ASTProperty')

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -100,7 +100,7 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     public function testRequireExpression()
     {
         $expr = $this->getFirstRequireExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTRequireExpression', $expr);
+        $this->assertInstanceOf(ASTRequireExpression::class, $expr);
 
         return $expr;
     }
@@ -162,7 +162,7 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     public function testRequireExpressionWithParenthesis()
     {
         $expr = $this->getFirstRequireExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTRequireExpression', $expr);
+        $this->assertInstanceOf(ASTRequireExpression::class, $expr);
 
         return $expr;
     }
@@ -224,7 +224,7 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTRequireExpression'
+            ASTRequireExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -63,7 +63,7 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     public function testReturnStatement()
     {
         $stmt = $this->getFirstReturnStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $stmt);
+        $this->assertInstanceOf(ASTReturnStatement::class, $stmt);
 
         return $stmt;
     }
@@ -143,7 +143,7 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTReturnStatement'
+            ASTReturnStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -139,7 +139,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     public function testScopeStatement()
     {
         $stmt = $this->getFirstScopeStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt);
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt);
 
         return $stmt;
     }
@@ -201,7 +201,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     public function testScopeStatementWithAlternative()
     {
         $stmt = $this->getFirstScopeStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt);
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt);
 
         return $stmt;
     }
@@ -263,7 +263,7 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTScopeStatement'
+            ASTScopeStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -63,7 +63,7 @@ class ASTScopeTest extends ASTNodeTestCase
     public function testScope()
     {
         $scope = $this->getFirstScopeInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScope', $scope);
+        $this->assertInstanceOf(ASTScope::class, $scope);
 
         return $scope;
     }
@@ -125,7 +125,7 @@ class ASTScopeTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTScope'
+            ASTScope::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -42,7 +42,10 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
+use PDepend\Source\Parser\InvalidStateException;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSelfReference} class.
@@ -62,10 +65,10 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
         $target = $this->getAbstractClassMock(
-            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            AbstractASTClassOrInterface::class,
             [__CLASS__]
         );
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         $reference = new ASTSelfReference($context, $target);
@@ -78,11 +81,11 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
         $target = $this->getAbstractClassMock(
-            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            AbstractASTClassOrInterface::class,
             [__CLASS__]
         );
 
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface');
@@ -99,7 +102,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      */
     public function testSelfReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -109,7 +112,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      */
     public function testSelfReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -152,7 +155,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     public function testSelfReference()
     {
         $reference = $this->getFirstSelfReferenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $reference);
+        $this->assertInstanceOf(ASTSelfReference::class, $reference);
 
         return $reference;
     }
@@ -212,12 +215,12 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      */
     protected function createNodeInstance()
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         return new ASTSelfReference(
             $context,
-            $this->getAbstractClassMock('\\PDepend\\Source\\AST\\AbstractASTClassOrInterface', [__CLASS__])
+            $this->getAbstractClassMock(AbstractASTClassOrInterface::class, [__CLASS__])
         );
     }
 
@@ -230,7 +233,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTSelfReference'
+            ASTSelfReference::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -73,7 +73,7 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     public function testShiftLeftExpression()
     {
         $expr = $this->getFirstShiftLeftExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTShiftLeftExpression', $expr);
+        $this->assertInstanceOf(ASTShiftLeftExpression::class, $expr);
 
         return $expr;
     }
@@ -135,7 +135,7 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTShiftLeftExpression'
+            ASTShiftLeftExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -73,7 +73,7 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     public function testShiftRightExpression()
     {
         $expr = $this->getFirstShiftRightExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTShiftRightExpression', $expr);
+        $this->assertInstanceOf(ASTShiftRightExpression::class, $expr);
 
         return $expr;
     }
@@ -135,7 +135,7 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTShiftRightExpression'
+            ASTShiftRightExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -63,7 +63,7 @@ class ASTStatementTest extends ASTNodeTestCase
     public function testStatement()
     {
         $stmt = $this->getFirstStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStatement', $stmt);
+        $this->assertInstanceOf(ASTStatement::class, $stmt);
 
         return $stmt;
     }
@@ -126,7 +126,7 @@ class ASTStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTStatement'
+            ASTStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -42,7 +42,10 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
+use PDepend\Source\Parser\InvalidStateException;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStaticReference} class.
@@ -62,10 +65,10 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
         $target = $this->getAbstractClassMock(
-            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            AbstractASTClassOrInterface::class,
             [__CLASS__]
         );
-        $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         $reference = new ASTStaticReference($context, $target);
@@ -78,11 +81,11 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
         $target = $this->getAbstractClassMock(
-            '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+            AbstractASTClassOrInterface::class,
             [__CLASS__]
         );
 
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface');
@@ -100,7 +103,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     public function testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\InvalidStateException'
+            InvalidStateException::class
         );
         $this->expectExceptionMessage(
             'The keyword "static" was used outside of a class/method scope.'
@@ -115,7 +118,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     public function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\InvalidStateException'
+            InvalidStateException::class
         );
         $this->expectExceptionMessage(
             'The keyword "static" was used outside of a class/method scope.'
@@ -162,7 +165,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     public function testStaticReference()
     {
         $reference = $this->getFirstStaticReferenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStaticReference', $reference);
+        $this->assertInstanceOf(ASTStaticReference::class, $reference);
 
         return $reference;
     }
@@ -222,13 +225,13 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
      */
     protected function createNodeInstance()
     {
-        $context = $this->getMockBuilder('\\PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         return new ASTStaticReference(
             $context,
             $this->getAbstractClassMock(
-                '\\PDepend\\Source\\AST\\AbstractASTClassOrInterface',
+                AbstractASTClassOrInterface::class,
                 [__CLASS__]
             )
         );
@@ -243,7 +246,7 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTStaticReference'
+            ASTStaticReference::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -63,7 +63,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     public function testStaticVariableDeclaration()
     {
         $declaration = $this->getFirstStaticVariableDeclarationInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStaticVariableDeclaration', $declaration);
+        $this->assertInstanceOf(ASTStaticVariableDeclaration::class, $declaration);
 
         return $declaration;
     }
@@ -125,7 +125,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTStaticVariableDeclaration'
+            ASTStaticVariableDeclaration::class
         );
     }
 

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -66,7 +66,7 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     public function testStringIndexExpression()
     {
         $expr = $this->getFirstStringIndexExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStringIndexExpression', $expr);
+        $this->assertInstanceOf(ASTStringIndexExpression::class, $expr);
 
         return $expr;
     }
@@ -128,7 +128,7 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTStringIndexExpression'
+            ASTStringIndexExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\TokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTString} class.
  *
@@ -87,7 +89,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testBacktickExpressionContainsExpectedCompoundVariable(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundVariable', $string->getChild(0));
+        $this->assertInstanceOf(ASTCompoundVariable::class, $string->getChild(0));
     }
 
     /**
@@ -126,7 +128,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsVariable(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $string->getChild(0));
+        $this->assertInstanceOf(ASTVariable::class, $string->getChild(0));
     }
 
     /**
@@ -135,7 +137,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsVariableAfterNotOperator(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $string->getChild(1));
+        $this->assertInstanceOf(ASTVariable::class, $string->getChild(1));
     }
 
     /**
@@ -144,7 +146,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsVariableAfterSilenceOperator(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $string->getChild(1));
+        $this->assertInstanceOf(ASTVariable::class, $string->getChild(1));
     }
 
     /**
@@ -153,7 +155,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsCompoundVariable(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundVariable', $string->getChild(0));
+        $this->assertInstanceOf(ASTCompoundVariable::class, $string->getChild(0));
     }
 
     /**
@@ -162,7 +164,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsCompoundExpressionAfterLiteral(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundExpression', $string->getChild(1));
+        $this->assertInstanceOf(ASTCompoundExpression::class, $string->getChild(1));
     }
 
     /**
@@ -171,7 +173,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsVariableAfterDollarTwoLiterals(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $string->getChild(1));
+        $this->assertInstanceOf(ASTVariable::class, $string->getChild(1));
     }
 
     /**
@@ -180,7 +182,7 @@ class ASTStringTest extends ASTNodeTestCase
     public function testDoubleQuoteStringContainsDollarLiteralForVariableVariable(): void
     {
         $string = $this->getFirstStringInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $string->getChild(0));
+        $this->assertInstanceOf(ASTLiteral::class, $string->getChild(0));
     }
 
     /**
@@ -188,7 +190,7 @@ class ASTStringTest extends ASTNodeTestCase
      */
     public function testUnclosedDoubleQuoteStringResultsInExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenException::class);
+        $this->expectException(TokenException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -249,7 +251,7 @@ class ASTStringTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTString'
+            ASTString::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\TokenStreamEndException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchLabel} class.
  *
@@ -100,7 +102,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     public function testSwitchLabel()
     {
         $label = $this->getFirstSwitchLabelInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $label);
 
         return $label;
     }
@@ -174,9 +176,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
         }
 
         $expected = [
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTSwitchStatement',
-            'PDepend\\Source\\AST\\ASTBreakStatement',
+            ASTExpression::class,
+            ASTSwitchStatement::class,
+            ASTBreakStatement::class,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -191,7 +193,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     public function testSwitchLabelWithNestedNonePhpCode()
     {
         $label = $this->getFirstSwitchLabelInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $label);
 
         return $label;
     }
@@ -253,7 +255,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     public function testSwitchLabelDefault()
     {
         $label = $this->getFirstSwitchLabelInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $label);
 
         return $label;
     }
@@ -327,8 +329,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
         }
 
         $expected = [
-            'PDepend\\Source\\AST\\ASTSwitchStatement',
-            'PDepend\\Source\\AST\\ASTBreakStatement',
+            ASTSwitchStatement::class,
+            ASTBreakStatement::class,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -343,7 +345,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     public function testSwitchLabelDefaultWithNestedNonePhpCode()
     {
         $label = $this->getFirstSwitchLabelInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $label);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $label);
 
         return $label;
     }
@@ -409,7 +411,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      */
     public function testParserThrowsExceptionForUnclosedSwitchLabelBody(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->getFirstSwitchLabelInFunction();
     }
@@ -423,7 +425,7 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTSwitchLabel'
+            ASTSwitchLabel::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -42,6 +42,9 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\TokenStreamEndException;
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchStatement} class.
  *
@@ -62,7 +65,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
         $stmt = $this->getFirstSwitchStatementInFunction();
         $children = $stmt->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $children[0]);
+        $this->assertInstanceOf(ASTExpression::class, $children[0]);
     }
 
     /**
@@ -73,8 +76,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
         $stmt = $this->getFirstSwitchStatementInFunction();
         $children = $stmt->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $children[1]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $children[2]);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $children[1]);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $children[2]);
     }
 
     /**
@@ -86,7 +89,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     public function testSwitchStatement()
     {
         $stmt = $this->getFirstSwitchStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $stmt);
+        $this->assertInstanceOf(ASTSwitchStatement::class, $stmt);
 
         return $stmt;
     }
@@ -160,7 +163,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      */
     public function testInvalidStatementInSwitchStatementResultsInExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->getFirstSwitchStatementInFunction();
     }
@@ -170,7 +173,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      */
     public function testUnclosedSwitchStatementResultsInExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->getFirstSwitchStatementInFunction();
     }
@@ -184,7 +187,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     public function testSwitchStatementWithAlternativeScope()
     {
         $stmt = $this->getFirstSwitchStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $stmt);
+        $this->assertInstanceOf(ASTSwitchStatement::class, $stmt);
 
         return $stmt;
     }
@@ -255,7 +258,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     public function testSwitchStatementWithNestedNonePhpCode()
     {
         $switch = $this->getFirstSwitchStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchStatement', $switch);
+        $this->assertInstanceOf(ASTSwitchStatement::class, $switch);
 
         return $switch;
     }
@@ -317,7 +320,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTSwitchStatement'
+            ASTSwitchStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -63,7 +63,7 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     public function testThrowStatement()
     {
         $stmt = $this->getFirstThrowStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $stmt);
+        $this->assertInstanceOf(ASTThrowStatement::class, $stmt);
 
         return $stmt;
     }
@@ -125,7 +125,7 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTThrowStatement'
+            ASTThrowStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -143,7 +143,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     public function testTraitAdaptationAlias()
     {
         $alias = $this->getFirstTraitAdaptationAliasInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptationAlias', $alias);
+        $this->assertInstanceOf(ASTTraitAdaptationAlias::class, $alias);
 
         return $alias;
     }
@@ -205,7 +205,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTraitAdaptationAlias'
+            ASTTraitAdaptationAlias::class
         );
     }
 
@@ -218,7 +218,7 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     public function testTraitReference()
     {
         $reference = $this->getFirstTraitReferenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
+        $this->assertInstanceOf(ASTTraitReference::class, $reference);
 
         return $reference;
     }
@@ -279,6 +279,6 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     private function getFirstTraitReferenceInClass()
     {
         return $this->getFirstTraitAdaptationAliasInClass()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTTraitReference');
+            ->getFirstChildOfType(ASTTraitReference::class);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\InvalidStateException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptationPrecedence} class.
  *
@@ -65,7 +67,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
         $this->assertCount(
             3,
             $stmt->findChildrenOfType(
-                'PDepend\\Source\\AST\\ASTTraitReference'
+                ASTTraitReference::class
             )
         );
     }
@@ -75,7 +77,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
      */
     public function testTraitAdaptationPrecedenceWithoutQualifiedReferenceThrowsExpectedException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\InvalidStateException::class);
+        $this->expectException(InvalidStateException::class);
 
         $this->getFirstTraitAdaptationPrecedenceInClass();
     }
@@ -89,7 +91,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     public function testTraitAdaptationPrecedence()
     {
         $precedence = $this->getFirstTraitAdaptationPrecedenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence', $precedence);
+        $this->assertInstanceOf(ASTTraitAdaptationPrecedence::class, $precedence);
 
         return $precedence;
     }
@@ -151,7 +153,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence'
+            ASTTraitAdaptationPrecedence::class
         );
     }
 
@@ -164,7 +166,7 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     public function testTraitReference()
     {
         $reference = $this->getFirstTraitReferenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
+        $this->assertInstanceOf(ASTTraitReference::class, $reference);
 
         return $reference;
     }
@@ -225,6 +227,6 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     private function getFirstTraitReferenceInClass()
     {
         return $this->getFirstTraitAdaptationPrecedenceInClass()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTTraitReference');
+            ->getFirstChildOfType(ASTTraitReference::class);
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -65,7 +65,7 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     public function testTraitAdaptation()
     {
         $scope = $this->getFirstTraitAdaptationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitAdaptation', $scope);
+        $this->assertInstanceOf(ASTTraitAdaptation::class, $scope);
 
         return $scope;
     }
@@ -127,7 +127,7 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTraitAdaptation'
+            ASTTraitAdaptation::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -63,7 +63,7 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
      */
     public function testGetTraitDelegatesToContextGetTraitMethod(): void
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
         $context->expects($this->once())
             ->method('getTrait')
@@ -82,7 +82,7 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     public function testTraitReference()
     {
         $reference = $this->getFirstTraitReferenceInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitReference', $reference);
+        $this->assertInstanceOf(ASTTraitReference::class, $reference);
 
         return $reference;
     }
@@ -144,7 +144,7 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTraitReference'
+            ASTTraitReference::class
         );
     }
 
@@ -168,7 +168,7 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
      */
     protected function getBuilderContextMock()
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
         return $context;

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -43,6 +43,9 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\ASTVisitor\ASTVisitor;
+use PDepend\Source\Builder\BuilderContext;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTrait} class.
  *
@@ -364,12 +367,12 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      */
     public function testAcceptInvokesVisitTraitOnGivenVisitor(): void
     {
-        $visitor = $this->getMockBuilder('PDepend\\Source\\ASTVisitor\\ASTVisitor')
+        $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->disableOriginalClone()
             ->getMock();
         $visitor->expects($this->once())
             ->method('visitTrait')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTTrait'));
+            ->with($this->isInstanceOf(ASTTrait::class));
 
         $trait = new ASTTrait('MyTrait');
         $trait->accept($visitor);
@@ -380,12 +383,12 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      */
     public function testMagicWakeupCallsRegisterTraitOnBuilderContext(): void
     {
-        $context = $this->getMockBuilder('PDepend\\Source\\Builder\\BuilderContext')
+        $context = $this->getMockBuilder(BuilderContext::class)
             ->disableOriginalClone()
             ->getMock();
         $context->expects($this->once())
             ->method('registerTrait')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTTrait'));
+            ->with($this->isInstanceOf(ASTTrait::class));
 
         $trait = new ASTTrait(__FUNCTION__);
         $trait->setContext($context);

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -66,7 +66,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $useStmt = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
         $methods = $useStmt->getAllMethods();
 
@@ -80,7 +80,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $useStmt = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
         $methods = $useStmt->getAllMethods();
 
@@ -94,7 +94,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $useStmt = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
         $methods = $useStmt->getAllMethods();
 
@@ -108,7 +108,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     {
         $class = $this->getFirstClassForTestCase();
         $useStmt = $class->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
         $methods = $useStmt->getAllMethods();
 
@@ -160,7 +160,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
         $methods = $useStmt->getAllMethods();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTrait',
+            ASTTrait::class,
             $methods[0]->getParent()
         );
     }
@@ -176,7 +176,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
         $methods = $useStmt->getAllMethods();
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTrait',
+            ASTTrait::class,
             $methods[0]->getParent()
         );
     }
@@ -386,7 +386,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     public function testTraitUseStatement()
     {
         $stmt = $this->getFirstTraitUseStatementInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitUseStatement', $stmt);
+        $this->assertInstanceOf(ASTTraitUseStatement::class, $stmt);
 
         return $stmt;
     }
@@ -448,7 +448,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     public function testTraitUseStatementInTrait()
     {
         $stmt = $this->getFirstTraitUseStatementInTrait();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTraitUseStatement', $stmt);
+        $this->assertInstanceOf(ASTTraitUseStatement::class, $stmt);
 
         return $stmt;
     }
@@ -510,7 +510,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
     }
 
@@ -522,7 +522,7 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     private function getFirstTraitUseStatementInTrait()
     {
         return $this->getFirstNodeOfTypeInTrait(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement'
+            ASTTraitUseStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -42,6 +42,8 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTryStatement} class.
  *
@@ -63,7 +65,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
     public function testTryStatement()
     {
         $stmt = $this->getFirstTryStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTryStatement', $stmt);
+        $this->assertInstanceOf(ASTTryStatement::class, $stmt);
 
         return $stmt;
     }
@@ -125,7 +127,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
      */
     public function testFirstChildOfTryStatementIsInstanceOfScopeStatement($stmt): void
     {
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(0));
     }
 
     /**
@@ -137,7 +139,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
      */
     public function testSecondChildOfTryStatementIsInstanceOfCatchStatement($stmt): void
     {
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCatchStatement', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTCatchStatement::class, $stmt->getChild(1));
     }
 
     /**
@@ -151,11 +153,11 @@ class ASTTryStatementTest extends ASTNodeTestCase
         }
 
         $expected = [
-            'PDepend\\Source\\AST\\ASTScopeStatement',
-            'PDepend\\Source\\AST\\ASTCatchStatement',
-            'PDepend\\Source\\AST\\ASTCatchStatement',
-            'PDepend\\Source\\AST\\ASTCatchStatement',
-            'PDepend\\Source\\AST\\ASTCatchStatement',
+            ASTScopeStatement::class,
+            ASTCatchStatement::class,
+            ASTCatchStatement::class,
+            ASTCatchStatement::class,
+            ASTCatchStatement::class,
         ];
 
         $this->assertEquals($expected, $actual);
@@ -166,7 +168,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
      */
     public function testParserThrowsExceptionWhenNoCatchStatementFollows(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->getFirstTryStatementInFunction();
     }
@@ -180,7 +182,7 @@ class ASTTryStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTryStatement'
+            ASTTryStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -63,7 +63,7 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     public function testArrayType()
     {
         $type = $this->getFirstArrayTypeInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeArray', $type);
+        $this->assertInstanceOf(ASTTypeArray::class, $type);
 
         return $type;
     }
@@ -143,7 +143,7 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTypeArray'
+            ASTTypeArray::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -73,7 +73,7 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     public function testCallableType()
     {
         $type = $this->getFirstCallableTypeInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeCallable', $type);
+        $this->assertInstanceOf(ASTTypeCallable::class, $type);
 
         return $type;
     }
@@ -135,7 +135,7 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTypeCallable'
+            ASTTypeCallable::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -63,7 +63,7 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     public function testIterableType()
     {
         $type = $this->getFirstArrayTypeInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeIterable', $type);
+        $this->assertInstanceOf(ASTTypeIterable::class, $type);
 
         return $type;
     }
@@ -143,7 +143,7 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTTypeIterable'
+            ASTTypeIterable::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -63,7 +63,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     public function testUnaryExpression()
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $expr);
+        $this->assertInstanceOf(ASTUnaryExpression::class, $expr);
 
         return $expr;
     }
@@ -122,7 +122,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     public function testUnaryExpressionNot()
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $expr);
+        $this->assertInstanceOf(ASTUnaryExpression::class, $expr);
 
         return $expr;
     }
@@ -165,7 +165,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     public function testUnaryExpressionSuppressWarning()
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnaryExpression', $expr);
+        $this->assertInstanceOf(ASTUnaryExpression::class, $expr);
 
         return $expr;
     }
@@ -211,7 +211,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTUnaryExpression'
+            ASTUnaryExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -63,7 +63,7 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     public function testUnsetStatement()
     {
         $stmt = $this->getFirstUnsetStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnsetStatement', $stmt);
+        $this->assertInstanceOf(ASTUnsetStatement::class, $stmt);
 
         return $stmt;
     }
@@ -126,7 +126,7 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTUnsetStatement'
+            ASTUnsetStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -71,7 +71,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
         $declarator = new ASTVariableDeclarator();
         $declarator->setValue(new ASTValue());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $declarator->getValue());
+        $this->assertInstanceOf(ASTValue::class, $declarator->getValue());
     }
 
     /**
@@ -100,7 +100,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     public function testVariableDeclarator()
     {
         $declarator = $this->getFirstVariableDeclaratorInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $declarator);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $declarator);
 
         return $declarator;
     }
@@ -154,7 +154,7 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+            ASTVariableDeclarator::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -98,7 +98,7 @@ class ASTVariableTest extends ASTNodeTestCase
     public function testVariable()
     {
         $variable = $this->getFirstVariableInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
+        $this->assertInstanceOf(ASTVariable::class, $variable);
 
         return $variable;
     }
@@ -160,7 +160,7 @@ class ASTVariableTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTVariable'
+            ASTVariable::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -63,7 +63,7 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     public function testVariableVariable()
     {
         $variable = $this->getFirstVariableVariableInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableVariable', $variable);
+        $this->assertInstanceOf(ASTVariableVariable::class, $variable);
 
         return $variable;
     }
@@ -125,7 +125,7 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTVariableVariable'
+            ASTVariableVariable::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -69,7 +69,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     public function testFirstChildOfWhileStatementIsASTExpression(): void
     {
         $stmt = $this->getFirstWhileStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTExpression::class, $stmt->getChild(0));
     }
 
     /**
@@ -78,7 +78,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     public function testSecondChildOfWhileStatementIsASTScopeStatement(): void
     {
         $stmt = $this->getFirstWhileStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScopeStatement', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(1));
     }
 
     /**
@@ -90,7 +90,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     public function testWhileStatement()
     {
         $stmt = $this->getFirstWhileStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTWhileStatement', $stmt);
+        $this->assertInstanceOf(ASTWhileStatement::class, $stmt);
 
         return $stmt;
     }
@@ -152,7 +152,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     public function testWhileStatementWithAlternativeScope()
     {
         $stmt = $this->getFirstWhileStatementInFunction();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTWhileStatement', $stmt);
+        $this->assertInstanceOf(ASTWhileStatement::class, $stmt);
 
         return $stmt;
     }
@@ -223,7 +223,7 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTWhileStatement'
+            ASTWhileStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -60,7 +60,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYield(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTYieldStatement', $stmt);
+        $this->assertInstanceOf(ASTYieldStatement::class, $stmt);
     }
 
     /**
@@ -70,13 +70,13 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTYieldStatement', $stmt);
+        $this->assertInstanceOf(ASTYieldStatement::class, $stmt);
         $assignment = $stmt->getParent();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAssignmentExpression', $assignment);
+        $this->assertInstanceOf(ASTAssignmentExpression::class, $assignment);
         $this->assertSame('$result', $assignment->getChild(0)->getImage());
 
         $this->assertSame([
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTLiteral::class,
         ], array_map('get_class', $stmt->getChildren()));
         $this->assertSame('23', $stmt->getChild(0)->getImage());
     }
@@ -87,7 +87,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldWithLiteral(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTLiteral::class, $stmt->getChild(0));
     }
 
     /**
@@ -96,7 +96,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldWithVariable(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(0));
+        $this->assertInstanceOf(ASTVariable::class, $stmt->getChild(0));
     }
 
     /**
@@ -105,8 +105,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldWithKeyValue(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(0));
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTVariable::class, $stmt->getChild(0));
+        $this->assertInstanceOf(ASTVariable::class, $stmt->getChild(1));
     }
 
     /**
@@ -115,8 +115,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldWithFunctionCalls(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $stmt->getChild(0));
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $stmt->getChild(1));
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $stmt->getChild(0));
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $stmt->getChild(1));
     }
 
     /**
@@ -125,7 +125,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldInsideForeach(): void
     {
         $stmt = $this->getFirstYieldStatementInFunction(__METHOD__);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTForeachStatement', $stmt->getParent()->getParent());
+        $this->assertInstanceOf(ASTForeachStatement::class, $stmt->getParent()->getParent());
     }
 
     /**
@@ -179,7 +179,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldValueAssignmentSimpleParent(ASTStatement $yield): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTAssignmentExpression',
+            ASTAssignmentExpression::class,
             $yield->getParent()->getParent()
         );
     }
@@ -207,7 +207,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     public function testYieldValueAssignmentKeyValueParent(ASTYieldStatement $yield): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTAssignmentExpression',
+            ASTAssignmentExpression::class,
             $yield->getParent()->getParent()->getParent()
         );
     }
@@ -235,7 +235,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
     {
         return $this->getFirstNodeOfTypeInFunction(
             $testCase,
-            'PDepend\\Source\\AST\\ASTYieldStatement'
+            ASTYieldStatement::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -74,7 +74,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return \PDepend\Source\AST\ASTNamespace[]
+     * @return ASTNamespace[]
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -75,7 +75,7 @@ class CollectionArtifactFilterTest extends AbstractTestCase
     {
         $class = new ASTClass(__CLASS__);
 
-        $filter = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTArtifactList\\ArtifactFilter')
+        $filter = $this->getMockBuilder(ArtifactFilter::class)
             ->getMock();
         $filter->expects($this->once())
             ->method('accept')

--- a/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
@@ -69,14 +69,14 @@ class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
         $class2 = new ASTClass('c2');
         $class2->setId(md5(42));
 
-        $reference1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTSelfReference')
+        $reference1 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference1->expects($this->once())
             ->method('getType')
             ->will($this->returnValue($class1));
 
-        $reference2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTSelfReference')
+        $reference2 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference2->expects($this->once())
@@ -105,14 +105,14 @@ class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
         $class2 = new ASTClass('c2');
         $class2->setId(md5(23));
 
-        $reference1 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTSelfReference')
+        $reference1 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference1->expects($this->once())
             ->method('getType')
             ->will($this->returnValue($class1));
 
-        $reference2 = $this->getMockBuilder('PDepend\\Source\\AST\\ASTSelfReference')
+        $reference2 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference2->expects($this->once())

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -44,6 +44,7 @@ namespace PDepend\Source\ASTVisitor;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTTrait;
 
 /**
@@ -207,13 +208,13 @@ class DefaultListenerTest extends AbstractTestCase
      */
     public function testListenerCallsStartVisitNodeForPassedParameterInstance(): void
     {
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+        $listener = $this->getMockBuilder(AbstractASTVisitListener::class)
             ->onlyMethods(['startVisitNode'])
             ->getMock();
         $listener->expects($this->once())
             ->method('startVisitNode');
 
-        $parameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTParameter')
+        $parameter = $this->getMockBuilder(ASTParameter::class)
             ->disableOriginalConstructor()
             ->getMock();
         $listener->startVisitParameter($parameter);
@@ -224,13 +225,13 @@ class DefaultListenerTest extends AbstractTestCase
      */
     public function testListenerCallsEndVisitNodeForPassedParameterInstance(): void
     {
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+        $listener = $this->getMockBuilder(AbstractASTVisitListener::class)
             ->onlyMethods(['endVisitNode'])
             ->getMock();
         $listener->expects($this->once())
             ->method('endVisitNode');
 
-        $parameter = $this->getMockBuilder('PDepend\\Source\\AST\\ASTParameter')
+        $parameter = $this->getMockBuilder(ASTParameter::class)
             ->disableOriginalConstructor()
             ->getMock();
         $listener->endVisitParameter($parameter);
@@ -243,7 +244,7 @@ class DefaultListenerTest extends AbstractTestCase
      */
     public function testListenerInvokesStartVisitNotForTrait(): void
     {
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+        $listener = $this->getMockBuilder(AbstractASTVisitListener::class)
             ->onlyMethods(['startVisitNode'])
             ->getMock();
         $listener->expects($this->once())
@@ -259,7 +260,7 @@ class DefaultListenerTest extends AbstractTestCase
      */
     public function testListenerInvokesEndVisitNotForTrait(): void
     {
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitListener')
+        $listener = $this->getMockBuilder(AbstractASTVisitListener::class)
             ->onlyMethods(['endVisitNode'])
             ->getMock();
         $listener->expects($this->once())

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -74,20 +74,20 @@ class DefaultVisitorTest extends AbstractTestCase
         $expected = [
             'pkgA',
             'classB',
-            'PDepend\\Source\\AST\\ASTCompilationUnit',
+            ASTCompilationUnit::class,
             'methodBA',
             'methodBB',
             'classA',
-            'PDepend\\Source\\AST\\ASTCompilationUnit',
+            ASTCompilationUnit::class,
             'methodAB',
             'methodAA',
             'pkgB',
             'interfsC',
-            'PDepend\\Source\\AST\\ASTCompilationUnit',
+            ASTCompilationUnit::class,
             'methodCB',
             'methodCA',
             'funcD',
-            'PDepend\\Source\\AST\\ASTCompilationUnit',
+            ASTCompilationUnit::class,
         ];
 
         $this->assertEquals($expected, $visitor->visits);
@@ -100,7 +100,7 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['visitParameter'])
             ->getMock();
         $visitor->expects($this->exactly(2))
@@ -116,7 +116,7 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['visitParameter'])
             ->getMock();
         $visitor->expects($this->exactly(3))
@@ -132,12 +132,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->exactly(2))
             ->method('startVisitParameter');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -152,12 +152,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->exactly(3))
             ->method('endVisitParameter');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -172,12 +172,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->once())
             ->method('startVisitInterface');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -192,12 +192,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->once())
             ->method('endVisitInterface');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -212,12 +212,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->once())
             ->method('startVisitProperty');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -232,12 +232,12 @@ class DefaultVisitorTest extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->once())
             ->method('endVisitProperty');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -258,7 +258,7 @@ class DefaultVisitorTest extends AbstractTestCase
         $namespace->addType(new ASTTrait('MyTraitTwo'))
             ->setCompilationUnit(new ASTCompilationUnit(__FILE__));
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['visitTrait'])
             ->getMock();
         $visitor->expects($this->exactly(2))
@@ -279,7 +279,7 @@ class DefaultVisitorTest extends AbstractTestCase
         $trait->addMethod($method0 = new ASTMethod('m0'));
         $trait->addMethod($method1 = new ASTMethod('m1'));
 
-        $visitor = $this->createMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor');
+        $visitor = $this->createMock(AbstractASTVisitor::class);
         $visitor->method('visitMethod')
             ->willReturnOnConsecutiveCalls($this->equalTo($method0), $this->equalTo($method1));
 
@@ -299,12 +299,12 @@ class DefaultVisitorTest extends AbstractTestCase
         $namespace = new ASTNamespace('MyPackage');
         $namespace->addType($trait);
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $listener->expects($this->once())
             ->method('startVisitTrait');
 
-        $visitor = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor')
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
             ->onlyMethods(['getVisitListeners'])
             ->getMock();
         $visitor->addVisitListener($listener);
@@ -342,7 +342,7 @@ class DefaultVisitorTest extends AbstractTestCase
      */
     public function testGetVisitListenersReturnsIterator(): void
     {
-        $visitor = $this->getAbstractClassMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor');
+        $visitor = $this->getAbstractClassMock(AbstractASTVisitor::class);
         $this->assertInstanceOf('Iterator', $visitor->getVisitListeners());
     }
 
@@ -351,9 +351,9 @@ class DefaultVisitorTest extends AbstractTestCase
      */
     public function testGetVisitListenersContainsAddedListener(): void
     {
-        $visitor = $this->getAbstractClassMock('\\PDepend\\Source\\ASTVisitor\\AbstractASTVisitor');
+        $visitor = $this->getAbstractClassMock(AbstractASTVisitor::class);
 
-        $listener = $this->getMockBuilder('\\PDepend\\Source\\ASTVisitor\\ASTVisitListener')
+        $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();
         $visitor->addVisitListener($listener);
 

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -47,6 +47,7 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTTrait;
+use PDepend\Source\Builder\Builder;
 
 /**
  * Test case for the {@link \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext}
@@ -67,11 +68,11 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testRegisterTraitCallsRestoreClassOnBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('restoreTrait')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTTrait'));
+            ->with($this->isInstanceOf(ASTTrait::class));
 
         $context = new GlobalBuilderContext($builder);
         $context->registerTrait(new ASTTrait(__CLASS__));
@@ -82,11 +83,11 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testRegisterClassCallsRestoreClassOnBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('restoreClass')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTClass'));
+            ->with($this->isInstanceOf(ASTClass::class));
 
         $context = new GlobalBuilderContext($builder);
         $context->registerClass(new ASTClass(__CLASS__));
@@ -97,11 +98,11 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testRegisterInterfaceCallsRestoreInterfaceOnBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('restoreInterface')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTInterface'));
+            ->with($this->isInstanceOf(ASTInterface::class));
 
         $context = new GlobalBuilderContext($builder);
         $context->registerInterface(new ASTInterface(__CLASS__));
@@ -112,11 +113,11 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testRegisterFunctionCallsRestoreFunctionOnBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('restoreFunction')
-            ->with($this->isInstanceOf('PDepend\\Source\\AST\\ASTFunction'));
+            ->with($this->isInstanceOf(ASTFunction::class));
 
         $context = new GlobalBuilderContext($builder);
         $context->registerFunction(new ASTFunction(__CLASS__));
@@ -129,7 +130,7 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testGetTraitDelegatesCallToWrappedBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('getTrait')
@@ -144,7 +145,7 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testGetClassDelegatesCallToWrappedBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('getClass')
@@ -159,7 +160,7 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testGetClassOrInterfaceDelegatesCallToWrappedBuilder(): void
     {
-        $builder = $this->getMockBuilder('\\PDepend\\Source\\Builder\\Builder')
+        $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects($this->once())
             ->method('getClassOrInterface')

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\Parser\TokenException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
@@ -58,7 +59,7 @@ class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
+        $this->assertInstanceOf(ASTFormalParameters::class, $children[0]);
 
         /** @var ASTFormalParameters $parametersBag */
         $parametersBag = $children[0];
@@ -93,7 +94,7 @@ class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
+        $this->assertInstanceOf(ASTFormalParameters::class, $children[0]);
 
         /** @var ASTFormalParameters $parametersBag */
         $parametersBag = $children[0];
@@ -125,7 +126,7 @@ class ConstructorPropertyPromotionTest extends PHPParserVersion80TestCase
 
     public function testPropertyPromotionOnRandomMethod(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenException::class);
+        $this->expectException(TokenException::class);
         $this->expectExceptionMessage('Unexpected token: private, line: 5, col: 9');
 
         $this->parseCodeResourceForTest();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -40,8 +40,18 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTMatchArgument;
+use PDepend\Source\AST\ASTMatchBlock;
+use PDepend\Source\AST\ASTMatchEntry;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTSwitchLabel;
+use PDepend\Source\AST\ASTThrowStatement;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Parser\UnexpectedTokenException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
@@ -70,72 +80,72 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
         $match = $returns[0]->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $match);
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $match);
         $this->assertSame($matchImage, $match->getImage());
         $this->assertSame('match', $match->getImageWithoutNamespace());
         /**
          * @var array{
-         *     \PDepend\Source\AST\ASTIdentifier,
-         *     \PDepend\Source\AST\ASTMatchArgument,
-         *     \PDepend\Source\AST\ASTMatchBlock,
+         *     ASTIdentifier,
+         *     ASTMatchArgument,
+         *     ASTMatchBlock,
          * } $children
          */
         $children = $match->getChildren();
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchArgument', $children[1]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchBlock', $children[2]);
+        $this->assertInstanceOf(ASTIdentifier::class, $children[0]);
+        $this->assertInstanceOf(ASTMatchArgument::class, $children[1]);
+        $this->assertInstanceOf(ASTMatchBlock::class, $children[2]);
         $this->assertSame($matchImage, $children[0]->getImage());
         $this->assertSame('match', $children[0]->getImageWithoutNamespace());
-        /** @var \PDepend\Source\AST\ASTVariable[] $arguments */
+        /** @var ASTVariable[] $arguments */
         $arguments = $children[1]->getChildren();
         $this->assertCount(1, $arguments);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $arguments[0]);
+        $this->assertInstanceOf(ASTVariable::class, $arguments[0]);
         $this->assertSame('$in', $arguments[0]->getImage());
-        /** @var \PDepend\Source\AST\ASTMatchEntry[] $entries */
+        /** @var ASTMatchEntry[] $entries */
         $entries = $children[2]->getChildren();
         $this->assertCount(3, $entries);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[0]);
-        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[0]);
+        /** @var ASTLiteral[] $literals */
         $literals = $entries[0]->getChildren();
         $this->assertCount(2, $literals);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[0]);
         $this->assertSame("'a'", $literals[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[1]);
         $this->assertSame("'A'", $literals[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[1]);
-        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[1]);
+        /** @var ASTLiteral[] $literals */
         $literals = $entries[1]->getChildren();
         $this->assertCount(2, $literals);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[0]);
         $this->assertSame("'b'", $literals[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[1]);
         $this->assertSame("'B'", $literals[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[2]);
-        /** @var array{\PDepend\Source\AST\ASTSwitchLabel, \PDepend\Source\AST\ASTThrowStatement} $pair */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[2]);
+        /** @var array{ASTSwitchLabel, ASTThrowStatement} $pair */
         $pair = $entries[2]->getChildren();
         $this->assertCount(2, $pair);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $pair[0]);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $pair[0]);
         $this->assertSame('default', $pair[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertInstanceOf(ASTThrowStatement::class, $pair[1]);
         $this->assertSame('throw', $pair[1]->getImage());
         $this->assertCount(1, $pair[1]->getChildren());
         $new = $pair[1]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertInstanceOf(ASTThrowStatement::class, $pair[1]);
         $this->assertSame('new', $new->getImage());
         $this->assertSame(['\InvalidArgumentException', ''], array_map(
             static fn($node) => $node->getImage(),
             $new->getChildren(),
         ));
         $this->assertSame([
-            ['PDepend\\Source\\AST\\ASTLiteral', 'Invalid code ['],
-            ['PDepend\\Source\\AST\\ASTVariable', '$in'],
-            ['PDepend\\Source\\AST\\ASTLiteral', ']'],
+            [ASTLiteral::class, 'Invalid code ['],
+            [ASTVariable::class, '$in'],
+            [ASTLiteral::class, ']'],
         ], array_map(
             static fn($node) => [$node::class, $node->getImage()],
             $new->getChild(1)->getChild(0)->getChildren(),
@@ -147,72 +157,72 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
         $match = $returns[0]->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $match);
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $match);
         $this->assertSame('match', $match->getImage());
         /**
          * @var array{
-         *     \PDepend\Source\AST\ASTIdentifier,
-         *     \PDepend\Source\AST\ASTMatchArgument,
-         *     \PDepend\Source\AST\ASTMatchBlock,
+         *     ASTIdentifier,
+         *     ASTMatchArgument,
+         *     ASTMatchBlock,
          * } $children
          */
         $children = $match->getChildren();
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchArgument', $children[1]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchBlock', $children[2]);
+        $this->assertInstanceOf(ASTIdentifier::class, $children[0]);
+        $this->assertInstanceOf(ASTMatchArgument::class, $children[1]);
+        $this->assertInstanceOf(ASTMatchBlock::class, $children[2]);
         $this->assertSame('match', $children[0]->getImage());
-        /** @var \PDepend\Source\AST\ASTVariable[] $arguments */
+        /** @var ASTVariable[] $arguments */
         $arguments = $children[1]->getChildren();
         $this->assertCount(1, $arguments);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $arguments[0]);
+        $this->assertInstanceOf(ASTVariable::class, $arguments[0]);
         $this->assertSame('$in', $arguments[0]->getImage());
-        /** @var \PDepend\Source\AST\ASTMatchEntry[] $entries */
+        /** @var ASTMatchEntry[] $entries */
         $entries = $children[2]->getChildren();
         $this->assertCount(3, $entries);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[0]);
-        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[0]);
+        /** @var ASTLiteral[] $literals */
         $literals = $entries[0]->getChildren();
         $this->assertCount(3, $literals);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[0]);
         $this->assertSame("'a'", $literals[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[1]);
         $this->assertSame("'b'", $literals[1]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[2]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[2]);
         $this->assertSame("'AB'", $literals[2]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[1]);
-        /** @var \PDepend\Source\AST\ASTLiteral[] $literals */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[1]);
+        /** @var ASTLiteral[] $literals */
         $literals = $entries[1]->getChildren();
         $this->assertCount(2, $literals);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[0]);
         $this->assertSame("1", $literals[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literals[1]);
+        $this->assertInstanceOf(ASTLiteral::class, $literals[1]);
         $this->assertSame("'One'", $literals[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMatchEntry', $entries[2]);
-        /** @var array{\PDepend\Source\AST\ASTSwitchLabel, \PDepend\Source\AST\ASTThrowStatement} $pair */
+        $this->assertInstanceOf(ASTMatchEntry::class, $entries[2]);
+        /** @var array{ASTSwitchLabel, ASTThrowStatement} $pair */
         $pair = $entries[2]->getChildren();
         $this->assertCount(2, $pair);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSwitchLabel', $pair[0]);
+        $this->assertInstanceOf(ASTSwitchLabel::class, $pair[0]);
         $this->assertSame('default', $pair[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertInstanceOf(ASTThrowStatement::class, $pair[1]);
         $this->assertSame('throw', $pair[1]->getImage());
         $this->assertCount(1, $pair[1]->getChildren());
         $new = $pair[1]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $pair[1]);
+        $this->assertInstanceOf(ASTThrowStatement::class, $pair[1]);
         $this->assertSame('new', $new->getImage());
         $this->assertSame(['\InvalidArgumentException', ''], array_map(
             static fn($node) => $node->getImage(),
             $new->getChildren(),
         ));
         $this->assertSame([
-            ['PDepend\\Source\\AST\\ASTLiteral', 'Invalid code ['],
-            ['PDepend\\Source\\AST\\ASTVariable', '$in'],
-            ['PDepend\\Source\\AST\\ASTLiteral', ']'],
+            [ASTLiteral::class, 'Invalid code ['],
+            [ASTVariable::class, '$in'],
+            [ASTLiteral::class, ']'],
         ], array_map(
             static fn($node) => [$node::class, $node->getImage()],
             $new->getChild(1)->getChild(0)->getChildren(),
@@ -221,7 +231,7 @@ class MatchExpressionTest extends PHPParserVersion80TestCase
 
     public function testMatchExpressionWithTooManyArguments(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
         $this->expectExceptionMessage('Unexpected token: ,, line: 5, col: 25');
 
         $this->parseCodeResourceForTest();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -41,7 +41,9 @@
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\AST\ASTVariable;
@@ -62,18 +64,18 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTArguments $arguments */
         $arguments = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
         $children = $arguments->getChildren();
 
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $children[0]);
         $this->assertSame('5623', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[1]);
+        $this->assertInstanceOf(ASTNamedArgument::class, $children[1]);
         /** @var ASTNamedArgument $argument */
         $argument = $children[1];
         $this->assertSame('thousands_separator', $argument->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $argument->getValue());
+        $this->assertInstanceOf(ASTLiteral::class, $argument->getValue());
         $this->assertSame("' '", $argument->getValue()->getImage());
         $this->assertSame("thousands_separator: ' '", $argument->getImage());
     }
@@ -84,19 +86,19 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTArguments $arguments */
         $arguments = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
         $children = $arguments->getChildren();
 
         $this->assertCount(4, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $children[0]);
         $this->assertSame("'/thing/{id}'", $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[3]);
+        $this->assertInstanceOf(ASTNamedArgument::class, $children[3]);
         /** @var ASTNamedArgument $argument */
         $argument = $children[3];
 
         $this->assertSame('methods', $argument->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $argument->getValue());
+        $this->assertInstanceOf(ASTArray::class, $argument->getValue());
     }
 
     public function testNamedArgumentsWithDefaultName(): void
@@ -105,12 +107,12 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTArguments $arguments */
         $arguments = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
         $children = $arguments->getChildren();
 
         $this->assertCount(1, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[0]);
+        $this->assertInstanceOf(ASTNamedArgument::class, $children[0]);
         $this->assertSame("default: 'bar'", $children[0]->getImage());
     }
 
@@ -120,19 +122,19 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTArguments $arguments */
         $arguments = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
         $children = $arguments->getChildren();
 
         $this->assertCount(4, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $children[0]);
+        $this->assertInstanceOf(ASTLiteral::class, $children[0]);
         $this->assertSame("'/thing/{id}'", $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTNamedArgument', $children[3]);
+        $this->assertInstanceOf(ASTNamedArgument::class, $children[3]);
         /** @var ASTNamedArgument $argument */
         $argument = $children[3];
 
         $this->assertSame('methods', $argument->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $argument->getValue());
+        $this->assertInstanceOf(ASTArray::class, $argument->getValue());
     }
 
     public function testNamedArgumentsFindVariable(): void
@@ -141,15 +143,15 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTNamedArgument $namedArgument */
         $namedArgument = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTNamedArgument'
+            ASTNamedArgument::class
         );
         /** @var ASTVariable[] $variables */
         $variables = $method->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTVariable'
+            ASTVariable::class
         );
         $this->assertCount(2, $variables);
 
-        $foundVariable = $namedArgument->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+        $foundVariable = $namedArgument->getFirstChildOfType(ASTVariable::class);
         $this->assertSame($variables[1], $foundVariable);
         $this->assertSame('$foo', $foundVariable->getImage());
         /** @var ASTExpression $expression */
@@ -159,7 +161,7 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $this->assertSame($namedArgument, $expressionParent);
         $this->assertSame(
             [$variables[1]],
-            $namedArgument->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable')
+            $namedArgument->findChildrenOfType(ASTVariable::class)
         );
     }
 
@@ -169,15 +171,15 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTNamedArgument $namedArgument */
         $namedArgument = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTNamedArgument'
+            ASTNamedArgument::class
         );
         /** @var ASTVariable[] $variables */
         $variables = $method->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTVariable'
+            ASTVariable::class
         );
         $this->assertCount(2, $variables);
 
-        $foundVariable = $namedArgument->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable');
+        $foundVariable = $namedArgument->getFirstChildOfType(ASTVariable::class);
         $this->assertSame($variables[1], $foundVariable);
         $this->assertSame('$foo', $foundVariable->getImage());
         /** @var ASTNamedArgument $variableParent */
@@ -185,7 +187,7 @@ class NamedArgumentsTest extends PHPParserVersion80TestCase
         $this->assertSame($namedArgument, $variableParent);
         $this->assertSame(
             [$variables[1]],
-            $namedArgument->findChildrenOfType('PDepend\\Source\\AST\\ASTVariable')
+            $namedArgument->findChildrenOfType(ASTVariable::class)
         );
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -41,7 +41,10 @@
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\Source\AST\ASTEchoStatement;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
@@ -60,7 +63,7 @@ class NullsafeOperatorTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTVariableDeclarator $variable */
         $variable = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator'
+            ASTVariableDeclarator::class
         );
 
         $this->assertSame('$obj', $variable->getImage());
@@ -71,14 +74,14 @@ class NullsafeOperatorTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTEchoStatement $variable */
-        $echo = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTEchoStatement');
+        $echo = $method->getFirstChildOfType(ASTEchoStatement::class);
         $chain = [];
         $node = $echo;
 
-        while ($node = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix')) {
-            if ($variable = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTVariable')) {
+        while ($node = $node->getFirstChildOfType(ASTMemberPrimaryPrefix::class)) {
+            if ($variable = $node->getFirstChildOfType(ASTVariable::class)) {
                 $chain[] = $variable->getImage();
-            } elseif ($property = $node->getFirstChildOfType('PDepend\\Source\\AST\\ASTPropertyPostfix')) {
+            } elseif ($property = $node->getFirstChildOfType(ASTPropertyPostfix::class)) {
                 $chain[] = $property->getImage();
             }
 

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion80TestCase.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP80;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -55,7 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
 abstract class PHPParserVersion80TestCase extends AbstractTestCase
 {
     /**
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
@@ -40,8 +40,15 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP80;
 
+use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTClassReference;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTThrowStatement;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
@@ -58,22 +65,22 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
 
         $expression = $returns[0]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $throw = $expression->getChild(2);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'should not be null\'', $exceptionMessage[0]->getImage());
     }
 
@@ -82,23 +89,23 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
 
         $expression = $returns[0]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $ternary = $expression->getChild(1);
         $throw = $ternary->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'should not be empty\'', $exceptionMessage[0]->getImage());
     }
 
@@ -107,28 +114,28 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
 
         $expression = $returns[0]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $ternary = $expression->getChild(1);
 
         $throw = $ternary->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'should be empty\'', $exceptionMessage[0]->getImage());
 
         $elseValue = $ternary->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $elseValue);
+        $this->assertInstanceOf(ASTVariable::class, $elseValue);
         $this->assertSame('$value', $elseValue->getImage());
     }
 
@@ -137,18 +144,18 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
 
         $closure = $returns[0]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClosure', $closure);
+        $this->assertInstanceOf(ASTClosure::class, $closure);
 
         $throw = $closure->getChild(1)->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\BadMethodCallException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'not implemented\'', $exceptionMessage[0]->getImage());
     }
 
@@ -157,77 +164,77 @@ class ThrowExpressionTest extends PHPParserVersion80TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTReturnStatement[] $returns */
-        $returns = $method->findChildrenOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $returns = $method->findChildrenOfType(ASTReturnStatement::class);
 
         $expression = $returns[0]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $throw = $expression->getChild(2);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'should not be null\'', $exceptionMessage[0]->getImage());
 
         $expression = $returns[1]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $throw = $expression->getChild(1)->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $exceptionMessage = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral');
+        $exceptionMessage = $throw->findChildrenOfType(ASTLiteral::class);
         $this->assertSame('\'should not be empty\'', $exceptionMessage[0]->getImage());
 
         $expression = $returns[2]->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $value = $expression->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $value);
+        $this->assertInstanceOf(ASTVariable::class, $value);
         $this->assertSame('$value', $value->getImage());
 
         $throw = $expression->getChild(2);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $throw);
+        $this->assertInstanceOf(ASTThrowStatement::class, $throw);
 
-        $exceptionClass = $throw->findChildrenOfType('PDepend\\Source\\AST\\ASTClassReference');
+        $exceptionClass = $throw->findChildrenOfType(ASTClassReference::class);
         $this->assertSame('\\InvalidArgumentException', $exceptionClass[0]->getImage());
 
-        $this->assertEmpty($throw->findChildrenOfType('PDepend\\Source\\AST\\ASTLiteral'));
+        $this->assertEmpty($throw->findChildrenOfType(ASTLiteral::class));
 
         $methods = $this->getFirstTypeForTestCase()
             ->getMethods();
         /** @var ASTMethod $arrayAccessMethod */
         $arrayAccessMethod = $methods[2];
         /** @var ASTReturnStatement $return */
-        $return = $arrayAccessMethod->getFirstChildOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+        $return = $arrayAccessMethod->getFirstChildOfType(ASTReturnStatement::class);
         $value = $return->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArrayIndexExpression', $value);
+        $this->assertInstanceOf(ASTArrayIndexExpression::class, $value);
 
         $children = $value->getChildren();
 
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+        $this->assertInstanceOf(ASTVariable::class, $children[0]);
         $this->assertSame('$a', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $children[1]);
+        $this->assertInstanceOf(ASTExpression::class, $children[1]);
 
         $children = $children[1]->getChildren();
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+        $this->assertInstanceOf(ASTVariable::class, $children[0]);
         $this->assertSame('$value', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $children[1]);
+        $this->assertInstanceOf(ASTExpression::class, $children[1]);
         $this->assertSame('??', $children[1]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTThrowStatement', $children[2]);
+        $this->assertInstanceOf(ASTThrowStatement::class, $children[2]);
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -45,6 +45,7 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Parser\ParserException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion80
@@ -62,16 +63,16 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTFormalParameter $parameter */
         $parameter = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFormalParameter'
+            ASTFormalParameter::class
         );
         $children = $parameter->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $children[0]);
+        $this->assertInstanceOf(ASTUnionType::class, $children[0]);
         /** @var ASTUnionType $unionType */
         $unionType = $children[0];
         $this->assertSame('array|int|float|Bar\Biz|null', $unionType->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $children[1]);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $children[1]);
         /** @var ASTVariableDeclarator $variable */
         $variable = $children[1];
         $this->assertSame('$number', $variable->getImage());
@@ -83,10 +84,10 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTType $return */
         $return = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType'
+            ASTType::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $return);
+        $this->assertInstanceOf(ASTUnionType::class, $return);
         $this->assertSame('int|float|Bar\Biz|null', $return->getImage());
     }
 
@@ -96,16 +97,16 @@ class UnionTypesTest extends PHPParserVersion80TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTType $return */
         $return = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType'
+            ASTType::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $return);
+        $this->assertInstanceOf(ASTUnionType::class, $return);
         $this->assertSame('array|iterable', $return->getImage());
     }
 
     public function testUnionTypesStandaloneNull(): void
     {
-        $this->expectException(\PDepend\Source\Parser\ParserException::class);
+        $this->expectException(ParserException::class);
         $this->expectExceptionMessage('null can not be used as a standalone type');
 
         $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -40,6 +40,11 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTTypeArray;
+
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -57,18 +62,18 @@ class ArrayUnpackingWithStringKeysTest extends PHPParserVersion81TestCase
     {
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeArray', $children[1]);
+        $this->assertInstanceOf(ASTTypeArray::class, $children[1]);
         $children = $children[2]->getChildren();
         $this->assertCount(1, $children);
         $return = $children[0];
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $return);
+        $this->assertInstanceOf(ASTReturnStatement::class, $return);
         $children = $return->getChildren();
         $this->assertCount(1, $children);
         $array = $children[0];
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $array);
+        $this->assertInstanceOf(ASTArray::class, $array);
         $children = $array->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArrayElement', $children[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArrayElement', $children[1]);
+        $this->assertInstanceOf(ASTArrayElement::class, $children[0]);
+        $this->assertInstanceOf(ASTArrayElement::class, $children[1]);
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -40,6 +40,8 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\AST\ASTArtifactList;
+use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTEnumCase;
 use PDepend\Source\AST\ASTInterface;
@@ -63,13 +65,13 @@ class EnumTest extends PHPParserVersion81TestCase
             ->getTypes();
 
         $this->assertCount(4, $types);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTInterface', $types[0]);
+        $this->assertInstanceOf(ASTInterface::class, $types[0]);
         $this->assertSame('HasColor', $types[0]->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $types[1]);
+        $this->assertInstanceOf(ASTEnum::class, $types[1]);
         $this->assertSame('Suit', $types[1]->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClass', $types[2]);
+        $this->assertInstanceOf(ASTClass::class, $types[2]);
         $this->assertSame('UseEnum', $types[2]->getName());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $types[3]);
+        $this->assertInstanceOf(ASTEnum::class, $types[3]);
         $this->assertSame('SpecialCases', $types[3]->getName());
 
         $methods = $types[1]->getMethods();
@@ -91,7 +93,7 @@ class EnumTest extends PHPParserVersion81TestCase
         /** @var ASTEnum $enum */
         $enum = $parameters[0]->getClass();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTEnum', $enum);
+        $this->assertInstanceOf(ASTEnum::class, $enum);
         $this->assertSame('Suit', $enum->getName());
         $this->assertSame('string', $enum->getType()->getImage());
         $this->assertTrue($enum->isBacked());
@@ -123,7 +125,7 @@ class EnumTest extends PHPParserVersion81TestCase
             )
         );
         $cases = $enum->getCases();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $cases);
+        $this->assertInstanceOf(ASTArtifactList::class, $cases);
         $this->assertSame(
             [
                 'HEARTS' => "'hearts'",

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -41,6 +41,7 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTLiteral;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
@@ -73,7 +74,7 @@ class ExplicitOctalNotationTest extends PHPParserVersion81TestCase
         $this->assertSame(
             '0o170',
             $this->getFirstMethodForTestCase()
-                ->getFirstChildOfType('PDepend\\Source\\AST\\ASTLiteral')->getImage()
+                ->getFirstChildOfType(ASTLiteral::class)->getImage()
         );
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -40,7 +40,13 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
@@ -56,24 +62,24 @@ class FirstClassCallableSyntaxTest extends PHPParserVersion81TestCase
     {
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeCallable', $children[1]);
+        $this->assertInstanceOf(ASTTypeCallable::class, $children[1]);
         $children = $children[2]->getChildren();
         $this->assertCount(1, $children);
         $return = $children[0];
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $return);
+        $this->assertInstanceOf(ASTReturnStatement::class, $return);
         $children = $return->getChildren();
         $this->assertCount(1, $children);
         $prefix = $children[0];
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $prefix);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $prefix);
         $children = $prefix->getChildren();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+        $this->assertInstanceOf(ASTVariable::class, $children[0]);
         /** @var ASTMethodPostfix $methodPostFix */
         $methodPostFix = $children[1];
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMethodPostfix', $methodPostFix);
+        $this->assertInstanceOf(ASTMethodPostfix::class, $methodPostFix);
         $this->assertSame('getTime', $methodPostFix->getImage());
         $children = $methodPostFix->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIdentifier', $children[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArguments', $children[1]);
+        $this->assertInstanceOf(ASTIdentifier::class, $children[0]);
+        $this->assertInstanceOf(ASTArguments::class, $children[1]);
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -40,6 +40,8 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\AST\ASTArguments;
+
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -53,42 +55,42 @@ class FirstClassCallableTest extends PHPParserVersion81TestCase
     public function testFirstClassCallable(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableWithComments(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableObjectMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableDynamicMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableStaticMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableDynamicStaticMethod(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 
     public function testFirstClassCallableInvocableObject(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $this->assertTrue($method->getFirstChildOfType('PDepend\Source\AST\ASTArguments')->isVariadicPlaceholder());
+        $this->assertTrue($method->getFirstChildOfType(ASTArguments::class)->isVariadicPlaceholder());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -62,7 +62,7 @@ class InInitializersTest extends PHPParserVersion81TestCase
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
+        $this->assertInstanceOf(ASTFormalParameters::class, $children[0]);
 
         /** @var ASTFormalParameters $parametersBag */
         $parametersBag = $children[0];
@@ -73,24 +73,24 @@ class InInitializersTest extends PHPParserVersion81TestCase
 
         $classRef = $parameters[0];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $classRef);
+        $this->assertInstanceOf(ASTFormalParameter::class, $classRef);
         $this->assertTrue($classRef->isPromoted());
         $this->assertTrue($classRef->isPublic());
 
         /** @var ASTVariableDeclarator $variable */
         $variable = $classRef->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variable);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variable);
 
         /** @var ASTValue $defaultValue */
         $defaultValue = $variable->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $defaultValue);
+        $this->assertInstanceOf(ASTValue::class, $defaultValue);
         $this->assertTrue($defaultValue->isValueAvailable());
 
         /** @var ASTAllocationExpression $expression */
         $expression = $defaultValue->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $expression);
+        $this->assertInstanceOf(ASTAllocationExpression::class, $expression);
         $this->assertSame('Bar', $expression->getChild(0)->getImage());
     }
 
@@ -99,7 +99,7 @@ class InInitializersTest extends PHPParserVersion81TestCase
         $method = $this->getFirstMethodForTestCase();
         $children = $method->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $children[0]);
+        $this->assertInstanceOf(ASTFormalParameters::class, $children[0]);
 
         /** @var ASTFormalParameters $parametersBag */
         $parametersBag = $children[0];
@@ -110,50 +110,50 @@ class InInitializersTest extends PHPParserVersion81TestCase
 
         $classRef = $parameters[0];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $classRef);
+        $this->assertInstanceOf(ASTFormalParameter::class, $classRef);
         $this->assertTrue($classRef->isPromoted());
         $this->assertTrue($classRef->isPublic());
 
         /** @var ASTClassOrInterfaceReference $variable */
         $type = $classRef->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $type);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $type);
         $this->assertSame('Bar', $type->getImage());
 
         /** @var ASTVariableDeclarator $variable */
         $variable = $classRef->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variable);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variable);
 
         /** @var ASTValue $defaultValue */
         $defaultValue = $variable->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $defaultValue);
+        $this->assertInstanceOf(ASTValue::class, $defaultValue);
         $this->assertTrue($defaultValue->isValueAvailable());
 
         /** @var ASTAllocationExpression $expression */
         $expression = $defaultValue->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $expression);
+        $this->assertInstanceOf(ASTAllocationExpression::class, $expression);
         $this->assertSame('Bar', $expression->getChild(0)->getImage());
 
         $str = $parameters[1];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $str);
+        $this->assertInstanceOf(ASTFormalParameter::class, $str);
         $this->assertTrue($str->isPromoted());
         $this->assertTrue($str->isProtected());
 
         /** @var ASTScalarType $variable */
         $type = $str->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
 
         /** @var ASTVariableDeclarator $variable */
         $variable = $str->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variable);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variable);
 
         /** @var ASTValue $defaultValue */
         $defaultValue = $variable->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $defaultValue);
+        $this->assertInstanceOf(ASTValue::class, $defaultValue);
         $this->assertTrue($defaultValue->isValueAvailable());
 
         /** @var ASTAllocationExpression $expression */
@@ -163,24 +163,24 @@ class InInitializersTest extends PHPParserVersion81TestCase
 
         $classRef = $parameters[2];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $classRef);
+        $this->assertInstanceOf(ASTFormalParameter::class, $classRef);
         $this->assertFalse($classRef->isPromoted());
         $this->assertFalse($classRef->isPublic());
 
         /** @var ASTVariableDeclarator $variable */
         $variable = $classRef->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variable);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variable);
 
         /** @var ASTValue $defaultValue */
         $defaultValue = $variable->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $defaultValue);
+        $this->assertInstanceOf(ASTValue::class, $defaultValue);
         $this->assertTrue($defaultValue->isValueAvailable());
 
         /** @var ASTAllocationExpression $expression */
         $expression = $defaultValue->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $expression);
+        $this->assertInstanceOf(ASTAllocationExpression::class, $expression);
         $this->assertSame('Biz', $expression->getChild(0)->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -45,6 +45,7 @@ use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Parser\ParserException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
@@ -61,15 +62,15 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTFormalParameter $parameter */
-        $parameter = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+        $parameter = $method->getFirstChildOfType(ASTFormalParameter::class);
         $children = $parameter->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[0]);
         /** @var ASTIntersectionType $intersectionType */
         $intersectionType = $children[0];
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $intersectionType->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $children[1]);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $children[1]);
         /** @var ASTVariableDeclarator $variable */
         $variable = $children[1];
         $this->assertSame('$iterator', $variable->getImage());
@@ -80,10 +81,10 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         /** @var ASTMethod $method */
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTFormalParameter $parameter */
-        $parameter = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+        $parameter = $method->getFirstChildOfType(ASTFormalParameter::class);
         $children = $parameter->getChildren();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[0]);
         /** @var ASTIntersectionType $intersectionType */
         $intersectionType = $children[0];
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $intersectionType->getImage());
@@ -95,16 +96,16 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
         $method = $this->getFirstMethodForTestCase();
         /** @var ASTType $return */
         $return = $method->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTType'
+            ASTType::class
         );
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $return);
+        $this->assertInstanceOf(ASTIntersectionType::class, $return);
         $this->assertSame('Iterator&\Countable&\ArrayAccess', $return->getImage());
     }
 
     public function testIntersectionTypesCantBeMixedWithUnionTypes(): void
     {
-        $this->expectException(\PDepend\Source\Parser\ParserException::class);
+        $this->expectException(ParserException::class);
         $this->expectExceptionMessage('Unexpected token');
 
         $this->getFirstMethodForTestCase();
@@ -112,7 +113,7 @@ class IntersectionTypesTest extends PHPParserVersion81TestCase
 
     public function testIntersectionTypesCantBeScalar(): void
     {
-        $this->expectException(\PDepend\Source\Parser\ParserException::class);
+        $this->expectException(ParserException::class);
         $this->expectExceptionMessage('int can not be used in an intersection type');
 
         $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -55,7 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
 abstract class PHPParserVersion81TestCase extends AbstractTestCase
 {
     /**
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -40,6 +40,8 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -53,7 +55,7 @@ class ReadonlyClassTest extends PHPParserVersion81TestCase
     public function testReadonlyClass(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: readonly, line: 2, col: 1, file: '

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -40,6 +40,8 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\State;
 
 /**
@@ -108,11 +110,11 @@ class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
         $assignment = $constructorNodes[1]->getChild(0)->getChild(0);
 
         $propertyPostfix = $assignment->getChild(0)->getChild(1);
-        self::assertInstanceOf('PDepend\\Source\\AST\\ASTPropertyPostfix', $propertyPostfix);
+        self::assertInstanceOf(ASTPropertyPostfix::class, $propertyPostfix);
         $this->assertSame('readonly', $propertyPostfix->getImage());
 
         $methodPostfix = $assignment->getChild(1)->getChild(1);
-        self::assertInstanceOf('PDepend\\Source\\AST\\ASTMethodPostfix', $methodPostfix);
+        self::assertInstanceOf(ASTMethodPostfix::class, $methodPostfix);
         $this->assertSame('readonly', $methodPostfix->getImage());
 
         $method = $class->getMethods()->offsetGet(1);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -44,6 +44,8 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
@@ -76,7 +78,7 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
             ['false', '$falsy'],
         ] as $index => $expected) {
             [$expectedType, $expectedVariable] = $expected;
-            $expectedTypeClass = $expected[2] ?? 'PDepend\\Source\\AST\\ASTScalarType';
+            $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];
 
             $this->assertInstanceOf(
@@ -86,7 +88,7 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
             );
             $this->assertSame(ltrim($expectedType, '?'), $type->getImage());
             $this->assertInstanceOf(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                ASTVariableDeclarator::class,
                 $variable,
                 "Wrong variable for $expectedType $expectedVariable"
             );
@@ -102,10 +104,10 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
         $nullish = $methods[0]->getReturnType();
         $falsy = $methods[1]->getReturnType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $nullish);
+        $this->assertInstanceOf(ASTScalarType::class, $nullish);
         $this->assertSame('null', $nullish->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $falsy);
+        $this->assertInstanceOf(ASTScalarType::class, $falsy);
         $this->assertSame('false', $falsy->getImage());
     }
 
@@ -123,14 +125,14 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
         $nullish = $nullish->getFormalParameter()->getType();
         $falsy = $falsy->getFormalParameter()->getType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $nullish);
+        $this->assertInstanceOf(ASTScalarType::class, $nullish);
         $this->assertSame('null', $nullish->getImage());
         $this->assertSame(3, $nullish->getStartLine());
         $this->assertSame(29, $nullish->getStartColumn());
         $this->assertSame(3, $nullish->getEndLine());
         $this->assertSame(32, $nullish->getEndColumn());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $falsy);
+        $this->assertInstanceOf(ASTScalarType::class, $falsy);
         $this->assertSame('false', $falsy->getImage());
         $this->assertSame(3, $falsy->getStartLine());
         $this->assertSame(44, $falsy->getStartColumn());

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -40,6 +40,11 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTIntersectionType;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTUnionType;
+
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -55,14 +60,14 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $method = $this->getFirstMethodForTestCase();
         $type = $method->getReturnType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $children = $type->getChildren();
 
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[0]);
         $this->assertSame('A&B', $children[0]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[1]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[1]);
         $this->assertSame('D', $children[1]->getImage());
     }
 
@@ -71,17 +76,17 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $method = $this->getFirstMethodForTestCase();
         $type = $method->getReturnType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $children = $type->getChildren();
 
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $children[0]);
+        $this->assertInstanceOf(ASTScalarType::class, $children[0]);
         $this->assertSame('null', $children[0]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $children[1]);
+        $this->assertInstanceOf(ASTUnionType::class, $children[1]);
         $this->assertSame('A|B|C', $children[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[2]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[2]);
         $this->assertSame('D&E&F', $children[2]->getImage());
     }
 
@@ -90,7 +95,7 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $method = $this->getFirstMethodForTestCase();
         $type = $method->getReturnType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $this->assertSame('(A&B&C)|true|(D&((E&F)|G))', $type->getImage());
     }
 
@@ -102,17 +107,17 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $parameter = $parameters[0];
         $type = $parameter->getFormalParameter()->getType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $children = $type->getChildren();
 
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[0]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[0]);
         $this->assertSame('A&B', $children[0]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[1]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[1]);
         $this->assertSame('D', $children[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[1]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[1]);
         $this->assertSame('null', $children[2]->getImage());
     }
 
@@ -124,17 +129,17 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $parameter = $parameters[0];
         $type = $parameter->getFormalParameter()->getType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $children = $type->getChildren();
 
         $this->assertCount(3, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $children[0]);
+        $this->assertInstanceOf(ASTScalarType::class, $children[0]);
         $this->assertSame('null', $children[0]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $children[1]);
+        $this->assertInstanceOf(ASTUnionType::class, $children[1]);
         $this->assertSame('A|B|C', $children[1]->getImage());
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTIntersectionType', $children[2]);
+        $this->assertInstanceOf(ASTIntersectionType::class, $children[2]);
         $this->assertSame('D&E&F', $children[2]->getImage());
     }
 
@@ -146,7 +151,7 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
         $parameter = $parameters[0];
         $type = $parameter->getFormalParameter()->getType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
+        $this->assertInstanceOf(ASTUnionType::class, $type);
         $this->assertSame('(A&B&C)|true|(D&((E&F)|G))', $type->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -40,6 +40,7 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTCompoundExpression;
 use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTConstantDefinition;
@@ -70,7 +71,7 @@ class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82Tes
         $constants = $enum->getConstants();
 
         $this->assertCount(1, $constants);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $constants['C']);
+        $this->assertInstanceOf(ASTArray::class, $constants['C']);
 
         $elements = $constants['C']->getChildren();
         $this->assertCount(1, $elements);

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -55,7 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
 abstract class PHPParserVersion82TestCase extends AbstractTestCase
 {
     /**
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -45,6 +45,7 @@ use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTVariableDeclarator;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion81
@@ -76,7 +77,7 @@ class TrueTypeTest extends PHPParserVersion82TestCase
             ['true', '$truthy'],
         ] as $index => $expected) {
             [$expectedType, $expectedVariable] = $expected;
-            $expectedTypeClass = $expected[2] ?? 'PDepend\\Source\\AST\\ASTScalarType';
+            $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];
 
             $this->assertInstanceOf(
@@ -86,7 +87,7 @@ class TrueTypeTest extends PHPParserVersion82TestCase
             );
             $this->assertSame(ltrim($expectedType, '?'), $type->getImage());
             $this->assertInstanceOf(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                ASTVariableDeclarator::class,
                 $variable,
                 "Wrong variable for $expectedType $expectedVariable"
             );
@@ -102,7 +103,7 @@ class TrueTypeTest extends PHPParserVersion82TestCase
         /** @var ASTScalarType $truthy */
         $truthy = $methods[0]->getReturnType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $truthy);
+        $this->assertInstanceOf(ASTScalarType::class, $truthy);
         $this->assertSame('true', $truthy->getImage());
         $this->assertTrue($truthy->isTrue());
     }
@@ -118,7 +119,7 @@ class TrueTypeTest extends PHPParserVersion82TestCase
 
         $truthy = $truthy->getFormalParameter()->getType();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $truthy);
+        $this->assertInstanceOf(ASTScalarType::class, $truthy);
         $this->assertSame('true', $truthy->getImage());
         $this->assertSame(3, $truthy->getStartLine());
         $this->assertSame(29, $truthy->getStartColumn());

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -40,6 +40,8 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\Parser\UnexpectedTokenException;
+
 /**
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
@@ -53,7 +55,7 @@ class TypedClassConstantsTest extends PHPParserVersion82TestCase
     public function testInterface(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: string, line: 4, col: 11, file: '
@@ -65,7 +67,7 @@ class TypedClassConstantsTest extends PHPParserVersion82TestCase
     public function testBroken(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: 7, line: 4, col: 11, file: '

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -40,8 +40,12 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP83;
 
+use PDepend\Source\AST\ASTCompoundExpression;
 use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTScope;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTVariable;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPBuilder
@@ -61,23 +65,23 @@ class DynamicClassConstantFetchTest extends PHPParserVersion83TestCase
         /** @var ASTScope $scope */
         $scope = $children[2];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScope', $scope);
+        $this->assertInstanceOf(ASTScope::class, $scope);
 
         /** @var ASTMemberPrimaryPrefix $return */
         $member = $scope->getChild(0)->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $member);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $member);
         $children = $member->getChildren();
 
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $children[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTPropertyPostfix', $children[1]);
+        $this->assertInstanceOf(ASTSelfReference::class, $children[0]);
+        $this->assertInstanceOf(ASTPropertyPostfix::class, $children[1]);
         $children = $children[1]->getChildren();
         $this->assertCount(1, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTCompoundExpression', $children[0]);
+        $this->assertInstanceOf(ASTCompoundExpression::class, $children[0]);
         $children = $children[0]->getChildren();
         $this->assertCount(1, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $children[0]);
+        $this->assertInstanceOf(ASTVariable::class, $children[0]);
         $this->assertSame('$bar', $children[0]->getImage());
     }
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP83;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -55,7 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
 abstract class PHPParserVersion83TestCase extends AbstractTestCase
 {
     /**
-     * @return \PDepend\Source\Language\PHP\AbstractPHPParser
+     * @return AbstractPHPParser
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -41,7 +41,9 @@
 namespace PDepend\Source\Language\PHP\Features\PHP83;
 
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantPostfix;
 use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTLiteral;
@@ -49,6 +51,7 @@ use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTValue;
+use PDepend\Source\Parser\UnexpectedTokenException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
@@ -69,22 +72,22 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $interface->getChild(0)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $interface->getConstant('TEST');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $constant);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $constant);
         $this->assertSame($constant, $value->getValue());
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
@@ -99,15 +102,15 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $enum->getChild(0)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTLiteral $constant */
         $constant = $enum->getConstant('TEST');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $constant);
+        $this->assertInstanceOf(ASTLiteral::class, $constant);
         $this->assertSame($constant, $value->getValue());
         $this->assertSame('"Test1"', $constant->getImage());
     }
@@ -123,11 +126,11 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $trait->getChild(0)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $trait->getConstant('TEST');
@@ -135,9 +138,9 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
@@ -152,11 +155,11 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $class->getChild(2)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $class->getConstant('TEST');
@@ -164,9 +167,9 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
 
         /** @var ASTClass $class */
@@ -175,11 +178,11 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $class->getChild(1)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $class->getConstant('TEST');
@@ -190,7 +193,7 @@ class TypedClassConstantsTest extends PHPParserVersion83TestCase
     public function testBroken(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: 7, line: 4, col: 11, file: '

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -41,7 +41,9 @@
 namespace PDepend\Source\Language\PHP\Features\PHP83;
 
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantPostfix;
 use PDepend\Source\AST\ASTEnum;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTLiteral;
@@ -50,6 +52,7 @@ use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTValue;
+use PDepend\Source\Parser\UnexpectedTokenException;
 
 /**
  * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
@@ -71,28 +74,28 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         /** @var ASTUnionType $type */
         $type = $constantDeclarator->getType();
         $this->assertCount(3, $type->getChildren());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(0));
+        $this->assertInstanceOf(ASTUnionType::class, $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(0));
         $this->assertSame('string', $type->getChild(0)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(1));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(1));
         $this->assertSame('int', $type->getChild(1)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(2));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(2));
         $this->assertSame('null', $type->getChild(2)->getImage());
 
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $interface->getConstant('TEST');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $constant);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $constant);
         $this->assertSame($constant, $value->getValue());
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
@@ -108,21 +111,21 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         /** @var ASTUnionType $type */
         $type = $constantDeclarator->getType();
         $this->assertCount(3, $type->getChildren());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(0));
+        $this->assertInstanceOf(ASTUnionType::class, $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(0));
         $this->assertSame('string', $type->getChild(0)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(1));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(1));
         $this->assertSame('int', $type->getChild(1)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(2));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(2));
         $this->assertSame('null', $type->getChild(2)->getImage());
 
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTLiteral $constant */
         $constant = $enum->getConstant('TEST');
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $constant);
+        $this->assertInstanceOf(ASTLiteral::class, $constant);
         $this->assertSame($constant, $value->getValue());
         $this->assertSame('"Test1"', $constant->getImage());
     }
@@ -140,15 +143,15 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         /** @var ASTUnionType $type */
         $type = $constantDeclarator->getType();
         $this->assertCount(2, $type->getChildren());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(0));
+        $this->assertInstanceOf(ASTUnionType::class, $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(0));
         $this->assertSame('string', $type->getChild(0)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(1));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(1));
         $this->assertSame('int', $type->getChild(1)->getImage());
 
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $trait->getConstant('TEST');
@@ -156,9 +159,9 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
     }
 
@@ -174,15 +177,15 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         /** @var ASTUnionType $type */
         $type = $constantDeclarator->getType();
         $this->assertCount(2, $type->getChildren());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTUnionType', $type);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(0));
+        $this->assertInstanceOf(ASTUnionType::class, $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(0));
         $this->assertSame('string', $type->getChild(0)->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type->getChild(1));
+        $this->assertInstanceOf(ASTScalarType::class, $type->getChild(1));
         $this->assertSame('int', $type->getChild(1)->getImage());
 
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $class->getConstant('TEST');
@@ -190,9 +193,9 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
 
         $children = $constant->getChildren();
         $this->assertCount(2, $children);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $children[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $children[0]);
         $this->assertSame('E', $children[0]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $children[1]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $children[1]);
         $this->assertSame('TEST', $children[1]->getImage());
 
         /** @var ASTClass $class */
@@ -201,11 +204,11 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
         $constantDeclarator = $class->getChild(1)->getChild(0);
         /** @var ASTScalarType $type */
         $type = $constantDeclarator->getType();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('string', $type->getImage());
         /** @var ASTValue $value */
         $value = $constantDeclarator->getValue();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTValue', $value);
+        $this->assertInstanceOf(ASTValue::class, $value);
 
         /** @var ASTMemberPrimaryPrefix $constant */
         $constant = $class->getConstant('TEST');
@@ -216,7 +219,7 @@ class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
     public function testBroken(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: 7, line: 4, col: 11, file: '

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -43,7 +43,100 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
+use PDepend\Source\AST\ASTArrayIndexExpression;
+use PDepend\Source\AST\ASTAssignmentExpression;
+use PDepend\Source\AST\ASTBooleanAndExpression;
+use PDepend\Source\AST\ASTBooleanOrExpression;
+use PDepend\Source\AST\ASTBreakStatement;
+use PDepend\Source\AST\ASTCastExpression;
+use PDepend\Source\AST\ASTCatchStatement;
+use PDepend\Source\AST\ASTClassFqnPostfix;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTClassReference;
+use PDepend\Source\AST\ASTCloneExpression;
+use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTComment;
+use PDepend\Source\AST\ASTCompoundExpression;
+use PDepend\Source\AST\ASTCompoundVariable;
+use PDepend\Source\AST\ASTConditionalExpression;
+use PDepend\Source\AST\ASTConstant;
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTConstantPostfix;
+use PDepend\Source\AST\ASTContinueStatement;
+use PDepend\Source\AST\ASTDeclareStatement;
+use PDepend\Source\AST\ASTDoWhileStatement;
+use PDepend\Source\AST\ASTEchoStatement;
+use PDepend\Source\AST\ASTElseIfStatement;
+use PDepend\Source\AST\ASTEvalExpression;
+use PDepend\Source\AST\ASTExitExpression;
+use PDepend\Source\AST\ASTExpression;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTFinallyStatement;
+use PDepend\Source\AST\ASTForeachStatement;
+use PDepend\Source\AST\ASTForInit;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTForStatement;
+use PDepend\Source\AST\ASTForUpdate;
 use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTGlobalStatement;
+use PDepend\Source\AST\ASTGotoStatement;
+use PDepend\Source\AST\ASTHeredoc;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTIfStatement;
+use PDepend\Source\AST\ASTIncludeExpression;
+use PDepend\Source\AST\ASTInstanceOfExpression;
+use PDepend\Source\AST\ASTIssetExpression;
+use PDepend\Source\AST\ASTLabelStatement;
+use PDepend\Source\AST\ASTListExpression;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTLogicalAndExpression;
+use PDepend\Source\AST\ASTLogicalOrExpression;
+use PDepend\Source\AST\ASTLogicalXorExpression;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTPostfixExpression;
+use PDepend\Source\AST\ASTPreDecrementExpression;
+use PDepend\Source\AST\ASTPreIncrementExpression;
+use PDepend\Source\AST\ASTRequireExpression;
+use PDepend\Source\AST\ASTReturnStatement;
+use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTScope;
+use PDepend\Source\AST\ASTScopeStatement;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTShiftLeftExpression;
+use PDepend\Source\AST\ASTShiftRightExpression;
+use PDepend\Source\AST\ASTStatement;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTStaticVariableDeclaration;
+use PDepend\Source\AST\ASTString;
+use PDepend\Source\AST\ASTStringIndexExpression;
+use PDepend\Source\AST\ASTSwitchLabel;
+use PDepend\Source\AST\ASTSwitchStatement;
+use PDepend\Source\AST\ASTThrowStatement;
+use PDepend\Source\AST\ASTTraitAdaptation;
+use PDepend\Source\AST\ASTTraitAdaptationAlias;
+use PDepend\Source\AST\ASTTraitAdaptationPrecedence;
+use PDepend\Source\AST\ASTTraitReference;
+use PDepend\Source\AST\ASTTraitUseStatement;
+use PDepend\Source\AST\ASTTryStatement;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\AST\ASTTypeIterable;
+use PDepend\Source\AST\ASTUnaryExpression;
+use PDepend\Source\AST\ASTUnsetStatement;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\AST\ASTVariableVariable;
+use PDepend\Source\AST\ASTWhileStatement;
 
 /**
  * Test case implementation for the default node builder implementation.
@@ -126,7 +219,7 @@ class PHPBuilderTest extends AbstractTestCase
      */
     public function testRestoreFunctionUsesGetNamespaceNameMethod(): void
     {
-        $function = $this->getMockBuilder('PDepend\\Source\\AST\\ASTFunction')
+        $function = $this->getMockBuilder(ASTFunction::class)
             ->setConstructorArgs([__FUNCTION__])
             ->getMock();
         $function->expects($this->once())
@@ -376,7 +469,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildMethod(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTMethod',
+            ASTMethod::class,
             $this->createBuilder()->buildMethod('method')
         );
     }
@@ -721,7 +814,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCommentReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTComment',
+            ASTComment::class,
             $this->createBuilder()->buildAstComment('// Hello')
         );
     }
@@ -732,7 +825,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTScalarTypeReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTScalarType',
+            ASTScalarType::class,
             $this->createBuilder()->buildAstScalarType('1')
         );
     }
@@ -743,7 +836,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTypeArrayReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTypeArray',
+            ASTTypeArray::class,
             $this->createBuilder()->buildAstTypeArray()
         );
     }
@@ -756,7 +849,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTypeCallableReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTypeCallable',
+            ASTTypeCallable::class,
             $this->createBuilder()->buildAstTypeCallable()
         );
     }
@@ -769,7 +862,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTypeIterableReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTypeIterable',
+            ASTTypeIterable::class,
             $this->createBuilder()->buildAstTypeIterable()
         );
     }
@@ -780,7 +873,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTHeredocReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTHeredoc',
+            ASTHeredoc::class,
             $this->createBuilder()->buildAstHeredoc()
         );
     }
@@ -791,7 +884,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTIdentifierReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTIdentifier',
+            ASTIdentifier::class,
             $this->createBuilder()->buildAstIdentifier('ID')
         );
     }
@@ -802,7 +895,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTLiteralReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTLiteral::class,
             $this->createBuilder()->buildAstLiteral('false')
         );
     }
@@ -813,7 +906,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTStringReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTString',
+            ASTString::class,
             $this->createBuilder()->buildAstString()
         );
     }
@@ -826,7 +919,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTArrayReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArray',
+            ASTArray::class,
             $this->createBuilder()->buildAstArray()
         );
     }
@@ -839,7 +932,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTArrayElementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArrayElement',
+            ASTArrayElement::class,
             $this->createBuilder()->buildAstArrayElement()
         );
     }
@@ -850,7 +943,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTScopeReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTScope',
+            ASTScope::class,
             $this->createBuilder()->buildAstScope()
         );
     }
@@ -861,7 +954,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTVariableReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTVariable',
+            ASTVariable::class,
             $this->createBuilder()->buildAstVariable('$name')
         );
     }
@@ -872,7 +965,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTVariableVariableReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTVariableVariable',
+            ASTVariableVariable::class,
             $this->createBuilder()->buildAstVariableVariable('$$x')
         );
     }
@@ -883,7 +976,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCompoundVariableReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTCompoundVariable',
+            ASTCompoundVariable::class,
             $this->createBuilder()->buildAstCompoundVariable('${x}')
         );
     }
@@ -894,7 +987,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTFieldDeclarationReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFieldDeclaration',
+            ASTFieldDeclaration::class,
             $this->createBuilder()->buildAstFieldDeclaration()
         );
     }
@@ -905,7 +998,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTConstantReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTConstant',
+            ASTConstant::class,
             $this->createBuilder()->buildAstConstant('X')
         );
     }
@@ -916,7 +1009,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTConstantDeclaratorReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTConstantDeclarator',
+            ASTConstantDeclarator::class,
             $this->createBuilder()->buildAstConstantDeclarator('X')
         );
     }
@@ -927,7 +1020,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTConstantDefinitionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTConstantDefinition',
+            ASTConstantDefinition::class,
             $this->createBuilder()->buildAstConstantDefinition('X')
         );
     }
@@ -938,7 +1031,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTConstantPostfixReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTConstantPostfix',
+            ASTConstantPostfix::class,
             $this->createBuilder()->buildAstConstantPostfix('X')
         );
     }
@@ -949,7 +1042,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTClassFqnPostfixReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTClassFqnPostfix',
+            ASTClassFqnPostfix::class,
             $this->createBuilder()->buildAstClassFqnPostfix()
         );
     }
@@ -960,7 +1053,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTAssignmentExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTAssignmentExpression',
+            ASTAssignmentExpression::class,
             $this->createBuilder()->buildAstAssignmentExpression('=')
         );
     }
@@ -973,7 +1066,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTShiftLeftExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTShiftLeftExpression',
+            ASTShiftLeftExpression::class,
             $this->createBuilder()->buildAstShiftLeftExpression()
         );
     }
@@ -986,7 +1079,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTShiftRightExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTShiftRightExpression',
+            ASTShiftRightExpression::class,
             $this->createBuilder()->buildAstShiftRightExpression()
         );
     }
@@ -997,7 +1090,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTBooleanAndExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTBooleanAndExpression',
+            ASTBooleanAndExpression::class,
             $this->createBuilder()->buildAstBooleanAndExpression()
         );
     }
@@ -1008,7 +1101,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTBooleanOrExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTBooleanOrExpression',
+            ASTBooleanOrExpression::class,
             $this->createBuilder()->buildAstBooleanOrExpression()
         );
     }
@@ -1019,7 +1112,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCastExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTCastExpression',
+            ASTCastExpression::class,
             $this->createBuilder()->buildAstCastExpression('(boolean)')
         );
     }
@@ -1030,7 +1123,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCloneExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTCloneExpression',
+            ASTCloneExpression::class,
             $this->createBuilder()->buildAstCloneExpression('clone')
         );
     }
@@ -1041,7 +1134,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCompoundExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTCompoundExpression',
+            ASTCompoundExpression::class,
             $this->createBuilder()->buildAstCompoundExpression()
         );
     }
@@ -1052,7 +1145,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTConditionalExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTConditionalExpression',
+            ASTConditionalExpression::class,
             $this->createBuilder()->buildAstConditionalExpression()
         );
     }
@@ -1063,7 +1156,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTEvalExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTEvalExpression',
+            ASTEvalExpression::class,
             $this->createBuilder()->buildAstEvalExpression('eval')
         );
     }
@@ -1074,7 +1167,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTExitExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTExitExpression',
+            ASTExitExpression::class,
             $this->createBuilder()->buildAstExitExpression('exit')
         );
     }
@@ -1085,7 +1178,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTExpression',
+            ASTExpression::class,
             $this->createBuilder()->buildAstExpression()
         );
     }
@@ -1096,7 +1189,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTIncludeExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTIncludeExpression',
+            ASTIncludeExpression::class,
             $this->createBuilder()->buildAstIncludeExpression()
         );
     }
@@ -1107,7 +1200,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTInstanceOfExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTInstanceOfExpression',
+            ASTInstanceOfExpression::class,
             $this->createBuilder()->buildAstInstanceOfExpression('instanceof')
         );
     }
@@ -1118,7 +1211,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTIssetExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTIssetExpression',
+            ASTIssetExpression::class,
             $this->createBuilder()->buildAstIssetExpression()
         );
     }
@@ -1129,7 +1222,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTListExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTListExpression',
+            ASTListExpression::class,
             $this->createBuilder()->buildAstListExpression('list')
         );
     }
@@ -1140,7 +1233,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTLogicalAndExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLogicalAndExpression',
+            ASTLogicalAndExpression::class,
             $this->createBuilder()->buildAstLogicalAndExpression('AND')
         );
     }
@@ -1151,7 +1244,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTLogicalOrExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLogicalOrExpression',
+            ASTLogicalOrExpression::class,
             $this->createBuilder()->buildAstLogicalOrExpression('OR')
         );
     }
@@ -1162,7 +1255,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTLogicalXorExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLogicalXorExpression',
+            ASTLogicalXorExpression::class,
             $this->createBuilder()->buildAstLogicalXorExpression('XOR')
         );
     }
@@ -1173,7 +1266,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTRequireExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTRequireExpression',
+            ASTRequireExpression::class,
             $this->createBuilder()->buildAstRequireExpression()
         );
     }
@@ -1184,7 +1277,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTStringIndexExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTStringIndexExpression',
+            ASTStringIndexExpression::class,
             $this->createBuilder()->buildAstStringIndexExpression()
         );
     }
@@ -1195,7 +1288,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTUnaryExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTUnaryExpression',
+            ASTUnaryExpression::class,
             $this->createBuilder()->buildAstUnaryExpression('+')
         );
     }
@@ -1206,7 +1299,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTBreakStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTBreakStatement',
+            ASTBreakStatement::class,
             $this->createBuilder()->buildAstBreakStatement('break')
         );
     }
@@ -1217,7 +1310,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTCatchStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTCatchStatement',
+            ASTCatchStatement::class,
             $this->createBuilder()->buildAstCatchStatement('catch')
         );
     }
@@ -1228,7 +1321,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTFinallyStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFinallyStatement',
+            ASTFinallyStatement::class,
             $this->createBuilder()->buildAstFinallyStatement()
         );
     }
@@ -1239,7 +1332,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTDeclareStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTDeclareStatement',
+            ASTDeclareStatement::class,
             $this->createBuilder()->buildAstDeclareStatement()
         );
     }
@@ -1250,7 +1343,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTIfStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTIfStatement',
+            ASTIfStatement::class,
             $this->createBuilder()->buildAstIfStatement('if')
         );
     }
@@ -1261,7 +1354,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTElseIfStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTElseIfStatement',
+            ASTElseIfStatement::class,
             $this->createBuilder()->buildAstElseIfStatement('elseif')
         );
     }
@@ -1272,7 +1365,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTContinueStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTContinueStatement',
+            ASTContinueStatement::class,
             $this->createBuilder()->buildAstContinueStatement('continue')
         );
     }
@@ -1283,7 +1376,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTDoWhileStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTDoWhileStatement',
+            ASTDoWhileStatement::class,
             $this->createBuilder()->buildAstDoWhileStatement('while')
         );
     }
@@ -1294,7 +1387,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTForStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTForStatement',
+            ASTForStatement::class,
             $this->createBuilder()->buildAstForStatement('for')
         );
     }
@@ -1305,7 +1398,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTForInitReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTForInit',
+            ASTForInit::class,
             $this->createBuilder()->buildAstForInit()
         );
     }
@@ -1316,7 +1409,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTForUpdateReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTForUpdate',
+            ASTForUpdate::class,
             $this->createBuilder()->buildAstForUpdate()
         );
     }
@@ -1327,7 +1420,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTForeachStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTForeachStatement',
+            ASTForeachStatement::class,
             $this->createBuilder()->buildAstForeachStatement('foreach')
         );
     }
@@ -1338,7 +1431,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTFormalParametersReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFormalParameters',
+            ASTFormalParameters::class,
             $this->createBuilder()->buildAstFormalParameters()
         );
     }
@@ -1349,7 +1442,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTFormalParameterReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFormalParameter',
+            ASTFormalParameter::class,
             $this->createBuilder()->buildAstFormalParameter()
         );
     }
@@ -1360,7 +1453,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTGlobalStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTGlobalStatement',
+            ASTGlobalStatement::class,
             $this->createBuilder()->buildAstGlobalStatement()
         );
     }
@@ -1371,7 +1464,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTGotoStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTGotoStatement',
+            ASTGotoStatement::class,
             $this->createBuilder()->buildAstGotoStatement('goto')
         );
     }
@@ -1382,7 +1475,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTLabelStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTLabelStatement',
+            ASTLabelStatement::class,
             $this->createBuilder()->buildAstLabelStatement('LABEL')
         );
     }
@@ -1393,7 +1486,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTReturnStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTReturnStatement',
+            ASTReturnStatement::class,
             $this->createBuilder()->buildAstReturnStatement('return')
         );
     }
@@ -1404,7 +1497,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTScopeStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTScopeStatement',
+            ASTScopeStatement::class,
             $this->createBuilder()->buildAstScopeStatement()
         );
     }
@@ -1415,7 +1508,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTStatement',
+            ASTStatement::class,
             $this->createBuilder()->buildAstStatement()
         );
     }
@@ -1428,7 +1521,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTraitUseStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTraitUseStatement',
+            ASTTraitUseStatement::class,
             $this->createBuilder()->buildAstTraitUseStatement()
         );
     }
@@ -1441,7 +1534,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTraitAdaptationReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTraitAdaptation',
+            ASTTraitAdaptation::class,
             $this->createBuilder()->buildAstTraitAdaptation()
         );
     }
@@ -1454,7 +1547,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTraitAdaptationAliasReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTraitAdaptationAlias',
+            ASTTraitAdaptationAlias::class,
             $this->createBuilder()->buildAstTraitAdaptationAlias(__CLASS__)
         );
     }
@@ -1467,7 +1560,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTraitAdaptationPrecedenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTraitAdaptationPrecedence',
+            ASTTraitAdaptationPrecedence::class,
             $this->createBuilder()->buildAstTraitAdaptationPrecedence(__CLASS__)
         );
     }
@@ -1478,7 +1571,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTSwitchStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTSwitchStatement',
+            ASTSwitchStatement::class,
             $this->createBuilder()->buildAstSwitchStatement()
         );
     }
@@ -1489,7 +1582,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTThrowStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTThrowStatement',
+            ASTThrowStatement::class,
             $this->createBuilder()->buildAstThrowStatement('throw')
         );
     }
@@ -1500,7 +1593,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTryStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTryStatement',
+            ASTTryStatement::class,
             $this->createBuilder()->buildAstTryStatement('try')
         );
     }
@@ -1511,7 +1604,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTUnsetStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTUnsetStatement',
+            ASTUnsetStatement::class,
             $this->createBuilder()->buildAstUnsetStatement()
         );
     }
@@ -1522,7 +1615,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTWhileStatementReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTWhileStatement',
+            ASTWhileStatement::class,
             $this->createBuilder()->buildAstWhileStatement('while')
         );
     }
@@ -1533,7 +1626,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTArrayIndexExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArrayIndexExpression',
+            ASTArrayIndexExpression::class,
             $this->createBuilder()->buildAstArrayIndexExpression()
         );
     }
@@ -1544,7 +1637,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTClosureReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTClosure',
+            ASTClosure::class,
             $this->createBuilder()->buildAstClosure()
         );
     }
@@ -1555,7 +1648,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTParentReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTParentReference',
+            ASTParentReference::class,
             $this->createBuilder()->buildAstParentReference(
                 $this->createBuilder()->buildAstClassOrInterfaceReference(__CLASS__)
             )
@@ -1568,7 +1661,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTSelfReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTSelfReference',
+            ASTSelfReference::class,
             $this->createBuilder()->buildAstSelfReference(
                 $this->createBuilder()->buildClass(__CLASS__)
             )
@@ -1581,7 +1674,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTStaticReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTStaticReference',
+            ASTStaticReference::class,
             $this->createBuilder()->buildAstStaticReference(
                 $this->createBuilder()->buildClass(__CLASS__)
             )
@@ -1596,7 +1689,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTTraitReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTTraitReference',
+            ASTTraitReference::class,
             $this->createBuilder()->buildAstTraitReference(__CLASS__)
         );
     }
@@ -1607,7 +1700,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTClassOrInterfaceReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
+            ASTClassOrInterfaceReference::class,
             $this->createBuilder()->buildAstClassOrInterfaceReference(__CLASS__)
         );
     }
@@ -1618,7 +1711,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTClassReferenceReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTClassReference',
+            ASTClassReference::class,
             $this->createBuilder()->buildAstClassReference(__CLASS__)
         );
     }
@@ -1631,7 +1724,7 @@ class PHPBuilderTest extends AbstractTestCase
         $builder = $this->createBuilder();
         $instance = $builder->buildAstScalarType(__FUNCTION__);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $instance);
+        $this->assertInstanceOf(ASTScalarType::class, $instance);
     }
 
     /**
@@ -1643,7 +1736,7 @@ class PHPBuilderTest extends AbstractTestCase
             ->buildAstAllocationExpression(__FUNCTION__);
 
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTAllocationExpression',
+            ASTAllocationExpression::class,
             $object
         );
     }
@@ -1654,7 +1747,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTArgumentsReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArguments',
+            ASTArguments::class,
             $this->createBuilder()->buildAstArguments()
         );
     }
@@ -1665,7 +1758,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTSwitchLabel(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTSwitchLabel',
+            ASTSwitchLabel::class,
             $this->createBuilder()->buildAstSwitchLabel('m')
         );
     }
@@ -1676,7 +1769,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTEchoStatetmentReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTEchoStatement',
+            ASTEchoStatement::class,
             $this->createBuilder()->buildAstEchoStatement('echo')
         );
     }
@@ -1687,7 +1780,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTVariableDeclaratorReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTVariableDeclarator',
+            ASTVariableDeclarator::class,
             $this->createBuilder()->buildAstVariableDeclarator('foo')
         );
     }
@@ -1698,7 +1791,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTStaticVariableDeclarationReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTStaticVariableDeclaration',
+            ASTStaticVariableDeclaration::class,
             $this->createBuilder()->buildAstStaticVariableDeclaration('$foo')
         );
     }
@@ -1709,7 +1802,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTPostfixExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTPostfixExpression',
+            ASTPostfixExpression::class,
             $this->createBuilder()->buildAstPostfixExpression('++')
         );
     }
@@ -1720,7 +1813,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTPreDecrementExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTPreDecrementExpression',
+            ASTPreDecrementExpression::class,
             $this->createBuilder()->buildAstPreDecrementExpression()
         );
     }
@@ -1731,7 +1824,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTPreIncrementExpressionReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTPreIncrementExpression',
+            ASTPreIncrementExpression::class,
             $this->createBuilder()->buildAstPreIncrementExpression()
         );
     }
@@ -1744,7 +1837,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTMemberPrimaryPrefixReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
+            ASTMemberPrimaryPrefix::class,
             $this->createBuilder()->buildAstMemberPrimaryPrefix('::')
         );
     }
@@ -1757,7 +1850,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTMethodPostfixReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTMethodPostfix',
+            ASTMethodPostfix::class,
             $this->createBuilder()->buildAstMethodPostfix('foo')
         );
     }
@@ -1768,7 +1861,7 @@ class PHPBuilderTest extends AbstractTestCase
     public function testBuildASTFunctionPostfixReturnsExpectedType(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTFunctionPostfix',
+            ASTFunctionPostfix::class,
             $this->createBuilder()->buildAstFunctionPostfix('foo')
         );
     }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -44,6 +44,18 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTProperty;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTType;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\Parser\TokenStreamEndException;
+use PDepend\Source\Parser\UnexpectedTokenException;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -327,7 +339,7 @@ class PHPParserGenericTest extends AbstractTestCase
      */
     public function testParserThrowsExpectedExceptionOnTokenStreamEnd(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -339,7 +351,7 @@ class PHPParserGenericTest extends AbstractTestCase
      */
     public function testParserThrowsExpectedExceptionForUnexpectedTokenType(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -455,9 +467,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesCallableTypeHint(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $type = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+        $type = $method->getFirstChildOfType(ASTType::class);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeCallable', $type);
+        $this->assertInstanceOf(ASTTypeCallable::class, $type);
     }
 
     /**
@@ -468,9 +480,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesNamespaceTypeHint(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $type = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+        $type = $method->getFirstChildOfType(ASTType::class);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $type);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $type);
     }
 
     /**
@@ -481,9 +493,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesArrayTypeHint(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $type = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+        $type = $method->getFirstChildOfType(ASTType::class);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTTypeArray', $type);
+        $this->assertInstanceOf(ASTTypeArray::class, $type);
     }
 
     /**
@@ -494,9 +506,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesSelfTypeHint(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $type = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTType');
+        $type = $method->getFirstChildOfType(ASTType::class);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $type);
+        $this->assertInstanceOf(ASTSelfReference::class, $type);
     }
 
     /**
@@ -507,7 +519,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesCompoundStaticMethodInvocation(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $postfix = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTMethodPostfix');
+        $postfix = $method->getFirstChildOfType(ASTMethodPostfix::class);
 
         $this->assertNotNull($postfix);
     }
@@ -520,7 +532,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesVariableStaticMethodInvocation(): void
     {
         $method = $this->getFirstMethodForTestCase();
-        $postfix = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTMethodPostfix');
+        $postfix = $method->getFirstChildOfType(ASTMethodPostfix::class);
 
         $this->assertNotNull($postfix);
     }
@@ -530,7 +542,7 @@ class PHPParserGenericTest extends AbstractTestCase
      */
     public function testParserThrowsExpectedExceptionForInvalidToken(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -540,7 +552,7 @@ class PHPParserGenericTest extends AbstractTestCase
      */
     public function testParserThrowsExpectedExceptionForTokenStreamEnd(): void
     {
-        $this->expectException(\PDepend\Source\Parser\TokenStreamEndException::class);
+        $this->expectException(TokenStreamEndException::class);
 
         $this->parseCodeResourceForTest();
     }
@@ -553,9 +565,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesRegularArraySyntax(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArray',
+            ASTArray::class,
             $this->getFirstMethodForTestCase()
-                ->getFirstChildOfType('PDepend\\Source\\AST\\ASTArray')
+                ->getFirstChildOfType(ASTArray::class)
         );
     }
 
@@ -567,9 +579,9 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testParserHandlesShortArraySyntax(): void
     {
         $this->assertInstanceOf(
-            'PDepend\\Source\\AST\\ASTArray',
+            ASTArray::class,
             $this->getFirstMethodForTestCase()
-                ->getFirstChildOfType('PDepend\\Source\\AST\\ASTArray')
+                ->getFirstChildOfType(ASTArray::class)
         );
     }
 
@@ -687,7 +699,7 @@ class PHPParserGenericTest extends AbstractTestCase
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
      *
-     * @return \PDepend\Source\AST\AbstractASTClassOrInterface
+     * @return AbstractASTClassOrInterface
      */
     protected function getFirstTypeForTestCase()
     {
@@ -701,7 +713,7 @@ class PHPParserGenericTest extends AbstractTestCase
      * Returns the first method that could be found in the code under test for
      * the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     protected function getFirstMethodForTestCase()
     {
@@ -714,7 +726,7 @@ class PHPParserGenericTest extends AbstractTestCase
      * Returns the first property that could be found in the code under test for
      * the calling test case.
      *
-     * @return \PDepend\Source\AST\ASTProperty
+     * @return ASTProperty
      */
     protected function getFirstPropertyForTestCase()
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
@@ -44,6 +44,11 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTReturnStatement;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -68,7 +73,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -79,7 +84,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -90,7 +95,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -101,7 +106,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -114,7 +119,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -127,7 +132,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -140,7 +145,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstClassForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -153,7 +158,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
         $class = $this->getFirstInterfaceForTestCase();
         $const = $class->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $const);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $const);
     }
 
     /**
@@ -162,7 +167,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     public function testComplexExpressionInParameterInitializer(): void
     {
         $node = $this->getFirstFunctionForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+            ->getFirstChildOfType(ASTFormalParameter::class);
 
         $this->assertNotNull($node);
     }
@@ -173,7 +178,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     public function testComplexExpressionInConstantDeclarator(): void
     {
         $node = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTConstantDeclarator');
+            ->getFirstChildOfType(ASTConstantDeclarator::class);
 
         $this->assertNotNull($node);
     }
@@ -184,7 +189,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     public function testComplexExpressionInFieldDeclaration(): void
     {
         $node = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFieldDeclaration');
+            ->getFirstChildOfType(ASTFieldDeclaration::class);
 
         $this->assertNotNull($node);
     }
@@ -195,7 +200,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     public function testPowExpressionInMethodBody(): void
     {
         $node = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTReturnStatement');
+            ->getFirstChildOfType(ASTReturnStatement::class);
 
         $this->assertSame('**', $node->getChild(0)->getChild(1)->getImage());
     }
@@ -206,7 +211,7 @@ class PHPParserGenericVersion56Test extends AbstractTestCase
     public function testPowExpressionInFieldDeclaration(): void
     {
         $node = $this->getFirstClassForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFieldDeclaration');
+            ->getFirstChildOfType(ASTFieldDeclaration::class);
 
         $this->assertNotNull($node);
     }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -46,6 +46,8 @@ namespace PDepend\Source\Language\PHP;
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTNamespace;
+use PDepend\Source\AST\ASTNode;
+use PDepend\Source\Parser\UnexpectedTokenException;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
@@ -303,8 +305,8 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     public function testSpaceshipOperatorWithStrings(): void
     {
         $expr = $this->getFirstClassMethodForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression');
+            ->getFirstChildOfType(ASTExpression::class)
+            ->getFirstChildOfType(ASTExpression::class);
 
         $this->assertSame('<=>', $expr->getImage());
     }
@@ -315,8 +317,8 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     public function testSpaceshipOperatorWithNumbers(): void
     {
         $expr = $this->getFirstClassMethodForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression');
+            ->getFirstChildOfType(ASTExpression::class)
+            ->getFirstChildOfType(ASTExpression::class);
 
         $this->assertSame('<=>', $expr->getImage());
     }
@@ -324,12 +326,12 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     /**
      * testSpaceshipOperatorWithArrays
      *
-     * @return \PDepend\Source\AST\ASTNode
+     * @return ASTNode
      */
     public function testSpaceshipOperatorWithArrays()
     {
         $expr = $this->getFirstClassMethodForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
+            ->getFirstChildOfType(ASTExpression::class)
             ->getChild(1);
 
         $this->assertSame('<=>', $expr->getImage());
@@ -375,8 +377,8 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
     public function testNullCoalesceOperator(): void
     {
         $expr = $this->getFirstClassMethodForTestCase()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression');
+            ->getFirstChildOfType(ASTExpression::class)
+            ->getFirstChildOfType(ASTExpression::class);
 
         $this->assertSame('??', $expr->getImage());
     }
@@ -389,7 +391,7 @@ class PHPParserGenericVersion70Test extends AbstractTestCase
 
     public function testListKeywordAsFunctionNameThrowsException(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
 
         $this->parseCodeResourceForTest();
     }

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion73Test.php
@@ -42,6 +42,7 @@ namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTFunctionPostfix;
@@ -50,6 +51,7 @@ use PDepend\Source\AST\ASTInstanceOfExpression;
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -67,7 +69,7 @@ class PHPParserVersion73Test extends AbstractTestCase
     public function testArrowFunctions(): void
     {
         $this->expectException(
-            'PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: fn, line: 4, col: 22, file:'
@@ -79,7 +81,7 @@ class PHPParserVersion73Test extends AbstractTestCase
     public function testHereDocAndNowDoc(): void
     {
         /** @var ASTHeredoc $heredoc */
-        $heredoc = $this->getFirstNodeOfTypeInFunction('', 'PDepend\\Source\\AST\\ASTArray');
+        $heredoc = $this->getFirstNodeOfTypeInFunction('', ASTArray::class);
         $arrayElements = $heredoc->getChildren();
         $children = $arrayElements[0]->getChildren();
         $children = $children[0]->getChildren();
@@ -149,9 +151,9 @@ class PHPParserVersion73Test extends AbstractTestCase
         $variables = $instanceOf->getChildren();
 
         $this->assertCount(2, $expression);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTLiteral', $literal);
+        $this->assertInstanceOf(ASTLiteral::class, $literal);
         $this->assertSame('false', $literal->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassOrInterfaceReference', $variables[0]);
+        $this->assertInstanceOf(ASTClassOrInterfaceReference::class, $variables[0]);
         $this->assertSame('DateTimeInterface', $variables[0]->getImage());
     }
 
@@ -163,18 +165,18 @@ class PHPParserVersion73Test extends AbstractTestCase
         $calls = $statements[0]->getChildren();
 
         $this->assertCount(1, $calls);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $calls[0]);
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $calls[0]);
 
         $children = $calls[0]->getChildren();
         /** @var ASTArguments $arguments */
         $arguments = $children[1];
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArguments', $arguments);
+        $this->assertInstanceOf(ASTArguments::class, $arguments);
 
         $arguments = $arguments->getChildren();
 
         $this->assertCount(1, $arguments);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $arguments[0]);
+        $this->assertInstanceOf(ASTVariable::class, $arguments[0]);
         $this->assertSame('$i', $arguments[0]->getImage());
     }
 

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion74Test.php
@@ -42,20 +42,33 @@ namespace PDepend\Source\Language\PHP;
 
 use OutOfBoundsException;
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTArray;
+use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTAssignmentExpression;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTClosure;
 use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTConstantDefinition;
+use PDepend\Source\AST\ASTConstantPostfix;
 use PDepend\Source\AST\ASTExpression;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTReturnStatement;
 use PDepend\Source\AST\ASTScalarType;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\AST\ASTTypeCallable;
+use PDepend\Source\AST\ASTTypeIterable;
+use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 
@@ -105,27 +118,27 @@ class PHPParserVersion74Test extends AbstractTestCase
             ['float', '$money'],
             ['bool', '$active'],
             ['string', '$name'],
-            ['array', '$list', 'PDepend\\Source\\AST\\ASTTypeArray'],
-            ['self', '$parent', 'PDepend\\Source\\AST\\ASTSelfReference'],
-            ['callable', '$event', 'PDepend\\Source\\AST\\ASTTypeCallable'],
-            ['\Closure', '$fqn', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['iterable', '$actions', 'PDepend\\Source\\AST\\ASTTypeIterable'],
-            ['object', '$bag', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['Role', '$role', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+            ['array', '$list', ASTTypeArray::class],
+            ['self', '$parent', ASTSelfReference::class],
+            ['callable', '$event', ASTTypeCallable::class],
+            ['\Closure', '$fqn', ASTClassOrInterfaceReference::class],
+            ['iterable', '$actions', ASTTypeIterable::class],
+            ['object', '$bag', ASTClassOrInterfaceReference::class],
+            ['Role', '$role', ASTClassOrInterfaceReference::class],
             ['?int', '$idN'],
             ['?float', '$moneyN'],
             ['?bool', '$activeN'],
             ['?string', '$nameN'],
-            ['?array', '$listN', 'PDepend\\Source\\AST\\ASTTypeArray'],
-            ['?self', '$parentN', 'PDepend\\Source\\AST\\ASTSelfReference'],
-            ['?callable', '$eventN', 'PDepend\\Source\\AST\\ASTTypeCallable'],
-            ['?\Closure', '$fqnN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['?iterable', '$actionsN', 'PDepend\\Source\\AST\\ASTTypeIterable'],
-            ['?object', '$bagN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['?Role', '$roleN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+            ['?array', '$listN', ASTTypeArray::class],
+            ['?self', '$parentN', ASTSelfReference::class],
+            ['?callable', '$eventN', ASTTypeCallable::class],
+            ['?\Closure', '$fqnN', ASTClassOrInterfaceReference::class],
+            ['?iterable', '$actionsN', ASTTypeIterable::class],
+            ['?object', '$bagN', ASTClassOrInterfaceReference::class],
+            ['?Role', '$roleN', ASTClassOrInterfaceReference::class],
         ] as $index => $expected) {
             [$expectedType, $expectedVariable] = $expected;
-            $expectedTypeClass = $expected[2] ?? 'PDepend\\Source\\AST\\ASTScalarType';
+            $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];
 
             $this->assertInstanceOf(
@@ -135,7 +148,7 @@ class PHPParserVersion74Test extends AbstractTestCase
             );
             $this->assertSame(ltrim($expectedType, '?'), $type->getImage());
             $this->assertInstanceOf(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                ASTVariableDeclarator::class,
                 $variable,
                 "Wrong variable for $expectedType $expectedVariable"
             );
@@ -159,7 +172,7 @@ class PHPParserVersion74Test extends AbstractTestCase
     public function testTypedPropertiesSyntaxError(): void
     {
         $this->expectException(
-            'PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: string, line: 4, col: 16, file:'
@@ -173,33 +186,33 @@ class PHPParserVersion74Test extends AbstractTestCase
         /** @var ASTClosure $closure */
         $closure = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFunctionPostfix'
+            ASTFunctionPostfix::class
         )->getChild(1)->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClosure', $closure);
+        $this->assertInstanceOf(ASTClosure::class, $closure);
         /** @var ASTFormalParameters $parameters */
         $parameters = $closure->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $parameters);
+        $this->assertInstanceOf(ASTFormalParameters::class, $parameters);
         $this->assertCount(1, $parameters->getChildren());
         /** @var ASTFormalParameter $parameter */
         $parameter = $parameters->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $parameter);
+        $this->assertInstanceOf(ASTFormalParameter::class, $parameter);
         /** @var ASTVariableDeclarator $parameter */
         $variableDeclarator = $parameter->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         $this->assertSame('$number', $variableDeclarator->getImage());
         /** @var ASTReturnStatement $parameters */
         $return = $closure->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $return);
+        $this->assertInstanceOf(ASTReturnStatement::class, $return);
         $this->assertSame('=>', $return->getImage());
         $this->assertCount(1, $return->getChildren());
         /** @var ASTExpression $expression */
         $expression = $return->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
         $this->assertSame([
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTVariable::class,
+            ASTExpression::class,
+            ASTLiteral::class,
         ], array_map('get_class', $expression->getChildren()));
         $this->assertSame([
             '$number',
@@ -216,37 +229,37 @@ class PHPParserVersion74Test extends AbstractTestCase
         /** @var ASTClosure $closure */
         $closure = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTFunctionPostfix'
+            ASTFunctionPostfix::class
         )->getChild(1)->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClosure', $closure);
+        $this->assertInstanceOf(ASTClosure::class, $closure);
         /** @var ASTFormalParameters $parameters */
         $parameters = $closure->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameters', $parameters);
+        $this->assertInstanceOf(ASTFormalParameters::class, $parameters);
         $this->assertCount(1, $parameters->getChildren());
         /** @var ASTFormalParameter $parameter */
         $parameter = $parameters->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFormalParameter', $parameter);
+        $this->assertInstanceOf(ASTFormalParameter::class, $parameter);
         /** @var ASTVariableDeclarator $parameter */
         $variableDeclarator = $parameter->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableDeclarator', $variableDeclarator);
+        $this->assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         $this->assertSame('$number', $variableDeclarator->getImage());
         /** @var ASTScalarType $parameters */
         $type = $closure->getChild(1);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTScalarType', $type);
+        $this->assertInstanceOf(ASTScalarType::class, $type);
         $this->assertSame('int', $type->getImage());
         /** @var ASTReturnStatement $parameters */
         $return = $closure->getChild(2);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTReturnStatement', $return);
+        $this->assertInstanceOf(ASTReturnStatement::class, $return);
         $this->assertSame('=>', $return->getImage());
         $this->assertCount(1, $return->getChildren());
         /** @var ASTExpression $expression */
         $expression = $return->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
         $this->assertSame([
-            'PDepend\\Source\\AST\\ASTVariable',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTVariable::class,
+            ASTExpression::class,
+            ASTLiteral::class,
         ], array_map('get_class', $expression->getChildren()));
         $this->assertSame([
             '$number',
@@ -268,7 +281,7 @@ class PHPParserVersion74Test extends AbstractTestCase
         /** @var ASTAssignmentExpression $assignment */
         $assignment = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTAssignmentExpression'
+            ASTAssignmentExpression::class
         );
 
         $this->assertSame('??=', $assignment->getImage());
@@ -278,14 +291,14 @@ class PHPParserVersion74Test extends AbstractTestCase
     {
         $expression = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArray'
+            ASTArray::class
         );
         $this->assertSame([
-            'PDepend\\Source\\AST\\ASTArrayElement',
-            'PDepend\\Source\\AST\\ASTArrayElement',
-            'PDepend\\Source\\AST\\ASTArrayElement',
-            'PDepend\\Source\\AST\\ASTArrayElement',
-            'PDepend\\Source\\AST\\ASTArrayElement',
+            ASTArrayElement::class,
+            ASTArrayElement::class,
+            ASTArrayElement::class,
+            ASTArrayElement::class,
+            ASTArrayElement::class,
         ], array_map('get_class', $expression->getChildren()));
         /** @var ASTNode[] $elements */
         $elements = array_map(
@@ -293,11 +306,11 @@ class PHPParserVersion74Test extends AbstractTestCase
             $expression->getChildren(),
         );
         $this->assertSame([
-            'PDepend\Source\AST\ASTLiteral',
-            'PDepend\Source\AST\ASTLiteral',
-            'PDepend\Source\AST\ASTExpression',
-            'PDepend\Source\AST\ASTLiteral',
-            'PDepend\Source\AST\ASTLiteral',
+            ASTLiteral::class,
+            ASTLiteral::class,
+            ASTExpression::class,
+            ASTLiteral::class,
+            ASTLiteral::class,
         ], array_map('get_class', $elements));
         /** @var ASTExpression $expression */
         $expression = $elements[2];
@@ -314,16 +327,16 @@ class PHPParserVersion74Test extends AbstractTestCase
     {
         $expression = $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTExpression'
+            ASTExpression::class
         );
         $this->assertSame([
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
-            'PDepend\\Source\\AST\\ASTExpression',
-            'PDepend\\Source\\AST\\ASTLiteral',
+            ASTLiteral::class,
+            ASTExpression::class,
+            ASTLiteral::class,
+            ASTExpression::class,
+            ASTLiteral::class,
+            ASTExpression::class,
+            ASTLiteral::class,
         ], array_map('get_class', $expression->getChildren()));
 
         $this->assertSame('6.674_083e-11', $expression->getChild(0)->getImage());
@@ -348,29 +361,29 @@ class PHPParserVersion74Test extends AbstractTestCase
         $constants = $class->getChildren();
 
         $this->assertCount(2, $constants);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constants[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDefinition', $constants[1]);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constants[0]);
+        $this->assertInstanceOf(ASTConstantDefinition::class, $constants[1]);
 
         /** @var ASTConstantDeclarator[] $declarators */
         $declarators = $constants[1]->getChildren();
 
         $this->assertCount(1, $declarators);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantDeclarator', $declarators[0]);
+        $this->assertInstanceOf(ASTConstantDeclarator::class, $declarators[0]);
 
         /** @var ASTExpression $expression */
         $expression = $declarators[0]->getValue()->getValue();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $expression);
+        $this->assertInstanceOf(ASTExpression::class, $expression);
 
         $nodes = $expression->getChildren();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $nodes[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTExpression', $nodes[1]);
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $nodes[0]);
+        $this->assertInstanceOf(ASTExpression::class, $nodes[1]);
         $this->assertSame('+', $nodes[1]->getImage());
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArray', $nodes[2]);
+        $this->assertInstanceOf(ASTArray::class, $nodes[2]);
 
         $nodes = $nodes[0]->getChildren();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $nodes[0]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTConstantPostfix', $nodes[1]);
+        $this->assertInstanceOf(ASTSelfReference::class, $nodes[0]);
+        $this->assertInstanceOf(ASTConstantPostfix::class, $nodes[1]);
         $this->assertSame('A', $nodes[1]->getImage());
     }
 
@@ -383,7 +396,7 @@ class PHPParserVersion74Test extends AbstractTestCase
 
     public function testCatchWithoutVariable(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
         $this->expectExceptionMessage('Unexpected token: ), line: 8, col: 27');
 
         $this->getFirstClassForTestCase();
@@ -391,7 +404,7 @@ class PHPParserVersion74Test extends AbstractTestCase
 
     public function testTrailingCommaInClosureUseListError(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
         $this->expectExceptionMessage('Unexpected token: ), line: 5, col: 32');
 
         $this->parseCodeResourceForTest();
@@ -399,7 +412,7 @@ class PHPParserVersion74Test extends AbstractTestCase
 
     public function testTrailingCommaInParameterList(): void
     {
-        $this->expectException(\PDepend\Source\Parser\UnexpectedTokenException::class);
+        $this->expectException(UnexpectedTokenException::class);
         $this->expectExceptionMessage('Unexpected token: ), line: 4, col: 43');
 
         $this->getFirstMethodForTestCase();

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion80Test.php
@@ -41,8 +41,11 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTCatchStatement;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\AST\ASTUnionType;
+use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
@@ -64,7 +67,7 @@ class PHPParserVersion80Test extends AbstractTestCase
     public function testCatchWithoutVariable(): void
     {
         $catchStatement = $this->getFirstMethodForTestCase()->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTCatchStatement'
+            ASTCatchStatement::class
         );
 
         $this->assertCount(2, $catchStatement->getChildren());
@@ -152,7 +155,7 @@ class PHPParserVersion80Test extends AbstractTestCase
         }, $children);
 
         foreach ([
-            ['null|int|float', '$number', 'PDepend\\Source\\AST\\ASTUnionType'],
+            ['null|int|float', '$number', ASTUnionType::class],
         ] as $index => $expected) {
             [$expectedType, $expectedVariable, $expectedTypeClass] = $expected;
             [$type, $variable] = $declarations[$index];
@@ -164,7 +167,7 @@ class PHPParserVersion80Test extends AbstractTestCase
             );
             $this->assertSame(ltrim($expectedType, '?'), $type->getImage());
             $this->assertInstanceOf(
-                'PDepend\\Source\\AST\\ASTVariableDeclarator',
+                ASTVariableDeclarator::class,
                 $variable,
                 "Wrong variable for $expectedType $expectedVariable"
             );

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Source\Language\PHP;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -465,7 +466,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
 
         $list = $this->parseCodeResourceForTest();
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList', $list);
+        $this->assertInstanceOf(ASTArtifactList::class, $list);
     }
 
     /**

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -44,6 +44,14 @@
 namespace PDepend\Source\Parser;
 
 use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTClassReference;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTStaticReference;
+use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\AST\ASTVariableVariable;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
@@ -65,7 +73,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionForSelfProperty(): void
     {
         $allocation = $this->getFirstAllocationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $allocation->getChild(0));
     }
 
     /**
@@ -76,7 +84,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionForParentProperty(): void
     {
         $allocation = $this->getFirstAllocationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $allocation->getChild(0));
     }
 
     /**
@@ -87,7 +95,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionForStaticProperty(): void
     {
         $allocation = $this->getFirstAllocationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $allocation->getChild(0));
     }
 
     /**
@@ -98,7 +106,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionForThisProperty(): void
     {
         $allocation = $this->getFirstAllocationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $allocation->getChild(0));
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $allocation->getChild(0));
     }
 
     /**
@@ -109,7 +117,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionForObjectProperty(): void
     {
         $allocation = $this->getFirstAllocationInClass();
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTMemberPrimaryPrefix', $allocation->getChild(0));
+        $this->assertInstanceOf(ASTMemberPrimaryPrefix::class, $allocation->getChild(0));
     }
 
     /**
@@ -118,10 +126,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForSimpleIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $reference = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassReference', $reference);
+        $this->assertInstanceOf(ASTClassReference::class, $reference);
         $this->assertEquals('Foo', $reference->getType()->getName());
     }
 
@@ -131,10 +139,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForSelfKeyword(): void
     {
         $method = $this->getFirstClassMethodForTestCase();
-        $allocation = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $method->getFirstChildOfType(ASTAllocationExpression::class);
         $self = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTSelfReference', $self);
+        $this->assertInstanceOf(ASTSelfReference::class, $self);
         $this->assertEquals(__FUNCTION__, $self->getType()->getName());
     }
 
@@ -145,10 +153,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForParentKeyword(): void
     {
         $method = $this->getFirstClassMethodForTestCase();
-        $allocation = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $method->getFirstChildOfType(ASTAllocationExpression::class);
         $parent = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParentReference', $parent);
+        $this->assertInstanceOf(ASTParentReference::class, $parent);
         $this->assertEquals(__FUNCTION__ . 'Parent', $parent->getType()->getName());
     }
 
@@ -158,10 +166,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForLocalNamespaceIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $reference = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassReference', $reference);
+        $this->assertInstanceOf(ASTClassReference::class, $reference);
         $this->assertEquals('Bar', $reference->getType()->getName());
     }
 
@@ -171,10 +179,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForAbsoluteNamespaceIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $reference = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassReference', $reference);
+        $this->assertInstanceOf(ASTClassReference::class, $reference);
         $this->assertEquals('Bar', $reference->getType()->getName());
     }
 
@@ -184,10 +192,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForAbsoluteNamespacedNamespaceIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $reference = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTClassReference', $reference);
+        $this->assertInstanceOf(ASTClassReference::class, $reference);
         $this->assertEquals('Foo', $reference->getType()->getName());
     }
 
@@ -197,10 +205,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForVariableIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $variable = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
+        $this->assertInstanceOf(ASTVariable::class, $variable);
         $this->assertEquals('$foo', $variable->getImage());
     }
 
@@ -210,14 +218,14 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForVariableVariableIdentifier(): void
     {
         $function = $this->getFirstFunctionForTestCase();
-        $allocation = $function->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $function->getFirstChildOfType(ASTAllocationExpression::class);
         $vvariable = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariableVariable', $vvariable);
+        $this->assertInstanceOf(ASTVariableVariable::class, $vvariable);
         $this->assertEquals('$', $vvariable->getImage());
 
         $variable = $vvariable->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $variable);
+        $this->assertInstanceOf(ASTVariable::class, $variable);
         $this->assertEquals('$foo', $variable->getImage());
     }
 
@@ -227,10 +235,10 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testAllocationExpressionGraphForStaticReference(): void
     {
         $method = $this->getFirstClassMethodForTestCase();
-        $allocation = $method->getFirstChildOfType('PDepend\\Source\\AST\\ASTAllocationExpression');
+        $allocation = $method->getFirstChildOfType(ASTAllocationExpression::class);
         $reference = $allocation->getChild(0);
 
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTStaticReference', $reference);
+        $this->assertInstanceOf(ASTStaticReference::class, $reference);
         $this->assertEquals(__FUNCTION__, $reference->getType()->getName());
     }
 
@@ -241,7 +249,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     public function testInvalidAllocationExpressionResultsInExpectedException(): void
     {
         $this->expectException(
-            '\\PDepend\\Source\\Parser\\UnexpectedTokenException'
+            UnexpectedTokenException::class
         );
         $this->expectExceptionMessage(
             'Unexpected token: ;, line: 4, col: 9, file: '
@@ -260,7 +268,7 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTAllocationExpression'
+            ASTAllocationExpression::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -43,6 +43,19 @@
 
 namespace PDepend\Source\Parser;
 
+use PDepend\Source\AST\ASTAllocationExpression;
+use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\AST\ASTConstantPostfix;
+use PDepend\Source\AST\ASTFunctionPostfix;
+use PDepend\Source\AST\ASTIdentifier;
+use PDepend\Source\AST\ASTMemberPrimaryPrefix;
+use PDepend\Source\AST\ASTMethodPostfix;
+use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\AST\ASTSelfReference;
+use PDepend\Source\AST\ASTVariable;
+
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
@@ -63,11 +76,11 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -80,11 +93,11 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTVariable',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTMemberPrimaryPrefix::class,
+                ASTVariable::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -97,10 +110,10 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTConstantPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTConstantPostfix::class,
+                ASTIdentifier::class,
             ]
         );
     }
@@ -113,10 +126,10 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfFunction(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTClassOrInterfaceReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTClassOrInterfaceReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -129,10 +142,10 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfMethod(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTSelfReference',
-                'PDepend\\Source\\AST\\ASTPropertyPostfix',
-                'PDepend\\Source\\AST\\ASTVariable',
+                ASTMemberPrimaryPrefix::class,
+                ASTSelfReference::class,
+                ASTPropertyPostfix::class,
+                ASTVariable::class,
             ]
         );
     }
@@ -145,11 +158,11 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $this->assertGraphEquals(
             $this->getFirstArgumentsOfMethod(),
             [
-                'PDepend\\Source\\AST\\ASTMemberPrimaryPrefix',
-                'PDepend\\Source\\AST\\ASTParentReference',
-                'PDepend\\Source\\AST\\ASTMethodPostfix',
-                'PDepend\\Source\\AST\\ASTIdentifier',
-                'PDepend\\Source\\AST\\ASTArguments',
+                ASTMemberPrimaryPrefix::class,
+                ASTParentReference::class,
+                ASTMethodPostfix::class,
+                ASTIdentifier::class,
+                ASTArguments::class,
             ]
         );
     }
@@ -162,7 +175,7 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $arguments = $this->getFirstArgumentsOfFunction();
 
         $allocation = $arguments->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTAllocationExpression', $allocation);
+        $this->assertInstanceOf(ASTAllocationExpression::class, $allocation);
     }
 
     /**
@@ -173,9 +186,9 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $arguments = $this->getFirstArgumentsOfFunction();
 
         $postfix = $arguments->getFirstChildOfType(
-            'PDepend\\Source\\AST\\ASTFunctionPostfix'
+            ASTFunctionPostfix::class
         );
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTFunctionPostfix', $postfix);
+        $this->assertInstanceOf(ASTFunctionPostfix::class, $postfix);
     }
 
     /**
@@ -186,7 +199,7 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $arguments = $this->getFirstArgumentsOfFunction();
 
         $child = $arguments->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTVariable', $child);
+        $this->assertInstanceOf(ASTVariable::class, $child);
     }
 
     /**
@@ -197,7 +210,7 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
         $arguments = $this->getFirstArgumentsOfFunction();
 
         $postfixes = $arguments->findChildrenOfType(
-            'PDepend\\Source\\AST\\ASTMethodPostfix'
+            ASTMethodPostfix::class
         );
         $this->assertCount(1, $postfixes);
     }
@@ -216,26 +229,26 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
     /**
      * Returns an arguments instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      */
     private function getFirstArgumentsOfFunction()
     {
         return $this->getFirstNodeOfTypeInFunction(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
     }
 
     /**
      * Returns an arguments instance for the currently executed test case.
      *
-     * @return \PDepend\Source\AST\ASTArguments
+     * @return ASTArguments
      */
     private function getFirstArgumentsOfMethod()
     {
         return $this->getFirstNodeOfTypeInClass(
             $this->getCallingTestMethod(),
-            'PDepend\\Source\\AST\\ASTArguments'
+            ASTArguments::class
         );
     }
 }

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -44,6 +44,7 @@
 namespace PDepend\Source\Parser;
 
 use PDepend\Source\AST\ASTFormalParameter;
+use PDepend\Source\AST\ASTParentReference;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
@@ -63,7 +64,7 @@ class ASTFormalParameterParsingTest extends AbstractParserTestCase
     public function testWithParentTypeHint(): void
     {
         $typeHint = $this->getFirstMethodFormalParameter()->getChild(0);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTParentReference', $typeHint);
+        $this->assertInstanceOf(ASTParentReference::class, $typeHint);
     }
 
     /**
@@ -99,6 +100,6 @@ class ASTFormalParameterParsingTest extends AbstractParserTestCase
             ->current()
             ->getMethods()
             ->current()
-            ->getFirstChildOfType('PDepend\\Source\\AST\\ASTFormalParameter');
+            ->getFirstChildOfType(ASTFormalParameter::class);
     }
 }

--- a/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Source\Parser;
 
+use PDepend\Source\AST\ASTClassOrInterfaceReference;
+
 /**
  * Test case for the namespace resolving in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
@@ -63,7 +65,7 @@ class NamespaceResovingTest extends AbstractParserTestCase
         $method = $this->getFirstClassMethodForTestCase();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTClassOrInterfaceReference') as $reference) {
+        foreach ($method->findChildrenOfType(ASTClassOrInterfaceReference::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 
@@ -88,7 +90,7 @@ class NamespaceResovingTest extends AbstractParserTestCase
         $method = $this->getFirstClassMethodForTestCase();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTClassOrInterfaceReference') as $reference) {
+        foreach ($method->findChildrenOfType(ASTClassOrInterfaceReference::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 
@@ -120,7 +122,7 @@ class NamespaceResovingTest extends AbstractParserTestCase
             ->current();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTClassOrInterfaceReference') as $reference) {
+        foreach ($method->findChildrenOfType(ASTClassOrInterfaceReference::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 
@@ -154,7 +156,7 @@ class NamespaceResovingTest extends AbstractParserTestCase
             ->current();
 
         $actual = [];
-        foreach ($method->findChildrenOfType('PDepend\\Source\\AST\\ASTClassOrInterfaceReference') as $reference) {
+        foreach ($method->findChildrenOfType(ASTClassOrInterfaceReference::class) as $reference) {
             $actual[] = $reference->getImage();
         }
 

--- a/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
+++ b/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
@@ -40,10 +40,9 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\PDepend\Source\Parser;
+namespace PDepend\Source\Parser;
 
 use PDepend\AbstractTestCase;
-use PDepend\Source\Parser\SymbolTable;
 
 /**
  * Test case for the {@link SymbolTable} class.
@@ -60,7 +59,7 @@ class SymbolTableTest extends AbstractTestCase
     public function testCannotAddSymbolToASymbolTableWithoutActiveScope(): void
     {
         $this->expectException(
-            '\PDepend\Source\Parser\NoActiveScopeException'
+            NoActiveScopeException::class
         );
         $this->expectExceptionMessage(
             'No active scope in symbol table.'
@@ -77,7 +76,7 @@ class SymbolTableTest extends AbstractTestCase
     public function testCannotPerformLookupOnASymbolTableWithoutActiveScope(): void
     {
         $this->expectException(
-            '\PDepend\Source\Parser\NoActiveScopeException'
+            NoActiveScopeException::class
         );
         $this->expectExceptionMessage(
             'No active scope in symbol table.'
@@ -94,7 +93,7 @@ class SymbolTableTest extends AbstractTestCase
     public function testCannotResetWithoutActiveScope(): void
     {
         $this->expectException(
-            '\PDepend\Source\Parser\NoActiveScopeException'
+            NoActiveScopeException::class
         );
         $this->expectExceptionMessage(
             'No active scope in symbol table.'
@@ -111,7 +110,7 @@ class SymbolTableTest extends AbstractTestCase
     public function testCannotDestroyWithoutActiveScope(): void
     {
         $this->expectException(
-            '\PDepend\Source\Parser\NoActiveScopeException'
+            NoActiveScopeException::class
         );
         $this->expectExceptionMessage(
             'No active scope in symbol table.'

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -533,7 +533,7 @@ class CommandTest extends AbstractTestCase
     public function testDebugErrorDisplay(): void
     {
         $file = tempnam(sys_get_temp_dir(), 'err');
-        $streamProperty = new ReflectionClass('PDepend\\Util\\Log');
+        $streamProperty = new ReflectionClass(Log::class);
         $streamProperty->setStaticPropertyValue('stream', fopen($file, 'a+'));
 
         Log::setSeverity(Log::DEBUG);

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -44,6 +44,9 @@ namespace PDepend\TextUI;
 
 use Exception;
 use PDepend\AbstractTestCase;
+use PDepend\Engine;
+use PDepend\Input\ExcludePathFilter;
+use PDepend\Input\ExtensionFilter;
 use PDepend\Input\Filter;
 use PDepend\Report\ReportGeneratorFactory;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
@@ -122,7 +125,7 @@ class RunnerTest extends AbstractTestCase
     {
         /** @var Filter[] $record */
         $record = [];
-        $engine = $this->getMockBuilder('PDepend\\Engine')
+        $engine = $this->getMockBuilder(Engine::class)
             ->disableOriginalConstructor()
             ->getMock();
         $engine->expects($this->exactly(2))
@@ -144,15 +147,15 @@ class RunnerTest extends AbstractTestCase
         }
 
         $this->assertCount(2, $record);
-        $this->assertInstanceOf('PDepend\\Input\\ExtensionFilter', $record[0]);
-        $this->assertInstanceOf('PDepend\\Input\\ExcludePathFilter', $record[1]);
+        $this->assertInstanceOf(ExtensionFilter::class, $record[0]);
+        $this->assertInstanceOf(ExcludePathFilter::class, $record[1]);
     }
 
     public function testSetExcludeNamespaces(): void
     {
         /** @var object[] $record */
         $record = [];
-        $engine = $this->getMockBuilder('PDepend\\Engine')
+        $engine = $this->getMockBuilder(Engine::class)
             ->disableOriginalConstructor()
             ->getMock();
         $engine->expects($this->exactly(2))
@@ -177,9 +180,9 @@ class RunnerTest extends AbstractTestCase
         }
 
         $this->assertCount(3, $record);
-        $this->assertInstanceOf('PDepend\\Input\\ExtensionFilter', $record[0]);
-        $this->assertInstanceOf('PDepend\\Input\\ExcludePathFilter', $record[1]);
-        $this->assertInstanceOf('PDepend\\Source\\AST\\ASTArtifactList\\PackageArtifactFilter', $record[2]);
+        $this->assertInstanceOf(ExtensionFilter::class, $record[0]);
+        $this->assertInstanceOf(ExcludePathFilter::class, $record[1]);
+        $this->assertInstanceOf(PackageArtifactFilter::class, $record[2]);
     }
 
     /**

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -43,6 +43,10 @@
 namespace PDepend\Util\Cache;
 
 use PDepend\AbstractTestCase;
+use PDepend\Application;
+use PDepend\Util\Cache\Driver\FileCacheDriver;
+use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\CacheFactory} class.
@@ -63,7 +67,7 @@ class CacheFactoryTest extends AbstractTestCase
         $factory = new CacheFactory(
             $this->createConfigurationFixture()
         );
-        $this->assertInstanceOf('\\PDepend\\Util\\Cache\\CacheDriver', $factory->create());
+        $this->assertInstanceOf(CacheDriver::class, $factory->create());
     }
 
     /**
@@ -104,7 +108,7 @@ class CacheFactoryTest extends AbstractTestCase
         $this->changeWorkingDirectory();
 
         $this->assertInstanceOf(
-            'PDepend\\Util\\Cache\\Driver\\FileCacheDriver',
+            FileCacheDriver::class,
             $this->createFactoryFixture()->create()
         );
     }
@@ -117,7 +121,7 @@ class CacheFactoryTest extends AbstractTestCase
         $this->changeWorkingDirectory();
 
         $this->assertInstanceOf(
-            'PDepend\\Util\\Cache\\Driver\\MemoryCacheDriver',
+            MemoryCacheDriver::class,
             $this->createFactoryFixture()->create()
         );
     }
@@ -127,7 +131,7 @@ class CacheFactoryTest extends AbstractTestCase
      */
     public function testCreateThrowsExpectedExceptionForUnknownCacheDriver(): void
     {
-        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+        $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('The value "fail" is not allowed for path "pdepend.cache.driver". Permissible values: "file", "memory"');
 
         $this->changeWorkingDirectory();
@@ -143,7 +147,7 @@ class CacheFactoryTest extends AbstractTestCase
      */
     protected function createFactoryFixture()
     {
-        $application = new \PDepend\Application();
+        $application = new Application();
         $application->setConfigurationFile(getcwd() . '/pdepend.xml');
         return new CacheFactory($application->getConfiguration());
     }

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Util\Cache\Driver;
 
 use PDepend\Util\Cache\AbstractDriverTestCase;
+use PDepend\Util\Cache\CacheDriver;
 use RuntimeException;
 
 /**
@@ -80,7 +81,7 @@ class FileCacheDriverTest extends AbstractDriverTestCase
     /**
      * Creates a test fixture.
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     protected function createDriver()
     {

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -43,6 +43,7 @@
 namespace PDepend\Util\Cache\Driver;
 
 use PDepend\Util\Cache\AbstractDriverTestCase;
+use PDepend\Util\Cache\CacheDriver;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\MemoryCacheDriver} class.
@@ -58,7 +59,7 @@ class MemoryCacheDriverTest extends AbstractDriverTestCase
     /**
      * Creates a test fixture.
      *
-     * @return \PDepend\Util\Cache\CacheDriver
+     * @return CacheDriver
      */
     protected function createDriver()
     {

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -43,6 +43,8 @@
 namespace PDepend\Util\Coverage;
 
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTCompilationUnit;
+use PDepend\Source\AST\ASTMethod;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\CloverReport} class.
@@ -182,18 +184,18 @@ class CloverReportTest extends AbstractTestCase
      * @param string $name Name of the mock method.
      * @param int $startLine
      * @param int $endLine
-     * @return \PDepend\Source\AST\ASTMethod
+     * @return ASTMethod
      */
     private function createMethodMock($name, $startLine = 1, $endLine = 4)
     {
-        $file = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTCompilationUnit')
+        $file = $this->getMockBuilder(ASTCompilationUnit::class)
             ->setConstructorArgs([null])
             ->getMock();
         $file->expects($this->any())
             ->method('getFileName')
             ->will($this->returnValue('/' . $name . '.php'));
 
-        $method = $this->getMockBuilder('\\PDepend\\Source\\AST\\ASTMethod')
+        $method = $this->getMockBuilder(ASTMethod::class)
             ->setConstructorArgs([$name])
             ->getMock();
         $method->expects($this->once())

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -64,7 +64,7 @@ class FactoryTest extends AbstractTestCase
         $factory = new Factory();
         $report = $factory->create(__DIR__ . '/_files/clover.xml');
 
-        $this->assertInstanceOf('PDepend\\Util\\Coverage\\CloverReport', $report);
+        $this->assertInstanceOf(CloverReport::class, $report);
     }
 
     /**

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -80,14 +80,14 @@ class IdBuilderTest extends AbstractTestCase
     {
         $builder = new IdBuilder();
 
-        $unitStub0 = $this->getMockBuilder('\PDepend\Source\AST\ASTCompilationUnit')
+        $unitStub0 = $this->getMockBuilder(ASTCompilationUnit::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $unitStub0->method('getFileName')
                 ->willReturn(__FILE__);
         $identifier0 = $builder->forFile($unitStub0);
 
-        $unitStub1 = $this->getMockBuilder('\PDepend\Source\AST\ASTCompilationUnit')
+        $unitStub1 = $this->getMockBuilder(ASTCompilationUnit::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         $unitStub1->method('getFileName')


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Convert string to `::class` const as well as import classes. This helps to reduce line length and makes things more consistent.