### PR TITLE
Merge latest changes from master

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,15 +38,13 @@ jobs:
       id: composer-cache
       uses: actions/cache@v4
       with:
-        path: |
-            vendor
-            ocular.phar
+        path: vendor
         key: ${{ runner.os }}-coverage-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
       run: |
-        composer require scrutinizer/ocular --no-update --no-interaction
+        composer require scrutinizer/ocular --no-update --no-interaction --dev
         composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
     - name: Coverage

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2803,6 +2803,11 @@ abstract class AbstractPHPParser
      * if (isset($foo, $bar, $baz)) {
      * //  -----------------------
      * }
+     *
+     * //  -----------------------
+     * if (isset($foo['bar'], BAR['baz']['foo'])) {
+     * //  -----------------------
+     * }
      * </code>
      *
      * @return ASTIssetExpression
@@ -5827,6 +5832,10 @@ abstract class AbstractPHPParser
             $node->addChild($this->parseVariableOrConstantOrPrimaryPrefix());
 
             $this->consumeComments();
+
+            while ($this->tokenizer->peek() === Tokens::T_SQUARED_BRACKET_OPEN) {
+                $this->parseListExpression();
+            }
 
             if ($this->tokenizer->peek() === Tokens::T_COMMA) {
                 $this->consumeToken(Tokens::T_COMMA);

--- a/src/test/php/PDepend/Bugs/ParserBug713Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug713Test.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PDepend\Bugs;
+
+use PDepend\Source\Language\PHP\PHPBuilder;
+use PDepend\Source\Language\PHP\PHPParserGeneric;
+use PDepend\Source\Language\PHP\PHPTokenizerInternal;
+use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+
+/**
+ * Test case for bug #713.
+ *
+ * @ticket 713
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseIssetExpression
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseVariableList
+ * @group regressiontest
+ */
+class ParserBug713Test extends AbstractRegressionTestCase
+{
+    /**
+     * Expect no uncaught exceptions.
+     * @doesNotPerformAssertions
+     */
+    public function testConstantArrayIndexIsset(): void
+    {
+        $cache = new MemoryCacheDriver();
+        $builder = new PHPBuilder();
+
+        $tokenizer = new PHPTokenizerInternal();
+        $tokenizer->setSourceFile($this->createCodeResourceURI('bugs/713/testConstantArrayIndexIsset.php'));
+
+        $parser = new PHPParserGeneric($tokenizer, $builder, $cache);
+        $parser->parse();
+    }
+}

--- a/src/test/resources/files/bugs/713/testConstantArrayIndexIsset.php
+++ b/src/test/resources/files/bugs/713/testConstantArrayIndexIsset.php
@@ -1,0 +1,15 @@
+<?php
+
+define('FOO', []);
+
+if (isset(FOO['bar'])) {}
+
+if (isset($foo['bar'])) {}
+
+if (isset(FOO['foo']['bar'])) {}
+
+if (isset($foo['foo']['bar'])) {}
+
+if (isset(FOO['foo']['bar'], $foo['foo']['bar'])) {}
+
+if (isset($foo['foo']['bar'], FOO['foo']['bar'])) {}


### PR DESCRIPTION
Type: bugfix / refactoring / documentation update)  
Breaking change: no

This merges all the latest changes from master in to 3.x. This makes it easy for us to see that 3.x is not missing anything from master by view either the git tree or diff between the two.

Since most of what has happened since we split is backports of various corrections there isn't much happening in this PR, only https://github.com/pdepend/pdepend/pull/808 and a small correction to coverage.yml