### PR TITLE
Return empty string instead of null when missing an ID

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -54,7 +54,7 @@ interface ASTArtifact extends ASTNode
     /**
      * Returns a id for this code node.
      *
-     * @return ?string
+     * @return string
      */
     public function getId();
 }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -169,11 +169,11 @@ class ASTCompilationUnit extends AbstractASTArtifact
     /**
      * Returns a id for this code node.
      *
-     * @return string|null
+     * @return string
      */
     public function getId()
     {
-        return $this->id ?? null;
+        return $this->id ?? '';
     }
 
     /**

--- a/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -67,15 +67,6 @@ class ASTCompilationUnitTest extends AbstractTestCase
     }
 
     /**
-     * testGetIdReturnsNullByDefault
-     */
-    public function testGetIdReturnsNullByDefault(): void
-    {
-        $file = new ASTCompilationUnit(__FILE__);
-        static::assertNull($file->getId());
-    }
-
-    /**
      * testGetIdReturnsInjectedIdValue
      */
     public function testGetIdReturnsInjectedIdValue(): void


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: yes

This PR includes some of the final changes needed before we can convert PHPDoc to type hints for return values.

The `getId()` method now returns an empty string instead of `null` when no ID is set. This change aligns with how we've been using it to a large extent, and there's no clear reason why it should explicitly return `null`. None of the documentation clearly stated that it would, and most of its signatures do not hint it as nullable.

Similarly, the `getImage()` and `getName()` methods sometimes defaulted to an empty string instead of `null`, and was changed to always do so instead. There are no explicit guards against getting a `null` from `getId()` either. The alternative would be to make every instance that uses `getId()` handle a possible `null`, which would look like [this commit](https://github.com/pdepend/pdepend/commit/dcc29616fc253dd96aac81c974c91f6c729c3d97), but I think this is a cleaner solution.

We could also make `ASTCompilationUnit` generate an ID similar to some of the other implementations if that's prefered, but that seems like a bigger diviation.