### PR TITLE
Correct a few return types

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -113,10 +113,8 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
 
     /**
      * Returns the start column for this ast node.
-     *
-     * @return int
      */
-    public function getStartColumn()
+    public function getStartColumn(): int
     {
         return $this->getMetadataInteger(2);
     }
@@ -133,10 +131,8 @@ class ASTAnonymousClass extends ASTClass implements ASTNode
 
     /**
      * Returns the end column for this ast node.
-     *
-     * @return int
      */
-    public function getEndColumn()
+    public function getEndColumn(): int
     {
         return $this->getMetadataInteger(3);
     }

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -54,7 +54,7 @@ interface ASTArtifact extends ASTNode
     /**
      * Returns a id for this code node.
      *
-     * @return string
+     * @return ?string
      */
     public function getId();
 }

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -52,7 +52,7 @@ namespace PDepend\Source\AST;
 interface ASTCallable extends ASTNode
 {
     /**
-     * @return ASTType
+     * @return ?ASTType
      */
     public function getReturnType();
 }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -183,7 +183,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
      * @return $this
      * @since  0.10.0
      */
-    public function setCache(CacheDriver $cache)
+    public function setCache(CacheDriver $cache): self
     {
         $this->cache = $cache;
 
@@ -236,7 +236,7 @@ class ASTCompilationUnit extends AbstractASTArtifact
         $this->childNodes[$artifact->getId()] = $artifact;
     }
 
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->childNodes;
     }

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -68,7 +68,7 @@ class ASTFormalParameter extends AbstractASTNode
      */
     protected $modifiers = 0;
 
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['modifiers', ...parent::__sleep()];
     }

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -106,7 +106,7 @@ class ASTFunction extends AbstractASTCallable
      * @return $this
      * @since  0.10.0
      */
-    public function setContext(BuilderContext $context)
+    public function setContext(BuilderContext $context): self
     {
         $this->context = $context;
 

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -63,7 +63,7 @@ class ASTIntersectionType extends AbstractASTCombinationType
         return true;
     }
 
-    protected function getSymbol()
+    protected function getSymbol(): string
     {
         return '&';
     }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -82,10 +82,8 @@ interface ASTNode
 
     /**
      * Returns the start column for this ast node.
-     *
-     * @return int
      */
-    public function getStartColumn();
+    public function getStartColumn(): int;
 
     /**
      * Returns the end line for this ast node.
@@ -96,10 +94,8 @@ interface ASTNode
 
     /**
      * Returns the end column for this ast node.
-     *
-     * @return int
      */
-    public function getEndColumn();
+    public function getEndColumn(): int;
 
     /**
      * Returns the node instance for the given index or throws an exception.

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -262,10 +262,9 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the column number where the property declaration starts.
      *
-     * @return int
      * @since  0.9.8
      */
-    public function getStartColumn()
+    public function getStartColumn(): int
     {
         return $this->variableDeclarator->getStartColumn();
     }
@@ -284,10 +283,9 @@ class ASTProperty extends AbstractASTArtifact
     /**
      * Returns the column number where the property declaration ends.
      *
-     * @return int
      * @since  0.9.8
      */
-    public function getEndColumn()
+    public function getEndColumn(): int
     {
         return $this->variableDeclarator->getEndColumn();
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -65,7 +65,7 @@ class ASTUnionType extends AbstractASTCombinationType
         return true;
     }
 
-    protected function getSymbol()
+    protected function getSymbol(): string
     {
         return '|';
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -275,7 +275,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         return $this->startLine;
     }
 
-    public function getStartColumn()
+    public function getStartColumn(): int
     {
         return $this->startColumn;
     }
@@ -290,7 +290,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         return $this->endLine;
     }
 
