### PR TITLE
Use a collector rather then passing data though the visitor

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -58,13 +58,8 @@ interface ASTNode
 {
     /**
      * ASTVisitor method for node tree traversal.
-     *
-     * @template T of array<string, mixed>|numeric-string
-     *
-     * @param T $data
-     * @return T
      */
-    public function accept(ASTVisitor $visitor, $data = []);
+    public function accept(ASTVisitor $visitor): void;
 
     /**
      * Returns the source image of this ast node.

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -295,18 +295,16 @@ abstract class AbstractASTArtifact implements ASTArtifact
         return $this->endColumn;
     }
 
-    /**
-     * @template T of array<string, mixed>|numeric-string
-     *
-     * @param T $data
-     * @return T
-     */
-    public function accept(ASTVisitor $visitor, $data = [])
+    public function accept(ASTVisitor $visitor): void
     {
         $methodName = 'visit' . substr(static::class, 22);
         $callable = [$visitor, $methodName];
-        assert(is_callable($callable));
+        if (is_callable($callable)) {
+            $callable($this);
 
-        return $callable($this, $data);
+            return;
+        }
+
+        $visitor->visit($this);
     }
 }

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -125,19 +125,17 @@ abstract class AbstractASTNode implements ASTNode
         }
     }
 
-    /**
-     * @template T of array<string, mixed>|numeric-string
-     *
-     * @param T $data
-     * @return T
-     */
-    public function accept(ASTVisitor $visitor, $data = [])
+    public function accept(ASTVisitor $visitor): void
     {
         $methodName = 'visit' . substr(static::class, 22);
         $callable = [$visitor, $methodName];
-        assert(is_callable($callable));
+        if (is_callable($callable)) {
+            $callable($this);
 
-        return $callable($this, $data);
+            return;
+        }
+
+        $visitor->visit($this);
     }
 
     /**

--- a/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/ASTVisitor.php
@@ -64,30 +64,6 @@ use PDepend\Source\AST\ASTTrait;
 interface ASTVisitor
 {
     /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string $method Name of the called method.
-     * @param array<int, mixed> $args Array with method argument.
-     * @return array<string, mixed>|numeric-string
-     * @since  0.9.12
-     */
-    public function __call($method, $args);
-
-    /**
      * Adds a new listener to this node visitor.
      */
     public function addVisitListener(ASTVisitListener $listener): void;
@@ -145,11 +121,7 @@ interface ASTVisitor
     public function visitProperty(ASTProperty $property): void;
 
     /**
-     * @template T of array<string, mixed>|numeric-string
-     *
      * @param ASTNode $node
-     * @param T $value
-     * @return T
      */
-    public function visit($node, $value);
+    public function visit($node): void;
 }

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -55,7 +55,6 @@ use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTTrait;
-use RuntimeException;
 
 /**
  * This abstract visitor implementation provides a default traversal algorithm
@@ -72,36 +71,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
      * @var ASTVisitListener[]
      */
     private $listeners = [];
-
-    /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string $method Name of the called method.
-     * @param array<int, mixed> $args Array with method argument.
-     * @since  0.9.12
-     */
-    public function __call($method, $args)
-    {
-        if (!isset($args[1])) {
-            throw new RuntimeException("No node to visit provided for $method.");
-        }
-
-        return $this->visit($args[0], $args[1]);
-    }
 
     /**
      * Returns an iterator with all registered visit listeners.
@@ -278,13 +247,11 @@ abstract class AbstractASTVisitor implements ASTVisitor
         $this->fireEndProperty($property);
     }
 
-    public function visit($node, $value)
+    public function visit($node): void
     {
         foreach ($node->getChildren() as $child) {
-            $value = $child->accept($this, $value);
+            $child->accept($this);
         }
-
-        return $value;
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -578,34 +578,15 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testAcceptInvokesVisitOnGivenVisitor(): void
     {
-        $methodName = 'visit' . substr(static::class, 22, -4);
+        $node = $this->createNodeInstance();
 
         $visitor = $this->getMockBuilder(ASTVisitor::class)
             ->getMock();
         $visitor->expects(static::once())
-            ->method('__call')
-            ->with(static::equalTo($methodName));
+            ->method('visit')
+            ->with(static::equalTo($node));
 
-        $node = $this->createNodeInstance();
         $node->accept($visitor);
-    }
-
-    /**
-     * testAcceptReturnsReturnValueOfVisitMethod
-     */
-    public function testAcceptReturnsReturnValueOfVisitMethod(): void
-    {
-        $methodName = 'visit' . substr(static::class, 22, -4);
-
-        $visitor = $this->getMockBuilder(ASTVisitor::class)
-            ->getMock();
-        $visitor->expects(static::once())
-            ->method('__call')
-            ->with(static::equalTo($methodName))
-            ->will(static::returnValue(42));
-
-        $node = $this->createNodeInstance();
-        static::assertEquals(42, $node->accept($visitor));
     }
 
     /**

--- a/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
+++ b/src/test/php/PDepend/Source/ASTVisitor/StubASTVisitor.php
@@ -127,32 +127,6 @@ class StubASTVisitor implements ASTVisitor
     public $function;
 
     /**
-     * Magic call method used to provide simplified visitor implementations.
-     * With this method we can call <b>visit${NodeClassName}</b> on each node.
-     *
-     * <code>
-     * $visitor->visitAllocationExpression($alloc);
-     *
-     * $visitor->visitStatement($stmt);
-     * </code>
-     *
-     * All visit methods takes two argument. The first argument is the current
-     * context ast node and the second argument is a data array or object that
-     * is used to collect data.
-     *
-     * The return value of this method is the second input argument, modified
-     * by the concrete visit method.
-     *
-     * @param string $method Name of the called method.
-     * @param array $args Array with method argument.
-     * @return array
-     * @since 0.9.12
-     */
-    public function __call($method, $args)
-    {
-    }
-
-    /**
      * Adds a new listener to this node visitor.
      */
     public function addVisitListener(ASTVisitListener $listener): void
@@ -242,7 +216,7 @@ class StubASTVisitor implements ASTVisitor
     {
     }
 
-    public function visit($node, $value): void
+    public function visit($node): void
     {
     }
 }


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

This avoids having the analyzers data be passed though all of the visitors by instead collecting the information directly in analyzer state. This keeps all the analyzer logic local and avoids other parts of the code base having to account for it and avoids any issues of the data not being forwarded properly.
Only two of the analyzers actually made use of this feature and one was even simpler when not doing so.