### PR TITLE
Fix coverage for ParserBug713Test

### DIFF
--- a/src/test/php/PDepend/Bugs/ParserBug713Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug713Test.php
@@ -12,6 +12,7 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @ticket 713
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseIssetExpression
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseVariableList
  * @group regressiontest
  */
 class ParserBug713Test extends AbstractRegressionTest


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Coverage is set to the wrong method, parseVariableList calls parseListExpression so probably that's where the confusion came from. Noticed cause I merged it to 3.x...