### PR TITLE
Type remaning null initialized properties

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -73,7 +73,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
     /**
      * @var array<string, array<string, array<int, string>>>
      */
-    private $nodeRelations = null;
+    private array $nodeRelations = [];
 
     /**
      * Hash with all calculated node metrics.

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -113,14 +113,14 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      *
      * @var array<string, array<string, float>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * Processes all {@link ASTNamespace} code nodes.
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->fireStartAnalyzer();
 
             $factory = new StrategyFactory();

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -86,15 +86,10 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * The coverage report instance representing the supplied coverage report
      * file.
-     *
-     * @var Report
      */
-    private $report = null;
+    private Report $report;
 
-    /**
-     * @var CyclomaticComplexityAnalyzer
-     */
-    private $ccnAnalyzer = null;
+    private CyclomaticComplexityAnalyzer $ccnAnalyzer;
 
     /**
      * Returns <b>true</b> when this analyzer is enabled.
@@ -238,7 +233,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      */
     private function createOrReturnCoverageReport()
     {
-        if ($this->report === null) {
+        if (!isset($this->report)) {
             $this->report = $this->createCoverageReport();
         }
         return $this->report;

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -95,7 +95,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      *
      * @var array<string, array<string, mixed>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * Nodes in which the current analyzed dependency is used.
@@ -136,7 +136,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->fireStartAnalyzer();
 
             $this->nodeMetrics = [];

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -149,14 +149,14 @@ class HierarchyAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
      *
      * @var array<string, array<string, int>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * Processes all {@link ASTNamespace} code nodes.
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->fireStartAnalyzer();
 
             // Init node metrics

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -130,7 +130,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      *
      * @var array<string, array<string, mixed>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * This method will return an <b>array</b> with all generated metric values
@@ -173,7 +173,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      */
     public function analyze($namespaces): void
     {
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->nodeMetrics = [];
 
             $this->fireStartAnalyzer();

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -112,7 +112,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
      *
      * @var array<string, array<string, int>>
      */
-    private $nodeMetrics = null;
+    private array $nodeMetrics;
 
     /**
      * This method will return an <b>array</b> with all generated metric values
@@ -170,7 +170,7 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
     public function analyze($namespaces): void
     {
         // Check for previous run
-        if ($this->nodeMetrics === null) {
+        if (!isset($this->nodeMetrics)) {
             $this->fireStartAnalyzer();
 
             $this->nodeMetrics = [];

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -75,7 +75,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    protected $code = null;
+    protected ASTArtifactList $code;
 
     /**
      * Set of all analyzed files.
@@ -85,10 +85,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     protected $fileSet = [];
     /**
      * The log output file.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * @var ClassDependencyAnalyzer|null
@@ -158,7 +156,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      */
     public function close(): void
     {
-        if ($this->logFile === null) {
+        if (!isset($this->logFile)) {
             throw new NoLogOutputException($this);
         }
 

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -67,24 +67,20 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
 {
     /**
      * The output file name.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * The context source code.
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    private $code = null;
+    private ASTArtifactList $code;
 
     /**
      * The context analyzer instance.
-     *
-     * @var DependencyAnalyzer
      */
-    private $analyzer = null;
+    private DependencyAnalyzer $analyzer;
 
     /**
      * Sets the output log file.
@@ -142,7 +138,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     public function close(): void
     {
         // Check for configured log file
-        if ($this->logFile === null) {
+        if (!isset($this->logFile)) {
             throw new NoLogOutputException($this);
         }
 

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -72,7 +72,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    protected $code = null;
+    protected ASTArtifactList $code;
 
     /**
      * Set of all analyzed files.
@@ -97,44 +97,32 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
 
     /**
      * The dependency result set.
-     *
-     * @var DependencyAnalyzer
      */
-    protected $analyzer = null;
+    protected DependencyAnalyzer $analyzer;
 
     /**
      * The Packages dom element.
-     *
-     * @var DOMNode
      */
-    protected $packages = null;
+    protected DOMNode $packages;
 
     /**
      * The Cycles dom element.
-     *
-     * @var DOMNode
      */
-    protected $cycles = null;
+    protected DOMNode $cycles;
 
     /**
      * The concrete classes element for the current package.
-     *
-     * @var DOMElement
      */
-    protected $concreteClasses = null;
+    protected DOMElement $concreteClasses;
 
     /**
      * The abstract classes element for the current package.
-     *
-     * @var DOMElement
      */
-    protected $abstractClasses = null;
+    protected DOMElement $abstractClasses;
     /**
      * The output log file.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * Sets the output log file.
@@ -192,7 +180,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     public function close(): void
     {
         // Check for configured output
-        if ($this->logFile === null) {
+        if (!isset($this->logFile)) {
             throw new NoLogOutputException($this);
         }
 

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -68,45 +68,33 @@ class Pyramid implements FileAwareGenerator
 {
     /**
      * The output file name.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * The used coupling analyzer.
-     *
-     * @var CouplingAnalyzer
      */
-    private $coupling = null;
+    private CouplingAnalyzer $coupling;
 
     /**
      * The used cyclomatic complexity analyzer.
-     *
-     * @var CyclomaticComplexityAnalyzer
      */
-    private $cyclomaticComplexity = null;
+    private CyclomaticComplexityAnalyzer $cyclomaticComplexity;
 
     /**
      * The used inheritance analyzer.
-     *
-     * @var InheritanceAnalyzer
      */
-    private $inheritance = null;
+    private InheritanceAnalyzer $inheritance;
 
     /**
      * The used node count analyzer.
-     *
-     * @var NodeCountAnalyzer
      */
-    private $nodeCount = null;
+    private NodeCountAnalyzer $nodeCount;
 
     /**
      * The used node loc analyzer.
-     *
-     * @var NodeLocAnalyzer
      */
-    private $nodeLoc = null;
+    private NodeLocAnalyzer $nodeLoc;
 
     /**
      * Holds defined thresholds for the computed proportions. This set is based
@@ -185,7 +173,7 @@ class Pyramid implements FileAwareGenerator
     public function close(): void
     {
         // Check for configured log file
-        if ($this->logFile === null) {
+        if (!isset($this->logFile)) {
             throw new NoLogOutputException($this);
         }
 
@@ -300,19 +288,19 @@ class Pyramid implements FileAwareGenerator
      */
     private function collectMetrics()
     {
-        if ($this->coupling === null) {
+        if (!isset($this->coupling)) {
             throw new RuntimeException('Missing Coupling analyzer.');
         }
-        if ($this->cyclomaticComplexity === null) {
+        if (!isset($this->cyclomaticComplexity)) {
             throw new RuntimeException('Missing Cyclomatic Complexity analyzer.');
         }
-        if ($this->inheritance === null) {
+        if (!isset($this->inheritance)) {
             throw new RuntimeException('Missing Inheritance analyzer.');
         }
-        if ($this->nodeCount === null) {
+        if (!isset($this->nodeCount)) {
             throw new RuntimeException('Missing Node Count analyzer.');
         }
-        if ($this->nodeLoc === null) {
+        if (!isset($this->nodeLoc)) {
             throw new RuntimeException('Missing Node LOC analyzer.');
         }
 

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -76,7 +76,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @var ASTArtifactList<ASTNamespace>
      */
-    protected $code = null;
+    protected ASTArtifactList $code;
 
     /**
      * Set of all analyzed files.
@@ -86,10 +86,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     protected $fileSet = [];
     /**
      * The log output file.
-     *
-     * @var string
      */
-    private $logFile = null;
+    private string $logFile;
 
     /**
      * List of all analyzers that implement the node aware interface
@@ -189,7 +187,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      */
     public function close(): void
     {
-        if ($this->logFile === null) {
+        if (!isset($this->logFile)) {
             throw new NoLogOutputException($this);
         }
 

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -57,17 +57,13 @@ final class CollectionArtifactFilter implements ArtifactFilter
 {
     /**
      * Singleton instance of this filter.
-     *
-     * @var CollectionArtifactFilter
      */
-    private static $instance = null;
+    private static CollectionArtifactFilter $instance;
 
     /**
      * An optional configured filter instance.
-     *
-     * @var ArtifactFilter
      */
-    private $filter = null;
+    private ?ArtifactFilter $filter = null;
 
     /**
      * Singleton method for this filter class.
@@ -76,7 +72,7 @@ final class CollectionArtifactFilter implements ArtifactFilter
      */
     public static function getInstance()
     {
-        if (self::$instance === null) {
+        if (!isset(self::$instance)) {
             self::$instance = new CollectionArtifactFilter();
         }
         return self::$instance;

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -58,7 +58,7 @@ class ASTClass extends AbstractASTClassOrInterface
      *
      * @var ASTProperty[]
      */
-    private $properties = null;
+    private array $properties;
 
 
     /**
@@ -124,7 +124,7 @@ class ASTClass extends AbstractASTClassOrInterface
      */
     public function getProperties()
     {
-        if ($this->properties === null) {
+        if (!isset($this->properties)) {
             $this->properties = [];
 
             $declarations = $this->findChildrenOfType(ASTFieldDeclaration::class);

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -57,10 +57,8 @@ class ASTClassOrInterfaceReference extends ASTType
 {
     /**
      * The global AST builder context.
-     *
-     * @var BuilderContext
      */
-    protected $context = null;
+    protected ?BuilderContext $context = null;
 
     /**
      * An already loaded type instance.

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -57,29 +57,19 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * The internal used cache instance.
      *
-     * @var CacheDriver|null
      * @since 0.10.0
      */
-    protected $cache = null;
+    protected CacheDriver $cache;
 
     /**
      * The unique identifier for this function.
-     *
-     * @var string|null
      */
-    protected $id = null;
+    protected ?string $id = null;
 
     /**
      * The source file name/path.
      */
     protected ?string $fileName = null;
-
-    /**
-     * The comment for this type.
-     *
-     * @var string|null
-     */
-    protected $comment = null;
 
     /**
      * List of classes, interfaces and functions that parsed from this file.
@@ -99,10 +89,8 @@ class ASTCompilationUnit extends AbstractASTArtifact
 
     /**
      * Normalized code in this file.
-     *
-     * @var string|null
      */
-    private $source = null;
+    private ?string $source = null;
 
     /**
      * Constructs a new source file instance.

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -81,17 +81,13 @@ class ASTConstantDeclarator extends AbstractASTNode
 {
     /**
      * The type of the constant if explicitly specified, <b>null</b> else.
-     *
-     * @var ASTType|null
      */
-    protected $type = null;
+    protected ?ASTType $type = null;
 
     /**
      * The initial declaration value for this node or <b>null</b>.
-     *
-     * @var ASTValue|null
      */
-    protected $value = null;
+    protected ?ASTValue $value = null;
 
     /**
      * Magic sleep method that returns an array with those property names that

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -51,16 +51,14 @@ namespace PDepend\Source\AST;
 class ASTEnumCase extends AbstractASTNode implements ASTArtifact
 {
     /**
-     * The enum definition of this case or <b>null</b>.
-     *
-     * @var ASTEnum|null
+     * The enum definition of this case.
      */
-    protected $enum = null;
+    protected ASTEnum $enum;
 
     /**
-     * Returns the enum definition of this case or <b>null</b>.
+     * Returns the enum definition of this case.
      *
-     * @return ?ASTEnum
+     * @return ASTEnum
      */
     public function getEnum()
     {

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -55,25 +55,21 @@ class ASTFunction extends AbstractASTCallable
     /**
      * The currently used builder context.
      *
-     * @var BuilderContext|null
      * @since 0.10.0
      */
-    protected $context = null;
+    protected BuilderContext $context;
 
     /**
      * The name of the parent namespace for this function. We use this property
      * to restore the parent namespace while we unserialize a cached object tree.
-     *
-     * @var string|null
      */
-    protected $namespaceName = null;
+    protected ?string $namespaceName = null;
     /**
      * The parent namespace for this function.
      *
-     * @var ASTNamespace|null
      * @since 0.10.0
      */
-    private $namespace = null;
+    private ?ASTNamespace $namespace = null;
 
     /**
      * The magic sleep method will be called by the PHP engine when this class

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -54,10 +54,8 @@ class ASTHeredoc extends ASTExpression
 {
     /**
      * Delimiter used for this heredoc instance.
-     *
-     * @var string
      */
-    protected $delimiter = null;
+    protected string $delimiter;
 
     /**
      * Sets the delimiter used for this heredoc instance.

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -73,10 +73,8 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * Does this namespace contain user defined functions, classes or interfaces?
-     *
-     * @var bool
      */
-    private $userDefined = null;
+    private bool $userDefined;
 
     /**
      * Constructs a new namespace for the given <b>$name</b>
@@ -109,7 +107,7 @@ class ASTNamespace extends AbstractASTArtifact
      */
     public function isUserDefined()
     {
-        if ($this->userDefined === null) {
+        if (!isset($this->userDefined)) {
             $this->userDefined = $this->checkUserDefined();
         }
         return $this->userDefined;

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -65,10 +65,8 @@ class ASTParameter extends AbstractASTArtifact
 {
     /**
      * The parent function or method instance.
-     *
-     * @var AbstractASTCallable
      */
-    private $declaringFunction = null;
+    private AbstractASTCallable $declaringFunction;
 
     /**
      * The parameter position.

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -52,10 +52,8 @@ class ASTProperty extends AbstractASTArtifact
 {
     /**
      * The parent type object.
-     *
-     * @var ASTClass
      */
-    private $declaringClass = null;
+    private ASTClass $declaringClass;
 
     /**
      * The wrapped field declaration instance.

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -63,19 +63,17 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * The currently used builder context.
      *
-     * @var BuilderContext
      * @since 0.10.0
      */
-    protected $context = null;
+    protected ?BuilderContext $context = null;
 
     /**
      * The full qualified class name, including the namespace or namespace name.
      *
-     * @var string
      * @since 0.10.0
      * @todo  To reduce memory usage, move property into new metadata string
      */
-    protected $qualifiedName = null;
+    protected string $qualifiedName;
 
     /**
      * Constructs a new type holder instance.

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -56,10 +56,8 @@ class ASTVariableDeclarator extends ASTExpression
 {
     /**
      * The initial declaration value for this node or <b>null</b>.
-     *
-     * @var ASTValue|null
      */
-    protected $value = null;
+    protected ?ASTValue $value = null;
 
     /**
      * The magic sleep method will be called by PHP's runtime environment right

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -62,10 +62,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * The unique identifier for this function.
-     *
-     * @var string|null
      */
-    protected $id = null;
+    protected ?string $id = null;
 
     /**
      * The line number where the item declaration starts.
@@ -89,17 +87,13 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * The source file for this item.
-     *
-     * @var ASTCompilationUnit|null
      */
-    protected $compilationUnit = null;
+    protected ?ASTCompilationUnit $compilationUnit = null;
 
     /**
      * The comment for this type.
-     *
-     * @var string|null
      */
-    protected $comment = null;
+    protected ?string $comment = null;
 
     /**
      * Constructs a new item for the given <b>$name</b>.

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -59,19 +59,17 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * The internal used cache instance.
      *
-     * @var CacheDriver|null
      * @since 0.10.0
      */
-    protected $cache = null;
+    protected CacheDriver $cache;
 
     /**
      * A reference instance for the return value of this callable. By
      * default and for any scalar type this property is <b>null</b>.
      *
-     * @var ASTClassOrInterfaceReference|null
      * @since 0.9.5
      */
-    protected $returnClassReference = null;
+    protected ?ASTClassOrInterfaceReference $returnClassReference = null;
 
     /**
      * List of all exceptions classes referenced by this callable.
@@ -97,9 +95,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     protected $nodes = [];
 
     /**
-     * @var ASTParameter[]|null
+     * @var ASTParameter[]
      */
-    private $parameters = null;
+    private array $parameters;
 
     /**
      * The magic sleep method will be called by the PHP engine when this class
@@ -336,14 +334,14 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an array with all method/function parameters.
      *
-     * @return ASTParameter[]|null
+     * @return ASTParameter[]
      */
     public function getParameters()
     {
-        if ($this->parameters === null) {
+        if (!isset($this->parameters)) {
             $this->initParameters();
         }
-        return $this->parameters;
+        return $this->parameters ?? null;
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -55,10 +55,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * The parent for this class node.
      *
-     * @var ASTClassReference|null
      * @since 0.9.5
      */
-    protected $parentClassReference = null;
+    protected ?ASTClassReference $parentClassReference = null;
 
     /**
      * List of all interfaces implemented/extended by the this type.
@@ -72,14 +71,14 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @var array<string, mixed>
      */
-    protected $constants = null;
+    protected ?array $constants = null;
 
     /**
      * An <b>array</b> with all constant declarators defined in this class or interface.
      *
      * @var array<string, ASTConstantDeclarator>
      */
-    protected $constantDeclarators = null;
+    protected array $constantDeclarators;
 
     /**
      * The magic sleep method is called by the PHP runtime environment before an
@@ -231,7 +230,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      */
     public function getConstantDeclarators()
     {
-        if ($this->constantDeclarators === null) {
+        if (!isset($this->constantDeclarators)) {
             $this->initConstantDeclarators();
         }
         return $this->constantDeclarators;

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -65,17 +65,13 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * The parent node of this node or <b>null</b> when this node is the root
      * of a node tree.
-     *
-     * @var ASTNode|null
      */
-    protected $parent = null;
+    protected ?ASTNode $parent = null;
 
     /**
      * An optional doc comment for this node.
-     *
-     * @var string
      */
-    protected $comment = null;
+    protected ?string $comment = null;
 
     /**
      * Metadata for this node instance, serialized in a string. This string

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -59,24 +59,13 @@ abstract class AbstractASTType extends AbstractASTArtifact
 {
     /**
      * The internal used cache instance.
-     *
-     * @var CacheDriver|null
      */
-    protected $cache = null;
+    protected CacheDriver $cache;
 
     /**
      * The currently used builder context.
-     *
-     * @var BuilderContext|null
      */
-    protected $context = null;
-
-    /**
-     * An <b>array</b> with all constants defined in this class or interface.
-     *
-     * @var array<string, mixed>|null
-     */
-    protected $constants = null;
+    protected BuilderContext $context;
 
     /**
      * This property will indicate that the class or interface is user defined.
@@ -97,10 +86,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Name of the parent namespace for this class or interface instance. Or
      * <b>NULL</b> when no namespace was specified.
-     *
-     * @var string|null
      */
-    protected $namespaceName = null;
+    protected ?string $namespaceName = null;
 
     /**
      * The modifiers for this class instance.
@@ -119,10 +106,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
     /**
      * The parent namespace for this class.
-     *
-     * @var ASTNamespace|null
      */
-    private $namespace = null;
+    private ?ASTNamespace $namespace = null;
 
     /**
      * The magic sleep method is called by the PHP runtime environment before an

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -69,7 +69,7 @@ class GlobalBuilderContext implements BuilderContext
      *
      * @var Builder<mixed>
      */
-    protected static $builder = null;
+    protected static Builder $builder;
 
     /**
      * Constructs a new builder context instance.

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -178,28 +178,27 @@ class PHPBuilder implements Builder
     /**
      * The internal used cache instance.
      *
-     * @var CacheDriver
      * @since 0.10.0
      */
-    protected $cache = null;
+    private CacheDriver $cache;
 
     /**
      * The ast builder context.
      *
      * @since 0.10.0
      */
-    protected BuilderContext $context;
+    private BuilderContext $context;
 
     /**
      * Default package which contains all functions and classes with an unknown
      * scope.
      */
-    protected ASTNamespace $defaultPackage;
+    private ASTNamespace $defaultPackage;
 
     /**
      * Default source file that acts as a dummy.
      */
-    protected ASTCompilationUnit $defaultCompilationUnit;
+    private ASTCompilationUnit $defaultCompilationUnit;
 
     /**
      * This property holds all packages found during the parsing phase.
@@ -207,7 +206,7 @@ class PHPBuilder implements Builder
      * @var ASTNamespace[]
      * @since 0.9.12
      */
-    private $preparedNamespaces = null;
+    private array $preparedNamespaces;
 
     /**
      * All generated {@link ASTTrait} objects
@@ -1980,7 +1979,7 @@ class PHPBuilder implements Builder
      */
     public function getNamespaces()
     {
-        if ($this->preparedNamespaces === null) {
+        if (!isset($this->preparedNamespaces)) {
             $this->preparedNamespaces = $this->getPreparedNamespaces();
         }
         return new ASTArtifactList($this->preparedNamespaces);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -603,31 +603,25 @@ class PHPTokenizerInternal implements FullTokenizer
 
     /**
      * The source file instance.
-     *
-     * @var ASTCompilationUnit|null
      */
-    protected $sourceFile = null;
+    private ASTCompilationUnit $sourceFile;
 
     /**
      * Count of all tokens.
-     *
-     * @var int
      */
-    protected $count = 0;
+    private int $count = 0;
 
     /**
      * Internal stream pointer index.
-     *
-     * @var int
      */
-    protected $index = 0;
+    private int $index = 0;
 
     /**
      * Prepared token list.
      *
-     * @var Token[]|null
+     * @var Token[]
      */
-    protected $tokens = null;
+    private array $tokens;
 
     /**
      * The next free identifier for unknown string tokens.
@@ -639,7 +633,7 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the name of the source file.
      *
-     * @return ASTCompilationUnit|null
+     * @return ASTCompilationUnit
      */
     public function getSourceFile()
     {
@@ -653,7 +647,7 @@ class PHPTokenizerInternal implements FullTokenizer
      */
     public function setSourceFile($sourceFile): void
     {
-        $this->tokens = null;
+        unset($this->tokens);
         $this->sourceFile = new ASTCompilationUnit($sourceFile);
     }
 
@@ -929,7 +923,7 @@ class PHPTokenizerInternal implements FullTokenizer
      */
     private function tokenize(): void
     {
-        if ($this->tokens !== null) {
+        if (isset($this->tokens)) {
             return;
         }
 

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -52,10 +52,8 @@ class ConfigurationInstance
 {
     /**
      * The unique configuration instance.
-     *
-     * @var Configuration|null
      */
-    private static $configuration = null;
+    private static ?Configuration $configuration = null;
 
     /**
      * Returns a configured config instance or <b>null</b>.

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -135,7 +135,7 @@ final class Type
      *
      * @var array<string, string>
      */
-    private static $typeNameToExtension = null;
+    private static array $typeNameToExtension;
 
     /**
      * Hash with all internal namespaces/extensions. Key and value are identical
@@ -144,7 +144,7 @@ final class Type
      * @var array<string, string>
      * @since 0.9.10
      */
-    private static $internalNamespaces = null;
+    private static array $internalNamespaces;
 
     /**
      * List of scalar php types.
@@ -282,7 +282,7 @@ final class Type
      */
     public static function getInternalNamespaces()
     {
-        if (self::$internalNamespaces === null) {
+        if (!isset(self::$internalNamespaces)) {
             self::$internalNamespaces = [];
             foreach (self::initTypeToExtension() as $namespace) {
                 self::$internalNamespaces[$namespace] = $namespace;
@@ -387,7 +387,7 @@ final class Type
     private static function initTypeToExtension()
     {
         // Skip when already done.
-        if (self::$typeNameToExtension !== null) {
+        if (isset(self::$typeNameToExtension)) {
             return self::$typeNameToExtension;
         }
 


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

To address https://github.com/pdepend/pdepend/pull/801#discussion_r1592485865 this PR finishes the process of figuring out when a property should be nullable or simple uninitialized. I also removed a few redundant overwrites in the process. This deals with the renaming properties that where not addressed by https://github.com/pdepend/pdepend/pull/806