-    public function getEndColumn()
+    public function getEndColumn(): int
     {
         return $this->endColumn;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -142,7 +142,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @return $this
      * @since  0.10.0
      */
-    public function setCache(CacheDriver $cache)
+    public function setCache(CacheDriver $cache): self
     {
         $this->cache = $cache;
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -177,7 +177,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a node iterator with all implemented interfaces.
      *
-     * @return AbstractASTClassOrInterface[]|ASTArtifactList<AbstractASTClassOrInterface>
+     * @return ASTArtifactList<AbstractASTClassOrInterface>
      * @since  0.9.5
      */
     public function getInterfaces()

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -184,10 +184,8 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Returns the start column for this ast node.
-     *
-     * @return int
      */
-    public function getStartColumn()
+    public function getStartColumn(): int
     {
         return $this->getMetadataInteger(2);
     }
@@ -204,10 +202,8 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Returns the end column for this ast node.
-     *
-     * @return int
      */
-    public function getEndColumn()
+    public function getEndColumn(): int
     {
         return $this->getMetadataInteger(3);
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -159,7 +159,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return $this
      */
-    public function setCache(CacheDriver $cache)
+    public function setCache(CacheDriver $cache): self
     {
         $this->cache = $cache;
 
@@ -171,7 +171,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return $this
      */
-    public function setContext(BuilderContext $context)
+    public function setContext(BuilderContext $context): self
     {
         $this->context = $context;
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -289,7 +289,7 @@ class PHPBuilder implements Builder
      * @return $this
      * @since  0.10.0
      */
-    public function setCache(CacheDriver $cache)
+    public function setCache(CacheDriver $cache): self
     {
         $this->cache = $cache;
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -92,7 +92,7 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
         return parent::isScalarOrCallableTypeHint($image);
     }
 
-    protected function isTypeHint($tokenType)
+    protected function isTypeHint($tokenType): bool
     {
         if (in_array($tokenType, [Tokens::T_TRUE, Tokens::T_PARENTHESIS_OPEN], true)) {
             return true;

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -126,7 +126,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $type The name or object type for the next storage method call.
      * @return $this
      */
-    public function type($type)
+    public function type($type): self
     {
         $this->type = $type;
 

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -131,7 +131,7 @@ class MemoryCacheDriver implements CacheDriver
      * @param string $type The name or object type for the next storage method call.
      * @return $this
      */
-    public function type($type)
+    public function type($type): self
     {
         $this->type = $type;
 

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -51,6 +51,7 @@ use Imagick;
 use PDepend\Input\ExcludePathFilter;
 use PDepend\Input\Iterator;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClosure;
@@ -62,6 +63,7 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Builder\BuilderContext;
@@ -448,7 +450,7 @@ abstract class AbstractTestCase extends TestCase
      * Creates a mocked class instance without calling the constructor.
      *
      * @param string $className Name of the class to mock.
-     * @return stdClass
+     * @return ASTProperty
      * @since 0.10.0
      */
     protected function getMockWithoutConstructor($className)
@@ -770,7 +772,7 @@ abstract class AbstractTestCase extends TestCase
      * Parses the test code associated with the calling test method.
      *
      * @param bool $ignoreAnnotations The parser should ignore annotations.
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     protected function parseCodeResourceForTest($ignoreAnnotations = false)
     {
@@ -786,7 +788,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {
@@ -810,7 +812,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $fileOrDirectory
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseSource($fileOrDirectory, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -45,6 +45,7 @@ namespace PDepend\Bugs;
 
 use PDepend\AbstractTestCase;
 use PDepend\Report\Summary\Xml;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
 /**
@@ -86,7 +87,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -47,6 +47,7 @@ namespace PDepend\Bugs;
 use PDepend\Source\AST\ASTConstant;
 use PDepend\Source\AST\ASTFunctionPostfix;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -110,12 +111,12 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
 
     /**
      * @param Builder<mixed> $builder
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return AbstractPHPParser&MockObject
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
     {
         return $this->getAbstractClassMock(
-            'PDepend\\Source\\Language\\PHP\\AbstractPHPParser',
+            AbstractPHPParser::class,
             [$tokenizer, $builder, $cache]
         );
     }

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -104,7 +104,7 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
     /**
      * Returns the first heredoc found in a class.
      *
-     * @return ASTHeredoc
+     * @return ?ASTHeredoc
      */
     protected function getFirstHeredocInClass()
     {

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -45,6 +45,7 @@ namespace PDepend\Issues;
 
 use ErrorException;
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTParameter;
 
@@ -71,7 +72,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * Parses the source for the calling test case.
      *
      * @param string $testCase
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     protected function parseTestCase($testCase = null)
     {
@@ -88,7 +89,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -45,6 +45,7 @@ namespace PDepend\Metrics;
 
 use Exception;
 use PDepend\AbstractTestCase;
+use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 
 /**
@@ -61,7 +62,7 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/MockCommand.php
+++ b/src/test/php/PDepend/MockCommand.php
@@ -8,15 +8,16 @@ use RuntimeException;
 
 class MockCommand extends Command
 {
-    public static function main()
+    public static function main(): int
     {
         $command = new self();
 
         return $command->run();
     }
 
-    protected function parseArguments(): void
+    protected function parseArguments(): bool
     {
+        return true;
     }
 
     protected function printVersion(): void

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -500,7 +500,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser sets the correct function return type.
      *
-     * @return ASTFunction[]
+     * @return ASTArtifactList<ASTFunction>
      */
     public function testParserSetsCorrectFunctionReturnType()
     {
@@ -922,7 +922,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Tests that the parser supports sub packages.
      *
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function testParserSetsFileLevelFunctionPackage()
     {
@@ -1449,7 +1449,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns the methods of an interface from the mixed code test file.
      *
-     * @return ASTMethod[]
+     * @return ASTArtifactList<ASTMethod>
      */
     protected function getInterfaceMethodsForTest()
     {
@@ -1476,7 +1476,7 @@ class ParserTest extends AbstractTestCase
     /**
      * Returns the methods of a class from the mixed code test file.
      *
-     * @return ASTMethod[]
+     * @return ASTArtifactList<ASTMethod>
      */
     protected function getClassMethodsForTest()
     {

--- a/src/test/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEnumTest.php
@@ -116,7 +116,7 @@ class ASTEnumTest extends AbstractASTArtifactTestCase
         $enum->setTokens([]);
     }
 
-    protected function createItem()
+    protected function createItem(): AbstractASTArtifact
     {
         $builder = new PHPBuilder();
         $builder->setCache(new MemoryCacheDriver());

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -728,7 +728,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -121,12 +121,11 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedEndColumn
      *
      * @param ASTScopeStatement $stmt
-     * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedEndLine
      */
-    public function testInlineScopeStatementHasExpectedEndColumn($stmt)
+    public function testInlineScopeStatementHasExpectedEndColumn($stmt): void
     {
         static::assertEquals(20, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -58,7 +58,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * testStaticVariableDeclaration
      *
-     * @return ASTStringIndexExpression
+     * @return ASTStaticVariableDeclaration
      * @since 1.0.2
      */
     public function testStaticVariableDeclaration()
@@ -120,7 +120,7 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Returns a node instance for the currently executed test case.
      *
-     * @return ASTStringIndexExpression
+     * @return ASTStaticVariableDeclaration
      */
     private function getFirstStaticVariableDeclarationInFunction()
     {

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -253,7 +253,7 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCode
      *
-     * @return ASTSwitch
+     * @return ASTSwitchStatement
      * @since 2.1.0
      */
     public function testSwitchStatementWithNestedNonePhpCode()

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -75,7 +75,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      *
      * @param string $testCase
      * @param bool $ignoreAnnotations
-     * @return ASTNamespace[]
+     * @return ASTArtifactList<ASTNamespace>
      */
     public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
     {

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -989,10 +989,7 @@ class PHPParserVersion81Test extends AbstractTestCase
         static::assertNull($parameter->getClass());
     }
 
-    /**
-     * @return ASTNamespace
-     */
-    public function testGroupUseStatementTrailingComma()
+    public function testGroupUseStatementTrailingComma(): void
     {
         $namespaces = $this->parseCodeResourceForTest();
         static::assertGreaterThan(0, count($namespaces));


### PR DESCRIPTION
Type: bugfix / refactoring / documentation update

This corrects a few return types that are either incorrect or cannot be trivially derived from PHPDoc (either because it's inherited or should be nullable).