### PR TITLE
[3.x[ Suhosin Workaround Removal

### DIFF
--- a/src/bin/pdepend.php
+++ b/src/bin/pdepend.php
@@ -51,17 +51,6 @@ if (str_starts_with('@php_bin@', '@php_bin')) {
 require_once __DIR__ . '/../../vendor/autoload.php';
 
 // Allow as much memory as possible by default
-if (extension_loaded('suhosin') && is_numeric(ini_get('suhosin.memory_limit'))) {
-    $limit = ini_get('memory_limit');
-    if (preg_match('(^(\d+)([BKMGT]))', $limit, $match)) {
-        $shift = ['B' => 0, 'K' => 10, 'M' => 20, 'G' => 30, 'T' => 40];
-        $limit = ($match[1] * (1 << $shift[$match[2]]));
-    }
-    if (ini_get('suhosin.memory_limit') > $limit && $limit > -1) {
-        ini_set('memory_limit', ini_get('suhosin.memory_limit'));
-    }
-} else {
-    ini_set('memory_limit', -1);
-}
+ini_set('memory_limit', -1);
 
 exit(Command::main());


### PR DESCRIPTION
Type: Refactoring
Issue: None
Breaking change: No

The Suhosin extension is abandoned and does not work properly under PHP 7.x, nor PHP 8.x.

> In November 2015, suhosin7 was created, to provide similar hardening features to PHP7 but failed to gain momentum among the community. The Snuffleupagus project aims at being its successor, for PHP7 and onwards.

https://en.wikipedia.org/wiki/Suhosin

Its direct successor, now called Suhosin-NG, has been updated in 2022 the last time.

https://suhosin.org/
https://github.com/sektioneins/suhosin-ng/wiki/News

Its indirect successor Snuffleupagus has a different extension name and enforces a maximum memory limit of 256 MB by default.
Thus, it's quite unlikely that a developer executes PHP Depend with such an extension enabled.

https://github.com/jvoisin/snuffleupagus/blob/f8824a79ff69a2246a61e6381f0bc1e377e16a90/config/ini_protection.rules#L139
https://github.com/jvoisin/snuffleupagus/blob/f8824a79ff69a2246a61e6381f0bc1e377e16a90/config/suhosin.rules#L139-L142

And if so, a new workaround can be implemented.

Related to https://github.com/phpmd/phpmd/pull/1157