### PR TITLE
Adjust templated return types

### DIFF
--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -327,7 +327,9 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
         ];
 
         foreach ($class->getParentClasses() as $parent) {
-            $this->initNodeMetricsForClass($parent);
+            if ($parent instanceof ASTClass) {
+                $this->initNodeMetricsForClass($parent);
+            }
         }
     }
 }

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -58,7 +58,7 @@ class ASTClassReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return ASTClass
+     * @return ASTClass|ASTEnum
      * @throws RuntimeException
      */
     public function getType()

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -118,7 +118,7 @@ interface ASTNode
      * @param class-string<T> $targetType
      * @return T|null
      */
-    public function getFirstChildOfType($targetType);
+    public function getFirstChildOfType($targetType): ?self;
 
     /**
      * This method will search recursive for all child nodes that are an

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -58,12 +58,12 @@ class ASTTraitReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return AbstractASTType
+     * @return ASTTrait
      * @throws RuntimeException
      */
     public function getType()
     {
-        if ($this->typeInstance === null) {
+        if (!$this->typeInstance instanceof ASTTrait) {
             if (!$this->context) {
                 throw new RuntimeException('No context set');
             }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -98,7 +98,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
-     * @return ASTClass|null
+     * @return ASTClass|ASTEnum|null
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function getParentClass()
@@ -131,7 +131,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * direct parent of this class is the first element in the returned array
      * and parent of this parent the second element and so on.
      *
-     * @return ASTClass[]
+     * @return array<int, ASTClass|ASTEnum>
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @since  1.0.0
      */

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -255,7 +255,7 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName
-     * @return ASTClass
+     * @return ASTClass|ASTEnum
      * @since  0.9.5
      */
     public function getClass($qualifiedName);

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -105,7 +105,7 @@ interface BuilderContext
      * Returns the class instance for the given qualified name.
      *
      * @param string $qualifiedName
-     * @return ASTClass
+     * @return ASTClass|ASTEnum;
      */
     public function getClass($qualifiedName);
 

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -149,7 +149,7 @@ class GlobalBuilderContext implements BuilderContext
      * Returns the class instance for the given qualified name.
      *
      * @param string $qualifiedName
-     * @return ASTClass
+     * @return ASTClass|ASTEnum
      */
     public function getClass($qualifiedName)
     {

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -2237,7 +2237,7 @@ class PHPBuilder implements Builder
      * @return T|null
      * @since  0.9.5
      */
-    protected function findType(array $instances, $qualifiedName)
+    protected function findType(array $instances, $qualifiedName): ?AbstractASTType
     {
         $classOrInterfaceName = $this->extractTypeName($qualifiedName);
         $caseInsensitiveName = strtolower($classOrInterfaceName);
@@ -2590,7 +2590,7 @@ class PHPBuilder implements Builder
      * @return T
      * @since 0.9.12
      */
-    private function buildAstNodeInstance($className, $image = null)
+    private function buildAstNodeInstance($className, $image = null): ASTNode
     {
         Log::debug("Creating: {$className}({$image})");
 

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -109,7 +109,7 @@ interface Tokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return int
+     * @return ?int
      * @since  0.9.12
      */
     public function peekNext();

--- a/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/src/test/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -113,7 +113,7 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
      * @param Builder<mixed> $builder
      * @return AbstractPHPParser&MockObject
      */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return $this->getAbstractClassMock(
             AbstractPHPParser::class,

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -83,11 +83,14 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeDelegatesToBuilderContextGetClassOrInterface(): void
     {
+        $class = $this->getMockBuilder(ASTClass::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getBuilderContextMock();
         $context->expects(static::once())
             ->method('getClassOrInterface')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($this));
+            ->will(static::returnValue($class));
 
         $reference = new ASTClassOrInterfaceReference(
             $context,
@@ -102,11 +105,14 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeCachesReturnValueOfBuilderContextGetClassOrInterface(): void
     {
+        $class = $this->getMockBuilder(ASTClass::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getBuilderContextMock();
         $context->expects(static::exactly(1))
             ->method('getClassOrInterface')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($this));
+            ->will(static::returnValue($class));
 
         $reference = new ASTClassOrInterfaceReference(
             $context,

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -62,11 +62,14 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeDelegatesToBuilderContextGetClass(): void
     {
+        $class = $this->getMockBuilder(ASTClass::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getBuilderContextMock();
         $context->expects(static::once())
             ->method('getClass')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($this));
+            ->will(static::returnValue($class));
 
         $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();
@@ -77,11 +80,14 @@ class ASTClassReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeCachesReturnValueOfBuilderContextGetClass(): void
     {
+        $class = $this->getMockBuilder(ASTClass::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getBuilderContextMock();
         $context->expects(static::exactly(1))
             ->method('getClass')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($this));
+            ->will(static::returnValue($class));
 
         $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();

--- a/src/test/php/PDepend/TestExtension.php
+++ b/src/test/php/PDepend/TestExtension.php
@@ -6,7 +6,7 @@ use PDepend\DependencyInjection\Extension;
 
 class TestExtension extends Extension
 {
-    public function getName()
+    public function getName(): string
     {
         return 'test';
     }


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: yes

This hints types that are templated and there for can't be converted automatically to type hints.
I have additionally hinted functions that are directly returning there input and relaxed some types to avoid unnecessarily strict return types which multiple concretes in a union.

Besides this the only remaning bit before we can apply return hints to the rest of the codebase is dealing with nullable `id()` and `getImage()`.