### PR TITLE
Also consider fallback case for home dir test

### DIFF
--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -71,8 +71,9 @@ class FileUtilTest extends AbstractTestCase
      */
     public function testGetUserHomeDirReturnsExpectedDirectory(): void
     {
+        $homeDir = getenv('HOME') ?: getenv('HOMEDRIVE') . getenv('HOMEPATH');
         static::assertEquals(
-            getenv('HOME'),
+            $homeDir,
             FileUtil::getUserHomeDir()
         );
     }


### PR DESCRIPTION
Type: bugfix
Issue: None
Breaking change: no

At work, my home dir is set to a network share, e.g. `M:\` but my home dir variable is not set which lets the code take the alternative path.

https://github.com/pdepend/pdepend/blob/b17cac0e1c27a6e84df11d83c3ac560f4c03ea11/src/main/php/PDepend/Util/FileUtil.php#L91-L94

This should work either way.