### PR TITLE
Correct parameter types

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -64,11 +64,9 @@ use Symfony\Component\DependencyInjection\TaggedContainerInterface;
  */
 class Application
 {
-    /** @var TaggedContainerInterface|null */
-    private $container;
+    private TaggedContainerInterface $container;
 
-    /** @var string */
-    private $configurationFile;
+    private string $configurationFile;
 
     /**
      * @param string $configurationFile
@@ -151,7 +149,7 @@ class Application
      */
     private function getContainer()
     {
-        if ($this->container === null) {
+        if (!isset($this->container)) {
             $this->container = $this->createContainer();
         }
 
@@ -176,7 +174,7 @@ class Application
             $container->registerExtension($extension);
         }
 
-        if ($this->configurationFile) {
+        if (isset($this->configurationFile)) {
             $loader->load($this->configurationFile);
         }
 

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -44,7 +44,6 @@
 namespace PDepend\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder as BaseTreeBuilder;
 
 /**
@@ -52,7 +51,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder as BaseTreeBuilder;
  */
 class TreeBuilder
 {
-    /** @var ArrayNodeDefinition|NodeDefinition */
+    /** @var ArrayNodeDefinition */
     protected $rootNode;
 
     /** @var BaseTreeBuilder */
@@ -65,26 +64,16 @@ class TreeBuilder
      */
     public function __construct($name = 'pdepend')
     {
-        $this->treeBuilder = new BaseTreeBuilder($name);
-
-        if (method_exists($this->treeBuilder, 'getRootNode')) {
-            $this->rootNode = $this->treeBuilder->getRootNode();
-
-            return;
-        }
-
-        // @codeCoverageIgnoreStart
-        if (method_exists($this->treeBuilder, 'root')) {
-            // Symfony < 4.2
-            $this->rootNode = $this->treeBuilder->root($name);
-        }
-        // @codeCoverageIgnoreEnd
+        $this->treeBuilder = new BaseTreeBuilder($name, 'array');
+        $rootNode = $this->treeBuilder->getRootNode();
+        assert($rootNode instanceof ArrayNodeDefinition);
+        $this->rootNode = $rootNode;
     }
 
     /**
      * Get the root node of the built tree.
      *
-     * @return ArrayNodeDefinition|NodeDefinition
+     * @return ArrayNodeDefinition
      */
     public function getRootNode()
     {

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -89,8 +89,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /** The log output file. */
     private string $logFile;
 
-    /** @var ClassDependencyAnalyzer|null */
-    private $dependencyAnalyzer;
+    private ClassDependencyAnalyzer $dependencyAnalyzer;
 
     /**
      * The internal used xml stack.
@@ -288,7 +287,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      */
     protected function writeNodeDependencies(DOMElement $xml, AbstractASTArtifact $node): void
     {
-        if (!$this->dependencyAnalyzer) {
+        if (!isset($this->dependencyAnalyzer)) {
             return;
         }
 

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -44,7 +44,6 @@
 namespace PDepend\Report;
 
 use RuntimeException;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\TaggedContainerInterface;
 
 /**
@@ -73,10 +72,7 @@ class ReportGeneratorFactory
     /** @var TaggedContainerInterface */
     private $container;
 
-    /**
-     * @param TaggedContainerInterface $container
-     */
-    public function __construct(ContainerInterface $container)
+    public function __construct(TaggedContainerInterface $container)
     {
         $this->container = $container;
     }

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -51,7 +51,7 @@ namespace PDepend\Source\AST;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 2.3
  */
-class ASTAnonymousClass extends ASTClass implements ASTNode
+class ASTAnonymousClass extends ASTClass
 {
     /**
      * Metadata for this node instance, serialized in a string. This string

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -150,11 +150,11 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns the physical file name for this object.
      *
-     * @return string|null
+     * @return string
      */
     public function getImage()
     {
-        return $this->fileName;
+        return $this->fileName ?? '';
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -56,9 +56,9 @@ class ASTTraitAdaptationAlias extends ASTStatement
     /**
      * The new aliased method name.
      *
-     * @var string
+     * @var ?string
      */
-    protected $newName;
+    protected $newName = null;
 
     /**
      * The new method modifier for the imported method.

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -89,11 +89,11 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Constructs a new item for the given <b>$name</b>.
      *
-     * @param string $name The item name.
+     * @param ?string $name The item name.
      */
-    public function __construct($name)
+    public function __construct(?string $name = null)
     {
-        $this->name = $name;
+        $this->name = $name ?? '';
     }
 
     /**

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -84,7 +84,7 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Constructs a new ast node instance.
      *
-     * @param string $image The source image for this node.
+     * @param ?string $image The source image for this node.
      */
     public function __construct($image = null)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -306,22 +306,14 @@ abstract class AbstractPHPParser
      */
     private $namespacePrefixReplaced = false;
 
-    /**
-     * The currently parsed file instance.
-     *
-     * @var ASTCompilationUnit
-     */
-    private $compilationUnit;
+    /** The currently parsed file instance. */
+    private ASTCompilationUnit $compilationUnit;
 
     /** The symbol table used to handle PHP use statements. */
     private SymbolTable $useSymbolTable;
 
-    /**
-     * The actually parsed class or interface instance.
-     *
-     * @var AbstractASTClassOrInterface|null
-     */
-    private $classOrInterface;
+    /** The actually parsed class or interface instance. */
+    private ?AbstractASTClassOrInterface $classOrInterface = null;
 
     /** @since 0.10.0 */
     private CacheDriver $cache;
@@ -331,7 +323,7 @@ abstract class AbstractPHPParser
      *
      * @var string|null
      */
-    private $namespaceName;
+    private $namespaceName = null;
 
     /**
      * Last parsed package tag.
@@ -1770,7 +1762,7 @@ abstract class AbstractPHPParser
         $this->parseCallableDeclaration($function);
 
         // First check for an existing namespace
-        if ($this->namespaceName !== null) {
+        if (isset($this->namespaceName)) {
             $namespaceName = $this->namespaceName;
         } elseif ($this->packageName !== Builder::DEFAULT_NAMESPACE) {
             $namespaceName = $this->packageName;
@@ -5584,7 +5576,7 @@ abstract class AbstractPHPParser
         // Strip optional comments
         $this->consumeComments();
 
-        if ($this->classOrInterface === null) {
+        if (!isset($this->classOrInterface)) {
             throw new InvalidStateException(
                 $token->startLine,
                 (string) $this->compilationUnit,
@@ -5614,7 +5606,7 @@ abstract class AbstractPHPParser
      */
     private function parseSelfReference(Token $token)
     {
-        if ($this->classOrInterface === null) {
+        if (!isset($this->classOrInterface)) {
             throw new InvalidStateException(
                 $token->startLine,
                 (string) $this->compilationUnit,
@@ -5701,7 +5693,7 @@ abstract class AbstractPHPParser
      */
     private function parseParentReference(Token $token)
     {
-        if ($this->classOrInterface === null) {
+        if (!isset($this->classOrInterface)) {
             throw new InvalidStateException(
                 $token->startLine,
                 (string) $this->compilationUnit,
@@ -7722,7 +7714,7 @@ abstract class AbstractPHPParser
             array_shift($fragments);
             array_unshift($fragments, $mapsTo);
         } elseif (
-            $this->namespaceName !== null
+            isset($this->namespaceName)
             && $this->namespacePrefixReplaced === false
         ) {
             // Prepend current namespace
@@ -7756,7 +7748,7 @@ abstract class AbstractPHPParser
             $this->consumeComments();
 
             // Add current namespace as first token
-            $qualifiedName = [(string) $this->namespaceName];
+            $qualifiedName = [$this->namespaceName ?? ''];
 
             // Set prefixed flag to true
             $this->namespacePrefixReplaced = true;
@@ -8812,7 +8804,7 @@ abstract class AbstractPHPParser
      */
     private function getNamespaceOrPackageName()
     {
-        if ($this->namespaceName === null) {
+        if (!isset($this->namespaceName)) {
             return $this->packageName;
         }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2423,13 +2423,13 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a trait instance for later reuse.
      *
-     * @param string $traitName
+     * @param ?string $traitName
      * @param ?string $namespaceName
      * @since 1.0.0
      */
     protected function storeTrait($traitName, $namespaceName, ASTTrait $trait): void
     {
-        $traitName = strtolower($traitName);
+        $traitName = strtolower($traitName ?? '');
         if (!isset($this->traits[$traitName][$namespaceName])) {
             $this->traits[$traitName][$namespaceName] = [];
         }
@@ -2442,13 +2442,13 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a class instance for later reuse.
      *
-     * @param string $className
+     * @param ?string $className
      * @param ?string $namespaceName
      * @since 0.9.5
      */
     protected function storeClass($className, $namespaceName, ASTClass $class): void
     {
-        $className = strtolower($className);
+        $className = strtolower($className ?? '');
         if (!isset($this->classes[$className][$namespaceName])) {
             $this->classes[$className][$namespaceName] = [];
         }
@@ -2461,13 +2461,13 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a class instance for later reuse.
      *
-     * @param string $enumName
+     * @param ?string $enumName
      * @param ?string $namespaceName
      * @since 2.11.0
      */
     protected function storeEnum($enumName, $namespaceName, ASTEnum $enum): void
     {
-        $enumName = strtolower($enumName);
+        $enumName = strtolower($enumName ?? '');
         if (!isset($this->classes[$enumName][$namespaceName])) {
             $this->classes[$enumName][$namespaceName] = [];
         }
@@ -2480,13 +2480,13 @@ class PHPBuilder implements Builder
     /**
      * This method will persist an interface instance for later reuse.
      *
-     * @param string $interfaceName
+     * @param ?string $interfaceName
      * @param ?string $namespaceName
      * @since 0.9.5
      */
     protected function storeInterface($interfaceName, $namespaceName, ASTInterface $interface): void
     {
-        $interfaceName = strtolower($interfaceName);
+        $interfaceName = strtolower($interfaceName ?? '');
         if (!isset($this->interfaces[$interfaceName][$namespaceName])) {
             $this->interfaces[$interfaceName][$namespaceName] = [];
         }
@@ -2586,7 +2586,7 @@ class PHPBuilder implements Builder
      * @template T of ASTNode
      *
      * @param class-string<T> $className
-     * @param string $image
+     * @param ?string $image
      * @return T
      * @since 0.9.12
      */

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -1331,7 +1331,7 @@ class ParserTest extends AbstractTestCase
      */
     public function testParserStopsProcessingWhenCacheContainsValidResult(): void
     {
-        $builder = $this->getMockBuilder(Builder::class)
+        $builder = $this->getMockBuilder(PHPBuilder::class)
             ->getMock();
 
         $tokenizer = new PHPTokenizerInternal();

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -52,7 +52,7 @@ use PDepend\Input\Filter;
 use PDepend\Report\ReportGeneratorFactory;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use RuntimeException;
-use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test case for the text ui runner.
@@ -136,7 +136,7 @@ class RunnerTest extends AbstractTestCase
             });
         $engine->expects(static::exactly(0))
             ->method('setCodeFilter');
-        $container = new Container();
+        $container = new ContainerBuilder();
 
         $runner = new Runner(new ReportGeneratorFactory($container), $engine);
         $runner->setExcludeDirectories([dirname(__DIR__)]);
@@ -169,7 +169,7 @@ class RunnerTest extends AbstractTestCase
             ->willReturnCallback(function (PackageArtifactFilter $excludePathFilter) use (&$record): void {
                 $record[] = $excludePathFilter;
             });
-        $container = new Container();
+        $container = new ContainerBuilder();
 
         $runner = new Runner(new ReportGeneratorFactory($container), $engine);
         $runner->setExcludeNamespaces(['PDepend']);


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: yes

When applying types of the properties these parts of the code will fail to work properly. Handled here to make it nice and clean to see the necessary changes. This mostly consist of:
- Correct a few types
- use uninitialized instead of null
- give proper types during tests

Alternatly to approving this you can also skip a step and approve https://github.com/pdepend/pdepend/pull/834 instead, which will add automatic conversion from PHPDoc to typehints on top of this PR.