### PR TITLE
Handle remaning null values

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,7 +6,7 @@ parameters:
         - src/main/php/PDepend/DbusUI/ResultPrinter.php
     universalObjectCratesClasses:
         - PDepend\Util\Configuration
-    level: 7
+    level: 8
     exceptions:
         reportUncheckedExceptionDeadCatch: true
         implicitThrows: false

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -83,14 +83,16 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         // Get owner type
         $type = $method->getParent();
 
-        if (($depType = $method->getReturnClass()) !== null) {
-            $this->processType($type, $depType);
-        }
-        foreach ($method->getExceptionClasses() as $depType) {
-            $this->processType($type, $depType);
-        }
-        foreach ($method->getDependencies() as $depType) {
-            $this->processType($type, $depType);
+        if ($type) {
+            if (($depType = $method->getReturnClass()) !== null) {
+                $this->processType($type, $depType);
+            }
+            foreach ($method->getExceptionClasses() as $depType) {
+                $this->processType($type, $depType);
+            }
+            foreach ($method->getDependencies() as $depType) {
+                $this->processType($type, $depType);
+            }
         }
 
         $this->fireEndMethod($method);
@@ -113,7 +115,7 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
         $namespace = $type->getNamespace();
         $dependencyNamespace = $dependency->getNamespace();
 
-        if ($namespace !== $dependencyNamespace) {
+        if ($namespace && $dependencyNamespace && $namespace !== $dependencyNamespace) {
             $this->initNode($namespace);
             $this->initNode($dependencyNamespace);
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -98,7 +98,7 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
             $this->nodes[$depClass->getId()]['out'][] = $class->getId();
         }
 
-        if ($depNamespace !== $namespace) {
+        if ($depNamespace && $namespace && $depNamespace !== $namespace) {
             $this->initNode($namespace);
             $this->initNode($depNamespace);
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -311,16 +311,18 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
 
         $declaringClass = $method->getParent();
 
-        $this->calculateCoupling(
-            $declaringClass,
-            $method->getReturnClass(),
-        );
+        if ($declaringClass) {
+            $this->calculateCoupling(
+                $declaringClass,
+                $method->getReturnClass(),
+            );
 
-        foreach ($method->getExceptionClasses() as $type) {
-            $this->calculateCoupling($declaringClass, $type);
-        }
-        foreach ($method->getDependencies() as $type) {
-            $this->calculateCoupling($declaringClass, $type);
+            foreach ($method->getExceptionClasses() as $type) {
+                $this->calculateCoupling($declaringClass, $type);
+            }
+            foreach ($method->getDependencies() as $type) {
+                $this->calculateCoupling($declaringClass, $type);
+            }
         }
 
         $this->countCalls($method);

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -230,9 +230,14 @@ class DependencyAnalyzer extends AbstractAnalyzer
     {
         $this->fireStartMethod($method);
 
-        $namespace = $method->getParent()->getNamespace();
-        foreach ($method->getDependencies() as $dependency) {
-            $this->collectDependencies($namespace, $dependency->getNamespace());
+        $namespace = $method->getParent()?->getNamespace();
+        if ($namespace) {
+            foreach ($method->getDependencies() as $dependency) {
+                $dependencyNamespace = $dependency->getNamespace();
+                if ($dependencyNamespace) {
+                    $this->collectDependencies($namespace, $dependencyNamespace);
+                }
+            }
         }
 
         $this->fireEndMethod($method);
@@ -282,23 +287,26 @@ class DependencyAnalyzer extends AbstractAnalyzer
      */
     protected function visitType(AbstractASTClassOrInterface $type): void
     {
-        $id = $type->getNamespace()->getId();
+        $namespace = $type->getNamespace();
+        $id = $namespace?->getId();
 
         // Increment total classes count
-        ++$this->nodeMetrics[$id][self::M_NUMBER_OF_CLASSES];
+        ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_CLASSES];
 
         // Check for abstract or concrete class
         if ($type->isAbstract()) {
-            ++$this->nodeMetrics[$id][self::M_NUMBER_OF_ABSTRACT_CLASSES];
+            ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_ABSTRACT_CLASSES];
         } else {
-            ++$this->nodeMetrics[$id][self::M_NUMBER_OF_CONCRETE_CLASSES];
+            ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_CONCRETE_CLASSES];
         }
 
-        foreach ($type->getDependencies() as $dependency) {
-            $this->collectDependencies(
-                $type->getNamespace(),
-                $dependency->getNamespace(),
-            );
+        if ($namespace) {
+            foreach ($type->getDependencies() as $dependency) {
+                $dependencyNamespace = $dependency->getNamespace();
+                if ($dependencyNamespace) {
+                    $this->collectDependencies($namespace, $dependencyNamespace);
+                }
+            }
         }
 
         foreach ($type->getMethods() as $method) {

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeCountAnalyzer.php
@@ -192,8 +192,8 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         // Update global class count
         ++$this->noc;
 
-        $id = $class->getNamespace()->getId();
-        ++$this->nodeMetrics[$id][self::M_NUMBER_OF_CLASSES];
+        $id = $class->getNamespace()?->getId();
+        ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_CLASSES];
 
         $this->nodeMetrics[$class->getId()] = [
             self::M_NUMBER_OF_METHODS => 0,
@@ -216,8 +216,8 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         // Update global function count
         ++$this->nof;
 
-        $id = $function->getNamespace()->getId();
-        ++$this->nodeMetrics[$id][self::M_NUMBER_OF_FUNCTIONS];
+        $id = $function->getNamespace()?->getId();
+        ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_FUNCTIONS];
 
         $this->fireEndFunction($function);
     }
@@ -236,8 +236,8 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         // Update global class count
         ++$this->noi;
 
-        $id = $interface->getNamespace()->getId();
-        ++$this->nodeMetrics[$id][self::M_NUMBER_OF_INTERFACES];
+        $id = $interface->getNamespace()?->getId();
+        ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_INTERFACES];
 
         $this->nodeMetrics[$interface->getId()] = [
             self::M_NUMBER_OF_METHODS => 0,
@@ -263,11 +263,11 @@ class NodeCountAnalyzer extends AbstractAnalyzer implements AnalyzerFilterAware,
         $parent = $method->getParent();
 
         // Update parent class or interface
-        $parentId = $parent->getId();
-        ++$this->nodeMetrics[$parentId][self::M_NUMBER_OF_METHODS];
+        $parentId = $parent?->getId();
+        ++$this->nodeMetrics[(string) $parentId][self::M_NUMBER_OF_METHODS];
 
-        $id = $parent->getNamespace()->getId();
-        ++$this->nodeMetrics[$id][self::M_NUMBER_OF_METHODS];
+        $id = $parent?->getNamespace()?->getId();
+        ++$this->nodeMetrics[(string) $id][self::M_NUMBER_OF_METHODS];
 
         $this->fireEndMethod($method);
     }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -211,7 +211,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     {
         return (array) $this->cache
             ->type('tokens')
-            ->restore($this->getId());
+            ->restore((string) $this->getId());
     }
 
     /**
@@ -223,7 +223,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
     {
         $this->cache
             ->type('tokens')
-            ->store($this->getId(), $tokens);
+            ->store((string) $this->getId(), $tokens);
     }
 
     /**

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -102,7 +102,7 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
     }
 
     /**
-     * @return ?ASTType
+     * @return ASTType
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -231,6 +231,9 @@ class ASTParameterTest extends AbstractTestCase
 
         $formalParameter = $this->getMockBuilder(ASTFormalParameter::class)
             ->getMock();
+        $formalParameter->expects(static::any())
+            ->method('getFirstChildOfType')
+            ->will(static::returnValue(new ASTVariableDeclarator('test')));
         $parameter = new ASTParameter($formalParameter);
         $parameter->accept($visitor);
     }


### PR DESCRIPTION
Type: refactoring

This resolves the PHPStan level 8 issues which deals with making sure not to operate on null values.

This should make adding native types to things much less risky, though there can still be blind spots and cases where things are not covariant.