### PR TITLE
Avoid relying loos comparison in test

### DIFF
--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -464,7 +464,7 @@ abstract class AbstractTestCase extends TestCase
         }
 
         foreach (new DirectoryIterator($dir) as $file) {
-            if ($file == '.' || $file == '..' || $file == '.svn') {
+            if ($file->isDot() || $file->getFilename() === '.svn') {
                 continue;
             }
             $pathName = realpath($file->getPathname());


### PR DESCRIPTION
Type: refactoring  
Breaking change: no

The $file is a SPL object that can be cast to a string, which is what happens with the loos comparison. This is the only place in the code base that relies on a loos comparison, so getting rid of it makes things more consistent and we can start requiring that strict compare is always used.