### PR TITLE
Use unpacking inside arrays

### DIFF
--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -177,7 +177,7 @@ class Pyramid implements FileAwareGenerator
         }
         $svg->loadXML($template);
 
-        $items = array_merge($metrics, $proportions);
+        $items = $proportions + $metrics;
         foreach ($items as $name => $value) {
             $node = $svg->getElementById("pdepend.{$name}");
             if (!$node) {

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -239,10 +239,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     {
         $projectMetrics = [];
         foreach ($this->projectAwareAnalyzers as $analyzer) {
-            $projectMetrics = array_merge(
-                $projectMetrics,
-                $analyzer->getProjectMetrics(),
-            );
+            $projectMetrics = $analyzer->getProjectMetrics() + $projectMetrics;
         }
         ksort($projectMetrics);
 
@@ -421,7 +418,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     {
         $metrics = [];
         foreach ($this->nodeAwareAnalyzers as $analyzer) {
-            $metrics = array_merge($metrics, $analyzer->getNodeMetrics($node));
+            $metrics = $analyzer->getNodeMetrics($node) + $metrics;
         }
 
         foreach ($metrics as $name => $value) {

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -72,7 +72,7 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
      */
     public function __sleep()
     {
-        return array_merge(['metadata'], parent::__sleep());
+        return ['metadata', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -86,7 +86,7 @@ class ASTClassOrInterfaceReference extends ASTType
      */
     public function __sleep()
     {
-        return array_merge(['context'], parent::__sleep());
+        return ['context', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -93,7 +93,7 @@ class ASTConstantDeclarator extends AbstractASTNode
      */
     public function __sleep()
     {
-        return array_merge(['value'], parent::__sleep());
+        return ['value', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -87,7 +87,7 @@ class ASTDeclareStatement extends ASTStatement
      */
     public function __sleep()
     {
-        return array_merge(['values'], parent::__sleep());
+        return ['values', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -95,10 +95,7 @@ class ASTEnum extends AbstractASTClassOrInterface
      */
     public function __sleep()
     {
-        return array_merge(
-            ['type'],
-            parent::__sleep(),
-        );
+        return ['type', ...parent::__sleep()];
     }
 
     /**
@@ -220,7 +217,7 @@ class ASTEnum extends AbstractASTClassOrInterface
             $interfaces[] = $backedEnum;
         }
 
-        return new ASTArtifactList(array_merge($interfaces, $this->getInterfacesClasses()));
+        return new ASTArtifactList([...$interfaces, ...$this->getInterfacesClasses()]);
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -69,7 +69,7 @@ class ASTFormalParameter extends AbstractASTNode
 
     public function __sleep()
     {
-        return array_merge(['modifiers'], parent::__sleep());
+        return ['modifiers', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -82,7 +82,7 @@ class ASTFunction extends AbstractASTCallable
      */
     public function __sleep()
     {
-        return array_merge(['context', 'namespaceName'], parent::__sleep());
+        return ['context', 'namespaceName', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -69,7 +69,7 @@ class ASTIncludeExpression extends ASTExpression
      */
     public function __sleep()
     {
-        return array_merge(['once'], parent::__sleep());
+        return ['once', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -71,7 +71,7 @@ class ASTMethod extends AbstractASTCallable
      */
     public function __sleep()
     {
-        return array_merge(['modifiers'], parent::__sleep());
+        return ['modifiers', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -80,7 +80,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      */
     public function __sleep()
     {
-        return array_merge(['reference'], parent::__sleep());
+        return ['reference', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -69,7 +69,7 @@ class ASTRequireExpression extends ASTExpression
      */
     public function __sleep()
     {
-        return array_merge(['once'], parent::__sleep());
+        return ['once', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -95,7 +95,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
         $this->qualifiedName = $this->getType()->getNamespaceName() . '\\' .
                                $this->getType()->getName();
 
-        return array_merge(['qualifiedName'], parent::__sleep());
+        return ['qualifiedName', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -69,7 +69,7 @@ class ASTSwitchLabel extends AbstractASTNode
      */
     public function __sleep()
     {
-        return array_merge(['default'], parent::__sleep());
+        return ['default', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -75,7 +75,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      */
     public function __sleep()
     {
-        return array_merge(['newName', 'newModifier'], parent::__sleep());
+        return ['newName', 'newModifier', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -67,7 +67,7 @@ class ASTVariableDeclarator extends ASTExpression
      */
     public function __sleep()
     {
-        return array_merge(['value'], parent::__sleep());
+        return ['value', ...parent::__sleep()];
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -91,10 +91,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      */
     public function __sleep()
     {
-        return array_merge(
-            ['constants', 'interfaceReferences', 'parentClassReference'],
-            parent::__sleep(),
-        );
+        return ['constants', 'interfaceReferences', 'parentClassReference', ...parent::__sleep()];
     }
 
     /**
@@ -392,10 +389,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
         }
 
         foreach ($this->getInterfaces() as $interface) {
-            $this->constantDeclarators = array_merge(
-                $this->constantDeclarators,
-                $interface->getConstantDeclarators(),
-            );
+            $this->constantDeclarators = $interface->getConstantDeclarators() + $this->constantDeclarators;
         }
 
         $definitions = $this->findChildrenOfType(ASTConstantDefinition::class);

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -625,12 +625,12 @@ abstract class AbstractPHPParser
 
             // Add mapping between image and qualified name to symbol table
             if ($image !== false) {
-                $this->useSymbolTable->add($image, implode('', array_merge($fragments, $subFragments)));
+                $this->useSymbolTable->add($image, implode('', [...$fragments, ...$subFragments]));
             }
         }
 
         if (isset($image, $subFragments) && $image !== false) {
-            $this->useSymbolTable->add($image, implode('', array_merge($fragments, $subFragments)));
+            $this->useSymbolTable->add($image, implode('', [...$fragments, ...$subFragments]));
         }
 
         $this->consumeToken(Tokens::T_CURLY_BRACE_CLOSE);


### PR DESCRIPTION
Type: refactoring
Breaking change: no

With unpacking in arrays (introduced in PHP 7.4) `array_merge()` can now be replaced by operators.