### PR TITLE
Update PHPCS and include it in the codestyle analasis

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -54,6 +54,9 @@ jobs:
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --prefer-dist --no-progress
 
+      - name: Run PHPCS for the codestyle
+        run: vendor/bin/phpcs --report=checkstyle -q | cs2pr || true
+
       - name: Run PHP Coding Standards Fixer
         run: |
           vendor/bin/php-cs-fixer fix --dry-run --diff --ansi || true

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "gregwar/rst": "^1.0",
         "phpstan/phpstan": "~1.11.0",
         "phpunit/phpunit": "^10.5.20",
-        "squizlabs/php_codesniffer": "^2.0.0"
+        "squizlabs/php_codesniffer": "^3.8.0"
     },
     "replace": {
         "symfony/polyfill-php80": "*"

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset name="PHPMD">
+<ruleset name="PDepend">
     <description>The coding standard for PDepend.</description>
     <file>./src/main/php/PDepend</file>
     <file>./src/test/php/PDepend</file>
@@ -10,7 +10,6 @@
     <arg name="extensions" value="php"/>
 
     <!-- General sniffs -->
-    <rule ref="Generic.Files.LineLength"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
     <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
@@ -33,16 +32,9 @@
     <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
-    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
-    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
-        <properties>
-            <property name="equalsSpacing" value="1"/>
-        </properties>
-    </rule>
 
     <!-- PSR-2 base standard -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR12"/>
 
     <rule ref="PSR2">
         <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,18 +1,94 @@
 <?xml version="1.0"?>
-<ruleset name="PHP_Depend">
-	<description>Coding standard for PDepend.</description>
+<ruleset name="PHPMD">
+    <description>The coding standard for PDepend.</description>
+    <file>./src/main/php/PDepend</file>
+    <file>./src/test/php/PDepend</file>
+    <!-- Include Slevomat standard -->
 
-	<file>scripts</file>
-	<file>src</file>
-        
-        <!-- Website content -->
-        <exclude-pattern>src/site/</exclude-pattern>
-        <!-- Files for unit tests -->
-        <exclude-pattern>src/test/resources/</exclude-pattern>
+<!--    <config name="installed_paths" value="../../slevomat/coding-standard,../../../slevomat/coding-standard,../vendor/slevomat/coding-standard"/>-->
 
-	<arg name="colors"/>
-	<arg value="np"/>
+    <arg name="extensions" value="php"/>
 
-	<rule ref="PSR2"/>
+    <!-- General sniffs -->
+    <rule ref="Generic.Files.LineLength"/>
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag"/>
+    <rule ref="Squiz.Classes.LowercaseClassKeywords"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopWithTestFunctionCall"/>
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
+    <rule ref="Squiz.Commenting.DocCommentAlignment"/>
+    <rule ref="Squiz.Operators.ValidLogicalOperators"/>
+    <rule ref="Generic.PHP.DeprecatedFunctions"/>
+    <rule ref="Squiz.PHP.DisallowSizeFunctionsInLoops"/>
+    <rule ref="Squiz.PHP.Eval"/>
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
+    <rule ref="Squiz.PHP.NonExecutableCode"/>
+    <rule ref="Squiz.Classes.ClassFileName"/>
+    <rule ref="Squiz.Scope.MemberVarScope"/>
+    <rule ref="Squiz.Scope.StaticThisUsage"/>
+    <rule ref="Squiz.WhiteSpace.CastSpacing"/>
+    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
+    <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
+    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace"/>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace"/>
+    <rule ref="Squiz.Functions.FunctionDeclarationArgumentSpacing">
+        <properties>
+            <property name="equalsSpacing" value="1"/>
+        </properties>
+    </rule>
+
+    <!-- PSR-2 base standard -->
+    <rule ref="PSR2"/>
+
+    <rule ref="PSR2">
+        <exclude name="PSR2.Classes.ClassDeclaration.OpenBraceNewLine"/>
+        <exclude name="PSR2.ControlStructures.ControlStructureSpacing.SpacingAfterOpenBrace"/>
+    </rule>
+    <rule ref="Squiz.WhiteSpace.ScopeClosingBrace.ContentBefore">
+        <severity>0</severity>
+    </rule>
+    <rule ref="Squiz.Commenting.FunctionCommentThrowTag.WrongNumber">
+        <severity>0</severity>
+    </rule>
+
+    <!-- Sniffs from Slevomat standard -->
+
+    <!-- Functional - improving the safety and behaviour of code -->
+<!--    <rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>-->
+<!--    <rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>-->
+<!--    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>-->
+<!--    <rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>-->
+<!--    <rule ref="SlevomatCodingStandard.PHP.DisallowDirectMagicInvokeCall"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>-->
+
+    <!-- Cleaning - detecting dead code -->
+<!--    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>-->
+<!--    <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>-->
+
+    <!-- Formatting - rules for consistent code looks -->
+<!--    <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment"/>-->
+<!--    <rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Commenting.EmptyComment"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>-->
+<!--    <rule ref="SlevomatCodingStandard.Classes.MethodSpacing"/>-->
 
 </ruleset>

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DbusUI/ResultPrinter.php
+++ b/src/main/php/PDepend/DbusUI/ResultPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/Compiler/ProcessListenerPass.php
+++ b/src/main/php/PDepend/DependencyInjection/Compiler/ProcessListenerPass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/Configuration.php
+++ b/src/main/php/PDepend/DependencyInjection/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Input/ExtensionFilter.php
+++ b/src/main/php/PDepend/Input/ExtensionFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Input/Filter.php
+++ b/src/main/php/PDepend/Input/Filter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CohesionAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -360,7 +361,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         if (null === $coupledType) {
             return;
         }
-        if ($coupledType->isSubtypeOf($declaringType)
+        if (
+            $coupledType->isSubtypeOf($declaringType)
             || $declaringType->isSubtypeOf($coupledType)
         ) {
             return;
@@ -368,17 +370,9 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
 
         $this->initDependencyMap($coupledType);
 
-        $this->dependencyMap[
-            $declaringType->getId()
-        ]['ce'][
-            $coupledType->getId()
-        ] = true;
+        $this->dependencyMap[$declaringType->getId()]['ce'][$coupledType->getId()] = true;
 
-        $this->dependencyMap[
-            $coupledType->getId()
-        ]['ca'][
-            $declaringType->getId()
-        ] = true;
+        $this->dependencyMap[$coupledType->getId()]['ca'][$declaringType->getId()] = true;
     }
 
     /**

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/HierarchyAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -537,7 +538,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $sum = '0';
         if ($node instanceof ASTConditionalExpression) {
             $sum = MathUtil::add($sum, $node->accept($this, '1'));
-        } elseif ($node instanceof ASTBooleanAndExpression
+        } elseif (
+            $node instanceof ASTBooleanAndExpression
             || $node instanceof ASTBooleanOrExpression
             || $node instanceof ASTLogicalAndExpression
             || $node instanceof ASTLogicalOrExpression

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -433,7 +434,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         for (; $i < $count; ++$i) {
             $token = $tokens[$i];
 
-            if ($token->type === Tokens::T_COMMENT
+            if (
+                $token->type === Tokens::T_COMMENT
                 || $token->type === Tokens::T_DOC_COMMENT
             ) {
                 $lines = &$clines;

--- a/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerCacheAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerFilterAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFilterAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerIterator.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerListener.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerNodeAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerNodeAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Metrics/AnalyzerProjectAware.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerProjectAware.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/ProcessListener.php
+++ b/src/main/php/PDepend/ProcessListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/CodeAwareGenerator.php
+++ b/src/main/php/PDepend/Report/CodeAwareGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/FileAwareGenerator.php
+++ b/src/main/php/PDepend/Report/FileAwareGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -346,7 +347,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $type->accept($this);
         }
 
-        if ($this->concreteClasses->firstChild === null
+        if (
+            $this->concreteClasses->firstChild === null
             && $this->abstractClasses->firstChild === null
         ) {
             return;

--- a/src/main/php/PDepend/Report/NoLogOutputException.php
+++ b/src/main/php/PDepend/Report/NoLogOutputException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAllocationExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTArray.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayIndexExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTAssignmentExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanAndExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTBooleanOrExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTBreakStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTCatchStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassFqnPostfix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceRecursiveInheritanceException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCloneExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTComment.php
+++ b/src/main/php/PDepend/Source/AST/ASTComment.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnitNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompoundVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTConditionalExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTConstant.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstant.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantPostfix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTContinueStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDoWhileStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTEchoStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTEvalExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTExitExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExitExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTFinallyStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTForInit.php
+++ b/src/main/php/PDepend/Source/AST/ASTForInit.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTForStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTForUpdate.php
+++ b/src/main/php/PDepend/Source/AST/ASTForUpdate.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTForeachStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameters.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunctionPostfix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGlobalStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTGotoStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIdentifier.php
+++ b/src/main/php/PDepend/Source/AST/ASTIdentifier.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIndexExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTInstanceOfExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTInvocation.php
+++ b/src/main/php/PDepend/Source/AST/ASTInvocation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIssetExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTLabelStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTListExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTListExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTLiteral.php
+++ b/src/main/php/PDepend/Source/AST/ASTLiteral.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalAndExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalOrExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTLogicalXorExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchBlock.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchEntry.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethodPostfix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -297,7 +298,8 @@ class ASTParameter extends AbstractASTArtifact
             return true;
         }
 
-        if (!($node instanceof ASTTypeArray)
+        if (
+            !($node instanceof ASTTypeArray)
             && !($node instanceof ASTScalarType)
             && $this->getClass() === null
         ) {

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPostfixExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreDecrementExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPreIncrementExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTPrintExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
+++ b/src/main/php/PDepend/Source/AST/ASTPropertyPostfix.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTReturnStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTScope.php
+++ b/src/main/php/PDepend/Source/AST/ASTScope.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTScopeStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticVariableDeclaration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTString.php
+++ b/src/main/php/PDepend/Source/AST/ASTString.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTStringIndexExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTThrowStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptation.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationPrecedence.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitMethodCollisionException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTryStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTryStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnaryExpression.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnsetStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableVariable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTWhileStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTYieldStatement.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/AST/State.php
+++ b/src/main/php/PDepend/Source/AST/State.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -5841,7 +5842,8 @@ abstract class AbstractPHPParser
                 $this->consumeToken(Tokens::T_COMMA);
                 $this->consumeComments();
 
-                if ($inCall &&
+                if (
+                    $inCall &&
                     $this->tokenizer->peek() === Tokens::T_PARENTHESIS_CLOSE
                 ) {
                     break;
@@ -7686,7 +7688,8 @@ abstract class AbstractPHPParser
             // Remove alias and add real namespace
             array_shift($fragments);
             array_unshift($fragments, $mapsTo);
-        } elseif ($this->namespaceName !== null
+        } elseif (
+            $this->namespaceName !== null
             && $this->namespacePrefixReplaced === false
         ) {
             // Prepend current namespace
@@ -8148,7 +8151,8 @@ abstract class AbstractPHPParser
         // Fetch next token type
         $tokenType = $this->tokenizer->peek();
 
-        if ($tokenType === Tokens::T_PARENTHESIS_OPEN
+        if (
+            $tokenType === Tokens::T_PARENTHESIS_OPEN
             || $tokenType === Tokens::T_DOUBLE_COLON
         ) {
             return $this->setNodePositionsAndReturn(
@@ -8805,7 +8809,8 @@ abstract class AbstractPHPParser
         }
 
         // Check for doc level comment
-        if ($this->globalPackageName === Builder::DEFAULT_NAMESPACE
+        if (
+            $this->globalPackageName === Builder::DEFAULT_NAMESPACE
             && $this->isFileComment() === true
         ) {
             $this->globalPackageName = $package;
@@ -9189,7 +9194,8 @@ abstract class AbstractPHPParser
             $this->consumeToken(Tokens::T_COLON);
             $type = $this->parseTypeHint();
 
-            if (!($type instanceof ASTScalarType) ||
+            if (
+                !($type instanceof ASTScalarType) ||
                 !in_array($type->getImage(), ['int', 'string'], true)
             ) {
                 throw new TokenException(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -2001,7 +2002,8 @@ class PHPBuilder implements Builder
         $namespaces = $this->namespaces;
 
         // Remove default package if empty
-        if (count($this->defaultPackage->getTypes()) === 0
+        if (
+            count($this->defaultPackage->getTypes()) === 0
             && count($this->defaultPackage->getFunctions()) === 0
         ) {
             unset($namespaces[self::DEFAULT_NAMESPACE]);

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -1077,9 +1078,11 @@ class PHPTokenizerInternal implements FullTokenizer
         $token = (array) current($tokens);
 
         // Skipp all non open tags
-        while ($token[0] !== T_OPEN_TAG_WITH_ECHO &&
+        while (
+            $token[0] !== T_OPEN_TAG_WITH_ECHO &&
                $token[0] !== T_OPEN_TAG &&
-               $token[0] !== false) {
+               $token[0] !== false
+        ) {
             $content .= ($token[1] ?? $token[0]);
 
             $token = (array) next($tokens);

--- a/src/main/php/PDepend/Source/Parser/InvalidStateException.php
+++ b/src/main/php/PDepend/Source/Parser/InvalidStateException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/MissingValueException.php
+++ b/src/main/php/PDepend/Source/Parser/MissingValueException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/NoActiveScopeException.php
+++ b/src/main/php/PDepend/Source/Parser/NoActiveScopeException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/ParserException.php
+++ b/src/main/php/PDepend/Source/Parser/ParserException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/TokenException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStreamEndException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
+++ b/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Tokenizer/Token.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Token.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Source/Tokenizer/Tokens.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokens.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -182,7 +183,8 @@ class Command
 
                     return self::INPUT_ERROR;
                 }
-                if ($analyzerOptions[$option]['value'] === 'file'
+                if (
+                    $analyzerOptions[$option]['value'] === 'file'
                     && file_exists($value) === false
                 ) {
                     echo 'Specified file ' . $option . '=' . $value

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Coverage/Report.php
+++ b/src/main/php/PDepend/Util/Coverage/Report.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/FileUtil.php
+++ b/src/main/php/PDepend/Util/FileUtil.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Log.php
+++ b/src/main/php/PDepend/Util/Log.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/ApplicationTest.php
+++ b/src/test/php/PDepend/ApplicationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
+++ b/src/test/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
+++ b/src/test/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
+++ b/src/test/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
+++ b/src/test/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
+++ b/src/test/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/src/test/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
+++ b/src/test/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
+++ b/src/test/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/src/test/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ConflictingImportTest.php
+++ b/src/test/php/PDepend/Bugs/ConflictingImportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
+++ b/src/test/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
+++ b/src/test/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/src/test/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/src/test/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
+++ b/src/test/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
+++ b/src/test/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
+++ b/src/test/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/src/test/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
+++ b/src/test/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
+++ b/src/test/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
+++ b/src/test/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
+++ b/src/test/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
+++ b/src/test/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
+++ b/src/test/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
+++ b/src/test/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/src/test/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug001Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug001Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug006Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug006Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug007Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug007Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug008Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug008Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug015Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug015Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug016Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug016Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug017Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug017Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug030Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug030Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug033Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug033Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug059Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug059Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug069Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug069Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug124Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug124Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
+++ b/src/test/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
+++ b/src/test/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
+++ b/src/test/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
+++ b/src/test/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
+++ b/src/test/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
+++ b/src/test/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
+++ b/src/test/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
+++ b/src/test/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
+++ b/src/test/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/src/test/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
+++ b/src/test/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
+++ b/src/test/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
+++ b/src/test/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/src/test/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/src/test/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Input/CompositeFilterTest.php
+++ b/src/test/php/PDepend/Input/CompositeFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Input/DummyFilter.php
+++ b/src/test/php/PDepend/Input/DummyFilter.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -205,7 +206,8 @@ class ExcludePathFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if ($filter->accept($file, $file)
+            if (
+                $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')
             ) {

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -105,7 +106,8 @@ class ExtensionFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if ($filter->accept($file, $file)
+            if (
+                $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')
             ) {

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/src/test/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/src/test/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/src/test/php/PDepend/Issues/NewClassInstanceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
+++ b/src/test/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
+++ b/src/test/php/PDepend/Metrics/AnalyzerIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/src/test/php/PDepend/Report/Dependencies/XmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/DummyAnalyzer.php
+++ b/src/test/php/PDepend/Report/DummyAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Overview/PyramidTest.php
+++ b/src/test/php/PDepend/Report/Overview/PyramidTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
+++ b/src/test/php/PDepend/Report/ReportGeneratorFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAndProjectAwareDummy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerNodeAwareDummy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
+++ b/src/test/php/PDepend/Report/Summary/AnalyzerProjectAwareDummy.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScalarTypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTTypeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTValueTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTValueTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
+++ b/src/test/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ClassOrInterfaceReferenceIteratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitListener.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubAbstractASTVisitor.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/AttributeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ConstructorPropertyPromotionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/MatchExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NamedArgumentsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/NullsafeOperatorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/PHPParserVersion81TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/ThrowExpressionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP80/UnionTypesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -73,10 +74,12 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
             ];
         }, $children);
 
-        foreach ([
-            ['null', '$nullish'],
-            ['false', '$falsy'],
-        ] as $index => $expected) {
+        foreach (
+            [
+                ['null', '$nullish'],
+                ['false', '$falsy'],
+            ] as $index => $expected
+        ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -72,9 +73,11 @@ class TrueTypeTest extends PHPParserVersion82TestCase
             ];
         }, $children);
 
-        foreach ([
-            ['true', '$truthy'],
-        ] as $index => $expected) {
+        foreach (
+            [
+                ['true', '$truthy'],
+            ] as $index => $expected
+        ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion56Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion70Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericVersion71Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -1156,30 +1157,32 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach ([
-            ['int', '$id'],
-            ['float', '$money'],
-            ['bool', '$active'],
-            ['string', '$name'],
-            ['array', '$list', 'PDepend\\Source\\AST\\ASTTypeArray'],
-            ['self', '$parent', 'PDepend\\Source\\AST\\ASTSelfReference'],
-            ['callable', '$event', 'PDepend\\Source\\AST\\ASTTypeCallable'],
-            ['\Closure', '$fqn', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['iterable', '$actions', 'PDepend\\Source\\AST\\ASTTypeIterable'],
-            ['object', '$bag', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['Role', '$role', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['?int', '$idN'],
-            ['?float', '$moneyN'],
-            ['?bool', '$activeN'],
-            ['?string', '$nameN'],
-            ['?array', '$listN', 'PDepend\\Source\\AST\\ASTTypeArray'],
-            ['?self', '$parentN', 'PDepend\\Source\\AST\\ASTSelfReference'],
-            ['?callable', '$eventN', 'PDepend\\Source\\AST\\ASTTypeCallable'],
-            ['?\Closure', '$fqnN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['?iterable', '$actionsN', 'PDepend\\Source\\AST\\ASTTypeIterable'],
-            ['?object', '$bagN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-            ['?Role', '$roleN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
-        ] as $index => $expected) {
+        foreach (
+            [
+                ['int', '$id'],
+                ['float', '$money'],
+                ['bool', '$active'],
+                ['string', '$name'],
+                ['array', '$list', 'PDepend\\Source\\AST\\ASTTypeArray'],
+                ['self', '$parent', 'PDepend\\Source\\AST\\ASTSelfReference'],
+                ['callable', '$event', 'PDepend\\Source\\AST\\ASTTypeCallable'],
+                ['\Closure', '$fqn', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+                ['iterable', '$actions', 'PDepend\\Source\\AST\\ASTTypeIterable'],
+                ['object', '$bag', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+                ['Role', '$role', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+                ['?int', '$idN'],
+                ['?float', '$moneyN'],
+                ['?bool', '$activeN'],
+                ['?string', '$nameN'],
+                ['?array', '$listN', 'PDepend\\Source\\AST\\ASTTypeArray'],
+                ['?self', '$parentN', 'PDepend\\Source\\AST\\ASTSelfReference'],
+                ['?callable', '$eventN', 'PDepend\\Source\\AST\\ASTTypeCallable'],
+                ['?\Closure', '$fqnN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+                ['?iterable', '$actionsN', 'PDepend\\Source\\AST\\ASTTypeIterable'],
+                ['?object', '$bagN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+                ['?Role', '$roleN', 'PDepend\\Source\\AST\\ASTClassOrInterfaceReference'],
+            ] as $index => $expected
+        ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = $expected[2] ?? 'PDepend\\Source\\AST\\ASTScalarType';
             [$type, $variable] = $declarations[$index];
@@ -1490,9 +1493,11 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach ([
-            ['null|int|float', '$number', 'PDepend\\Source\\AST\\ASTUnionType'],
-        ] as $index => $expected) {
+        foreach (
+            [
+                ['null|int|float', '$number', 'PDepend\\Source\\AST\\ASTUnionType'],
+            ] as $index => $expected
+        ) {
             [$expectedType, $expectedVariable, $expectedTypeClass] = $expected;
             [$type, $variable] = $declarations[$index];
 

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
+++ b/src/test/php/PDepend/Source/Parser/AbstractParserTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/src/test/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
+++ b/src/test/php/PDepend/Source/Parser/SymbolTableTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/src/test/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
+++ b/src/test/php/PDepend/Source/Tokenizer/TokenTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/src/test/php/PDepend/TextUI/ResultPrinterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
+++ b/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/ConfigurationTest.php
+++ b/src/test/php/PDepend/Util/ConfigurationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/src/test/php/PDepend/Util/Coverage/FactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/FileUtilTest.php
+++ b/src/test/php/PDepend/Util/FileUtilTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/IdBuilderTest.php
+++ b/src/test/php/PDepend/Util/IdBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/TypeTest.php
+++ b/src/test/php/PDepend/Util/TypeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/Util/Utf8UtilTest.php
+++ b/src/test/php/PDepend/Util/Utf8UtilTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/src/test/php/PDepend/bootstrap.php
+++ b/src/test/php/PDepend/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is part of PDepend.
  *


### PR DESCRIPTION
Breaking change: no

Like we talked about in the chat, this will make PHPCS rules not fail the PR, but also make them appear as inline comments to make it easy to se what parts of the proposed code is not ideal.

This PR also gives you an example of what this looks like since the current code base has a few violations compared to the config:

![image](https://github.com/pdepend/pdepend/assets/204594/de03745d-f429-4872-a4d2-11fdd94dc025)

I suggest that we deal with these in follow ups and not this PR so we do not mix various types of changes.
