### PR TITLE
Set explicit return value for ambigious method

### DIFF
--- a/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/src/test/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -146,11 +146,15 @@ class GlobalBuilderContextTest extends AbstractTestCase
      */
     public function testGetClassDelegatesCallToWrappedBuilder(): void
     {
+        $class = $this->getMockBuilder(ASTClass::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
         $builder->expects(static::once())
             ->method('getClass')
-            ->with(static::equalTo(__CLASS__));
+            ->with(static::equalTo(__CLASS__))
+            ->will(static::returnValue($class));
 
         $context = new GlobalBuilderContext($builder);
         $context->getClass(__CLASS__);


### PR DESCRIPTION
Type: refactoring
Breaking change: no

Mocks cannot be created with implicit return types for functions with union returns, so this change needs to be done in preperation for converting PHPDoc to return value type hints. Together with https://github.com/pdepend/pdepend/pull/845 this is the final such changes needed before we can do the conversion.