### PR TITLE
Avoid undefined index notice

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -229,8 +229,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      */
     private function updateProjectMetrics($nodeId): void
     {
-        $this->ccn += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_1];
-        $this->ccn2 += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_2];
+        $this->ccn += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_1] ?? 0;
+        $this->ccn2 += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_2] ?? 0;
     }
 
     /**


### PR DESCRIPTION
Type: bugfix

This is triggering issue (reported by PHPUnit warnings) on PHPMD side. `?? 0` make explicit what happens and resolve the notice:
```
Trying to access array offset on null
```