### PR TITLE
Correctly type hint some return values

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -181,10 +181,8 @@ class ASTMethod extends AbstractASTCallable
 
     /**
      * Returns the parent type object or <b>null</b>
-     *
-     * @return AbstractASTClassOrInterface|null
      */
-    public function getParent()
+    public function getParent(): ?AbstractASTClassOrInterface
     {
         return $this->parentClass;
     }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -111,7 +111,7 @@ interface ASTNode
      *
      * @return ASTNode[]
      */
-    public function getChildren();
+    public function getChildren(): array;
 
     /**
      * This method will search recursive for the first child node that is an
@@ -142,10 +142,8 @@ interface ASTNode
     /**
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
-     *
-     * @return ?ASTNode
      */
-    public function getParent();
+    public function getParent(): ?self;
 
     /**
      * Sets the parent node of this node.

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -162,7 +162,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         }
     }
 
-    public function getChild($index)
+    public function getChild($index): ASTNode
     {
         $children = $this->getChildren();
         if (isset($children[$index])) {
@@ -178,12 +178,12 @@ abstract class AbstractASTArtifact implements ASTArtifact
         );
     }
 
-    public function getChildren()
+    public function getChildren(): array
     {
         return [];
     }
 
-    public function getFirstChildOfType($targetType)
+    public function getFirstChildOfType($targetType): ?ASTNode
     {
         $children = $this->getChildren();
         foreach ($children as $node) {
@@ -198,7 +198,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         return null;
     }
 
-    public function findChildrenOfType($targetType, array &$results = [])
+    public function findChildrenOfType($targetType, array &$results = []): array
     {
         $children = $this->getChildren();
         foreach ($children as $node) {
@@ -211,7 +211,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         return $results;
     }
 
-    public function getParent()
+    public function getParent(): ?ASTNode
     {
         return $this->parent;
     }
@@ -221,7 +221,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
         $this->parent = $node;
     }
 
-    public function getParentsOfType($parentType)
+    public function getParentsOfType($parentType): array
     {
         $parents = [];
 

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -168,7 +168,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @return AbstractASTNode[]
      * @since  0.9.8
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->nodes;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -348,7 +348,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @return ASTNode[]
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->nodes;
     }
@@ -363,7 +363,7 @@ abstract class AbstractASTNode implements ASTNode
      * @param class-string<T> $targetType
      * @return T|null
      */
-    public function getFirstChildOfType($targetType)
+    public function getFirstChildOfType($targetType): ?ASTNode
     {
         foreach ($this->nodes as $node) {
             if ($node instanceof $targetType) {
@@ -423,10 +423,8 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the parent node of this node or <b>null</b> when this node is
      * the root of a node tree.
-     *
-     * @return ?ASTNode
      */
-    public function getParent()
+    public function getParent(): ?ASTNode
     {
         return $this->parent;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -192,7 +192,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return ASTNode[]
      */
-    public function getChildren()
+    public function getChildren(): array
     {
         return $this->nodes;
     }

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -156,7 +156,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     /**
      * testClassReferenceForJavaStyleArrayNotation
      *
-     * @return ASTClassOrInterfaceReference
+     * @return ASTClass
      */
     public function testClassReferenceForJavaStyleArrayNotation()
     {


### PR DESCRIPTION
Type: refactoring  
Breaking change: yes

These are some more types that could not be converted automatically, mostly because of inherited doc or templating.