### PR TITLE
Convert PHPDoc to return type hints

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -83,10 +83,9 @@ class Application
     }
 
     /**
-     * @return Configuration
      * @throws Exception
      */
-    public function getConfiguration()
+    public function getConfiguration(): Configuration
     {
         $obj = $this->getContainer()->get('pdepend.configuration');
         assert($obj instanceof Configuration);
@@ -95,10 +94,9 @@ class Application
     }
 
     /**
-     * @return Engine
      * @throws Exception
      */
-    public function getEngine()
+    public function getEngine(): Engine
     {
         $obj = $this->getContainer()->get('pdepend.engine');
         assert($obj instanceof Engine);
@@ -107,10 +105,9 @@ class Application
     }
 
     /**
-     * @return Runner
      * @throws Exception
      */
-    public function getRunner()
+    public function getRunner(): Runner
     {
         $obj = $this->getContainer()->get('pdepend.textui.runner'); // TODO: Use standard name? textui is detail.
         assert($obj instanceof Runner);
@@ -119,10 +116,9 @@ class Application
     }
 
     /**
-     * @return ReportGeneratorFactory
      * @throws Exception
      */
-    public function getReportGeneratorFactory()
+    public function getReportGeneratorFactory(): ReportGeneratorFactory
     {
         $obj = $this->getContainer()->get('pdepend.report_generator_factory');
         assert($obj instanceof ReportGeneratorFactory);
@@ -131,10 +127,9 @@ class Application
     }
 
     /**
-     * @return AnalyzerFactory
      * @throws Exception
      */
-    public function getAnalyzerFactory()
+    public function getAnalyzerFactory(): AnalyzerFactory
     {
         $obj = $this->getContainer()->get('pdepend.analyzer_factory');
         assert($obj instanceof AnalyzerFactory);
@@ -143,10 +138,9 @@ class Application
     }
 
     /**
-     * @return TaggedContainerInterface
      * @throws Exception
      */
-    private function getContainer()
+    private function getContainer(): TaggedContainerInterface
     {
         if (!isset($this->container)) {
             $this->container = $this->createContainer();
@@ -156,10 +150,9 @@ class Application
     }
 
     /**
-     * @return TaggedContainerInterface
      * @throws Exception
      */
-    private function createContainer()
+    private function createContainer(): TaggedContainerInterface
     {
         $extensions = [new PdependExtension()];
 
@@ -188,7 +181,7 @@ class Application
      * @return array<string, array<string, string>>
      * @throws Exception
      */
-    public function getAvailableLoggerOptions()
+    public function getAvailableLoggerOptions(): array
     {
         return $this->getAvailableOptionsFor('pdepend.logger');
     }
@@ -199,7 +192,7 @@ class Application
      * @return array<string, array<string, string>>
      * @throws Exception
      */
-    public function getAvailableAnalyzerOptions()
+    public function getAvailableAnalyzerOptions(): array
     {
         return $this->getAvailableOptionsFor('pdepend.analyzer');
     }
@@ -208,7 +201,7 @@ class Application
      * @return array<string, array<string, string>>
      * @throws Exception
      */
-    private function getAvailableOptionsFor(string $serviceTag)
+    private function getAvailableOptionsFor(string $serviceTag): array
     {
         $container = $this->getContainer();
 

--- a/src/main/php/PDepend/DependencyInjection/Extension.php
+++ b/src/main/php/PDepend/DependencyInjection/Extension.php
@@ -64,10 +64,8 @@ abstract class Extension
 {
     /**
      * Return name of the extension
-     *
-     * @return string
      */
-    abstract public function getName();
+    abstract public function getName(): string;
 
     /**
      * Loads a specific configuration.
@@ -107,27 +105,23 @@ abstract class Extension
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses(): array
     {
         return [];
     }
 
     /**
      * Returns name of the service definition config without extension and path.
-     *
-     * @return string
      */
-    protected function getServiceDefinitionsName()
+    protected function getServiceDefinitionsName(): string
     {
         return 'services';
     }
 
     /**
      * Returns service definition configs path.
-     *
-     * @return string
      */
-    protected function getServiceDefinitionsPath()
+    protected function getServiceDefinitionsPath(): string
     {
         $reflection = new ReflectionClass($this);
 

--- a/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
+++ b/src/main/php/PDepend/DependencyInjection/ExtensionManager.php
@@ -83,7 +83,7 @@ class ExtensionManager
      *
      * @return array<Extension>
      */
-    public function getActivatedExtensions()
+    public function getActivatedExtensions(): array
     {
         return $this->extensions;
     }

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -115,9 +115,8 @@ class PdependExtension extends SymfonyExtension
 
     /**
      * @param array<string, array<string, string>> $config
-     * @return stdClass
      */
-    private function createSettings(array $config)
+    private function createSettings(array $config): stdClass
     {
         $settings = new stdClass();
 

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -68,20 +68,16 @@ class TreeBuilder
 
     /**
      * Get the root node of the built tree.
-     *
-     * @return ArrayNodeDefinition
      */
-    public function getRootNode()
+    public function getRootNode(): ArrayNodeDefinition
     {
         return $this->rootNode;
     }
 
     /**
      * Get the base Symfony tree builder.
-     *
-     * @return BaseTreeBuilder
      */
-    public function getTreeBuilder()
+    public function getTreeBuilder(): BaseTreeBuilder
     {
         return $this->treeBuilder;
     }

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilderFactory.php
@@ -67,10 +67,8 @@ class TreeBuilderFactory
 
     /**
      * Generates the configuration tree builder.
-     *
-     * @return TreeBuilder
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $home = FileUtil::getUserHomeDirOrSysTempDir();
 

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -281,7 +281,7 @@ class Engine
      * @return ASTArtifactList<ASTNamespace>
      * @throws InvalidArgumentException
      */
-    public function analyze()
+    public function analyze(): ASTArtifactList
     {
         $this->builder = new PHPBuilder();
 
@@ -318,10 +318,9 @@ class Engine
     /**
      * Returns the number of analyzed php classes and interfaces.
      *
-     * @return int
      * @throws RuntimeException
      */
-    public function countClasses()
+    public function countClasses(): int
     {
         if (!isset($this->namespaces)) {
             $msg = 'countClasses() doesn\'t work before the source was analyzed.';
@@ -343,7 +342,7 @@ class Engine
      *
      * @return ParserException[]
      */
-    public function getExceptions()
+    public function getExceptions(): array
     {
         return $this->parseExceptions;
     }
@@ -351,10 +350,9 @@ class Engine
     /**
      * Returns the number of analyzed namespaces.
      *
-     * @return int
      * @throws RuntimeException
      */
-    public function countNamespaces()
+    public function countNamespaces(): int
     {
         if (!isset($this->namespaces)) {
             $msg = 'countNamespaces() doesn\'t work before the source was analyzed.';
@@ -375,11 +373,10 @@ class Engine
     /**
      * Returns the analyzed namespace for the given name.
      *
-     * @return ASTNamespace
      * @throws OutOfBoundsException
      * @throws RuntimeException
      */
-    public function getNamespace(string $name)
+    public function getNamespace(string $name): ASTNamespace
     {
         if (!isset($this->namespaces)) {
             $msg = 'getNamespace() doesn\'t work before the source was analyzed.';
@@ -401,7 +398,7 @@ class Engine
      * @return ASTArtifactList<ASTNamespace>
      * @throws RuntimeException
      */
-    public function getNamespaces()
+    public function getNamespaces(): ASTArtifactList
     {
         if (!isset($this->namespaces)) {
             $msg = 'getNamespaces() doesn\'t work before the source was analyzed.';
@@ -586,7 +583,7 @@ class Engine
      * @return ArrayIterator<int, string>
      * @throws RuntimeException
      */
-    private function createFileIterator()
+    private function createFileIterator(): ArrayIterator
     {
         if (count($this->directories) === 0 && count($this->files) === 0) {
             throw new RuntimeException('No source directory and file set.');
@@ -647,7 +644,7 @@ class Engine
      * @return Analyzer[]
      * @throws InvalidArgumentException
      */
-    private function createAnalyzers(array $options)
+    private function createAnalyzers(array $options): array
     {
         $analyzers = $this->analyzerFactory->createRequiredForGenerators($this->generators);
 
@@ -672,10 +669,7 @@ class Engine
         return $analyzers;
     }
 
-    /**
-     * @return bool
-     */
-    private function isPhpStream(string $path)
+    private function isPhpStream(string $path): bool
     {
         return str_starts_with($path, $this->phpStreamPrefix);
     }

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -91,10 +91,9 @@ class ExcludePathFilter implements Filter
      * exclude patterns as an absolute path.
      *
      * @param string $path The absolute path to a source file.
-     * @return bool
      * @since  0.10.0
      */
-    protected function notAbsolute(string $path)
+    protected function notAbsolute(string $path): bool
     {
         return !preg_match($this->pattern, str_replace('\\', '/', $path));
     }
@@ -104,10 +103,9 @@ class ExcludePathFilter implements Filter
      * exclude patterns as an relative path.
      *
      * @param string $path The relative path to a source file.
-     * @return bool
      * @since  0.10.0
      */
-    protected function notRelative(string $path)
+    protected function notRelative(string $path): bool
     {
         $subPath = str_replace('\\', '/', $path);
 

--- a/src/main/php/PDepend/Input/Iterator.php
+++ b/src/main/php/PDepend/Input/Iterator.php
@@ -85,10 +85,9 @@ class Iterator extends FilterIterator
     /**
      * Returns the full qualified realpath for the currently active file.
      *
-     * @return string
      * @since  0.10.0
      */
-    protected function getFullPath()
+    protected function getFullPath(): string
     {
         return $this->getInnerIterator()->current()->getRealpath();
     }
@@ -97,10 +96,9 @@ class Iterator extends FilterIterator
      * Returns the local path of the current file, if the root path property was
      * set. If not, this method returns the absolute file path.
      *
-     * @return string
      * @since  0.10.0
      */
-    protected function getLocalPath()
+    protected function getLocalPath(): string
     {
         if ($this->rootPath && str_starts_with($this->getFullPath(), $this->rootPath)) {
             return substr($this->getFullPath(), strlen($this->rootPath));

--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -103,9 +103,8 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * value will be <b>FALSE</b>.
      *
      * @param ASTClass|ASTCompilationUnit|ASTFunction|ASTInterface|ASTMethod $node
-     * @return bool
      */
-    protected function restoreFromCache(AbstractASTArtifact $node)
+    protected function restoreFromCache(AbstractASTArtifact $node): bool
     {
         $id = $node->getId();
         if ($node->isCached() && isset($this->metricsCached[$id])) {

--- a/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AggregateAnalyzer.php
@@ -58,7 +58,7 @@ interface AggregateAnalyzer extends Analyzer
      *
      * @return array<string>
      */
-    public function getRequiredAnalyzers();
+    public function getRequiredAnalyzers(): array;
 
     /**
      * Adds a required sub analyzer.

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzer.php
@@ -118,7 +118,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      *
      * @return array<int, AbstractASTClassOrInterface>
      */
-    public function getAfferents(AbstractASTArtifact $node)
+    public function getAfferents(AbstractASTArtifact $node): array
     {
         $afferents = [];
         if (isset($this->afferentNodes[$node->getId()])) {
@@ -133,7 +133,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      *
      * @return array<int, AbstractASTClassOrInterface>
      */
-    public function getEfferents(AbstractASTArtifact $node)
+    public function getEfferents(AbstractASTArtifact $node): array
     {
         $efferents = [];
         if (isset($this->efferentNodes[$node->getId()])) {
@@ -269,7 +269,7 @@ class ClassDependencyAnalyzer extends AbstractAnalyzer
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.
      */
-    protected function collectCycle(array &$list, AbstractASTArtifact $node)
+    protected function collectCycle(array &$list, AbstractASTArtifact $node): bool
     {
         if (in_array($node, $list, true)) {
             $list[] = $node;

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -142,7 +142,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      *
      * @return array<string>
      */
-    public function getRequiredAnalyzers()
+    public function getRequiredAnalyzers(): array
     {
         return [CyclomaticComplexityAnalyzer::class];
     }
@@ -301,9 +301,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * counts protected and public properties of parent classes.
      *
      * @param ASTClass|ASTEnum|ASTTrait $class The context class instance.
-     * @return int
      */
-    private function calculateVarsi(AbstractASTClassOrInterface $class)
+    private function calculateVarsi(AbstractASTClassOrInterface $class): int
     {
         // List of properties, this method only counts not overwritten properties
         $properties = [];
@@ -326,10 +325,8 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Calculates the Weight Method Per Class metric, this method only counts
      * protected and public methods of parent classes.
-     *
-     * @return int
      */
-    private function calculateWmciForClass(AbstractASTClassOrInterface $class)
+    private function calculateWmciForClass(AbstractASTClassOrInterface $class): int
     {
         $ccn = $this->calculateWmci($class);
 
@@ -351,10 +348,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     /**
      * Calculates the Weight Method Per Class metric for a trait.
      *
-     * @return int
      * @since  1.0.6
      */
-    private function calculateWmciForTrait(ASTTrait $trait)
+    private function calculateWmciForTrait(ASTTrait $trait): int
     {
         return array_sum($this->calculateWmci($trait));
     }
@@ -365,7 +361,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * @return int[]
      * @since  1.0.6
      */
-    private function calculateWmci(AbstractASTType $type)
+    private function calculateWmci(AbstractASTType $type): array
     {
         $ccn = [];
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -195,7 +195,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * @param string $id2 Identifier for the outgoing edges.
      * @return array<string, float>
      */
-    protected function computeCodeRank(string $id1, string $id2)
+    protected function computeCodeRank(string $id1, string $id2): array
     {
         $dampingFactory = self::DAMPING_FACTOR;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/CodeRankStrategyI.php
@@ -58,5 +58,5 @@ interface CodeRankStrategyI extends ASTVisitor
      *
      * @return array<string, array<string, array<int, string>>>
      */
-    public function getCollectedNodes();
+    public function getCollectedNodes(): array;
 }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/InheritanceStrategy.php
@@ -69,7 +69,7 @@ class InheritanceStrategy extends AbstractASTVisitor implements CodeRankStrategy
      *
      * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
-    public function getCollectedNodes()
+    public function getCollectedNodes(): array
     {
         return $this->nodes;
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategy.php
@@ -68,7 +68,7 @@ class MethodStrategy extends AbstractASTVisitor implements CodeRankStrategyI
      *
      * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
-    public function getCollectedNodes()
+    public function getCollectedNodes(): array
     {
         return $this->nodes;
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategy.php
@@ -67,7 +67,7 @@ class PropertyStrategy extends AbstractASTVisitor implements CodeRankStrategyI
      *
      * @return array<string, array{in: string[], out: string[], name: string, type: class-string}>
      */
-    public function getCollectedNodes()
+    public function getCollectedNodes(): array
     {
         return $this->nodes;
     }

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -78,10 +78,8 @@ class StrategyFactory
 
     /**
      * Creates the default code rank strategy.
-     *
-     * @return CodeRankStrategyI
      */
-    public function createDefaultStrategy()
+    public function createDefaultStrategy(): CodeRankStrategyI
     {
         return $this->createStrategy($this->defaultStrategy);
     }
@@ -90,11 +88,10 @@ class StrategyFactory
      * Creates a code rank strategy for the given identifier.
      *
      * @param string $strategyName The strategy identifier.
-     * @return CodeRankStrategyI
      * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
      */
-    public function createStrategy(string $strategyName)
+    public function createStrategy(string $strategyName): CodeRankStrategyI
     {
         if (!isset($this->validStrategies[$strategyName])) {
             throw new InvalidArgumentException(

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -114,7 +114,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      *
      * @return array<string>
      */
-    public function getRequiredAnalyzers()
+    public function getRequiredAnalyzers(): array
     {
         return [CyclomaticComplexityAnalyzer::class];
     }
@@ -190,10 +190,8 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
 
     /**
      * Calculates the crap index for the given callable.
-     *
-     * @return float
      */
-    private function calculateCrapIndex(AbstractASTCallable $callable)
+    private function calculateCrapIndex(AbstractASTCallable $callable): float
     {
         $report = $this->createOrReturnCoverageReport();
 
@@ -212,10 +210,8 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
 
     /**
      * Calculates the code coverage for the given callable object.
-     *
-     * @return float
      */
-    private function calculateCoverage(AbstractASTCallable $callable)
+    private function calculateCoverage(AbstractASTCallable $callable): float
     {
         return $this->createOrReturnCoverageReport()->getCoverage($callable);
     }
@@ -223,20 +219,16 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
     /**
      * Returns a previously created report instance or creates a new report
      * instance.
-     *
-     * @return Report
      */
-    private function createOrReturnCoverageReport()
+    private function createOrReturnCoverageReport(): Report
     {
         return $this->report ??= $this->createCoverageReport();
     }
 
     /**
      * Creates a new coverage report instance.
-     *
-     * @return Report
      */
-    private function createCoverageReport()
+    private function createCoverageReport(): Report
     {
         $factory = new Factory();
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -115,10 +115,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
 
     /**
      * Returns the cyclomatic complexity for the given <b>$node</b> instance.
-     *
-     * @return int
      */
-    public function getCcn(ASTArtifact $node)
+    public function getCcn(ASTArtifact $node): int
     {
         $metrics = $this->getNodeMetrics($node);
 
@@ -128,10 +126,8 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
     /**
      * Returns the extended cyclomatic complexity for the given <b>$node</b>
      * instance.
-     *
-     * @return int
      */
-    public function getCcn2(ASTArtifact $node)
+    public function getCcn2(ASTArtifact $node): int
     {
         $metrics = $this->getNodeMetrics($node);
 

--- a/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/DependencyAnalyzer.php
@@ -162,7 +162,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      *
      * @return array<string, int>
      */
-    public function getStats(AbstractASTArtifact $node)
+    public function getStats(AbstractASTArtifact $node): array
     {
         $stats = [];
         if (isset($this->nodeMetrics[$node->getId()])) {
@@ -177,7 +177,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      *
      * @return AbstractASTArtifact[]
      */
-    public function getAfferents(AbstractASTArtifact $node)
+    public function getAfferents(AbstractASTArtifact $node): array
     {
         $afferents = [];
         if (isset($this->afferentNodes[$node->getId()])) {
@@ -193,7 +193,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      *
      * @return ASTNamespace[]
      */
-    public function getEfferents(AbstractASTArtifact $node)
+    public function getEfferents(AbstractASTArtifact $node): array
     {
         $efferents = [];
         if (isset($this->efferentNodes[$node->getId()])) {
@@ -211,7 +211,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * @param ASTNamespace $node
      * @return AbstractASTArtifact[]|null
      */
-    public function getCycle(AbstractASTArtifact $node)
+    public function getCycle(AbstractASTArtifact $node): ?array
     {
         if (array_key_exists($node->getId(), $this->collectedCycles)) {
             return $this->collectedCycles[$node->getId()];
@@ -450,7 +450,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.
      */
-    protected function collectCycle(array &$list, ASTNamespace $namespace)
+    protected function collectCycle(array &$list, ASTNamespace $namespace): bool
     {
         if (in_array($namespace, $list, true)) {
             $list[] = $namespace;

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -409,7 +409,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * @param bool $search Optional boolean flag, search start.
      * @return array<int, int>
      */
-    private function linesOfCode(array $tokens, bool $search = false)
+    private function linesOfCode(array $tokens, bool $search = false): array
     {
         $clines = [];
         $elines = [];

--- a/src/main/php/PDepend/Metrics/AnalyzerFactory.php
+++ b/src/main/php/PDepend/Metrics/AnalyzerFactory.php
@@ -70,7 +70,7 @@ class AnalyzerFactory
      * @return Analyzer[]
      * @throws InvalidArgumentException
      */
-    public function createRequiredForGenerators(array $generators)
+    public function createRequiredForGenerators(array $generators): array
     {
         $analyzers = [];
 

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -114,7 +114,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return [
             'pdepend.analyzer.class_dependency',
@@ -136,9 +136,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         if ($analyzer instanceof ClassDependencyAnalyzer) {
             $this->dependencyAnalyzer = $analyzer;

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -94,7 +94,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return ['pdepend.analyzer.dependency'];
     }
@@ -114,9 +114,8 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         if ($analyzer instanceof DependencyAnalyzer) {
             $this->analyzer = $analyzer;
@@ -217,7 +216,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
     /**
      * @return array<int, array{size: int, abstraction: int, instability: int, distance: int, name: string, ratio: int}>
      */
-    private function getItems()
+    private function getItems(): array
     {
         $items = [];
         foreach ($this->code as $namespace) {

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -131,7 +131,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return ['pdepend.analyzer.dependency'];
     }
@@ -151,9 +151,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         if ($analyzer instanceof DependencyAnalyzer) {
             $this->analyzer = $analyzer;

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -118,7 +118,7 @@ class Pyramid implements FileAwareGenerator
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return [
             'pdepend.analyzer.coupling',
@@ -134,9 +134,8 @@ class Pyramid implements FileAwareGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         if ($analyzer instanceof CyclomaticComplexityAnalyzer) {
             $this->cyclomaticComplexity = $analyzer;
@@ -219,9 +218,8 @@ class Pyramid implements FileAwareGenerator
      *
      * @param string $name The metric/field identfier.
      * @param mixed $value The metric/field value.
-     * @return string|null
      */
-    private function computeThreshold(string $name, mixed $value)
+    private function computeThreshold(string $name, mixed $value): ?string
     {
         if (!isset($this->thresholds[$name])) {
             return null;
@@ -250,7 +248,7 @@ class Pyramid implements FileAwareGenerator
      * @param array<string, float> $metrics The aggregated project metrics.
      * @return array<string, float>
      */
-    private function computeProportions(array $metrics)
+    private function computeProportions(array $metrics): array
     {
         $orders = [
             ['cyclo', 'loc', 'nom', 'noc', 'nop'],
@@ -281,7 +279,7 @@ class Pyramid implements FileAwareGenerator
      * @return array<string, float|int>
      * @throws RuntimeException If one of the required analyzers isn't set.
      */
-    private function collectMetrics()
+    private function collectMetrics(): array
     {
         if (!isset($this->coupling)) {
             throw new RuntimeException('Missing Coupling analyzer.');

--- a/src/main/php/PDepend/Report/ReportGenerator.php
+++ b/src/main/php/PDepend/Report/ReportGenerator.php
@@ -58,9 +58,8 @@ interface ReportGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer);
+    public function log(Analyzer $analyzer): bool;
 
     /**
      * Closes the logger process and writes the output file.
@@ -75,5 +74,5 @@ interface ReportGenerator
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers();
+    public function getAcceptedAnalyzers(): array;
 }

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -80,10 +80,9 @@ class ReportGeneratorFactory
      *
      * @param string $identifier The generator identifier.
      * @param string $fileName The log output file name.
-     * @return ReportGenerator
      * @throws RuntimeException
      */
-    public function createGenerator(string $identifier, string $fileName)
+    public function createGenerator(string $identifier, string $fileName): ReportGenerator
     {
         if (!isset($this->instances[$identifier])) {
             $loggerServices = $this->container->findTaggedServiceIds('pdepend.logger');

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -129,7 +129,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return [
             'pdepend.analyzer.cyclomatic_complexity',
@@ -163,9 +163,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         $accepted = false;
         if ($analyzer instanceof AnalyzerProjectAware) {

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -98,10 +98,8 @@ class ASTAnonymousClass extends ASTClass
 
     /**
      * Returns the start line for this ast node.
-     *
-     * @return int
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->getMetadataInteger(0);
     }
@@ -116,10 +114,8 @@ class ASTAnonymousClass extends ASTClass
 
     /**
      * Returns the end line for this ast node.
-     *
-     * @return int
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->getMetadataInteger(1);
     }
@@ -158,10 +154,8 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
-     *
-     * @return bool
      */
-    public function isAnonymous()
+    public function isAnonymous(): bool
     {
         return true;
     }
@@ -169,10 +163,9 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @return int
      * @since 0.10.4
      */
-    protected function getMetadataInteger(int $index)
+    protected function getMetadataInteger(int $index): int
     {
         return (int) $this->getMetadata($index);
     }
@@ -191,10 +184,9 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Returns the value that was stored under the given index.
      *
-     * @return string
      * @since 0.10.4
      */
-    protected function getMetadata(int $index)
+    protected function getMetadata(int $index): string
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
 
@@ -218,10 +210,9 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @since 0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 4;
     }

--- a/src/main/php/PDepend/Source/AST/ASTArguments.php
+++ b/src/main/php/PDepend/Source/AST/ASTArguments.php
@@ -69,10 +69,9 @@ class ASTArguments extends AbstractASTNode
     /**
      * This method will return true if the argument list is declared as foo(...)
      *
-     * @return bool
      * @since 2.11.0
      */
-    public function isVariadicPlaceholder()
+    public function isVariadicPlaceholder(): bool
     {
         return $this->getMetadataBoolean(4);
     }
@@ -89,10 +88,8 @@ class ASTArguments extends AbstractASTNode
 
     /**
      * Rather the given arguments list can still take one more argument.
-     *
-     * @return bool
      */
-    public function acceptsMoreArguments()
+    public function acceptsMoreArguments(): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTArrayElement.php
+++ b/src/main/php/PDepend/Source/AST/ASTArrayElement.php
@@ -66,10 +66,8 @@ class ASTArrayElement extends ASTExpression
     /**
      * This method will return <b>true</b> when the element value is passed by
      * reference.
-     *
-     * @return bool
      */
-    public function isByReference()
+    public function isByReference(): bool
     {
         return $this->getMetadataBoolean(5);
     }
@@ -85,11 +83,10 @@ class ASTArrayElement extends ASTExpression
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 6;
     }

--- a/src/main/php/PDepend/Source/AST/ASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifact.php
@@ -53,8 +53,6 @@ interface ASTArtifact extends ASTNode
 {
     /**
      * Returns a id for this code node.
-     *
-     * @return string
      */
-    public function getId();
+    public function getId(): string;
 }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/ArtifactFilter.php
@@ -56,8 +56,6 @@ interface ArtifactFilter
     /**
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
-     *
-     * @return bool
      */
-    public function accept(ASTArtifact $node);
+    public function accept(ASTArtifact $node): bool;
 }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -64,10 +64,8 @@ final class CollectionArtifactFilter implements ArtifactFilter
 
     /**
      * Singleton method for this filter class.
-     *
-     * @return CollectionArtifactFilter
      */
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (!isset(self::$instance)) {
             self::$instance = new self();
@@ -90,10 +88,8 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
-     *
-     * @return bool
      */
-    public function accept(ASTArtifact $node)
+    public function accept(ASTArtifact $node): bool
     {
         if ($this->filter === null) {
             return true;

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/NullArtifactFilter.php
@@ -56,10 +56,8 @@ class NullArtifactFilter implements ArtifactFilter
     /**
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
-     *
-     * @return bool
      */
-    public function accept(ASTArtifact $node)
+    public function accept(ASTArtifact $node): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/PackageArtifactFilter.php
@@ -76,10 +76,8 @@ class PackageArtifactFilter implements ArtifactFilter
     /**
      * Returns <b>true</b> if the given node should be part of the node iterator,
      * otherwise this method will return <b>false</b>.
-     *
-     * @return bool
      */
-    public function accept(ASTArtifact $node)
+    public function accept(ASTArtifact $node): bool
     {
         $namespace = null;
         // NOTE: This looks a little bit ugly and it seems better to exclude

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -54,5 +54,5 @@ interface ASTCallable extends ASTNode
     /**
      * @return ?ASTType
      */
-    public function getReturnType();
+    public function getReturnType(): ?ASTType;
 }

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -95,50 +95,40 @@ class ASTCastExpression extends ASTUnaryExpression
 
     /**
      * Returns <b>true</b> when this node represents an array cast-expression.
-     *
-     * @return bool
      */
-    public function isArray()
+    public function isArray(): bool
     {
         return ($this->getImage() === '(array)');
     }
 
     /**
      * Returns <b>true</b> when this node represents an object cast-expression.
-     *
-     * @return bool
      */
-    public function isObject()
+    public function isObject(): bool
     {
         return ($this->getImage() === '(object)');
     }
 
     /**
      * Returns <b>true</b> when this node represents a boolean cast-expression.
-     *
-     * @return bool
      */
-    public function isBoolean()
+    public function isBoolean(): bool
     {
         return ($this->getImage() === '(bool)' || $this->getImage() === '(boolean)');
     }
 
     /**
      * Returns <b>true</b> when this node represents an integer cast-expression.
-     *
-     * @return bool
      */
-    public function isInteger()
+    public function isInteger(): bool
     {
         return ($this->getImage() === '(int)' || $this->getImage() === '(integer)');
     }
 
     /**
      * Returns <b>true</b> when this node represents a float cast-expression.
-     *
-     * @return bool
      */
-    public function isFloat()
+    public function isFloat(): bool
     {
         return ($this->getImage() === '(real)'
             || $this->getImage() === '(float)'
@@ -148,20 +138,16 @@ class ASTCastExpression extends ASTUnaryExpression
 
     /**
      * Returns <b>true</b> when this node represents a string cast-expression.
-     *
-     * @return bool
      */
-    public function isString()
+    public function isString(): bool
     {
         return (strcmp('(string)', $this->getImage()) === 0);
     }
 
     /**
      * Returns <b>true</b> when this node represents an unset cast-expression.
-     *
-     * @return bool
      */
-    public function isUnset()
+    public function isUnset(): bool
     {
         return ($this->getImage() === '(unset)');
     }

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -78,30 +78,24 @@ class ASTClass extends AbstractASTClassOrInterface
 
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
-     *
-     * @return bool
      */
-    public function isAbstract()
+    public function isAbstract(): bool
     {
         return (($this->modifiers & State::IS_EXPLICIT_ABSTRACT) === State::IS_EXPLICIT_ABSTRACT);
     }
 
     /**
      * This method will return <b>true</b> when this class is declared as final.
-     *
-     * @return bool
      */
-    public function isFinal()
+    public function isFinal(): bool
     {
         return (($this->modifiers & State::IS_FINAL) === State::IS_FINAL);
     }
 
     /**
      * This method will return <b>true</b> when this class is declared as readonly.
-     *
-     * @return bool
      */
-    public function isReadonly()
+    public function isReadonly(): bool
     {
         return (($this->modifiers & State::IS_READONLY) === State::IS_READONLY);
     }
@@ -109,10 +103,8 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
-     *
-     * @return bool
      */
-    public function isAnonymous()
+    public function isAnonymous(): bool
     {
         return false;
     }
@@ -122,7 +114,7 @@ class ASTClass extends AbstractASTClassOrInterface
      *
      * @return ASTArtifactList<ASTProperty>
      */
-    public function getProperties()
+    public function getProperties(): ASTArtifactList
     {
         if (!isset($this->properties)) {
             $this->properties = [];
@@ -146,10 +138,8 @@ class ASTClass extends AbstractASTClassOrInterface
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @return bool
      */
-    public function isSubtypeOf(AbstractASTType $type)
+    public function isSubtypeOf(AbstractASTType $type): bool
     {
         if ($type === $this) {
             return true;
@@ -174,10 +164,9 @@ class ASTClass extends AbstractASTClassOrInterface
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return int
      * @since  0.9.4
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->modifiers;
     }

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -87,10 +87,9 @@ class ASTClassOrInterfaceReference extends ASTType
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return AbstractASTClassOrInterface
      * @throws RuntimeException
      */
-    public function getType()
+    public function getType(): AbstractASTClassOrInterface
     {
         if ($this->typeInstance === null) {
             if (!$this->context) {

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIterator.php
@@ -73,7 +73,7 @@ class ASTClassOrInterfaceReferenceIterator extends ASTArtifactList
      * @param ASTClassOrInterfaceReference[] $references
      * @return AbstractASTClassOrInterface[]
      */
-    protected function createClassesAndInterfaces(array $references)
+    protected function createClassesAndInterfaces(array $references): array
     {
         $classesAndInterfaces = [];
 

--- a/src/main/php/PDepend/Source/AST/ASTClassReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassReference.php
@@ -58,10 +58,9 @@ class ASTClassReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return ASTClass|ASTEnum
      * @throws RuntimeException
      */
-    public function getType()
+    public function getType(): ASTClass|ASTEnum
     {
         if (!$this->typeInstance instanceof ASTClass) {
             if (!$this->context) {

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -53,10 +53,7 @@ namespace PDepend\Source\AST;
  */
 class ASTClosure extends AbstractASTNode implements ASTCallable
 {
-    /**
-     * @return ASTType|null
-     */
-    public function getReturnType()
+    public function getReturnType(): ?ASTType
     {
         foreach ($this->nodes as $node) {
             if ($node instanceof ASTType) {
@@ -70,10 +67,8 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     /**
      * This method will return <b>true</b> when this closure returns by
      * reference.
-     *
-     * @return bool
      */
-    public function returnsByReference()
+    public function returnsByReference(): bool
     {
         return $this->getMetadataBoolean(5);
     }
@@ -108,10 +103,9 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * }
      * </code>
      *
-     * @return bool
      * @since  1.0.0
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return $this->getMetadataBoolean(6);
     }
@@ -130,11 +124,10 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @see    ASTNode#getMetadataSize()
      * @since  1.0.0
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 7;
     }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -139,40 +139,32 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the string representation of this class.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->fileName ?? '';
     }
 
     /**
      * Returns the physical file name for this object.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->fileName ?? '';
     }
 
     /**
      * Returns the physical file name for this object.
-     *
-     * @return string|null
      */
-    public function getFileName()
+    public function getFileName(): ?string
     {
         return $this->fileName;
     }
 
     /**
      * Returns a id for this code node.
-     *
-     * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         return $this->id ?? '';
     }
@@ -192,10 +184,8 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns normalized source code with stripped whitespaces.
-     *
-     * @return string|null
      */
-    public function getSource()
+    public function getSource(): ?string
     {
         $this->readSource();
 
@@ -207,7 +197,7 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      *
      * @return array<Token>
      */
-    public function getTokens()
+    public function getTokens(): array
     {
         /** @var Token[] */
         return (array) $this->cache
@@ -247,10 +237,9 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      * this value must always be <em>1</em>, while it can be <em>0</em> for a
      * not existing dummy file.
      *
-     * @return int
      * @since  0.10.0
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         if ($this->startLine === 0) {
             $this->readSource();
@@ -264,10 +253,9 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      * this value must always be greater <em>0</em>, while it can be <em>0</em>
      * for a not existing dummy file.
      *
-     * @return int
      * @since  0.10.0
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         if ($this->endLine === 0) {
             $this->readSource();
@@ -281,10 +269,9 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      * from the cache and not currently parsed. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return bool
      * @since  0.10.0
      */
-    public function isCached()
+    public function isCached(): bool
     {
         return $this->cached;
     }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDeclarator.php
@@ -99,10 +99,8 @@ class ASTConstantDeclarator extends AbstractASTNode
 
     /**
      * Returns the explicitly specified type of the constant.
-     *
-     * @return ASTType|null
      */
-    public function getType()
+    public function getType(): ?ASTType
     {
         return $this->type;
     }
@@ -117,10 +115,8 @@ class ASTConstantDeclarator extends AbstractASTNode
 
     /**
      * Returns the initial declaration value for this node.
-     *
-     * @return ASTValue|null
      */
-    public function getValue()
+    public function getValue(): ?ASTValue
     {
         return $this->value;
     }

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -66,10 +66,8 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
-     *
-     * @return int
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->getMetadataInteger(5);
     }
@@ -104,10 +102,8 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPublic()
+    public function isPublic(): bool
     {
         return (($this->getModifiers() & State::IS_PUBLIC) === State::IS_PUBLIC);
     }
@@ -115,10 +111,8 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return (($this->getModifiers() & State::IS_PROTECTED) === State::IS_PROTECTED);
     }
@@ -126,10 +120,8 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return (($this->getModifiers() & State::IS_PRIVATE) === State::IS_PRIVATE);
     }
@@ -137,11 +129,10 @@ class ASTConstantDefinition extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 6;
     }

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -96,7 +96,7 @@ class ASTDeclareStatement extends ASTStatement
      *
      * @return ASTValue[]
      */
-    public function getValues()
+    public function getValues(): array
     {
         return $this->values;
     }

--- a/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTElseIfStatement.php
@@ -57,10 +57,9 @@ class ASTElseIfStatement extends ASTStatement
      * Returns <b>true</b> when this <b>elseif</b>-statement is followed by an
      * <b>else</b>-statement.
      *
-     * @return bool
      * @since  0.9.12
      */
-    public function hasElse()
+    public function hasElse(): bool
     {
         return count($this->nodes) === 3;
     }

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -98,10 +98,8 @@ class ASTEnum extends AbstractASTClassOrInterface
      *   - either: ASTScalarType('string')
      *   - or:     ASTScalarType('int')
      * Returns null if basic enumeration: https://www.php.net/manual/en/language.enumerations.basics.php
-     *
-     * @return ASTScalarType|null
      */
-    public function getType()
+    public function getType(): ?ASTScalarType
     {
         return $this->type;
     }
@@ -109,30 +107,24 @@ class ASTEnum extends AbstractASTClassOrInterface
     /**
      * Returns <b>true</b> if backed enumeration: https://www.php.net/manual/en/language.enumerations.backed.php
      * Returns <b>false</b> if basic enumeration: https://www.php.net/manual/en/language.enumerations.basics.php
-     *
-     * @return bool
      */
-    public function isBacked()
+    public function isBacked(): bool
     {
         return $this->type !== null;
     }
 
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
-     *
-     * @return bool
      */
-    public function isAbstract()
+    public function isAbstract(): bool
     {
         return false;
     }
 
     /**
      * This method will return <b>true</b> when this class is declared as final.
-     *
-     * @return bool
      */
-    public function isFinal()
+    public function isFinal(): bool
     {
         return true;
     }
@@ -140,10 +132,8 @@ class ASTEnum extends AbstractASTClassOrInterface
     /**
      * Will return <b>true</b> if this class was declared anonymous in an
      * allocation expression.
-     *
-     * @return bool
      */
-    public function isAnonymous()
+    public function isAnonymous(): bool
     {
         return false;
     }
@@ -153,7 +143,7 @@ class ASTEnum extends AbstractASTClassOrInterface
      *
      * @return ASTArtifactList<ASTEnumCase>
      */
-    public function getCases()
+    public function getCases(): ASTArtifactList
     {
         return new ASTArtifactList(
             $this->findChildrenOfType(ASTEnumCase::class),
@@ -165,7 +155,7 @@ class ASTEnum extends AbstractASTClassOrInterface
      *
      * @return ASTArtifactList<ASTProperty>
      */
-    public function getProperties()
+    public function getProperties(): ASTArtifactList
     {
         /** @var ASTProperty[] $list */
         $list = [];
@@ -176,7 +166,7 @@ class ASTEnum extends AbstractASTClassOrInterface
     /**
      * @return ASTArtifactList<AbstractASTClassOrInterface>
      */
-    public function getInterfaces()
+    public function getInterfaces(): ASTArtifactList
     {
         $unitEnum = new ASTInterface('UnitEnum');
 
@@ -220,10 +210,8 @@ class ASTEnum extends AbstractASTClassOrInterface
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @return bool
      */
-    public function isSubtypeOf(AbstractASTType $type)
+    public function isSubtypeOf(AbstractASTType $type): bool
     {
         if ($type === $this) {
             return true;
@@ -248,10 +236,9 @@ class ASTEnum extends AbstractASTClassOrInterface
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return int
      * @since  0.9.4
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->modifiers;
     }

--- a/src/main/php/PDepend/Source/AST/ASTEnumCase.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnumCase.php
@@ -56,10 +56,8 @@ class ASTEnumCase extends AbstractASTNode implements ASTArtifact
 
     /**
      * Returns the enum definition of this case.
-     *
-     * @return ASTEnum
      */
-    public function getEnum()
+    public function getEnum(): ASTEnum
     {
         return $this->enum;
     }
@@ -72,18 +70,12 @@ class ASTEnumCase extends AbstractASTNode implements ASTArtifact
         $this->enum = $enum;
     }
 
-    /**
-     * @return string
-     */
-    public function getId()
+    public function getId(): string
     {
         return $this->getEnum()->getImage() . '::' . $this->getImage();
     }
 
-    /**
-     * @return ASTNode|null
-     */
-    public function getValue()
+    public function getValue(): ?ASTNode
     {
         return $this->nodes[0] ?? null;
     }

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -72,10 +72,8 @@ class ASTFieldDeclaration extends AbstractASTNode
 {
     /**
      * Checks if this parameter has a type.
-     *
-     * @return bool
      */
-    public function hasType()
+    public function hasType(): bool
     {
         return (reset($this->nodes) instanceof ASTType);
     }
@@ -83,10 +81,9 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns the type of this parameter.
      *
-     * @return ASTType
      * @throws OutOfBoundsException
      */
-    public function getType()
+    public function getType(): ASTType
     {
         $child = $this->getChild(0);
         if ($child instanceof ASTType) {
@@ -99,10 +96,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
-     *
-     * @return int
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->getMetadataInteger(5);
     }
@@ -138,10 +133,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPublic()
+    public function isPublic(): bool
     {
         return (($this->getModifiers() & State::IS_PUBLIC) === State::IS_PUBLIC);
     }
@@ -149,10 +142,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return (($this->getModifiers() & State::IS_PROTECTED) === State::IS_PROTECTED);
     }
@@ -160,10 +151,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return (($this->getModifiers() & State::IS_PRIVATE) === State::IS_PRIVATE);
     }
@@ -171,10 +160,8 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns <b>true</b> when this node is declared as static, otherwise
      * the returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return (($this->getModifiers() & State::IS_STATIC) === State::IS_STATIC);
     }
@@ -182,11 +169,10 @@ class ASTFieldDeclaration extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 6;
     }

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -71,10 +71,8 @@ class ASTFormalParameter extends AbstractASTNode
 
     /**
      * Checks if this parameter has a type.
-     *
-     * @return bool
      */
-    public function hasType()
+    public function hasType(): bool
     {
         return (reset($this->nodes) instanceof ASTType);
     }
@@ -82,10 +80,9 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Returns the type of this parameter.
      *
-     * @return ASTType
      * @throws OutOfBoundsException
      */
-    public function getType()
+    public function getType(): ASTType
     {
         $child = $this->getChild(0);
         if ($child instanceof ASTType) {
@@ -99,10 +96,9 @@ class ASTFormalParameter extends AbstractASTNode
      * This method will return <b>true</b> when the parameter is declared as a
      * variable argument list <b>...</b>.
      *
-     * @return bool
      * @since 2.0.7
      */
-    public function isVariableArgList()
+    public function isVariableArgList(): bool
     {
         return $this->getMetadataBoolean(6);
     }
@@ -119,10 +115,8 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * This method will return <b>true</b> when the parameter is passed by
      * reference.
-     *
-     * @return bool
      */
-    public function isPassedByReference()
+    public function isPassedByReference(): bool
     {
         return $this->getMetadataBoolean(5);
     }
@@ -138,11 +132,10 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @see    ASTNode#getMetadataSize()
      * @since  0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 7;
     }
@@ -150,10 +143,9 @@ class ASTFormalParameter extends AbstractASTNode
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return int
      * @since  0.9.4
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->modifiers;
     }
@@ -194,10 +186,8 @@ class ASTFormalParameter extends AbstractASTNode
      * returned value will be <b>false</b>.
      *
      * Can happen only on constructor promotion property.
-     *
-     * @return bool
      */
-    public function isPromoted()
+    public function isPromoted(): bool
     {
         return ($this->getModifiers() & (State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE)) !== 0;
     }
@@ -207,10 +197,8 @@ class ASTFormalParameter extends AbstractASTNode
      * returned value will be <b>false</b>.
      *
      * Can happen only on constructor promotion property.
-     *
-     * @return bool
      */
-    public function isPublic()
+    public function isPublic(): bool
     {
         return ($this->getModifiers() & State::IS_PUBLIC) === State::IS_PUBLIC;
     }
@@ -220,10 +208,8 @@ class ASTFormalParameter extends AbstractASTNode
      * returned value will be <b>false</b>.
      *
      * Can happen only on constructor promotion property.
-     *
-     * @return bool
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return ($this->getModifiers() & State::IS_PROTECTED) === State::IS_PROTECTED;
     }
@@ -233,10 +219,8 @@ class ASTFormalParameter extends AbstractASTNode
      * returned value will be <b>false</b>.
      *
      * Can happen only on constructor promotion property.
-     *
-     * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return ($this->getModifiers() & State::IS_PRIVATE) === State::IS_PRIVATE;
     }

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -118,7 +118,7 @@ class ASTFunction extends AbstractASTCallable
      *
      * @return ?ASTNamespace
      */
-    public function getNamespace()
+    public function getNamespace(): ?ASTNamespace
     {
         return $this->namespace;
     }
@@ -150,7 +150,7 @@ class ASTFunction extends AbstractASTCallable
      * @return ?string
      * @since  0.10.0
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): ?string
     {
         return $this->namespaceName;
     }

--- a/src/main/php/PDepend/Source/AST/ASTIfStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTIfStatement.php
@@ -57,10 +57,9 @@ class ASTIfStatement extends ASTStatement
      * Returns <b>true</b> when this <b>if</b>-statement is followed by an
      * <b>else</b>-statement.
      *
-     * @return bool
      * @since  0.9.12
      */
-    public function hasElse()
+    public function hasElse(): bool
     {
         return (count($this->nodes) === 3);
     }

--- a/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTIncludeExpression.php
@@ -71,10 +71,8 @@ class ASTIncludeExpression extends ASTExpression
 
     /**
      * Does this node represent a <b>include_once</b>-expression?
-     *
-     * @return bool
      */
-    public function isOnce()
+    public function isOnce(): bool
     {
         return $this->once;
     }

--- a/src/main/php/PDepend/Source/AST/ASTInterface.php
+++ b/src/main/php/PDepend/Source/AST/ASTInterface.php
@@ -76,10 +76,8 @@ class ASTInterface extends AbstractASTClassOrInterface
 
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
-     *
-     * @return bool
      */
-    public function isAbstract()
+    public function isAbstract(): bool
     {
         return true;
     }
@@ -99,10 +97,8 @@ class ASTInterface extends AbstractASTClassOrInterface
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
-     *
-     * @return bool
      */
-    public function isSubtypeOf(AbstractASTType $type)
+    public function isSubtypeOf(AbstractASTType $type): bool
     {
         if ($type === $this) {
             return true;
@@ -121,10 +117,9 @@ class ASTInterface extends AbstractASTClassOrInterface
     /**
      * Returns the declared modifiers for this type.
      *
-     * @return int
      * @since  0.9.4
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->modifiers;
     }

--- a/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTIntersectionType.php
@@ -55,10 +55,8 @@ class ASTIntersectionType extends AbstractASTCombinationType
 {
     /**
      * For this specific type it is always an intersection type.
-     *
-     * @return bool
      */
-    public function isIntersection()
+    public function isIntersection(): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTMatchArgument.php
@@ -59,10 +59,8 @@ class ASTMatchArgument extends ASTArguments
 {
     /**
      * Rather the given arguments list can still take one more argument.
-     *
-     * @return bool
      */
-    public function acceptsMoreArguments()
+    public function acceptsMoreArguments(): bool
     {
         return count($this->getChildren()) < 1;
     }

--- a/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
+++ b/src/main/php/PDepend/Source/AST/ASTMemberPrimaryPrefix.php
@@ -75,10 +75,8 @@ class ASTMemberPrimaryPrefix extends AbstractASTNode
     /**
      * Returns <b>true</b> when this member primary prefix represents a static
      * property or method access.
-     *
-     * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return ($this->getImage() === '::');
     }

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -75,10 +75,9 @@ class ASTMethod extends AbstractASTCallable
      * This method returns a OR combined integer of the declared modifiers for
      * this method.
      *
-     * @return int
      * @since  1.0.0
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->modifiers;
     }
@@ -111,10 +110,8 @@ class ASTMethod extends AbstractASTCallable
 
     /**
      * Returns <b>true</b> if this is an abstract method.
-     *
-     * @return bool
      */
-    public function isAbstract()
+    public function isAbstract(): bool
     {
         return (($this->modifiers & State::IS_ABSTRACT) === State::IS_ABSTRACT);
     }
@@ -122,10 +119,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPublic()
+    public function isPublic(): bool
     {
         return (($this->modifiers & State::IS_PUBLIC) === State::IS_PUBLIC);
     }
@@ -133,10 +128,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return (($this->modifiers & State::IS_PROTECTED) === State::IS_PROTECTED);
     }
@@ -144,10 +137,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return (($this->modifiers & State::IS_PRIVATE) === State::IS_PRIVATE);
     }
@@ -155,10 +146,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> when this node is declared as static, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return (($this->modifiers & State::IS_STATIC) === State::IS_STATIC);
     }
@@ -166,10 +155,8 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns <b>true</b> when this node is declared as final, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isFinal()
+    public function isFinal(): bool
     {
         return (($this->modifiers & State::IS_FINAL) === State::IS_FINAL);
     }
@@ -199,7 +186,7 @@ class ASTMethod extends AbstractASTCallable
      * @throws ASTCompilationUnitNotFoundException When no parent was set.
      * @since  0.10.0
      */
-    public function getCompilationUnit()
+    public function getCompilationUnit(): ?ASTCompilationUnit
     {
         if ($this->parentClass === null) {
             throw new ASTCompilationUnitNotFoundException($this);

--- a/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamedArgument.php
@@ -61,26 +61,17 @@ class ASTNamedArgument extends AbstractASTNode
         $this->addChild($value);
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @return ASTNode
-     */
-    public function getValue()
+    public function getValue(): ASTNode
     {
         return $this->getChild(0);
     }
 
-    /**
-     * @return string
-     */
-    public function getImage()
+    public function getImage(): string
     {
         return sprintf('%s: %s', $this->name, $this->getChild(0)->getImage());
     }

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -86,10 +86,9 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>class/method</b> is user defined. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return bool
      * @since  0.9.10
      */
-    public function isUserDefined()
+    public function isUserDefined(): bool
     {
         if (!isset($this->userDefined)) {
             $this->userDefined = $this->checkUserDefined();
@@ -103,10 +102,9 @@ class ASTNamespace extends AbstractASTArtifact
      * <b>class/method</b> is user defined. Otherwise this method will return
      * <b>false</b>.
      *
-     * @return bool
      * @since  0.9.10
      */
-    private function checkUserDefined()
+    private function checkUserDefined(): bool
     {
         foreach ($this->types as $type) {
             if ($type->isUserDefined()) {
@@ -124,7 +122,7 @@ class ASTNamespace extends AbstractASTArtifact
      * @return ASTArtifactList<ASTTrait>
      * @since  1.0.0
      */
-    public function getTraits()
+    public function getTraits(): ASTArtifactList
     {
         return $this->getTypesOfType(ASTTrait::class);
     }
@@ -135,7 +133,7 @@ class ASTNamespace extends AbstractASTArtifact
      *
      * @return ASTArtifactList<ASTClass>
      */
-    public function getClasses()
+    public function getClasses(): ASTArtifactList
     {
         return $this->getTypesOfType(ASTClass::class);
     }
@@ -146,7 +144,7 @@ class ASTNamespace extends AbstractASTArtifact
      *
      * @return ASTArtifactList<ASTEnum>
      */
-    public function getEnums()
+    public function getEnums(): ASTArtifactList
     {
         return $this->getTypesOfType(ASTEnum::class);
     }
@@ -157,7 +155,7 @@ class ASTNamespace extends AbstractASTArtifact
      *
      * @return ASTArtifactList<ASTInterface>
      */
-    public function getInterfaces()
+    public function getInterfaces(): ASTArtifactList
     {
         return $this->getTypesOfType(ASTInterface::class);
     }
@@ -172,7 +170,7 @@ class ASTNamespace extends AbstractASTArtifact
      * @return ASTArtifactList<T>
      * @since  1.0.0
      */
-    private function getTypesOfType($className)
+    private function getTypesOfType($className): ASTArtifactList
     {
         $types = [];
         foreach ($this->types as $type) {
@@ -190,7 +188,7 @@ class ASTNamespace extends AbstractASTArtifact
      *
      * @return ASTArtifactList<AbstractASTClassOrInterface>
      */
-    public function getTypes()
+    public function getTypes(): ASTArtifactList
     {
         return new ASTArtifactList($this->types);
     }
@@ -199,9 +197,8 @@ class ASTNamespace extends AbstractASTArtifact
      * Adds the given type to this namespace and returns the input type instance.
      *
      * @param AbstractASTClassOrInterface $type
-     * @return AbstractASTClassOrInterface
      */
-    public function addType(AbstractASTType $type)
+    public function addType(AbstractASTType $type): AbstractASTClassOrInterface
     {
         // Skip if this namespace already contains this type
         if (in_array($type, $this->types, true)) {
@@ -242,17 +239,15 @@ class ASTNamespace extends AbstractASTArtifact
      *
      * @return ASTArtifactList<ASTFunction>
      */
-    public function getFunctions()
+    public function getFunctions(): ASTArtifactList
     {
         return new ASTArtifactList($this->functions);
     }
 
     /**
      * Adds the given function to this namespace and returns the input instance.
-     *
-     * @return ASTFunction
      */
-    public function addFunction(ASTFunction $function)
+    public function addFunction(ASTFunction $function): ASTFunction
     {
         $namespace = $function->getNamespace();
         if ($namespace !== null) {
@@ -279,10 +274,7 @@ class ASTNamespace extends AbstractASTArtifact
         }
     }
 
-    /**
-     * @return bool
-     */
-    public function isPackageAnnotation()
+    public function isPackageAnnotation(): bool
     {
         return $this->packageAnnotation;
     }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -57,17 +57,13 @@ interface ASTNode
 {
     /**
      * Returns the source image of this ast node.
-     *
-     * @return string
      */
-    public function getImage();
+    public function getImage(): string;
 
     /**
      * Returns the start line for this ast node.
-     *
-     * @return int
      */
-    public function getStartLine();
+    public function getStartLine(): int;
 
     /**
      * Returns the start column for this ast node.
@@ -76,10 +72,8 @@ interface ASTNode
 
     /**
      * Returns the end line for this ast node.
-     *
-     * @return int
      */
-    public function getEndLine();
+    public function getEndLine(): int;
 
     /**
      * Returns the end column for this ast node.
@@ -89,10 +83,9 @@ interface ASTNode
     /**
      * Returns the node instance for the given index or throws an exception.
      *
-     * @return ASTNode
      * @throws OutOfBoundsException When no node exists at the given index.
      */
-    public function getChild(int $index);
+    public function getChild(int $index): self;
 
     /**
      * This method returns all direct children of the actual node.
@@ -125,7 +118,7 @@ interface ASTNode
      *                     is only for internal usage.
      * @return T[]
      */
-    public function findChildrenOfType($targetType, array &$results = []);
+    public function findChildrenOfType($targetType, array &$results = []): array;
 
     /**
      * Returns the parent node of this node or <b>null</b> when this node is
@@ -144,7 +137,7 @@ interface ASTNode
      *
      * @return ASTNode[]
      */
-    public function getParentsOfType(string $parentType);
+    public function getParentsOfType(string $parentType): array;
 
     /**
      * Returns a doc comment for this node or <b>null</b> when no comment was
@@ -152,7 +145,7 @@ interface ASTNode
      *
      * @return ?string
      */
-    public function getComment();
+    public function getComment(): ?string;
 
     /**
      * Sets the raw doc comment for this node.

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -101,10 +101,8 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
 
     /**
      * This method returns a string representation of this parameter.
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $required = $this->isOptional() ? 'optional' : 'required';
         $reference = $this->isPassedByReference() ? '&' : '';
@@ -150,20 +148,16 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the item name.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->variableDeclarator->getImage();
     }
 
     /**
      * Returns the line number where the item declaration can be found.
-     *
-     * @return int
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->formalParameter->getStartLine();
     }
@@ -173,7 +167,7 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      *
      * @return int The last source line for this item.
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->formalParameter->getEndLine();
     }
@@ -184,7 +178,7 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * @return ?AbstractASTCallable
      * @since  0.9.5
      */
-    public function getDeclaringFunction()
+    public function getDeclaringFunction(): ?AbstractASTCallable
     {
         return $this->declaringFunction;
     }
@@ -203,11 +197,10 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * This method will return the class where the parent method was declared.
      * The returned value will be <b>null</b> if the parent is a function.
      *
-     * @return AbstractASTClassOrInterface|null
      * @since  0.9.5
      * @todo Review this for refactoring, maybe create a empty getParent()?
      */
-    public function getDeclaringClass()
+    public function getDeclaringClass(): ?AbstractASTClassOrInterface
     {
         if ($this->declaringFunction instanceof ASTMethod) {
             return $this->declaringFunction->getParent();
@@ -218,10 +211,8 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the parameter position in the method/function signature.
-     *
-     * @return int
      */
-    public function getPosition()
+    public function getPosition(): int
     {
         return $this->position;
     }
@@ -240,10 +231,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * Returns the class type of this parameter. This method will return
      * <b>null</b> for all scalar type, only classes or interfaces are used.
      *
-     * @return AbstractASTClassOrInterface|null
      * @since  0.9.5
      */
-    public function getClass()
+    public function getClass(): ?AbstractASTClassOrInterface
     {
         $classReference = $this->formalParameter->getFirstChildOfType(
             ASTClassOrInterfaceReference::class,
@@ -259,10 +249,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when the parameter is passed by
      * reference.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function isPassedByReference()
+    public function isPassedByReference(): bool
     {
         return $this->formalParameter->isPassedByReference();
     }
@@ -271,10 +260,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when the parameter was declared with
      * the array type hint, otherwise the it will return <b>false</b>.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function isArray()
+    public function isArray(): bool
     {
         $node = $this->formalParameter->getChild(0);
 
@@ -286,10 +274,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * scalar or it is an <b>array</b> or type explicit declared with a default
      * value <b>null</b>.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function allowsNull()
+    public function allowsNull(): bool
     {
         $node = $this->formalParameter->getChild(0);
 
@@ -316,10 +303,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when this parameter is optional and
      * can be left blank on invocation.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function isOptional()
+    public function isOptional(): bool
     {
         return $this->optional;
     }
@@ -342,10 +328,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when the parameter declaration
      * contains a default value.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function isDefaultValueAvailable()
+    public function isDefaultValueAvailable(): bool
     {
         $value = $this->variableDeclarator->getValue();
         if ($value === null) {
@@ -373,18 +358,13 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the wrapped formal parameter instance.
-     *
-     * @return ASTFormalParameter
      */
-    public function getFormalParameter()
+    public function getFormalParameter(): ASTFormalParameter
     {
         return $this->formalParameter;
     }
 
-    /**
-     * @return bool
-     */
-    private function isTypeAllowingNull(ASTNode $node)
+    private function isTypeAllowingNull(ASTNode $node): bool
     {
         if ($node instanceof ASTUnionType) {
             foreach ($node->getChildren() as $child) {

--- a/src/main/php/PDepend/Source/AST/ASTParentReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTParentReference.php
@@ -84,20 +84,17 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
     /**
      * Returns the visual representation for this node type.
      *
-     * @return string
      * @since  0.10.4
      */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }
 
     /**
      * Returns the concrete type instance associated with with this placeholder.
-     *
-     * @return AbstractASTClassOrInterface
      */
-    public function getType()
+    public function getType(): AbstractASTClassOrInterface
     {
         return $this->reference->getType();
     }

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -74,10 +74,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * This method returns a string representation of this parameter.
      *
-     * @return string
      * @since  0.9.6
      */
-    public function __toString()
+    public function __toString(): string
     {
         $static = '';
 
@@ -103,10 +102,8 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the item name.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->variableDeclarator->getImage();
     }
@@ -115,10 +112,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      * This method returns a OR combined integer of the declared modifiers for
      * this property.
      *
-     * @return int
      * @since  0.9.6
      */
-    public function getModifiers()
+    public function getModifiers(): int
     {
         return $this->fieldDeclaration->getModifiers();
     }
@@ -126,10 +122,8 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns <b>true</b> if this node is marked as public, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPublic()
+    public function isPublic(): bool
     {
         return $this->fieldDeclaration->isPublic();
     }
@@ -137,10 +131,8 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns <b>true</b> if this node is marked as protected, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isProtected()
+    public function isProtected(): bool
     {
         return $this->fieldDeclaration->isProtected();
     }
@@ -148,10 +140,8 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns <b>true</b> if this node is marked as private, otherwise the
      * returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return $this->fieldDeclaration->isPrivate();
     }
@@ -159,10 +149,8 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns <b>true</b> when this node is declared as static, otherwise
      * the returned value will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return $this->fieldDeclaration->isStatic();
     }
@@ -171,10 +159,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when this property doc comment
      * contains an array type hint, otherwise the it will return <b>false</b>.
      *
-     * @return bool
      * @since  0.9.6
      */
-    public function isArray()
+    public function isArray(): bool
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
             ASTType::class,
@@ -190,10 +177,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when this property doc comment
      * contains a primitive type hint, otherwise the it will return <b>false</b>.
      *
-     * @return bool
      * @since  0.9.6
      */
-    public function isScalar()
+    public function isScalar(): bool
     {
         $typeNode = $this->fieldDeclaration->getFirstChildOfType(
             ASTType::class,
@@ -209,10 +195,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      * Returns the type of this property. This method will return <b>null</b>
      * for all scalar type, only class properties will have a type.
      *
-     * @return AbstractASTClassOrInterface|null
      * @since  0.9.5
      */
-    public function getClass()
+    public function getClass(): ?AbstractASTClassOrInterface
     {
         $reference = $this->fieldDeclaration->getFirstChildOfType(
             ASTClassOrInterfaceReference::class,
@@ -229,7 +214,7 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      *
      * @return ?string
      */
-    public function getComment()
+    public function getComment(): ?string
     {
         return $this->fieldDeclaration->getComment();
     }
@@ -237,10 +222,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns the line number where the property declaration can be found.
      *
-     * @return int
      * @since  0.9.6
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->variableDeclarator->getStartLine();
     }
@@ -258,10 +242,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * Returns the line number where the property declaration ends.
      *
-     * @return int
      * @since  0.9.6
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->variableDeclarator->getEndLine();
     }
@@ -279,10 +262,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
     /**
      * This method will return the class where this property was declared.
      *
-     * @return AbstractASTClassOrInterface
      * @since  0.9.6
      */
-    public function getDeclaringClass()
+    public function getDeclaringClass(): AbstractASTClassOrInterface
     {
         return $this->declaringClass;
     }
@@ -301,10 +283,9 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      * This method will return <b>true</b> when the parameter declaration
      * contains a default value.
      *
-     * @return bool
      * @since  0.9.6
      */
-    public function isDefaultValueAvailable()
+    public function isDefaultValueAvailable(): bool
     {
         $value = $this->variableDeclarator->getValue();
         if ($value === null) {

--- a/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTRequireExpression.php
@@ -71,10 +71,8 @@ class ASTRequireExpression extends ASTExpression
 
     /**
      * Does this node represent a <b>require_once</b>-expression?
-     *
-     * @return bool
      */
-    public function isOnce()
+    public function isOnce(): bool
     {
         return $this->once;
     }

--- a/src/main/php/PDepend/Source/AST/ASTScalarType.php
+++ b/src/main/php/PDepend/Source/AST/ASTScalarType.php
@@ -57,40 +57,32 @@ class ASTScalarType extends ASTType
     /**
      * This method will return <b>true</b> when this type is a php primitive.
      * For this concrete implementation the return value will be always true.
-     *
-     * @return bool
      */
-    public function isScalar()
+    public function isScalar(): bool
     {
         return true;
     }
 
     /**
      * This method will return <b>true</b> when this type is exactly null.
-     *
-     * @return bool
      */
-    public function isNull()
+    public function isNull(): bool
     {
         return $this->getImage() === 'null';
     }
 
     /**
      * This method will return <b>true</b> when this type is exactly false.
-     *
-     * @return bool
      */
-    public function isFalse()
+    public function isFalse(): bool
     {
         return $this->getImage() === 'false';
     }
 
     /**
      * This method will return <b>true</b> when this type is exactly false.
-     *
-     * @return bool
      */
-    public function isTrue()
+    public function isTrue(): bool
     {
         return $this->getImage() === 'true';
     }

--- a/src/main/php/PDepend/Source/AST/ASTSelfReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTSelfReference.php
@@ -102,10 +102,9 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * Returns the visual representation for this node type.
      *
-     * @return string
      * @since  0.10.4
      */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }
@@ -113,11 +112,10 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
     /**
      * Returns the class or interface instance that this node instance represents.
      *
-     * @return AbstractASTClassOrInterface
      * @throws RuntimeException
      * @since  0.10.0
      */
-    public function getType()
+    public function getType(): AbstractASTClassOrInterface
     {
         if ($this->typeInstance === null) {
             if (!$this->context) {

--- a/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftLeftExpression.php
@@ -58,10 +58,8 @@ class ASTShiftLeftExpression extends ASTExpression
 
     /**
      * Returns the source image of this ast node.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }

--- a/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTShiftRightExpression.php
@@ -58,10 +58,8 @@ class ASTShiftRightExpression extends ASTExpression
 
     /**
      * Returns the source image of this ast node.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }

--- a/src/main/php/PDepend/Source/AST/ASTStaticReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTStaticReference.php
@@ -60,10 +60,9 @@ class ASTStaticReference extends ASTSelfReference
     /**
      * Returns the visual representation for this node type.
      *
-     * @return string
      * @since  0.10.4
      */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }

--- a/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
+++ b/src/main/php/PDepend/Source/AST/ASTSwitchLabel.php
@@ -71,10 +71,8 @@ class ASTSwitchLabel extends AbstractASTNode
 
     /**
      * Returns <b>true</b> when this node is the default label.
-     *
-     * @return bool
      */
-    public function isDefault()
+    public function isDefault(): bool
     {
         return $this->default;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTrait.php
+++ b/src/main/php/PDepend/Source/AST/ASTTrait.php
@@ -73,7 +73,7 @@ class ASTTrait extends ASTClass
      * @since  1.0.6
      * @todo   Return properties declared by a trait.
      */
-    public function getProperties()
+    public function getProperties(): ASTArtifactList
     {
         /** @var ASTProperty[] $list */
         $list = [];
@@ -87,7 +87,7 @@ class ASTTrait extends ASTClass
      *
      * @return ASTMethod[]
      */
-    public function getAllMethods()
+    public function getAllMethods(): array
     {
         $methods = $this->getTraitMethods();
 
@@ -101,10 +101,9 @@ class ASTTrait extends ASTClass
     /**
      * Checks that this user type is a subtype of the given <b>$type</b> instance.
      *
-     * @return bool
      * @todo   Should we handle trait subtypes?
      */
-    public function isSubtypeOf(AbstractASTType $type)
+    public function isSubtypeOf(AbstractASTType $type): bool
     {
         return false;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -86,10 +86,8 @@ class ASTTraitAdaptationAlias extends ASTStatement
     /**
      * Returns the new method modifier or <b>-1</b> when this alias does not
      * specify a new method modifier.
-     *
-     * @return int
      */
-    public function getNewModifier()
+    public function getNewModifier(): int
     {
         return $this->newModifier;
     }
@@ -110,7 +108,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      *
      * @return ?string
      */
-    public function getNewName()
+    public function getNewName(): ?string
     {
         return $this->newName;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTraitReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitReference.php
@@ -58,10 +58,9 @@ class ASTTraitReference extends ASTClassOrInterfaceReference
     /**
      * Returns the concrete type instance associated with with this placeholder.
      *
-     * @return ASTTrait
      * @throws RuntimeException
      */
-    public function getType()
+    public function getType(): ASTTrait
     {
         if (!$this->typeInstance instanceof ASTTrait) {
             if (!$this->context) {

--- a/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitUseStatement.php
@@ -61,7 +61,7 @@ class ASTTraitUseStatement extends ASTStatement
      *
      * @return ASTMethod[]
      */
-    public function getAllMethods()
+    public function getAllMethods(): array
     {
         if (!isset($this->allMethods)) {
             $this->allMethods = [];
@@ -81,10 +81,8 @@ class ASTTraitUseStatement extends ASTStatement
      * by precedence statement in this use statement. It will return <b>true</b>
      * if the given <b>$method</b> is excluded, otherwise the return value of
      * this method will be <b>false</b>.
-     *
-     * @return bool
      */
-    public function hasExcludeFor(ASTMethod $method)
+    public function hasExcludeFor(ASTMethod $method): bool
     {
         $methodName = strtolower($method->getImage());
         $methodParent = $method->getParent();
@@ -132,7 +130,7 @@ class ASTTraitUseStatement extends ASTStatement
      *
      * @return ASTMethod[]
      */
-    private function getAliasesFor(ASTMethod $method)
+    private function getAliasesFor(ASTMethod $method): array
     {
         $name = strtolower($method->getImage());
 
@@ -195,7 +193,7 @@ class ASTTraitUseStatement extends ASTStatement
      *
      * @return ASTTraitAdaptationAlias[]
      */
-    private function getAliases()
+    private function getAliases(): array
     {
         return $this->findChildrenOfType(ASTTraitAdaptationAlias::class);
     }

--- a/src/main/php/PDepend/Source/AST/ASTType.php
+++ b/src/main/php/PDepend/Source/AST/ASTType.php
@@ -55,10 +55,8 @@ class ASTType extends AbstractASTNode
 {
     /**
      * This method will return <b>true</b> when the underlying type is an array.
-     *
-     * @return bool
      */
-    public function isArray()
+    public function isArray(): bool
     {
         return false;
     }
@@ -66,30 +64,24 @@ class ASTType extends AbstractASTNode
     /**
      * This method will return <b>true</b> when the underlying data type is a
      * php primitive.
-     *
-     * @return bool
      */
-    public function isScalar()
+    public function isScalar(): bool
     {
         return false;
     }
 
     /**
      * This method will return <b>true</b> when this type use union pipe to specify multiple types.
-     *
-     * @return bool
      */
-    public function isUnion()
+    public function isUnion(): bool
     {
         return false;
     }
 
     /**
      * This method will return <b>true</b> when this type uses intersection ampersand to specify multiple types.
-     *
-     * @return bool
      */
-    public function isIntersection()
+    public function isIntersection(): bool
     {
         return false;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeArray.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeArray.php
@@ -56,10 +56,7 @@ class ASTTypeArray extends ASTType
     /** The visual image for this node type. */
     public const IMAGE = 'array';
 
-    /**
-     * @return string
-     */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }
@@ -68,10 +65,8 @@ class ASTTypeArray extends ASTType
      * This method will return <b>true</b> when the underlying type is an array.
      * For this concrete type implementation the returned value will be always
      * <b>true</b>.
-     *
-     * @return bool
      */
-    public function isArray()
+    public function isArray(): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeCallable.php
@@ -56,10 +56,7 @@ class ASTTypeCallable extends ASTType
     /** The visual image for this node type. */
     public const IMAGE = 'callable';
 
-    /**
-     * @return string
-     */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }

--- a/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
+++ b/src/main/php/PDepend/Source/AST/ASTTypeIterable.php
@@ -56,10 +56,7 @@ class ASTTypeIterable extends ASTType
     /** The visual image for this node type. */
     public const IMAGE = 'iterable';
 
-    /**
-     * @return string
-     */
-    public function getImage()
+    public function getImage(): string
     {
         return self::IMAGE;
     }
@@ -68,10 +65,8 @@ class ASTTypeIterable extends ASTType
      * This method will return <b>true</b> when the underlying type is an array.
      * For this concrete type implementation the returned value will be always
      * <b>true</b>.
-     *
-     * @return bool
      */
-    public function isArray()
+    public function isArray(): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTUnionType.php
+++ b/src/main/php/PDepend/Source/AST/ASTUnionType.php
@@ -57,10 +57,8 @@ class ASTUnionType extends AbstractASTCombinationType
     /**
      * This method will return <b>true</b> when this type use union pipe to specify multiple types.
      * For this concrete implementation the return value will be always true.
-     *
-     * @return bool
      */
-    public function isUnion()
+    public function isUnion(): bool
     {
         return true;
     }

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -86,10 +86,8 @@ class ASTValue
 
     /**
      * This method will return <b>true</b> when the PHP-value is already set.
-     *
-     * @return bool
      */
-    public function isValueAvailable()
+    public function isValueAvailable(): bool
     {
         return $this->valueAvailable;
     }

--- a/src/main/php/PDepend/Source/AST/ASTVariable.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariable.php
@@ -63,10 +63,9 @@ class ASTVariable extends ASTExpression
      * This method will return <b>true</b> when this variable instance represents
      * the <b>$this</b> scope of a class instance.
      *
-     * @return bool
      * @since  0.10.0
      */
-    public function isThis()
+    public function isThis(): bool
     {
         return ($this->getImage() === '$this');
     }

--- a/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
+++ b/src/main/php/PDepend/Source/AST/ASTVariableDeclarator.php
@@ -74,10 +74,8 @@ class ASTVariableDeclarator extends ASTExpression
     /**
      * Returns the initial declaration value for this node or <b>null</b> when
      * no default value exists.
-     *
-     * @return ASTValue|null
      */
-    public function getValue()
+    public function getValue(): ?ASTValue
     {
         return $this->value;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -93,10 +93,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Returns the source image of this ast node.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->name;
     }
@@ -114,10 +112,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Returns a id for this code node.
-     *
-     * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         if (!isset($this->id)) {
             $this->id = md5(uniqid('', true));
@@ -139,10 +135,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Returns the source file for this item.
-     *
-     * @return ASTCompilationUnit|null
      */
-    public function getCompilationUnit()
+    public function getCompilationUnit(): ?ASTCompilationUnit
     {
         return $this->compilationUnit;
     }
@@ -234,10 +228,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
     /**
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
-     *
-     * @return string|null
      */
-    public function getComment()
+    public function getComment(): ?string
     {
         return $this->comment;
     }
@@ -262,10 +254,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Returns the line number where the class or interface declaration starts.
-     *
-     * @return int
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->startLine;
     }
@@ -277,10 +267,8 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Returns the line number where the class or interface declaration ends.
-     *
-     * @return int
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->endLine;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCallable.php
@@ -173,7 +173,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      *
      * @return Token[]
      */
-    public function getTokens()
+    public function getTokens(): array
     {
         /** @var Token[] */
         return (array) $this->cache
@@ -204,10 +204,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns the line number where the callable declaration starts.
      *
-     * @return int
      * @since  0.9.6
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->startLine;
     }
@@ -215,10 +214,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns the line number where the callable declaration ends.
      *
-     * @return int
      * @since  0.9.6
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->endLine;
     }
@@ -226,10 +224,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns all {@link AbstractASTClassOrInterface}
      * objects this function depends on.
-     *
-     * @return ASTClassOrInterfaceReferenceIterator
      */
-    public function getDependencies()
+    public function getDependencies(): ASTClassOrInterfaceReferenceIterator
     {
         return new ASTClassOrInterfaceReferenceIterator(
             $this->findChildrenOfType(
@@ -243,10 +239,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * the return value of this callable. The returned value will be <b>null</b>
      * if there is no return value or the return value is scalat.
      *
-     * @return AbstractASTClassOrInterface|null
      * @since  0.9.5
      */
-    public function getReturnClass()
+    public function getReturnClass(): ?AbstractASTClassOrInterface
     {
         if ($this->returnClassReference) {
             return $this->returnClassReference->getType();
@@ -262,10 +257,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * Tests if this callable has a return class and return <b>true</b> if it is
      * configured.
      *
-     * @return bool
      * @since 2.2.4
      */
-    public function hasReturnClass()
+    public function hasReturnClass(): bool
     {
         if ($this->returnClassReference) {
             return true;
@@ -277,10 +271,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
         return false;
     }
 
-    /**
-     * @return ASTType|null
-     */
-    public function getReturnType()
+    public function getReturnType(): ?ASTType
     {
         foreach ($this->nodes as $node) {
             if ($node instanceof ASTType) {
@@ -319,10 +310,8 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns an iterator with thrown exception
      * {@link AbstractASTClassOrInterface} instances.
-     *
-     * @return ASTClassOrInterfaceReferenceIterator
      */
-    public function getExceptionClasses()
+    public function getExceptionClasses(): ASTClassOrInterfaceReferenceIterator
     {
         return new ASTClassOrInterfaceReferenceIterator(
             $this->exceptionClassReferences,
@@ -334,7 +323,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      *
      * @return ASTParameter[]
      */
-    public function getParameters()
+    public function getParameters(): array
     {
         if (!isset($this->parameters)) {
             $this->initParameters();
@@ -347,10 +336,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * This method will return <b>true</b> when this method returns a value by
      * reference, otherwise the return value will be <b>false</b>.
      *
-     * @return bool
      * @since  0.9.5
      */
-    public function returnsReference()
+    public function returnsReference(): bool
     {
         return $this->returnsReference;
     }
@@ -373,7 +361,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * @return array<string, mixed>
      * @since  0.9.6
      */
-    public function getStaticVariables()
+    public function getStaticVariables(): array
     {
         $staticVariables = [];
 
@@ -403,10 +391,9 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * restored from the cache and not currently parsed. Otherwise this method
      * will return <b>false</b>.
      *
-     * @return bool
      * @since  0.10.0
      */
-    public function isCached()
+    public function isCached(): bool
     {
         return $this->compilationUnit?->isCached() ?? false;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -97,10 +97,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns the parent class or <b>null</b> if this class has no parent.
      *
-     * @return ASTClass|ASTEnum|null
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      */
-    public function getParentClass()
+    public function getParentClass(): null|ASTClass|ASTEnum
     {
         // No parent? Stop here!
         if ($this->parentClassReference === null) {
@@ -134,7 +133,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @throws ASTClassOrInterfaceRecursiveInheritanceException
      * @since  1.0.0
      */
-    public function getParentClasses()
+    public function getParentClasses(): array
     {
         $parents = [];
         $parent = $this;
@@ -153,10 +152,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns a reference onto the parent class of this class node or <b>null</b>.
      *
-     * @return ASTClassReference|null
      * @since  0.9.5
      */
-    public function getParentClassReference()
+    public function getParentClassReference(): ?ASTClassReference
     {
         return $this->parentClassReference;
     }
@@ -179,7 +177,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @return ASTArtifactList<AbstractASTClassOrInterface>
      * @since  0.9.5
      */
-    public function getInterfaces()
+    public function getInterfaces(): ASTArtifactList
     {
         return new ASTArtifactList($this->getInterfacesClasses());
     }
@@ -190,7 +188,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @return ASTClassOrInterfaceReference[]
      * @since  0.10.4
      */
-    public function getInterfaceReferences()
+    public function getInterfaceReferences(): array
     {
         return $this->interfaceReferences;
     }
@@ -212,7 +210,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @return array<string, mixed>
      */
-    public function getConstants()
+    public function getConstants(): array
     {
         $constants = $this->constants;
         if ($constants === null) {
@@ -228,7 +226,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @return array<string, ASTConstantDeclarator>
      */
-    public function getConstantDeclarators()
+    public function getConstantDeclarators(): array
     {
         if (!isset($this->constantDeclarators)) {
             $this->initConstantDeclarators();
@@ -243,10 +241,9 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      *
      * @phpstan-assert-if-true !null $this->constants
      * @param string $name Name of the searched constant.
-     * @return bool
      * @since  0.9.6
      */
-    public function hasConstant(string $name)
+    public function hasConstant(string $name): bool
     {
         if ($this->constants === null) {
             $this->constants = $this->initConstants();
@@ -277,7 +274,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @return ASTMethod[]
      * @since  0.9.10
      */
-    public function getAllMethods()
+    public function getAllMethods(): array
     {
         $methods = [];
         foreach ($this->getInterfaces() as $interface) {
@@ -306,10 +303,8 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
     /**
      * Returns all {@link AbstractASTClassOrInterface}
      * objects this type depends on.
-     *
-     * @return ASTClassOrInterfaceReferenceIterator
      */
-    public function getDependencies()
+    public function getDependencies(): ASTClassOrInterfaceReferenceIterator
     {
         $references = $this->interfaceReferences;
         if ($this->parentClassReference !== null) {
@@ -321,24 +316,20 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
 
     /**
      * Returns <b>true</b> if this is an abstract class or an interface.
-     *
-     * @return bool
      */
-    abstract public function isAbstract();
+    abstract public function isAbstract(): bool;
 
     /**
      * Returns the declared modifiers for this type.
-     *
-     * @return int
      */
-    abstract public function getModifiers();
+    abstract public function getModifiers(): int;
 
     /**
      * Returns an array with all implemented interfaces.
      *
      * @return AbstractASTClassOrInterface[]
      */
-    protected function getInterfacesClasses()
+    protected function getInterfacesClasses(): array
     {
         $stack = $this->getParentClasses();
         array_unshift($stack, $this);

--- a/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTCombinationType.php
@@ -53,17 +53,12 @@ namespace PDepend\Source\AST;
  */
 abstract class AbstractASTCombinationType extends ASTType
 {
-    /**
-     * @return string
-     */
-    abstract protected function getSymbol();
+    abstract protected function getSymbol(): string;
 
     /**
      * Return concatenated allowed types string representation.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return implode($this->getSymbol(), array_map(function ($type) {
             $image = $type->getImage();

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -135,20 +135,16 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Returns the source image of this ast node.
-     *
-     * @return string
      */
-    public function getImage()
+    public function getImage(): string
     {
         return $this->getMetadata(4);
     }
 
     /**
      * Returns the source image of this ast node without the namespace prefix.
-     *
-     * @return string
      */
-    public function getImageWithoutNamespace()
+    public function getImageWithoutNamespace(): string
     {
         $imagePath = explode('\\', $this->getMetadata(4));
 
@@ -157,10 +153,8 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Returns the start line for this ast node.
-     *
-     * @return int
      */
-    public function getStartLine()
+    public function getStartLine(): int
     {
         return $this->getMetadataInteger(0);
     }
@@ -175,10 +169,8 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Returns the end line for this ast node.
-     *
-     * @return int
      */
-    public function getEndLine()
+    public function getEndLine(): int
     {
         return $this->getMetadataInteger(1);
     }
@@ -212,10 +204,9 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @return int
      * @since 0.10.4
      */
-    protected function getMetadataInteger(int $index)
+    protected function getMetadataInteger(int $index): int
     {
         return (int) $this->getMetadata($index);
     }
@@ -234,10 +225,9 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns a boolean value that was stored under the given index.
      *
-     * @return bool
      * @since 0.10.4
      */
-    protected function getMetadataBoolean(int $index)
+    protected function getMetadataBoolean(int $index): bool
     {
         return (bool) $this->getMetadata($index);
     }
@@ -256,10 +246,9 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the value that was stored under the given index.
      *
-     * @return string
      * @since 0.10.4
      */
-    protected function getMetadata(int $index)
+    protected function getMetadata(int $index): string
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
 
@@ -283,10 +272,9 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the total number of the used property bag.
      *
-     * @return int
      * @since 0.10.4
      */
-    protected function getMetadataSize()
+    protected function getMetadataSize(): int
     {
         return 5;
     }
@@ -294,10 +282,9 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the node instance for the given index or throws an exception.
      *
-     * @return ASTNode
      * @throws OutOfBoundsException When no node exists at the given index.
      */
-    public function getChild(int $index)
+    public function getChild(int $index): ASTNode
     {
         if (isset($this->nodes[$index])) {
             return $this->nodes[$index];
@@ -358,7 +345,7 @@ abstract class AbstractASTNode implements ASTNode
      *                     is only for internal usage.
      * @return T[]
      */
-    public function findChildrenOfType($targetType, array &$results = [])
+    public function findChildrenOfType($targetType, array &$results = []): array
     {
         foreach ($this->nodes as $node) {
             if ($node instanceof $targetType) {
@@ -403,7 +390,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @return ASTNode[]
      */
-    public function getParentsOfType(string $parentType)
+    public function getParentsOfType(string $parentType): array
     {
         $parents = [];
 
@@ -432,7 +419,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @return ?string
      */
-    public function getComment()
+    public function getComment(): ?string
     {
         return $this->comment;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -194,10 +194,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * This method will return <b>true</b> when this type has a declaration in
      * the analyzed source files.
-     *
-     * @return bool
      */
-    public function isUserDefined()
+    public function isUserDefined(): bool
     {
         return $this->userDefined;
     }
@@ -216,7 +214,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return ASTArtifactList<ASTMethod>
      */
-    public function getMethods()
+    public function getMethods(): ASTArtifactList
     {
         if (is_array($this->methods)) {
             return new ASTArtifactList($this->methods);
@@ -239,10 +237,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
     /**
      * Adds the given method to this type.
-     *
-     * @return ASTMethod
      */
-    public function addMethod(ASTMethod $method)
+    public function addMethod(ASTMethod $method): ASTMethod
     {
         if ($this instanceof AbstractASTClassOrInterface) {
             $method->setParent($this);
@@ -258,7 +254,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return Token[]
      */
-    public function getTokens()
+    public function getTokens(): array
     {
         /** @var Token[] */
         return (array) $this->cache
@@ -292,10 +288,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
             ->store($this->getId(), $tokens);
     }
 
-    /**
-     * @return string
-     */
-    public function getNamespacedName()
+    public function getNamespacedName(): string
     {
         if (null === $this->namespace || $this->namespace->isPackageAnnotation()) {
             return $this->name;
@@ -309,7 +302,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return ?string
      */
-    public function getNamespaceName()
+    public function getNamespaceName(): ?string
     {
         return $this->namespaceName;
     }
@@ -319,7 +312,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return ?ASTNamespace
      */
-    public function getNamespace()
+    public function getNamespace(): ?ASTNamespace
     {
         return $this->namespace;
     }
@@ -346,10 +339,8 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * This method will return <b>true</b> when this class or interface instance
      * was restored from the cache and not currently parsed. Otherwise this
      * method will return <b>false</b>.
-     *
-     * @return bool
      */
-    public function isCached()
+    public function isCached(): bool
     {
         return $this->compilationUnit?->isCached() ?? false;
     }
@@ -359,16 +350,15 @@ abstract class AbstractASTType extends AbstractASTArtifact
      *
      * @return ASTMethod[]
      */
-    abstract public function getAllMethods();
+    abstract public function getAllMethods(): array;
 
     /**
      * Checks that this user type is a subtype of the given <b>$type</b>
      * instance.
      *
-     * @return bool
      * @since  1.0.6
      */
-    abstract public function isSubtypeOf(self $type);
+    abstract public function isSubtypeOf(self $type): bool;
 
     /**
      * Returns an array with {@link ASTMethod} objects
@@ -378,7 +368,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      * @throws ASTTraitMethodCollisionException
      * @since  1.0.0
      */
-    protected function getTraitMethods()
+    protected function getTraitMethods(): array
     {
         $methods = [];
 

--- a/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/main/php/PDepend/Source/ASTVisitor/AbstractASTVisitor.php
@@ -78,7 +78,7 @@ abstract class AbstractASTVisitor implements ASTVisitor
      *
      * @return Iterator<ASTVisitListener>
      */
-    public function getVisitListeners()
+    public function getVisitListeners(): Iterator
     {
         return new ArrayIterator($this->listeners);
     }

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -192,27 +192,24 @@ interface Builder extends IteratorAggregate
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @return AbstractASTClassOrInterface
      * @since  0.9.5
      */
-    public function getClassOrInterface(string $qualifiedName);
+    public function getClassOrInterface(string $qualifiedName): AbstractASTClassOrInterface;
 
     /**
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstClassOrInterfaceReference(string $qualifiedName);
+    public function buildAstClassOrInterfaceReference(string $qualifiedName): ASTClassOrInterfaceReference;
 
     /**
      * Builds a new php trait instance.
      *
-     * @return ASTTrait
      * @since  1.0.0
      */
-    public function buildTrait(string $qualifiedName);
+    public function buildTrait(string $qualifiedName): ASTTrait;
 
     /**
      * Restores an existing trait instance within the context of this builder.
@@ -226,34 +223,28 @@ interface Builder extends IteratorAggregate
      * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
-     * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait(string $qualifiedName);
+    public function getTrait(string $qualifiedName): ASTTrait;
 
     /**
      * Builds a new code class instance.
-     *
-     * @return ASTClass
      */
-    public function buildClass(string $qualifiedName);
+    public function buildClass(string $qualifiedName): ASTClass;
 
     /**
      * Builds an anonymous class instance.
-     *
-     * @return ASTAnonymousClass
      */
-    public function buildAnonymousClass();
+    public function buildAnonymousClass(): ASTAnonymousClass;
 
     /**
      * This method will try to find an already existing instance for the given
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @return ASTClass|ASTEnum
      * @since  0.9.5
      */
-    public function getClass(string $qualifiedName);
+    public function getClass(string $qualifiedName): ASTClass|ASTEnum;
 
     /**
      * Restores an existing class instance within the context of this builder.
@@ -273,17 +264,14 @@ interface Builder extends IteratorAggregate
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     * @return ASTClassReference
      * @since  0.9.5
      */
-    public function buildAstClassReference(string $qualifiedName);
+    public function buildAstClassReference(string $qualifiedName): ASTClassReference;
 
     /**
      * Builds a new new interface instance.
-     *
-     * @return ASTInterface
      */
-    public function buildInterface(string $qualifiedName);
+    public function buildInterface(string $qualifiedName): ASTInterface;
 
     /**
      * Restores an existing interface instance within the context of this builder.
@@ -298,236 +286,205 @@ interface Builder extends IteratorAggregate
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
-     * @return ASTInterface
      * @since  0.9.5
      */
-    public function getInterface(string $qualifiedName);
+    public function getInterface(string $qualifiedName): ASTInterface;
 
     /**
      * Builds a new namespace instance.
-     *
-     * @return ASTNamespace
      */
-    public function buildNamespace(string $name);
+    public function buildNamespace(string $name): ASTNamespace;
 
     /**
      * Builds a new method instance.
-     *
-     * @return ASTMethod
      */
-    public function buildMethod(string $name);
+    public function buildMethod(string $name): ASTMethod;
 
     /**
      * Builds a new function instance.
-     *
-     * @return ASTFunction
      */
-    public function buildFunction(string $name);
+    public function buildFunction(string $name): ASTFunction;
 
     /**
      * Builds a new self reference instance.
      *
-     * @return ASTSelfReference
      * @since  0.9.6
      */
-    public function buildAstSelfReference(AbstractASTClassOrInterface $type);
+    public function buildAstSelfReference(AbstractASTClassOrInterface $type): ASTSelfReference;
 
     /**
      * Builds a new parent reference instance.
      *
      * @param ASTClassOrInterfaceReference $reference The type instance that reference the concrete target of parent.
-     * @return ASTParentReference
      * @since  0.9.6
      */
-    public function buildAstParentReference(ASTClassOrInterfaceReference $reference);
+    public function buildAstParentReference(ASTClassOrInterfaceReference $reference): ASTParentReference;
 
     /**
      * Builds a new static reference instance.
      *
-     * @return ASTStaticReference
      * @since  0.9.6
      */
-    public function buildAstStaticReference(AbstractASTClassOrInterface $owner);
+    public function buildAstStaticReference(AbstractASTClassOrInterface $owner): ASTStaticReference;
 
     /**
      * Builds a new field declaration node.
      *
-     * @return ASTFieldDeclaration
      * @since  0.9.6
      */
-    public function buildAstFieldDeclaration();
+    public function buildAstFieldDeclaration(): ASTFieldDeclaration;
 
     /**
      * Builds a new variable declarator node.
      *
      * @param string $image The source image for the variable declarator.
-     * @return ASTVariableDeclarator
      * @since  0.9.6
      */
-    public function buildAstVariableDeclarator(string $image);
+    public function buildAstVariableDeclarator(string $image): ASTVariableDeclarator;
 
     /**
      * Builds a new constant node.
      *
      * @param string $image The source image for the constant.
-     * @return ASTConstant
      * @since  0.9.6
      */
-    public function buildAstConstant(string $image);
+    public function buildAstConstant(string $image): ASTConstant;
 
     /**
      * Builds a new variable node.
      *
      * @param string $image The source image for the variable.
-     * @return ASTVariable
      * @since  0.9.6
      */
-    public function buildAstVariable(string $image);
+    public function buildAstVariable(string $image): ASTVariable;
 
     /**
      * Builds a new variable variable node.
      *
      * @param string $image The source image for the variable variable.
-     * @return ASTVariableVariable
      * @since  0.9.6
      */
-    public function buildAstVariableVariable(string $image);
+    public function buildAstVariableVariable(string $image): ASTVariableVariable;
 
     /**
      * Builds a new compound variable node.
      *
      * @param string $image The source image for the compound variable.
-     * @return ASTCompoundVariable
      * @since  0.9.6
      */
-    public function buildAstCompoundVariable(string $image);
+    public function buildAstCompoundVariable(string $image): ASTCompoundVariable;
 
     /**
      * Builds a new compound expression node.
      *
-     * @return ASTCompoundExpression
      * @since  0.9.6
      */
-    public function buildAstCompoundExpression();
+    public function buildAstCompoundExpression(): ASTCompoundExpression;
 
     /**
      * Builds a new static variable declaration node.
      *
      * @param string $image The source image for the static declaration.
-     * @return ASTStaticVariableDeclaration
      * @since  0.9.6
      */
-    public function buildAstStaticVariableDeclaration(string $image);
+    public function buildAstStaticVariableDeclaration(string $image): ASTStaticVariableDeclaration;
 
     /**
      * Builds a new closure node.
      *
-     * @return ASTClosure
      * @since  0.9.12
      */
-    public function buildAstClosure();
+    public function buildAstClosure(): ASTClosure;
 
     /**
      * Builds a new formal parameters node.
      *
-     * @return ASTFormalParameters
      * @since  0.9.6
      */
-    public function buildAstFormalParameters();
+    public function buildAstFormalParameters(): ASTFormalParameters;
 
     /**
      * Builds a new formal parameter node.
      *
-     * @return ASTFormalParameter
      * @since  0.9.6
      */
-    public function buildAstFormalParameter();
+    public function buildAstFormalParameter(): ASTFormalParameter;
 
     /**
      * Builds a new expression node.
      *
-     * @return ASTExpression
      * @since 0.9.8
      */
-    public function buildAstExpression(?string $image = null);
+    public function buildAstExpression(?string $image = null): ASTExpression;
 
     /**
      * Builds a new assignment expression node.
      *
      * @param string $image The assignment operator.
-     * @return ASTAssignmentExpression
      * @since  0.9.8
      */
-    public function buildAstAssignmentExpression(string $image);
+    public function buildAstAssignmentExpression(string $image): ASTAssignmentExpression;
 
     /**
      * Builds a new allocation expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTAllocationExpression
      * @since  0.9.6
      */
-    public function buildAstAllocationExpression(string $image);
+    public function buildAstAllocationExpression(string $image): ASTAllocationExpression;
 
     /**
      * Builds a new eval-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTEvalExpression
      * @since  0.9.12
      */
-    public function buildAstEvalExpression(string $image);
+    public function buildAstEvalExpression(string $image): ASTEvalExpression;
 
     /**
      * Builds a new exit-expression instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTExitExpression
      * @since  0.9.12
      */
-    public function buildAstExitExpression(string $image);
+    public function buildAstExitExpression(string $image): ASTExitExpression;
 
     /**
      * Builds a new clone-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTCloneExpression
      * @since  0.9.12
      */
-    public function buildAstCloneExpression(string $image);
+    public function buildAstCloneExpression(string $image): ASTCloneExpression;
 
     /**
      * Builds a new list-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTListExpression
      * @since  0.9.12
      */
-    public function buildAstListExpression(string $image);
+    public function buildAstListExpression(string $image): ASTListExpression;
 
     /**
      * Builds a new include- or include_once-expression.
      *
-     * @return ASTIncludeExpression
      * @since  0.9.12
      */
-    public function buildAstIncludeExpression();
+    public function buildAstIncludeExpression(): ASTIncludeExpression;
 
     /**
      * Builds a new require- or require_once-expression.
      *
-     * @return ASTRequireExpression
      * @since  0.9.12
      */
-    public function buildAstRequireExpression();
+    public function buildAstRequireExpression(): ASTRequireExpression;
 
     /**
      * Builds a new array-expression node.
      *
-     * @return ASTArrayIndexExpression
      * @since  0.9.12
      */
-    public function buildAstArrayIndexExpression();
+    public function buildAstArrayIndexExpression(): ASTArrayIndexExpression;
 
     /**
      * Builds a new string-expression node.
@@ -538,19 +495,17 @@ interface Builder extends IteratorAggregate
      * //     --------
      * </code>
      *
-     * @return ASTStringIndexExpression
      * @since  0.9.12
      */
-    public function buildAstStringIndexExpression();
+    public function buildAstStringIndexExpression(): ASTStringIndexExpression;
 
     /**
      * Builds a new instanceof-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTInstanceOfExpression
      * @since  0.9.6
      */
-    public function buildAstInstanceOfExpression(string $image);
+    public function buildAstInstanceOfExpression(string $image): ASTInstanceOfExpression;
 
     /**
      * Builds a new isset-expression node.
@@ -567,10 +522,9 @@ interface Builder extends IteratorAggregate
      * }
      * </code>
      *
-     * @return ASTIssetExpression
      * @since  0.9.12
      */
-    public function buildAstIssetExpression();
+    public function buildAstIssetExpression(): ASTIssetExpression;
 
     /**
      * Builds a new boolean conditional-expression.
@@ -581,10 +535,9 @@ interface Builder extends IteratorAggregate
      *         --------------
      * </code>
      *
-     * @return ASTConditionalExpression
      * @since  0.9.8
      */
-    public function buildAstConditionalExpression();
+    public function buildAstConditionalExpression(): ASTConditionalExpression;
 
     /**
      * Builds a new print-expression.
@@ -595,170 +548,150 @@ interface Builder extends IteratorAggregate
      * -------------
      * </code>
      *
-     * @return ASTPrintExpression
      * @since 2.3
      */
-    public function buildAstPrintExpression();
+    public function buildAstPrintExpression(): ASTPrintExpression;
 
     /**
      * Build a new shift left expression.
      *
-     * @return ASTShiftLeftExpression
      * @since  1.0.1
      */
-    public function buildAstShiftLeftExpression();
+    public function buildAstShiftLeftExpression(): ASTShiftLeftExpression;
 
     /**
      * Build a new shift right expression.
      *
-     * @return ASTShiftRightExpression
      * @since  1.0.1
      */
-    public function buildAstShiftRightExpression();
+    public function buildAstShiftRightExpression(): ASTShiftRightExpression;
 
     /**
      * Builds a new boolean and-expression.
      *
-     * @return ASTBooleanAndExpression
      * @since  0.9.8
      */
-    public function buildAstBooleanAndExpression();
+    public function buildAstBooleanAndExpression(): ASTBooleanAndExpression;
 
     /**
      * Builds a new boolean or-expression.
      *
-     * @return ASTBooleanOrExpression
      * @since  0.9.8
      */
-    public function buildAstBooleanOrExpression();
+    public function buildAstBooleanOrExpression(): ASTBooleanOrExpression;
 
     /**
      * Builds a new logical <b>and</b>-expression.
      *
-     * @return ASTLogicalAndExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalAndExpression();
+    public function buildAstLogicalAndExpression(): ASTLogicalAndExpression;
 
     /**
      * Builds a new logical <b>or</b>-expression.
      *
-     * @return ASTLogicalOrExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalOrExpression();
+    public function buildAstLogicalOrExpression(): ASTLogicalOrExpression;
 
     /**
      * Builds a new logical <b>xor</b>-expression.
      *
-     * @return ASTLogicalXorExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalXorExpression();
+    public function buildAstLogicalXorExpression(): ASTLogicalXorExpression;
 
     /**
      * Builds a new trait use-statement node.
      *
-     * @return ASTTraitUseStatement
      * @since  1.0.0
      */
-    public function buildAstTraitUseStatement();
+    public function buildAstTraitUseStatement(): ASTTraitUseStatement;
 
     /**
      * Builds a new trait adaptation scope.
      *
-     * @return ASTTraitAdaptation
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptation();
+    public function buildAstTraitAdaptation(): ASTTraitAdaptation;
 
     /**
      * Builds a new trait adaptation alias statement.
      *
      * @param string $image The trait method name.
-     * @return ASTTraitAdaptationAlias
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationAlias(string $image);
+    public function buildAstTraitAdaptationAlias(string $image): ASTTraitAdaptationAlias;
 
     /**
      * Builds a new trait adaptation precedence statement.
      *
      * @param string $image The trait method name.
-     * @return ASTTraitAdaptationPrecedence
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationPrecedence(string $image);
+    public function buildAstTraitAdaptationPrecedence(string $image): ASTTraitAdaptationPrecedence;
 
     /**
      * Builds a new trait reference node.
      *
      * @param string $qualifiedName The full qualified trait name.
-     * @return ASTTraitReference
      * @since  1.0.0
      */
-    public function buildAstTraitReference(string $qualifiedName);
+    public function buildAstTraitReference(string $qualifiedName): ASTTraitReference;
 
     /**
      * Builds a new switch-statement-node.
      *
-     * @return ASTSwitchStatement
      * @since  0.9.8
      */
-    public function buildAstSwitchStatement();
+    public function buildAstSwitchStatement(): ASTSwitchStatement;
 
     /**
      * Builds a new switch-label node.
      *
      * @param string $image The source image of this label.
-     * @return ASTSwitchLabel
      * @since  0.9.8
      */
-    public function buildAstSwitchLabel(string $image);
+    public function buildAstSwitchLabel(string $image): ASTSwitchLabel;
 
     /**
      * Builds a new catch-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTCatchStatement
      * @since  0.9.8
      */
-    public function buildAstCatchStatement(string $image);
+    public function buildAstCatchStatement(string $image): ASTCatchStatement;
 
     /**
      * Builds a new finally-statement node.
      *
-     * @return ASTFinallyStatement
      * @since  2.0.0
      */
-    public function buildAstFinallyStatement();
+    public function buildAstFinallyStatement(): ASTFinallyStatement;
 
     /**
      * Builds a new if statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTIfStatement
      * @since  0.9.8
      */
-    public function buildAstIfStatement(string $image);
+    public function buildAstIfStatement(string $image): ASTIfStatement;
 
     /**
      * Builds a new elseif-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTElseIfStatement
      * @since  0.9.8
      */
-    public function buildAstElseIfStatement(string $image);
+    public function buildAstElseIfStatement(string $image): ASTElseIfStatement;
 
     /**
      * Builds a new for-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTForStatement
      * @since  0.9.8
      */
-    public function buildAstForStatement(string $image);
+    public function buildAstForStatement(string $image): ASTForStatement;
 
     /**
      * Builds a new for-init node.
@@ -769,10 +702,9 @@ interface Builder extends IteratorAggregate
      *      ------------------------
      * </code>
      *
-     * @return ASTForInit
      * @since  0.9.8
      */
-    public function buildAstForInit();
+    public function buildAstForInit(): ASTForInit;
 
     /**
      * Builds a new for-update node.
@@ -783,37 +715,33 @@ interface Builder extends IteratorAggregate
      *                                        -------------------------------
      * </code>
      *
-     * @return ASTForUpdate
      * @since  0.9.12
      */
-    public function buildAstForUpdate();
+    public function buildAstForUpdate(): ASTForUpdate;
 
     /**
      * Builds a new foreach-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTForeachStatement
      * @since  0.9.8
      */
-    public function buildAstForeachStatement(string $image);
+    public function buildAstForeachStatement(string $image): ASTForeachStatement;
 
     /**
      * Builds a new while-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTWhileStatement
      * @since  0.9.8
      */
-    public function buildAstWhileStatement(string $image);
+    public function buildAstWhileStatement(string $image): ASTWhileStatement;
 
     /**
      * Builds a new do/while-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTDoWhileStatement
      * @since  0.9.12
      */
-    public function buildAstDoWhileStatement(string $image);
+    public function buildAstDoWhileStatement(string $image): ASTDoWhileStatement;
 
     /**
      * Builds a new declare-statement node.
@@ -836,10 +764,9 @@ interface Builder extends IteratorAggregate
      * -----------
      * </code>
      *
-     * @return ASTDeclareStatement
      * @since  0.10.0
      */
-    public function buildAstDeclareStatement();
+    public function buildAstDeclareStatement(): ASTDeclareStatement;
 
     /**
      * Builds a new member primary expression node.
@@ -863,19 +790,17 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source image of this expression.
-     * @return ASTMemberPrimaryPrefix
      * @since  0.9.6
      */
-    public function buildAstMemberPrimaryPrefix(string $image);
+    public function buildAstMemberPrimaryPrefix(string $image): ASTMemberPrimaryPrefix;
 
     /**
      * Builds a new identifier node.
      *
      * @param string $image The image of this identifier.
-     * @return ASTIdentifier
      * @since  0.9.6
      */
-    public function buildAstIdentifier(string $image);
+    public function buildAstIdentifier(string $image): ASTIdentifier;
 
     /**
      * Builds a new function postfix expression.
@@ -891,10 +816,9 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTFunctionPostfix
      * @since  0.9.6
      */
-    public function buildAstFunctionPostfix(string $image);
+    public function buildAstFunctionPostfix(string $image): ASTFunctionPostfix;
 
     /**
      * Builds a new method postfix expression.
@@ -910,10 +834,9 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTMethodPostfix
      * @since  0.9.6
      */
-    public function buildAstMethodPostfix(string $image);
+    public function buildAstMethodPostfix(string $image): ASTMethodPostfix;
 
     /**
      * Builds a new constant postfix expression.
@@ -925,10 +848,9 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTConstantPostfix
      * @since  0.9.6
      */
-    public function buildAstConstantPostfix(string $image);
+    public function buildAstConstantPostfix(string $image): ASTConstantPostfix;
 
     /**
      * Builds a new property postfix expression.
@@ -944,10 +866,9 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTPropertyPostfix
      * @since  0.9.6
      */
-    public function buildAstPropertyPostfix(string $image);
+    public function buildAstPropertyPostfix(string $image): ASTPropertyPostfix;
 
     /**
      * Builds a new full qualified class name postfix expression.
@@ -962,10 +883,9 @@ interface Builder extends IteratorAggregate
      * //       -----
      * </code>
      *
-     * @return ASTClassFqnPostfix
      * @since  2.0.0
      */
-    public function buildAstClassFqnPostfix();
+    public function buildAstClassFqnPostfix(): ASTClassFqnPostfix;
 
     /**
      * Builds a new arguments list.
@@ -980,10 +900,9 @@ interface Builder extends IteratorAggregate
      * //       ------------
      * </code>
      *
-     * @return ASTArguments
      * @since  0.9.6
      */
-    public function buildAstArguments();
+    public function buildAstArguments(): ASTArguments;
 
     /**
      * Builds a new argument match expression single-item slot.
@@ -992,10 +911,9 @@ interface Builder extends IteratorAggregate
      * match($x)
      * </code>
      *
-     * @return ASTMatchArgument
      * @since  0.9.6
      */
-    public function buildAstMatchArgument();
+    public function buildAstMatchArgument(): ASTMatchArgument;
 
     /**
      * Builds a new argument match expression single-item slot.
@@ -1006,10 +924,9 @@ interface Builder extends IteratorAggregate
      * }
      * </code>
      *
-     * @return ASTMatchBlock
      * @since  2.9.0
      */
-    public function buildAstMatchBlock();
+    public function buildAstMatchBlock(): ASTMatchBlock;
 
     /**
      * Builds a new argument match expression single-item slot.
@@ -1018,10 +935,9 @@ interface Builder extends IteratorAggregate
      * "foo" => "bar",
      * </code>
      *
-     * @return ASTMatchEntry
      * @since  2.9.0
      */
-    public function buildAstMatchEntry();
+    public function buildAstMatchEntry(): ASTMatchEntry;
 
     /**
      * Builds a new named argument node.
@@ -1030,66 +946,57 @@ interface Builder extends IteratorAggregate
      * number_format(5623, thousands_separator: ' ')
      * </code>
      *
-     * @return ASTNamedArgument
      * @since  2.9.0
      */
-    public function buildAstNamedArgument(string $name, ASTNode $value);
+    public function buildAstNamedArgument(string $name, ASTNode $value): ASTNamedArgument;
 
     /**
      * Builds a new array type node.
      *
-     * @return ASTTypeArray
      * @since  0.9.6
      */
-    public function buildAstTypeArray();
+    public function buildAstTypeArray(): ASTTypeArray;
 
     /**
      * Builds a new node for the callable type.
      *
-     * @return ASTTypeCallable
      * @since  1.0.0
      */
-    public function buildAstTypeCallable();
+    public function buildAstTypeCallable(): ASTTypeCallable;
 
     /**
      * Builds a new node for the iterable type.
      *
-     * @return ASTTypeIterable
      * @since  2.5.1
      */
-    public function buildAstTypeIterable();
+    public function buildAstTypeIterable(): ASTTypeIterable;
 
     /**
      * Builds a new primitive type node.
      *
-     * @return ASTScalarType
      * @since  0.9.6
      */
-    public function buildAstScalarType(string $image);
+    public function buildAstScalarType(string $image): ASTScalarType;
 
     /**
      * Builds a new node for the union type.
      *
-     * @return ASTUnionType
      * @since  2.9.0
      */
-    public function buildAstUnionType();
+    public function buildAstUnionType(): ASTUnionType;
 
     /**
      * Builds a new node for the intersection type.
-     *
-     * @return ASTIntersectionType
      */
-    public function buildAstIntersectionType();
+    public function buildAstIntersectionType(): ASTIntersectionType;
 
     /**
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.
-     * @return ASTLiteral
      * @since  0.9.6
      */
-    public function buildAstLiteral(string $image);
+    public function buildAstLiteral(string $image): ASTLiteral;
 
     /**
      * Builds a new php string node.
@@ -1106,34 +1013,30 @@ interface Builder extends IteratorAggregate
      * // |-- ASTLiteral             -  ">"
      * </code>
      *
-     * @return ASTString
      * @since  0.9.10
      */
-    public function buildAstString();
+    public function buildAstString(): ASTString;
 
     /**
      * Builds a new php array node.
      *
-     * @return ASTArray
      * @since  1.0.0
      */
-    public function buildAstArray();
+    public function buildAstArray(): ASTArray;
 
     /**
      * Builds a new array element node.
      *
-     * @return ASTArrayElement
      * @since  1.0.0
      */
-    public function buildAstArrayElement();
+    public function buildAstArrayElement(): ASTArrayElement;
 
     /**
      * Builds a new heredoc node.
      *
-     * @return ASTHeredoc
      * @since  0.9.12
      */
-    public function buildAstHeredoc();
+    public function buildAstHeredoc(): ASTHeredoc;
 
     /**
      * Builds a new constant definition node.
@@ -1148,10 +1051,9 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source code image for this node.
-     * @return ASTConstantDefinition
      * @since  0.9.6
      */
-    public function buildAstConstantDefinition(string $image);
+    public function buildAstConstantDefinition(string $image): ASTConstantDefinition;
 
     /**
      * Builds a new constant declarator node.
@@ -1185,181 +1087,160 @@ interface Builder extends IteratorAggregate
      * </code>
      *
      * @param string $image The source code image for this node.
-     * @return ASTConstantDeclarator
      * @since  0.9.6
      */
-    public function buildAstConstantDeclarator(string $image);
+    public function buildAstConstantDeclarator(string $image): ASTConstantDeclarator;
 
     /**
      * Builds a new comment node instance.
      *
      * @param string $cdata The comment text.
-     * @return ASTComment
      * @since  0.9.8
      */
-    public function buildAstComment(string $cdata);
+    public function buildAstComment(string $cdata): ASTComment;
 
     /**
      * Builds a new unary expression node instance.
      *
      * @param string $image The unary expression image/character.
-     * @return ASTUnaryExpression
      * @since  0.9.11
      */
-    public function buildAstUnaryExpression(string $image);
+    public function buildAstUnaryExpression(string $image): ASTUnaryExpression;
 
     /**
      * Builds a new cast-expression node instance.
      *
      * @param string $image The cast-expression image/character.
-     * @return ASTCastExpression
      * @since  0.10.0
      */
-    public function buildAstCastExpression(string $image);
+    public function buildAstCastExpression(string $image): ASTCastExpression;
 
     /**
      * Builds a new postfix-expression node instance.
      *
      * @param string $image The postfix-expression image/character.
-     * @return ASTPostfixExpression
      * @since  0.10.0
      */
-    public function buildAstPostfixExpression(string $image);
+    public function buildAstPostfixExpression(string $image): ASTPostfixExpression;
 
     /**
      * Builds a new pre-increment-expression node instance.
      *
-     * @return ASTPreIncrementExpression
      * @since  0.10.0
      */
-    public function buildAstPreIncrementExpression();
+    public function buildAstPreIncrementExpression(): ASTPreIncrementExpression;
 
     /**
      * Builds a new pre-decrement-expression node instance.
      *
-     * @return ASTPreDecrementExpression
      * @since  0.10.0
      */
-    public function buildAstPreDecrementExpression();
+    public function buildAstPreDecrementExpression(): ASTPreDecrementExpression;
 
     /**
      * Builds a new function/method scope instance.
      *
-     * @return ASTScope
      * @since  0.9.12
      */
-    public function buildAstScope();
+    public function buildAstScope(): ASTScope;
 
     /**
      * Builds a new statement instance.
      *
-     * @return ASTStatement
      * @since  0.9.12
      */
-    public function buildAstStatement();
+    public function buildAstStatement(): ASTStatement;
 
     /**
      * Builds a new return-statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTReturnStatement
      * @since  0.9.12
      */
-    public function buildAstReturnStatement(string $image);
+    public function buildAstReturnStatement(string $image): ASTReturnStatement;
 
     /**
      * Builds a new break-statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTBreakStatement
      * @since  0.9.12
      */
-    public function buildAstBreakStatement(string $image);
+    public function buildAstBreakStatement(string $image): ASTBreakStatement;
 
     /**
      * Builds a new continue-statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTContinueStatement
      * @since  0.9.12
      */
-    public function buildAstContinueStatement(string $image);
+    public function buildAstContinueStatement(string $image): ASTContinueStatement;
 
     /**
      * Builds a new scope-statement instance.
      *
-     * @return ASTScopeStatement
      * @since  0.9.12
      */
-    public function buildAstScopeStatement();
+    public function buildAstScopeStatement(): ASTScopeStatement;
 
     /**
      * Builds a new try-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTTryStatement
      * @since  0.9.12
      */
-    public function buildAstTryStatement(string $image);
+    public function buildAstTryStatement(string $image): ASTTryStatement;
 
     /**
      * Builds a new throw-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTThrowStatement
      * @since  0.9.12
      */
-    public function buildAstThrowStatement(string $image);
+    public function buildAstThrowStatement(string $image): ASTThrowStatement;
 
     /**
      * Builds a new goto-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTGotoStatement
      * @since  0.9.12
      */
-    public function buildAstGotoStatement(string $image);
+    public function buildAstGotoStatement(string $image): ASTGotoStatement;
 
     /**
      * Builds a new label-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTLabelStatement
      * @since  0.9.12
      */
-    public function buildAstLabelStatement(string $image);
+    public function buildAstLabelStatement(string $image): ASTLabelStatement;
 
     /**
      * Builds a new global-statement instance.
      *
-     * @return ASTGlobalStatement
      * @since  0.9.12
      */
-    public function buildAstGlobalStatement();
+    public function buildAstGlobalStatement(): ASTGlobalStatement;
 
     /**
      * Builds a new unset-statement instance.
      *
-     * @return ASTUnsetStatement
      * @since  0.9.12
      */
-    public function buildAstUnsetStatement();
+    public function buildAstUnsetStatement(): ASTUnsetStatement;
 
     /**
      * Builds a new exit-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTEchoStatement
      * @since  0.9.12
      */
-    public function buildAstEchoStatement(string $image);
+    public function buildAstEchoStatement(string $image): ASTEchoStatement;
 
     /**
      * Builds a new yield-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTYieldStatement
      * @since  $version$
      */
-    public function buildAstYieldStatement(string $image);
+    public function buildAstYieldStatement(string $image): ASTYieldStatement;
 }

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -96,10 +96,9 @@ interface BuilderContext
      * Returns the trait instance for the given qualified name.
      *
      * @param string $qualifiedName Full qualified trait name.
-     * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait(string $qualifiedName);
+    public function getTrait(string $qualifiedName): ASTTrait;
 
     /**
      * Returns the class instance for the given qualified name.
@@ -110,8 +109,6 @@ interface BuilderContext
 
     /**
      * Returns a class or an interface instance for the given qualified name.
-     *
-     * @return AbstractASTClassOrInterface
      */
-    public function getClassOrInterface(string $qualifiedName);
+    public function getClassOrInterface(string $qualifiedName): AbstractASTClassOrInterface;
 }

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -136,30 +136,25 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the trait instance for the given qualified name.
      *
-     * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait(string $qualifiedName)
+    public function getTrait(string $qualifiedName): ASTTrait
     {
         return $this->getBuilder()->getTrait($qualifiedName);
     }
 
     /**
      * Returns the class instance for the given qualified name.
-     *
-     * @return ASTClass|ASTEnum
      */
-    public function getClass(string $qualifiedName)
+    public function getClass(string $qualifiedName): ASTClass|ASTEnum
     {
         return $this->getBuilder()->getClass($qualifiedName);
     }
 
     /**
      * Returns a class or an interface instance for the given qualified name.
-     *
-     * @return AbstractASTClassOrInterface
      */
-    public function getClassOrInterface(string $qualifiedName)
+    public function getClassOrInterface(string $qualifiedName): AbstractASTClassOrInterface
     {
         return $this->getBuilder()->getClassOrInterface($qualifiedName);
     }
@@ -169,7 +164,7 @@ class GlobalBuilderContext implements BuilderContext
      *
      * @return Builder<mixed>
      */
-    protected function getBuilder()
+    protected function getBuilder(): Builder
     {
         return self::$builder;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -382,18 +382,14 @@ abstract class AbstractPHPParser
     /**
      * Returns the maximum allowed nesting/recursion level.
      *
-     * @return int
      * @since 0.9.12
      */
-    private function getMaxNestingLevel()
+    private function getMaxNestingLevel(): int
     {
         return $this->maxNestingLevel;
     }
 
-    /**
-     * @return ASTType
-     */
-    private function parseReturnTypeHint()
+    private function parseReturnTypeHint(): ASTType
     {
         $this->consumeComments();
         $this->consumeQuestionMark();
@@ -405,10 +401,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a scalar type hint or a callable type hint.
      *
-     * @return ASTType
      * @throws ParserException
      */
-    private function parseScalarOrCallableTypeHint(string $image)
+    private function parseScalarOrCallableTypeHint(string $image): ASTType
     {
         return match (strtolower($image)) {
             'int',
@@ -430,10 +425,7 @@ abstract class AbstractPHPParser
         }
     }
 
-    /**
-     * @return int
-     */
-    private function getModifiersForConstantDefinition(int $tokenType, int $modifiers)
+    private function getModifiersForConstantDefinition(int $tokenType, int $modifiers): int
     {
         $allowed = State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE;
         $modifiers &= $allowed;
@@ -452,10 +444,7 @@ abstract class AbstractPHPParser
         return $modifiers;
     }
 
-    /**
-     * @return ASTType
-     */
-    private function parseEndReturnTypeHint()
+    private function parseEndReturnTypeHint(): ASTType
     {
         return $this->parseTypeHint();
     }
@@ -579,10 +568,7 @@ abstract class AbstractPHPParser
         $this->namespacePrefixReplaced = $namespacePrefixReplaced;
     }
 
-    /**
-     * @return AbstractASTNode
-     */
-    private function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments)
+    private function parseConstantArgument(ASTConstant $constant, ASTArguments $arguments): AbstractASTNode
     {
         if ($this->tokenizer->peek() === Tokens::T_COLON) {
             $token = $this->tokenizer->next();
@@ -598,10 +584,7 @@ abstract class AbstractPHPParser
         return $constant;
     }
 
-    /**
-     * @return ASTNode|null
-     */
-    private function parseArgumentExpression()
+    private function parseArgumentExpression(): ?ASTNode
     {
         if ($this->tokenizer->peekNext() === Tokens::T_COLON) {
             $token = $this->tokenizer->currentToken();
@@ -622,10 +605,8 @@ abstract class AbstractPHPParser
 
     /**
      * Determines if the following expression can be stored as a static value.
-     *
-     * @return bool
      */
-    private function isFollowedByStaticValueOrStaticArray()
+    private function isFollowedByStaticValueOrStaticArray(): bool
     {
         // If we can't anticipate, we should assume it can be a dynamic value
         if (!($this->tokenizer instanceof FullTokenizer)) {
@@ -814,10 +795,9 @@ abstract class AbstractPHPParser
      * Tests if the given token type is a reserved keyword in the supported PHP
      * version.
      *
-     * @return bool
      * @since 1.1.1
      */
-    private function isKeyword(int $tokenType)
+    private function isKeyword(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_CLASS,
@@ -833,11 +813,10 @@ abstract class AbstractPHPParser
      * Parses a valid class or interface name and returns the image of the parsed
      * token.
      *
-     * @return string
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
-    private function parseClassName()
+    private function parseClassName(): string
     {
         $type = $this->tokenizer->peek();
 
@@ -853,10 +832,9 @@ abstract class AbstractPHPParser
      * name part.
      *
      * @param int $tokenType The type of a parsed token.
-     * @return bool
      * @since 0.10.6
      */
-    private function isClassName(int $tokenType)
+    private function isClassName(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_DIR,
@@ -883,12 +861,11 @@ abstract class AbstractPHPParser
      * literal representing the function name. If no valid token exists in the
      * token stream, this method will throw an exception.
      *
-     * @return string
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      * @since 0.10.0
      */
-    private function parseFunctionName()
+    private function parseFunctionName(): string
     {
         $tokenType = $this->tokenizer->peek();
 
@@ -899,10 +876,7 @@ abstract class AbstractPHPParser
         throw $this->getUnexpectedNextTokenException();
     }
 
-    /**
-     * @return bool
-     */
-    protected function isConstantName(int $tokenType)
+    protected function isConstantName(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_CALLABLE,
@@ -980,10 +954,9 @@ abstract class AbstractPHPParser
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @return bool
      * @since 2.3
      */
-    protected function isFunctionName(int $tokenType)
+    protected function isFunctionName(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_STRING,
@@ -997,11 +970,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return string
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */
-    private function parseMethodName()
+    private function parseMethodName(): string
     {
         $tokenType = $this->tokenizer->peek();
 
@@ -1012,10 +984,7 @@ abstract class AbstractPHPParser
         throw $this->getUnexpectedNextTokenException();
     }
 
-    /**
-     * @return bool
-     */
-    private function isMethodName(int $tokenType)
+    private function isMethodName(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_CLASS => true,
@@ -1026,10 +995,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait declaration.
      *
-     * @return ASTTrait
      * @since 1.0.0
      */
-    private function parseTraitDeclaration()
+    private function parseTraitDeclaration(): ASTTrait
     {
         $this->tokenStack->push();
 
@@ -1044,10 +1012,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parses the signature of a trait.
-     *
-     * @return ASTTrait
      */
-    private function parseTraitSignature()
+    private function parseTraitSignature(): ASTTrait
     {
         $this->consumeToken(Tokens::T_TRAIT);
         $this->consumeComments();
@@ -1065,10 +1031,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parses the dependencies in a interface signature.
-     *
-     * @return ASTInterface
      */
-    private function parseInterfaceDeclaration()
+    private function parseInterfaceDeclaration(): ASTInterface
     {
         $this->tokenStack->push();
 
@@ -1085,10 +1049,9 @@ abstract class AbstractPHPParser
      * Parses the signature of an interface and finally returns a configured
      * interface instance.
      *
-     * @return ASTInterface
      * @since 0.10.2
      */
-    private function parseInterfaceSignature()
+    private function parseInterfaceSignature(): ASTInterface
     {
         $this->consumeToken(Tokens::T_INTERFACE);
         $this->consumeComments();
@@ -1127,10 +1090,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parses the dependencies in a class signature.
-     *
-     * @return ASTClass
      */
-    private function parseClassDeclaration()
+    private function parseClassDeclaration(): ASTClass
     {
         $startToken = $this->tokenizer->currentToken();
         $this->tokenStack->push();
@@ -1151,10 +1112,9 @@ abstract class AbstractPHPParser
      * or abstract, the T_CLASS token, the class name, an optional parent class
      * and an optional list of implemented interfaces.
      *
-     * @return ASTClass
      * @since 1.0.0
      */
-    private function parseClassSignature()
+    private function parseClassSignature(): ASTClass
     {
         $this->parseClassModifiers();
         $this->consumeToken(Tokens::T_CLASS);
@@ -1417,10 +1377,9 @@ abstract class AbstractPHPParser
      * This method will parse a list of modifiers and a following property or
      * method.
      *
-     * @return ASTNode
      * @since 0.9.6
      */
-    private function parseMethodOrFieldDeclaration(int $modifiers = 0)
+    private function parseMethodOrFieldDeclaration(int $modifiers = 0): ASTNode
     {
         $this->tokenStack->push();
         $tokenType = $this->tokenizer->peek();
@@ -1496,10 +1455,9 @@ abstract class AbstractPHPParser
     /**
      * Override this in later PHPParserVersions as necessary
      *
-     * @return AbstractASTNode
      * @throws UnexpectedTokenException
      */
-    private function parseUnknownDeclaration(int $tokenType, int $modifiers)
+    private function parseUnknownDeclaration(int $tokenType, int $modifiers): AbstractASTNode
     {
         /**
          * Typed properties
@@ -1542,10 +1500,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTFieldDeclaration
      * @since 0.9.6
      */
-    private function parseFieldDeclaration()
+    private function parseFieldDeclaration(): ASTFieldDeclaration
     {
         $declaration = $this->builder->buildAstFieldDeclaration();
         $declaration->setComment($this->docComment);
@@ -1586,10 +1543,9 @@ abstract class AbstractPHPParser
      * This method parses a simple function or a PHP 5.3 lambda function or
      * closure.
      *
-     * @return ASTCallable
      * @since 0.9.5
      */
-    private function parseFunctionOrClosureDeclaration()
+    private function parseFunctionOrClosureDeclaration(): ASTCallable
     {
         $this->tokenStack->push();
 
@@ -1626,10 +1582,9 @@ abstract class AbstractPHPParser
      * <b>true</b> when a reference token was found, otherwise this method will
      * return <b>false</b>.
      *
-     * @return bool
      * @since 0.9.8
      */
-    private function parseOptionalByReference()
+    private function parseOptionalByReference(): bool
     {
         return $this->isNextTokenByReference() && $this->parseByReference();
     }
@@ -1637,20 +1592,17 @@ abstract class AbstractPHPParser
     /**
      * Tests that the next available token is the returns by reference token.
      *
-     * @return bool
      * @since 0.9.8
      */
-    private function isNextTokenByReference()
+    private function isNextTokenByReference(): bool
     {
         return ($this->tokenizer->peek() === Tokens::T_BITWISE_AND);
     }
 
     /**
      * This method parses a returns by reference token and returns <b>true</b>.
-     *
-     * @return bool
      */
-    private function parseByReference()
+    private function parseByReference(): bool
     {
         $this->consumeToken(Tokens::T_BITWISE_AND);
         $this->consumeComments();
@@ -1661,10 +1613,9 @@ abstract class AbstractPHPParser
     /**
      * Tests that the next available token is an opening parenthesis.
      *
-     * @return bool
      * @since 0.9.10
      */
-    private function isNextTokenFormalParameterList()
+    private function isNextTokenFormalParameterList(): bool
     {
         $this->consumeComments();
 
@@ -1674,10 +1625,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a function declaration.
      *
-     * @return ASTFunction
      * @since 0.9.5
      */
-    private function parseFunctionDeclaration()
+    private function parseFunctionDeclaration(): ASTFunction
     {
         $this->consumeComments();
 
@@ -1714,10 +1664,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a method declaration.
      *
-     * @return ASTMethod
      * @since 0.9.5
      */
-    private function parseMethodDeclaration()
+    private function parseMethodDeclaration(): ASTMethod
     {
         // Read function keyword
         $this->consumeToken(Tokens::T_FUNCTION);
@@ -1746,10 +1695,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a PHP 5.3 closure or lambda function.
      *
-     * @return ASTClosure
      * @since 0.9.5
      */
-    private function parseClosureDeclaration()
+    private function parseClosureDeclaration(): ASTClosure
     {
         $this->tokenStack->push();
 
@@ -1812,10 +1760,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait use statement.
      *
-     * @return ASTTraitUseStatement
      * @since 1.0.0
      */
-    private function parseTraitUseStatement()
+    private function parseTraitUseStatement(): ASTTraitUseStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_USE);
@@ -1838,10 +1785,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a trait reference instance.
      *
-     * @return ASTTraitReference
      * @since 1.0.0
      */
-    private function parseTraitReference()
+    private function parseTraitReference(): ASTTraitReference
     {
         $this->consumeComments();
         $this->tokenStack->push();
@@ -1878,10 +1824,9 @@ abstract class AbstractPHPParser
     /**
      * Parses the adaptation expression of a trait use statement.
      *
-     * @return ASTTraitAdaptation
      * @since 1.0.0
      */
-    private function parseTraitAdaptation()
+    private function parseTraitAdaptation(): ASTTraitAdaptation
     {
         $this->tokenStack->push();
 
@@ -1927,7 +1872,7 @@ abstract class AbstractPHPParser
      * @return array{string, ?ASTNode}
      * @since 1.0.0
      */
-    private function parseTraitMethodReference()
+    private function parseTraitMethodReference(): array
     {
         $this->tokenStack->push();
 
@@ -1955,10 +1900,9 @@ abstract class AbstractPHPParser
      * Parses a trait adaptation alias statement.
      *
      * @param array{string, ?ASTNode} $reference Parsed method reference array.
-     * @return ASTTraitAdaptationAlias
      * @since 1.0.0
      */
-    private function parseTraitAdaptationAliasStatement(array $reference)
+    private function parseTraitAdaptationAliasStatement(array $reference): ASTTraitAdaptationAlias
     {
         $stmt = $this->builder->buildAstTraitAdaptationAlias($reference[0]);
 
@@ -2003,11 +1947,10 @@ abstract class AbstractPHPParser
      * Parses a trait adaptation precedence statement.
      *
      * @param array{string, ?ASTNode} $reference Parsed method reference array.
-     * @return ASTTraitAdaptationPrecedence
      * @throws InvalidStateException
      * @since 1.0.0
      */
-    private function parseTraitAdaptationPrecedenceStatement(array $reference)
+    private function parseTraitAdaptationPrecedenceStatement(array $reference): ASTTraitAdaptationPrecedence
     {
         if (!isset($reference[1])) {
             throw new InvalidStateException(
@@ -2051,11 +1994,10 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTAllocationExpression
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseAllocationExpression()
+    private function parseAllocationExpression(): ASTAllocationExpression
     {
         $this->tokenStack->push();
 
@@ -2087,10 +2029,9 @@ abstract class AbstractPHPParser
     /**
      * Parse the instanciation for new keyword without arguments.
      *
-     * @return ASTAllocationExpression
      * @throws ParserException
      */
-    private function parseAllocationExpressionValue()
+    private function parseAllocationExpressionValue(): ASTAllocationExpression
     {
         $token = $this->consumeToken(Tokens::T_NEW);
         $this->consumeComments();
@@ -2121,10 +2062,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a eval-expression node.
      *
-     * @return ASTEvalExpression
      * @since 0.9.12
      */
-    private function parseEvalExpression()
+    private function parseEvalExpression(): ASTEvalExpression
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_EVAL);
@@ -2138,10 +2078,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses an exit-expression.
      *
-     * @return ASTExitExpression
      * @since 0.9.12
      */
-    private function parseExitExpression()
+    private function parseExitExpression(): ASTExitExpression
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_EXIT);
@@ -2159,10 +2098,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a clone-expression node.
      *
-     * @return ASTCloneExpression
      * @since 0.9.12
      */
-    private function parseCloneExpression()
+    private function parseCloneExpression(): ASTCloneExpression
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_CLONE);
@@ -2186,10 +2124,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single list-statement node.
      *
-     * @return ASTListExpression
      * @since 0.9.12
      */
-    private function parseListExpression()
+    private function parseListExpression(): ASTListExpression
     {
         $this->tokenStack->push();
 
@@ -2249,9 +2186,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parse individual slot of a list() expression.
-     * @return ASTNode
      */
-    private function parseListSlotExpression()
+    private function parseListSlotExpression(): ASTNode
     {
         $startToken = $this->tokenizer->currentToken();
         $node = $this->parseOptionalExpression();
@@ -2272,10 +2208,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a include-expression node.
      *
-     * @return ASTIncludeExpression
      * @since 0.9.12
      */
-    private function parseIncludeExpression()
+    private function parseIncludeExpression(): ASTIncludeExpression
     {
         $expr = $this->builder->buildAstIncludeExpression();
 
@@ -2285,10 +2220,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a include_once-expression node.
      *
-     * @return ASTIncludeExpression
      * @since 0.9.12
      */
-    private function parseIncludeOnceExpression()
+    private function parseIncludeOnceExpression(): ASTIncludeExpression
     {
         $expr = $this->builder->buildAstIncludeExpression();
         $expr->setOnce();
@@ -2299,10 +2233,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a require-expression node.
      *
-     * @return ASTRequireExpression
      * @since 0.9.12
      */
-    private function parseRequireExpression()
+    private function parseRequireExpression(): ASTRequireExpression
     {
         $expr = $this->builder->buildAstRequireExpression();
 
@@ -2312,10 +2245,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a require_once-expression node.
      *
-     * @return ASTRequireExpression
      * @since 0.9.12
      */
-    private function parseRequireOnceExpression()
+    private function parseRequireOnceExpression(): ASTRequireExpression
     {
         $expr = $this->builder->buildAstRequireExpression();
         $expr->setOnce();
@@ -2357,10 +2289,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a cast-expression node.
      *
-     * @return ASTCastExpression
      * @since 0.10.0
      */
-    private function parseCastExpression()
+    private function parseCastExpression(): ASTCastExpression
     {
         $token = $this->consumeToken($this->tokenizer->peek());
 
@@ -2383,7 +2314,7 @@ abstract class AbstractPHPParser
      * @return list<ASTNode>
      * @since 0.10.0
      */
-    private function parseIncrementExpression(array $expressions)
+    private function parseIncrementExpression(array $expressions): array
     {
         $expression = end($expressions);
         if ($expression && $this->isReadWriteVariable($expression)) {
@@ -2403,10 +2334,9 @@ abstract class AbstractPHPParser
      * Parses a post increment-expression and adds the given child to that node.
      *
      * @param ASTNode $child The child expression node.
-     * @return ASTPostfixExpression
      * @since 0.10.0
      */
-    private function parsePostIncrementExpression(ASTNode $child)
+    private function parsePostIncrementExpression(ASTNode $child): ASTPostfixExpression
     {
         $token = $this->consumeToken(Tokens::T_INC);
 
@@ -2425,10 +2355,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a pre increment-expression and adds the given child to that node.
      *
-     * @return ASTPreIncrementExpression
      * @since 0.10.0
      */
-    private function parsePreIncrementExpression()
+    private function parsePreIncrementExpression(): ASTPreIncrementExpression
     {
         $token = $this->consumeToken(Tokens::T_INC);
 
@@ -2451,7 +2380,7 @@ abstract class AbstractPHPParser
      * @return list<ASTNode>
      * @since 0.10.0
      */
-    private function parseDecrementExpression(array $expressions)
+    private function parseDecrementExpression(array $expressions): array
     {
         $expression = end($expressions);
         if ($expression && $this->isReadWriteVariable($expression)) {
@@ -2471,10 +2400,9 @@ abstract class AbstractPHPParser
      * Parses a post decrement-expression and adds the given child to that node.
      *
      * @param ASTNode $child The child expression node.
-     * @return ASTPostfixExpression
      * @since 0.10.0
      */
-    private function parsePostDecrementExpression(ASTNode $child)
+    private function parsePostDecrementExpression(ASTNode $child): ASTPostfixExpression
     {
         $token = $this->consumeToken(Tokens::T_DEC);
 
@@ -2493,10 +2421,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a pre decrement-expression and adds the given child to that node.
      *
-     * @return ASTPreDecrementExpression
      * @since 0.10.0
      */
-    private function parsePreDecrementExpression()
+    private function parsePreDecrementExpression(): ASTPreDecrementExpression
     {
         $token = $this->consumeToken(Tokens::T_DEC);
 
@@ -2586,10 +2513,9 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param AbstractASTNode $node The context source node.
-     * @return AbstractASTNode
      * @since 0.9.12
      */
-    private function parseArrayIndexExpression(AbstractASTNode $node)
+    private function parseArrayIndexExpression(AbstractASTNode $node): AbstractASTNode
     {
         $expr = $this->builder->buildAstArrayIndexExpression();
         $expr->addChild($node);
@@ -2612,10 +2538,9 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param AbstractASTNode $node The context source node.
-     * @return AbstractASTNode
      * @since 0.9.12
      */
-    private function parseStringIndexExpression(AbstractASTNode $node)
+    private function parseStringIndexExpression(AbstractASTNode $node): AbstractASTNode
     {
         $expr = $this->builder->buildAstStringIndexExpression();
         $expr->addChild($node);
@@ -2631,10 +2556,9 @@ abstract class AbstractPHPParser
     /**
      * This method checks if the next available token starts an arguments node.
      *
-     * @return bool
      * @since 0.9.8
      */
-    private function isNextTokenArguments()
+    private function isNextTokenArguments(): bool
     {
         $this->consumeComments();
 
@@ -2713,10 +2637,9 @@ abstract class AbstractPHPParser
      *          -----------------------------
      * </code>
      *
-     * @return ASTInstanceOfExpression
      * @since 0.9.6
      */
-    private function parseInstanceOfExpression()
+    private function parseInstanceOfExpression(): ASTInstanceOfExpression
     {
         // Consume the "instanceof" keyword and strip comments
         $token = $this->consumeToken(Tokens::T_INSTANCEOF);
@@ -2747,10 +2670,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTIssetExpression
      * @since 0.9.12
      */
-    private function parseIssetExpression()
+    private function parseIssetExpression(): ASTIssetExpression
     {
         $startToken = $this->consumeToken(Tokens::T_ISSET);
         $this->consumeComments();
@@ -2773,10 +2695,7 @@ abstract class AbstractPHPParser
         return $expr;
     }
 
-    /**
-     * @return ASTClassOrInterfaceReference
-     */
-    private function parseStandAloneExpressionTypeReference(int $tokenType)
+    private function parseStandAloneExpressionTypeReference(int $tokenType): ASTClassOrInterfaceReference
     {
         return match ($tokenType) {
             Tokens::T_SELF => $this->parseSelfReference($this->consumeToken(Tokens::T_SELF)),
@@ -2787,10 +2706,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return AbstractASTNode
      * @throws ParserException
      */
-    private function parseStandAloneExpressionType(bool $classRef)
+    private function parseStandAloneExpressionType(bool $classRef): AbstractASTNode
     {
         // Peek next token and look for a static type identifier
         $this->consumeComments();
@@ -2840,10 +2758,9 @@ abstract class AbstractPHPParser
      *         --------------
      * </code>
      *
-     * @return ASTConditionalExpression
      * @since 0.9.8
      */
-    private function parseConditionalExpression()
+    private function parseConditionalExpression(): ASTConditionalExpression
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_QUESTION_MARK);
@@ -2863,10 +2780,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a shift left expression node.
      *
-     * @return ASTShiftLeftExpression
      * @since 1.0.1
      */
-    private function parseShiftLeftExpression()
+    private function parseShiftLeftExpression(): ASTShiftLeftExpression
     {
         $token = $this->consumeToken(Tokens::T_SL);
 
@@ -2884,10 +2800,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a shift right expression node.
      *
-     * @return ASTShiftRightExpression
      * @since 1.0.1
      */
-    private function parseShiftRightExpression()
+    private function parseShiftRightExpression(): ASTShiftRightExpression
     {
         $token = $this->consumeToken(Tokens::T_SR);
 
@@ -2905,10 +2820,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a boolean and-expression.
      *
-     * @return ASTBooleanAndExpression
      * @since 0.9.8
      */
-    private function parseBooleanAndExpression()
+    private function parseBooleanAndExpression(): ASTBooleanAndExpression
     {
         $token = $this->consumeToken(Tokens::T_BOOLEAN_AND);
 
@@ -2926,10 +2840,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a boolean or-expression.
      *
-     * @return ASTBooleanOrExpression
      * @since 0.9.8
      */
-    private function parseBooleanOrExpression()
+    private function parseBooleanOrExpression(): ASTBooleanOrExpression
     {
         $token = $this->consumeToken(Tokens::T_BOOLEAN_OR);
 
@@ -2947,10 +2860,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>and</b>-expression.
      *
-     * @return ASTLogicalAndExpression
      * @since 0.9.8
      */
-    private function parseLogicalAndExpression()
+    private function parseLogicalAndExpression(): ASTLogicalAndExpression
     {
         $token = $this->consumeToken(Tokens::T_LOGICAL_AND);
 
@@ -2968,10 +2880,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>or</b>-expression.
      *
-     * @return ASTLogicalOrExpression
      * @since 0.9.8
      */
-    private function parseLogicalOrExpression()
+    private function parseLogicalOrExpression(): ASTLogicalOrExpression
     {
         $token = $this->consumeToken(Tokens::T_LOGICAL_OR);
 
@@ -2989,10 +2900,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a logical <b>xor</b>-expression.
      *
-     * @return ASTLogicalXorExpression
      * @since 0.9.8
      */
-    private function parseLogicalXorExpression()
+    private function parseLogicalXorExpression(): ASTLogicalXorExpression
     {
         $token = $this->consumeToken(Tokens::T_LOGICAL_XOR);
 
@@ -3011,10 +2921,9 @@ abstract class AbstractPHPParser
      * Parses a class or interface reference node.
      *
      * @param bool $classReference Force a class reference.
-     * @return ASTClassOrInterfaceReference
      * @since 0.9.8
      */
-    private function parseClassOrInterfaceReference(bool $classReference)
+    private function parseClassOrInterfaceReference(bool $classReference): ASTClassOrInterfaceReference
     {
         $this->tokenStack->push();
 
@@ -3119,11 +3028,10 @@ abstract class AbstractPHPParser
     /**
      * Parse a scope enclosed by curly braces.
      *
-     * @return ASTScopeStatement
      * @throws ParserException
      * @since 0.9.12
      */
-    private function parseRegularScope()
+    private function parseRegularScope(): ASTScopeStatement
     {
         $this->tokenStack->push();
 
@@ -3141,10 +3049,9 @@ abstract class AbstractPHPParser
      * Parses the scope of a statement that is surrounded with PHP's alternative
      * syntax for statements.
      *
-     * @return ASTScopeStatement
      * @since 0.10.0
      */
-    private function parseAlternativeScope()
+    private function parseAlternativeScope(): ASTScopeStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_COLON);
@@ -3160,11 +3067,10 @@ abstract class AbstractPHPParser
      * Parses all statements that exist in a scope an adds them to a scope
      * instance.
      *
-     * @return ASTScopeStatement
      * @throws ParserException
      * @since 0.10.0
      */
-    private function parseScopeStatements()
+    private function parseScopeStatements(): ASTScopeStatement
     {
         $scope = $this->builder->buildAstScopeStatement();
         while (($child = $this->parseOptionalStatement()) !== null) {
@@ -3194,10 +3100,9 @@ abstract class AbstractPHPParser
      * method will return <b>false</b>.
      *
      * @param int $tokenType The token type identifier.
-     * @return bool
      * @since 0.10.0
      */
-    private function isAlternativeScopeTermination(int $tokenType)
+    private function isAlternativeScopeTermination(int $tokenType): bool
     {
         return in_array(
             $tokenType,
@@ -3256,9 +3161,8 @@ abstract class AbstractPHPParser
      * Return true if children remain to be added, false else.
      *
      * @param AbstractASTNode $exprList
-     * @return bool
      */
-    private function addChildToList(ASTNode $exprList, ASTNode $expr)
+    private function addChildToList(ASTNode $exprList, ASTNode $expr): bool
     {
         $exprList->addChild($expr);
 
@@ -3282,11 +3186,10 @@ abstract class AbstractPHPParser
      * This method parses an expression node and returns it. When no expression
      * was found this method will throw an InvalidStateException.
      *
-     * @return ASTNode
      * @throws ParserException
      * @since 1.0.1
      */
-    private function parseExpression()
+    private function parseExpression(): ASTNode
     {
         if (null === ($expr = $this->parseOptionalExpression())) {
             $token = $this->consumeToken($this->tokenizer->peek());
@@ -3305,11 +3208,10 @@ abstract class AbstractPHPParser
      * This method optionally parses an expression node and returns it. When no
      * expression was found this method will return <b>null</b>.
      *
-     * @return ASTNode|null
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseOptionalExpression()
+    private function parseOptionalExpression(): ?ASTNode
     {
         $expressions = [];
 
@@ -3679,7 +3581,7 @@ abstract class AbstractPHPParser
      * @throws UnexpectedTokenException
      * @since 2.2
      */
-    private function parseOptionalExpressionForVersion()
+    private function parseOptionalExpressionForVersion(): ?ASTNode
     {
         $this->consumeComments();
         $nextTokenType = $this->tokenizer->peek();
@@ -3743,11 +3645,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a switch statement.
      *
-     * @return ASTSwitchStatement
      * @throws ParserException
      * @since 0.9.8
      */
-    private function parseSwitchStatement()
+    private function parseSwitchStatement(): ASTSwitchStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_SWITCH);
@@ -3821,11 +3722,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a case label of a switch statement.
      *
-     * @return ASTSwitchLabel
      * @throws ParserException
      * @since 0.9.8
      */
-    private function parseSwitchLabel()
+    private function parseSwitchLabel(): ASTSwitchLabel
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_CASE);
@@ -3847,10 +3747,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses the default label of a switch statement.
      *
-     * @return ASTSwitchLabel
      * @since 0.9.8
      */
-    private function parseSwitchLabelDefault()
+    private function parseSwitchLabelDefault(): ASTSwitchLabel
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_DEFAULT);
@@ -3954,11 +3853,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a try-statement + associated catch-statements.
      *
-     * @return ASTTryStatement
      * @throws ParserException
      * @since 0.9.12
      */
-    private function parseTryStatement()
+    private function parseTryStatement(): ASTTryStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_TRY);
@@ -3989,10 +3887,9 @@ abstract class AbstractPHPParser
      * This method parses a throw-statement.
      *
      * @param int[] $allowedTerminationTokens list of extra token types that can terminate the statement
-     * @return ASTThrowStatement
      * @since 0.9.12
      */
-    private function parseThrowStatement(array $allowedTerminationTokens = [])
+    private function parseThrowStatement(array $allowedTerminationTokens = []): ASTThrowStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_THROW);
@@ -4008,10 +3905,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a goto-statement.
      *
-     * @return ASTGotoStatement
      * @since 0.9.12
      */
-    private function parseGotoStatement()
+    private function parseGotoStatement(): ASTGotoStatement
     {
         $this->tokenStack->push();
 
@@ -4030,10 +3926,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a label-statement.
      *
-     * @return ASTLabelStatement
      * @since 0.9.12
      */
-    private function parseLabelStatement()
+    private function parseLabelStatement(): ASTLabelStatement
     {
         $this->tokenStack->push();
 
@@ -4049,10 +3944,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a global-statement.
      *
-     * @return ASTGlobalStatement
      * @since 0.9.12
      */
-    private function parseGlobalStatement()
+    private function parseGlobalStatement(): ASTGlobalStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_GLOBAL);
@@ -4068,10 +3962,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a unset-statement.
      *
-     * @return ASTUnsetStatement
      * @since 0.9.12
      */
-    private function parseUnsetStatement()
+    private function parseUnsetStatement(): ASTUnsetStatement
     {
         $this->tokenStack->push();
 
@@ -4094,10 +3987,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a catch-statement.
      *
-     * @return ASTCatchStatement
      * @since 0.9.8
      */
-    private function parseCatchStatement()
+    private function parseCatchStatement(): ASTCatchStatement
     {
         $this->tokenStack->push();
         $this->consumeComments();
@@ -4162,10 +4054,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a finally-statement.
      *
-     * @return ASTFinallyStatement
      * @since 2.0.0
      */
-    private function parseFinallyStatement()
+    private function parseFinallyStatement(): ASTFinallyStatement
     {
         $this->tokenStack->push();
         $this->consumeComments();
@@ -4181,10 +4072,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single if-statement node.
      *
-     * @return ASTIfStatement
      * @since 0.9.8
      */
-    private function parseIfStatement()
+    private function parseIfStatement(): ASTIfStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_IF);
@@ -4201,10 +4091,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single elseif-statement node.
      *
-     * @return ASTElseIfStatement
      * @since 0.9.8
      */
-    private function parseElseIfStatement()
+    private function parseElseIfStatement(): ASTElseIfStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_ELSEIF);
@@ -4254,11 +4143,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single for-statement node.
      *
-     * @return ASTForStatement
      * @throws ParserException
      * @since 0.9.8
      */
-    private function parseForStatement()
+    private function parseForStatement(): ASTForStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_FOR);
@@ -4295,10 +4183,9 @@ abstract class AbstractPHPParser
      *      ------------------------
      * </code>
      *
-     * @return ASTForInit|null
      * @since 0.9.8
      */
-    private function parseForInit()
+    private function parseForInit(): ?ASTForInit
     {
         $this->consumeComments();
 
@@ -4317,11 +4204,10 @@ abstract class AbstractPHPParser
     /**
      * Parses the expression part of a for-statement.
      *
-     * @return ASTNode|null
      * @throws ParserException
      * @since 0.9.12
      */
-    private function parseForExpression()
+    private function parseForExpression(): ?ASTNode
     {
         return $this->parseOptionalExpression();
     }
@@ -4335,10 +4221,9 @@ abstract class AbstractPHPParser
      *                                        -------------------------------
      * </code>
      *
-     * @return ASTForUpdate|null
      * @since 0.9.12
      */
-    private function parseForUpdate()
+    private function parseForUpdate(): ?ASTForUpdate
     {
         $this->consumeComments();
         if (Tokens::T_PARENTHESIS_CLOSE === $this->tokenizer->peek()) {
@@ -4356,10 +4241,9 @@ abstract class AbstractPHPParser
     /**
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
-     * @return bool
      * @since 2.6.0
      */
-    private function isListUnpacking(?int $tokenType = null)
+    private function isListUnpacking(?int $tokenType = null): bool
     {
         return in_array($tokenType ?: $this->tokenizer->peek(), [Tokens::T_LIST, Tokens::T_SQUARED_BRACKET_OPEN], true);
     }
@@ -4369,7 +4253,7 @@ abstract class AbstractPHPParser
      *
      * @return ASTNode[]
      */
-    private function parseForeachChildren()
+    private function parseForeachChildren(): array
     {
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
             return [$this->parseVariableOrMemberByReference()];
@@ -4397,10 +4281,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single foreach-statement node.
      *
-     * @return ASTForeachStatement
      * @since 0.9.8
      */
-    private function parseForeachStatement()
+    private function parseForeachStatement(): ASTForeachStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_FOREACH);
@@ -4430,10 +4313,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single while-statement node.
      *
-     * @return ASTWhileStatement
      * @since 0.9.8
      */
-    private function parseWhileStatement()
+    private function parseWhileStatement(): ASTWhileStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_WHILE);
@@ -4449,10 +4331,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a do/while-statement.
      *
-     * @return ASTDoWhileStatement
      * @since 0.9.12
      */
-    private function parseDoWhileStatement()
+    private function parseDoWhileStatement(): ASTDoWhileStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_DO);
@@ -4491,10 +4372,9 @@ abstract class AbstractPHPParser
      * -----------
      * </code>
      *
-     * @return ASTDeclareStatement
      * @since 0.10.0
      */
-    private function parseDeclareStatement()
+    private function parseDeclareStatement(): ASTDeclareStatement
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_DECLARE);
@@ -4552,10 +4432,9 @@ abstract class AbstractPHPParser
     /**
      * This method builds a return statement from a given token.
      *
-     * @return ASTReturnStatement
      * @since 2.7.0
      */
-    private function buildReturnStatement(Token $token)
+    private function buildReturnStatement(Token $token): ASTReturnStatement
     {
         $stmt = $this->builder->buildAstReturnStatement($token->image);
 
@@ -4569,10 +4448,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a single return-statement node.
      *
-     * @return ASTReturnStatement
      * @since 0.9.12
      */
-    private function parseReturnStatement()
+    private function parseReturnStatement(): ASTReturnStatement
     {
         $this->tokenStack->push();
 
@@ -4588,10 +4466,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a break-statement node.
      *
-     * @return ASTBreakStatement
      * @since 0.9.12
      */
-    private function parseBreakStatement()
+    private function parseBreakStatement(): ASTBreakStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_BREAK);
@@ -4608,10 +4485,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a continue-statement node.
      *
-     * @return ASTContinueStatement
      * @since 0.9.12
      */
-    private function parseContinueStatement()
+    private function parseContinueStatement(): ASTContinueStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_CONTINUE);
@@ -4628,10 +4504,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses a echo-statement node.
      *
-     * @return ASTEchoStatement
      * @since 0.9.12
      */
-    private function parseEchoStatement()
+    private function parseEchoStatement(): ASTEchoStatement
     {
         $this->tokenStack->push();
         $token = $this->consumeToken(Tokens::T_ECHO);
@@ -4653,10 +4528,9 @@ abstract class AbstractPHPParser
      * (new MyClass())->bar();
      * </code>
      *
-     * @return ASTNode
      * @since 1.0.0
      */
-    private function parseParenthesisExpressionOrPrimaryPrefix()
+    private function parseParenthesisExpressionOrPrimaryPrefix(): ASTNode
     {
         return $this->parseParenthesisExpressionOrPrimaryPrefixForVersion(
             $this->parseParenthesisExpression(),
@@ -4680,10 +4554,7 @@ abstract class AbstractPHPParser
         return $expr;
     }
 
-    /**
-     * @return bool
-     */
-    private function isNextTokenObjectOperator()
+    private function isNextTokenObjectOperator(): bool
     {
         return in_array($this->tokenizer->peek(), [
             Tokens::T_OBJECT_OPERATOR,
@@ -4692,11 +4563,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @return Token
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
-    private function consumeObjectOperatorToken()
+    private function consumeObjectOperatorToken(): Token
     {
         return $this->consumeToken(
             $this->tokenizer->peek() === Tokens::T_NULLSAFE_OBJECT_OPERATOR
@@ -4709,10 +4579,9 @@ abstract class AbstractPHPParser
      * Parses any expression that is surrounded by an opening and a closing
      * parenthesis
      *
-     * @return ASTExpression
      * @since 0.9.8
      */
-    private function parseParenthesisExpression()
+    private function parseParenthesisExpression(): ASTExpression
     {
         $this->tokenStack->push();
         $this->consumeComments();
@@ -4769,11 +4638,10 @@ abstract class AbstractPHPParser
      * func();
      * </code>
      *
-     * @return ASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseMemberPrefixOrFunctionPostfix()
+    private function parseMemberPrefixOrFunctionPostfix(): ASTNode
     {
         $this->tokenStack->push();
         $this->tokenStack->push();
@@ -4843,11 +4711,10 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node This node represents the function identifier. An identifier can be a static string,
      *                      a variable, a compound variable or any other valid php function identifier.
-     * @return AbstractASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseFunctionPostfix(ASTNode $node)
+    private function parseFunctionPostfix(ASTNode $node): AbstractASTNode
     {
         $image = $this->extractPostfixImage($node);
 
@@ -4899,10 +4766,9 @@ abstract class AbstractPHPParser
      * This method parses a PHP version specific identifier for method and
      * property postfix expressions.
      *
-     * @return ASTNode
      * @since 1.0.0
      */
-    private function parsePostfixIdentifier()
+    private function parsePostfixIdentifier(): ASTNode
     {
         $tokenType = $this->tokenizer->peek();
         if ($this->isConstantName($tokenType)) {
@@ -4960,11 +4826,10 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The left node in the parsed member primary expression.
-     * @return AbstractASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseMemberPrimaryPrefix(ASTNode $node)
+    private function parseMemberPrimaryPrefix(ASTNode $node): AbstractASTNode
     {
         // Consume double colon and optional comments
         $token = $this->consumeObjectOperatorToken();
@@ -5022,11 +4887,10 @@ abstract class AbstractPHPParser
      *
      * @param AbstractASTNode $node This node represents primary prefix left expression. It will
      *                              be the first child of the parsed member primary expression.
-     * @return AbstractASTNode
      * @throws ParserException
      * @since 1.0.1
      */
-    private function parseOptionalStaticMemberPrimaryPrefix(AbstractASTNode $node)
+    private function parseOptionalStaticMemberPrimaryPrefix(AbstractASTNode $node): AbstractASTNode
     {
         $this->consumeComments();
 
@@ -5061,11 +4925,10 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param ASTNode $node The left node in the parsed member primary expression.
-     * @return AbstractASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseStaticMemberPrimaryPrefix(ASTNode $node)
+    private function parseStaticMemberPrimaryPrefix(ASTNode $node): AbstractASTNode
     {
         $token = $this->consumeToken(Tokens::T_DOUBLE_COLON);
 
@@ -5093,10 +4956,9 @@ abstract class AbstractPHPParser
      * This method parses a method- or constant-postfix expression. This expression
      * will contain an identifier node as nested child.
      *
-     * @return ASTNode
      * @since 0.9.6
      */
-    private function parseMethodOrConstantPostfix()
+    private function parseMethodOrConstantPostfix(): ASTNode
     {
         $this->tokenStack->push();
 
@@ -5119,11 +4981,10 @@ abstract class AbstractPHPParser
      *
      * @param ASTNode $node The identifier for the parsed postfix expression node. This node
      *                      will be the first child of the returned postfix node instance.
-     * @return ASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseMethodOrPropertyPostfix(ASTNode $node)
+    private function parseMethodOrPropertyPostfix(ASTNode $node): ASTNode
     {
         // Strip optional comments
         $this->consumeComments();
@@ -5140,10 +5001,9 @@ abstract class AbstractPHPParser
      * Parses/Creates a property postfix node instance.
      *
      * @param ASTNode $node Node that represents the image of the property postfix node.
-     * @return ASTPropertyPostfix
      * @since 0.10.2
      */
-    private function parsePropertyPostfix(ASTNode $node)
+    private function parsePropertyPostfix(ASTNode $node): ASTPropertyPostfix
     {
         $image = $this->extractPostfixImage($node);
 
@@ -5163,10 +5023,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a full qualified class name postfix.
      *
-     * @return ASTClassFqnPostfix
      * @since 2.0.0
      */
-    private function parseFullQualifiedClassNamePostfix()
+    private function parseFullQualifiedClassNamePostfix(): ASTClassFqnPostfix
     {
         $this->tokenStack->push();
 
@@ -5184,10 +5043,9 @@ abstract class AbstractPHPParser
      * return the image of the entire <b>$node</b>.
      *
      * @param ASTNode $node The context node that may be wrapped by multiple array or string index expressions.
-     * @return string
      * @since 1.0.0
      */
-    private function extractPostfixImage(ASTNode $node)
+    private function extractPostfixImage(ASTNode $node): string
     {
         while ($node instanceof ASTIndexExpression) {
             $node = $node->getChild(0);
@@ -5200,10 +5058,9 @@ abstract class AbstractPHPParser
      * Parses a method postfix node instance.
      *
      * @param ASTNode $node Node that represents the image of the method postfix node.
-     * @return AbstractASTNode
      * @since 1.0.0
      */
-    private function parseMethodPostfix(ASTNode $node)
+    private function parseMethodPostfix(ASTNode $node): AbstractASTNode
     {
         $args = $this->parseArguments();
         $image = $this->extractPostfixImage($node);
@@ -5225,11 +5082,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses the arguments passed to a function- or method-call.
      *
-     * @return ASTArguments
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseArguments()
+    private function parseArguments(): ASTArguments
     {
         $this->consumeComments();
 
@@ -5307,10 +5163,9 @@ abstract class AbstractPHPParser
      * variables, object/static method. All these expressions are valid in
      * several php language constructs like, isset, empty, unset etc.
      *
-     * @return ASTNode
      * @since 0.9.12
      */
-    private function parseVariableOrConstantOrPrimaryPrefix()
+    private function parseVariableOrConstantOrPrimaryPrefix(): ASTNode
     {
         $this->consumeComments();
 
@@ -5339,11 +5194,10 @@ abstract class AbstractPHPParser
      * variable is followed by an object operator, double colon or opening
      * parenthesis.
      *
-     * @return AbstractASTNode
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseVariableOrFunctionPostfixOrMemberPrimaryPrefix()
+    private function parseVariableOrFunctionPostfixOrMemberPrimaryPrefix(): AbstractASTNode
     {
         $this->tokenStack->push();
 
@@ -5367,10 +5221,9 @@ abstract class AbstractPHPParser
      * Parses an assingment expression node.
      *
      * @param ASTNode $left The left part of the assignment expression that will be parsed by this method.
-     * @return ASTAssignmentExpression
      * @since 0.9.12
      */
-    private function parseAssignmentExpression(ASTNode $left)
+    private function parseAssignmentExpression(ASTNode $left): ASTAssignmentExpression
     {
         $token = $this->consumeToken($this->tokenizer->peek());
 
@@ -5398,12 +5251,11 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTStaticReference} node.
      *
      * @param Token $token The "static" keyword token.
-     * @return ASTStaticReference
      * @throws ParserException
      * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseStaticReference(Token $token)
+    private function parseStaticReference(Token $token): ASTStaticReference
     {
         // Strip optional comments
         $this->consumeComments();
@@ -5431,12 +5283,11 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTSelfReference} node.
      *
      * @param Token $token The "self" keyword token.
-     * @return ASTSelfReference
      * @throws ParserException
      * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseSelfReference(Token $token)
+    private function parseSelfReference(Token $token): ASTSelfReference
     {
         if (!isset($this->classOrInterface)) {
             throw new InvalidStateException(
@@ -5460,10 +5311,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a simple PHP constant use and returns a corresponding node.
      *
-     * @return ASTNode|null
      * @since 1.0.0
      */
-    private function parseConstant()
+    private function parseConstant(): ?ASTNode
     {
         $this->tokenStack->push();
 
@@ -5494,12 +5344,11 @@ abstract class AbstractPHPParser
      * contains the self reference as its first child when the self token is
      * followed by a double colon token.
      *
-     * @return ASTNode
      * @throws ParserException
      * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseConstantOrSelfMemberPrimaryPrefix()
+    private function parseConstantOrSelfMemberPrimaryPrefix(): ASTNode
     {
         // Read self token and strip optional comments
         $token = $this->consumeToken(Tokens::T_SELF);
@@ -5518,12 +5367,11 @@ abstract class AbstractPHPParser
      * This method parses a {@link ASTParentReference} node.
      *
      * @param Token $token The "self" keyword token.
-     * @return ASTParentReference
      * @throws ParserException
      * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseParentReference(Token $token)
+    private function parseParentReference(Token $token): ASTParentReference
     {
         if (!isset($this->classOrInterface)) {
             throw new InvalidStateException(
@@ -5567,12 +5415,11 @@ abstract class AbstractPHPParser
      * that contains the parent reference as its first child when the self token
      * is followed by a double colon token.
      *
-     * @return ASTNode
      * @throws ParserException
      * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseConstantOrParentMemberPrimaryPrefix()
+    private function parseConstantOrParentMemberPrimaryPrefix(): ASTNode
     {
         // Consume parent token and strip optional comments
         $token = $this->consumeToken(Tokens::T_PARENT);
@@ -5601,10 +5448,9 @@ abstract class AbstractPHPParser
      * //     ----------
      * </code>
      *
-     * @return ASTNode
      * @since 0.9.18
      */
-    private function parseVariableOrMemberOptionalByReference()
+    private function parseVariableOrMemberOptionalByReference(): ASTNode
     {
         $this->consumeComments();
 
@@ -5629,10 +5475,9 @@ abstract class AbstractPHPParser
      * //     ----------
      * </code>
      *
-     * @return ASTUnaryExpression
      * @since 0.9.18
      */
-    private function parseVariableOrMemberByReference()
+    private function parseVariableOrMemberByReference(): ASTUnaryExpression
     {
         $this->tokenStack->push();
 
@@ -5648,11 +5493,10 @@ abstract class AbstractPHPParser
     /**
      * This method parses a simple PHP variable.
      *
-     * @return ASTVariable
      * @throws UnexpectedTokenException
      * @since 0.9.6
      */
-    private function parseVariable()
+    private function parseVariable(): ASTVariable
     {
         $token = $this->consumeToken(Tokens::T_VARIABLE);
 
@@ -5727,12 +5571,11 @@ abstract class AbstractPHPParser
      * ------
      * </code>
      *
-     * @return AbstractASTNode
      * @throws ParserException
      * @throws UnexpectedTokenException
      * @since 0.9.6
      */
-    private function parseCompoundVariableOrVariableVariableOrVariable()
+    private function parseCompoundVariableOrVariableVariableOrVariable(): AbstractASTNode
     {
         if ($this->tokenizer->peek() === Tokens::T_DOLLAR) {
             return $this->parseCompoundVariableOrVariableVariable();
@@ -5744,10 +5587,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a PHP compound variable or a simple literal node.
      *
-     * @return ASTNode
      * @since 0.9.19
      */
-    private function parseCompoundVariableOrLiteral()
+    private function parseCompoundVariableOrLiteral(): ASTNode
     {
         $this->tokenStack->push();
 
@@ -5782,12 +5624,11 @@ abstract class AbstractPHPParser
      * this is compound variable, otherwise it can be a variable-variable or a
      * compound-variable.
      *
-     * @return AbstractASTNode
      * @throws ParserException
      * @throws UnexpectedTokenException
      * @since 0.9.6
      */
-    private function parseCompoundVariableOrVariableVariable()
+    private function parseCompoundVariableOrVariableVariable(): AbstractASTNode
     {
         $this->tokenStack->push();
 
@@ -5829,10 +5670,9 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param Token $token The dollar token.
-     * @return ASTCompoundVariable
      * @since 0.10.0
      */
-    private function parseCompoundVariable(Token $token)
+    private function parseCompoundVariable(Token $token): ASTCompoundVariable
     {
         return $this->parseBraceExpression(
             $this->builder->buildAstCompoundVariable($token->image),
@@ -5858,10 +5698,9 @@ abstract class AbstractPHPParser
      * //      -
      * </code>
      *
-     * @return ASTNode
      * @since 0.9.10
      */
-    private function parseCompoundExpressionOrLiteral()
+    private function parseCompoundExpressionOrLiteral(): ASTNode
     {
         $token = $this->consumeToken(Tokens::T_CURLY_BRACE_OPEN);
         $this->consumeComments();
@@ -5896,12 +5735,11 @@ abstract class AbstractPHPParser
      * ------------------
      * </code>
      *
-     * @return ASTCompoundExpression
      * @throws ParserException
      * @throws ParserException
      * @since 0.9.6
      */
-    private function parseCompoundExpression()
+    private function parseCompoundExpression(): ASTCompoundExpression
     {
         $this->consumeComments();
 
@@ -5916,10 +5754,9 @@ abstract class AbstractPHPParser
      * Parses a static identifier expression, as it is used for method and
      * function names.
      *
-     * @return ASTIdentifier
      * @since 0.9.12
      */
-    private function parseIdentifier(int $tokenType = Tokens::T_STRING)
+    private function parseIdentifier(int $tokenType = Tokens::T_STRING): ASTIdentifier
     {
         $token = $this->consumeToken($tokenType);
 
@@ -5939,10 +5776,9 @@ abstract class AbstractPHPParser
      * instance of {@link ASTString} that represents a string
      * in double quotes or surrounded by backticks.
      *
-     * @return ASTNode
      * @throws UnexpectedTokenException
      */
-    private function parseLiteralOrString()
+    private function parseLiteralOrString(): ASTNode
     {
         $tokenType = $this->tokenizer->peek();
 
@@ -5975,11 +5811,10 @@ abstract class AbstractPHPParser
     /**
      * Parses an integer value.
      *
-     * @return ASTLiteral
      * @throws UnexpectedTokenException
      * @since 1.0.0
      */
-    private function parseIntegerNumber()
+    private function parseIntegerNumber(): ASTLiteral
     {
         $token = $this->consumeToken(Tokens::T_LNUMBER);
         $number = $token->image;
@@ -6024,10 +5859,9 @@ abstract class AbstractPHPParser
     /**
      * Parses an array structure.
      *
-     * @return ASTArray
      * @since 1.0.0
      */
-    private function doParseArray(bool $static = false)
+    private function doParseArray(bool $static = false): ASTArray
     {
         $this->tokenStack->push();
 
@@ -6043,10 +5877,9 @@ abstract class AbstractPHPParser
      * Tests if the next token is a valid array start delimiter in the supported
      * PHP version.
      *
-     * @return bool
      * @since 1.0.0
      */
-    private function isArrayStartDelimiter()
+    private function isArrayStartDelimiter(): bool
     {
         return match ($this->tokenizer->peek()) {
             Tokens::T_ARRAY,
@@ -6158,10 +5991,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match key.
      *
-     * @return ASTNode
      * @since 2.9.0
      */
-    private function parseMatchEntryKey()
+    private function parseMatchEntryKey(): ASTNode
     {
         $this->consumeComments();
 
@@ -6183,10 +6015,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match value expression.
      *
-     * @return ASTNode
      * @since 2.9.0
      */
-    private function parseMatchEntryValue()
+    private function parseMatchEntryValue(): ASTNode
     {
         $this->consumeComments();
 
@@ -6200,10 +6031,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a single match entry key-expression pair.
      *
-     * @return ASTMatchEntry
      * @since 2.9.0
      */
-    private function parseMatchEntry()
+    private function parseMatchEntry(): ASTMatchEntry
     {
         $this->consumeComments();
 
@@ -6238,10 +6068,9 @@ abstract class AbstractPHPParser
      * An array element can have a simple value, a key/value pair, a value by
      * reference or a key/value pair with a referenced value.
      *
-     * @return ASTArrayElement
      * @since 1.0.0
      */
-    private function parseArrayElement(bool $static = false)
+    private function parseArrayElement(bool $static = false): ASTArrayElement
     {
         $this->consumeComments();
 
@@ -6282,10 +6111,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a here- or nowdoc string instance.
      *
-     * @return ASTHeredoc
      * @since 0.9.12
      */
-    private function parseHeredoc()
+    private function parseHeredoc(): ASTHeredoc
     {
         $this->tokenStack->push();
         $this->consumeToken(Tokens::T_START_HEREDOC);
@@ -6303,10 +6131,9 @@ abstract class AbstractPHPParser
      * Parses a simple string sequence between two tokens of the same type.
      *
      * @param int $tokenType The start/stop token type.
-     * @return string
      * @since 0.9.10
      */
-    private function parseStringSequence(int $tokenType)
+    private function parseStringSequence(int $tokenType): string
     {
         $type = $tokenType;
         $string = '';
@@ -6335,11 +6162,10 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param int $delimiterType The start/stop token type.
-     * @return ASTString
      * @throws UnexpectedTokenException
      * @since 0.9.10
      */
-    private function parseString(int $delimiterType)
+    private function parseString(int $delimiterType): ASTString
     {
         $token = $this->consumeToken($delimiterType);
 
@@ -6414,10 +6240,9 @@ abstract class AbstractPHPParser
     /**
      * This method parses an escaped sequence of literal tokens.
      *
-     * @return ASTLiteral
      * @since 0.9.10
      */
-    private function parseEscapedAstLiteralString()
+    private function parseEscapedAstLiteralString(): ASTLiteral
     {
         $this->tokenStack->push();
 
@@ -6451,10 +6276,9 @@ abstract class AbstractPHPParser
      * This method parses a simple literal and configures the position
      * properties.
      *
-     * @return ASTLiteral
      * @since 0.9.10
      */
-    private function parseLiteral()
+    private function parseLiteral(): ASTLiteral
     {
         $token = $this->consumeToken($this->tokenizer->peek());
 
@@ -6469,10 +6293,7 @@ abstract class AbstractPHPParser
         return $node;
     }
 
-    /**
-     * @return int
-     */
-    private function checkReadonlyToken()
+    private function checkReadonlyToken(): int
     {
         if ($this->addTokenToStackIfType(Tokens::T_READONLY)) {
             return State::IS_READONLY;
@@ -6483,10 +6304,8 @@ abstract class AbstractPHPParser
 
     /**
      * Parse the modifiers for construct parameter
-     *
-     * @return int
      */
-    private function parseConstructFormalParameterModifiers()
+    private function parseConstructFormalParameterModifiers(): int
     {
         static $states = [
             Tokens::T_PUBLIC => State::IS_PUBLIC,
@@ -6513,9 +6332,8 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
-     * @return ASTNode
      */
-    private function parseFormalParameterOrPrefix(ASTCallable $callable)
+    private function parseFormalParameterOrPrefix(ASTCallable $callable): ASTNode
     {
         $modifier = 0;
 
@@ -6537,10 +6355,9 @@ abstract class AbstractPHPParser
      *
      * @param ASTCallable $callable the callable object (closure, function or method)
      *                              requiring the given parameters list.
-     * @return ASTFormalParameters
      * @since 0.9.5
      */
-    private function parseFormalParameters(ASTCallable $callable)
+    private function parseFormalParameters(ASTCallable $callable): ASTFormalParameters
     {
         $this->consumeComments();
 
@@ -6606,10 +6423,9 @@ abstract class AbstractPHPParser
      * //                ---
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterOrTypeHintOrByReference()
+    private function parseFormalParameterOrTypeHintOrByReference(): ASTFormalParameter
     {
         $this->consumeComments();
         $this->consumeQuestionMark();
@@ -6623,10 +6439,7 @@ abstract class AbstractPHPParser
         );
     }
 
-    /**
-     * @return ASTFormalParameter
-     */
-    private function parseFormalParameterFromType(int $tokenType)
+    private function parseFormalParameterFromType(int $tokenType): ASTFormalParameter
     {
         if ($this->isTypeHint($tokenType)) {
             $typeHint = $this->parseOptionalTypeHint();
@@ -6653,10 +6466,9 @@ abstract class AbstractPHPParser
      * //                ---------
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterAndArrayTypeHint()
+    private function parseFormalParameterAndArrayTypeHint(): ASTFormalParameter
     {
         $node = $this->parseArrayType();
 
@@ -6666,10 +6478,7 @@ abstract class AbstractPHPParser
         return $parameter;
     }
 
-    /**
-     * @return ASTTypeArray
-     */
-    private function parseArrayType()
+    private function parseArrayType(): ASTTypeArray
     {
         $token = $this->consumeToken(Tokens::T_ARRAY);
 
@@ -6687,10 +6496,9 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version after the next token.
      *
-     * @return ASTType
      * @since 2.9.2
      */
-    private function parseOptionalTypeHint()
+    private function parseOptionalTypeHint(): ASTType
     {
         $this->tokenStack->push();
 
@@ -6706,10 +6514,9 @@ abstract class AbstractPHPParser
      * //                ------------
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterAndTypeHint(ASTNode $typeHint)
+    private function parseFormalParameterAndTypeHint(ASTNode $typeHint): ASTFormalParameter
     {
         $classReference = $this->setNodePositionsAndReturn($typeHint);
         $parameter = $this->parseFormalParameterOrByReference();
@@ -6731,10 +6538,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterAndParentTypeHint()
+    private function parseFormalParameterAndParentTypeHint(): ASTFormalParameter
     {
         $reference = $this->parseParentType();
         $parameter = $this->parseFormalParameterOrByReference();
@@ -6743,10 +6549,7 @@ abstract class AbstractPHPParser
         return $parameter;
     }
 
-    /**
-     * @return ASTParentReference
-     */
-    private function parseParentType()
+    private function parseParentType(): ASTParentReference
     {
         return $this->parseParentReference($this->consumeToken(Tokens::T_PARENT));
     }
@@ -6764,10 +6567,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterAndSelfTypeHint()
+    private function parseFormalParameterAndSelfTypeHint(): ASTFormalParameter
     {
         $self = $this->parseSelfType();
 
@@ -6790,10 +6592,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 2.9.2
      */
-    private function parseFormalParameterAndStaticTypeHint()
+    private function parseFormalParameterAndStaticTypeHint(): ASTFormalParameter
     {
         $self = $this->parseStaticType();
 
@@ -6803,18 +6604,12 @@ abstract class AbstractPHPParser
         return $parameter;
     }
 
-    /**
-     * @return ASTSelfReference
-     */
-    private function parseSelfType()
+    private function parseSelfType(): ASTSelfReference
     {
         return $this->parseSelfReference($this->consumeToken(Tokens::T_SELF));
     }
 
-    /**
-     * @return ASTStaticReference
-     */
-    private function parseStaticType()
+    private function parseStaticType(): ASTStaticReference
     {
         return $this->parseStaticReference($this->consumeToken(Tokens::T_STATIC));
     }
@@ -6829,10 +6624,9 @@ abstract class AbstractPHPParser
      * //                 ---  -------
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterOrByReference()
+    private function parseFormalParameterOrByReference(): ASTFormalParameter
     {
         $this->consumeComments();
         if ($this->tokenizer->peek() === Tokens::T_BITWISE_AND) {
@@ -6851,10 +6645,9 @@ abstract class AbstractPHPParser
      * //                 ---  --------
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameterAndByReference()
+    private function parseFormalParameterAndByReference(): ASTFormalParameter
     {
         $this->consumeToken(Tokens::T_BITWISE_AND);
         $this->consumeComments();
@@ -6875,10 +6668,9 @@ abstract class AbstractPHPParser
      * //               --  -------
      * </code>
      *
-     * @return ASTFormalParameter
      * @since 0.9.6
      */
-    private function parseFormalParameter()
+    private function parseFormalParameter(): ASTFormalParameter
     {
         $parameter = $this->builder->buildAstFormalParameter();
 
@@ -6898,10 +6690,9 @@ abstract class AbstractPHPParser
      * Tests if the given token type is a valid formal parameter in the supported
      * PHP version.
      *
-     * @return bool
      * @since 1.0.0
      */
-    protected function isTypeHint(int $tokenType)
+    protected function isTypeHint(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_SELF,
@@ -6921,11 +6712,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version.
      *
-     * @return ASTType
      * @throws ParserException
      * @since 1.0.0
      */
-    private function parseBasicTypeHint()
+    private function parseBasicTypeHint(): ASTType
     {
         $this->consumeQuestionMark();
 
@@ -6960,10 +6750,7 @@ abstract class AbstractPHPParser
         }
     }
 
-    /**
-     * @return ASTType
-     */
-    protected function parseSingleTypeHint()
+    protected function parseSingleTypeHint(): ASTType
     {
         $this->consumeComments();
 
@@ -7030,10 +6817,7 @@ abstract class AbstractPHPParser
         return $type;
     }
 
-    /**
-     * @return ASTUnionType
-     */
-    private function parseUnionTypeHint(ASTType $firstType)
+    private function parseUnionTypeHint(ASTType $firstType): ASTUnionType
     {
         $types = [$firstType];
 
@@ -7052,10 +6836,7 @@ abstract class AbstractPHPParser
         return $unionType;
     }
 
-    /**
-     * @return ASTIntersectionType
-     */
-    private function parseIntersectionTypeHint(ASTType $firstType)
+    private function parseIntersectionTypeHint(ASTType $firstType): ASTIntersectionType
     {
         $token = $this->tokenizer->currentToken();
         $types = [$firstType];
@@ -7081,10 +6862,7 @@ abstract class AbstractPHPParser
         return $intersectionType;
     }
 
-    /**
-     * @return ASTType
-     */
-    private function parseTypeHintCombination(ASTType $type)
+    private function parseTypeHintCombination(ASTType $type): ASTType
     {
         $peek = $this->tokenizer->peek();
 
@@ -7101,10 +6879,7 @@ abstract class AbstractPHPParser
         return $type;
     }
 
-    /**
-     * @return bool
-     */
-    protected function canNotBeStandAloneType(ASTNode $type)
+    protected function canNotBeStandAloneType(ASTNode $type): bool
     {
         return $type instanceof ASTScalarType && ($type->isFalse() || $type->isNull());
     }
@@ -7112,11 +6887,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a type hint that is valid in the supported PHP version.
      *
-     * @return ASTType
      * @throws ParserException
      * @since 1.0.0
      */
-    protected function parseTypeHint()
+    protected function parseTypeHint(): ASTType
     {
         $this->consumeComments();
         $token = $this->tokenizer->currentToken();
@@ -7138,10 +6912,9 @@ abstract class AbstractPHPParser
     /**
      * Extracts all dependencies from a callable body.
      *
-     * @return ASTScope
      * @since 0.9.12
      */
-    private function parseScope()
+    private function parseScope(): ASTScope
     {
         $scope = $this->builder->buildAstScope();
 
@@ -7163,12 +6936,11 @@ abstract class AbstractPHPParser
     /**
      * Parse a statement.
      *
-     * @return ASTNode
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      * @since 1.0.0
      */
-    private function parseStatement()
+    private function parseStatement(): ASTNode
     {
         if ($stmt = $this->parseOptionalStatement()) {
             return $stmt;
@@ -7180,11 +6952,10 @@ abstract class AbstractPHPParser
     /**
      * Parses an optional statement or returns <b>null</b>.
      *
-     * @return ASTNode|null
      * @throws ParserException
      * @since 0.9.8
      */
-    private function parseOptionalStatement()
+    private function parseOptionalStatement(): ?ASTNode
     {
         switch ($this->tokenizer->peek()) {
             case Tokens::T_ECHO:
@@ -7349,10 +7120,9 @@ abstract class AbstractPHPParser
      * Parses a sequence of none php code tokens and returns the token type of
      * the next token.
      *
-     * @return int
      * @since 0.9.12
      */
-    private function parseNonePhpCode()
+    private function parseNonePhpCode(): int
     {
         $this->consumeToken(Tokens::T_CLOSE_TAG);
 
@@ -7381,10 +7151,9 @@ abstract class AbstractPHPParser
      * Parses a comment and optionally an embedded class or interface type
      * annotation.
      *
-     * @return ASTComment
      * @since 0.9.8
      */
-    private function parseCommentWithOptionalInlineClassOrInterfaceReference()
+    private function parseCommentWithOptionalInlineClassOrInterfaceReference(): ASTComment
     {
         $token = $this->consumeToken(Tokens::T_COMMENT);
 
@@ -7481,11 +7250,10 @@ abstract class AbstractPHPParser
      * PDepend\Source\Parser::parse();
      * </code>
      *
-     * @return string
      * @throws NoActiveScopeException
      * @link   http://php.net/manual/en/language.namespaces.importing.php
      */
-    private function parseQualifiedName()
+    private function parseQualifiedName(): string
     {
         $fragments = $this->parseQualifiedNameRaw();
 
@@ -7523,7 +7291,7 @@ abstract class AbstractPHPParser
      * @return array<string>
      * @since 0.9.5
      */
-    private function parseQualifiedNameRaw()
+    private function parseQualifiedNameRaw(): array
     {
         // Reset namespace prefix flag
         $this->namespacePrefixReplaced = false;
@@ -7579,10 +7347,8 @@ abstract class AbstractPHPParser
 
     /**
      * Determines if the given image is a PHP 7 type hint.
-     *
-     * @return bool
      */
-    protected function isScalarOrCallableTypeHint(string $image)
+    protected function isScalarOrCallableTypeHint(string $image): bool
     {
         return match (strtolower($image)) {
             'int',
@@ -7599,9 +7365,8 @@ abstract class AbstractPHPParser
 
     /**
      * @param array<string> $previousElements
-     * @return string|null
      */
-    private function parseQualifiedNameElement(array $previousElements)
+    private function parseQualifiedNameElement(array $previousElements): ?string
     {
         if (Tokens::T_CURLY_BRACE_OPEN !== $this->tokenizer->peek()) {
             return $this->parseClassName();
@@ -7759,7 +7524,7 @@ abstract class AbstractPHPParser
      * @param array<string> $fragments
      * @return false|string
      */
-    private function parseNamespaceImage(array $fragments)
+    private function parseNamespaceImage(array $fragments): bool|string
     {
         if ($this->tokenizer->peek() === Tokens::T_AS) {
             $this->consumeToken(Tokens::T_AS);
@@ -7786,10 +7551,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTConstantDefinition
      * @since 0.9.6
      */
-    private function parseConstantDefinition()
+    private function parseConstantDefinition(): ASTConstantDefinition
     {
         $this->tokenStack->push();
 
@@ -7821,10 +7585,9 @@ abstract class AbstractPHPParser
     /**
      * Constant cannot be typed before PHP 8.3.
      *
-     * @return ASTConstantDeclarator
      * @since  1.16.0
      */
-    protected function parseTypedConstantDeclarator()
+    protected function parseTypedConstantDeclarator(): ASTConstantDeclarator
     {
         throw $this->getUnexpectedNextTokenException();
     }
@@ -7860,10 +7623,9 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTConstantDeclarator
      * @since 0.9.6
      */
-    private function parseConstantDeclarator()
+    private function parseConstantDeclarator(): ASTConstantDeclarator
     {
         // Remove leading comments and create a new token stack
         $this->consumeComments();
@@ -7903,7 +7665,7 @@ abstract class AbstractPHPParser
      * @return ?ASTValue
      * @since 2.2.x
      */
-    protected function parseConstantDeclaratorValue()
+    protected function parseConstantDeclaratorValue(): ?ASTValue
     {
         if ($this->isFollowedByStaticValueOrStaticArray()) {
             return $this->parseVariableDefaultValue();
@@ -7953,12 +7715,11 @@ abstract class AbstractPHPParser
      * };
      * </code>
      *
-     * @return ASTNode
      * @throws ParserException
      * @throws UnexpectedTokenException
      * @since 0.9.6
      */
-    private function parseStaticVariableDeclarationOrMemberPrimaryPrefix()
+    private function parseStaticVariableDeclarationOrMemberPrimaryPrefix(): ASTNode
     {
         $this->tokenStack->push();
 
@@ -8015,10 +7776,9 @@ abstract class AbstractPHPParser
      * </code>
      *
      * @param Token $token Token with the "static" keyword.
-     * @return ASTStaticVariableDeclaration
      * @since 0.9.6
      */
-    private function parseStaticVariableDeclaration(Token $token)
+    private function parseStaticVariableDeclaration(Token $token): ASTStaticVariableDeclaration
     {
         $staticDeclaration = $this->builder->buildAstStaticVariableDeclaration(
             $token->image,
@@ -8066,11 +7826,10 @@ abstract class AbstractPHPParser
      * }
      * </code>
      *
-     * @return ASTVariableDeclarator
      * @throws MissingValueException
      * @since 0.9.6
      */
-    private function parseVariableDeclarator()
+    private function parseVariableDeclarator(): ASTVariableDeclarator
     {
         $this->tokenStack->push();
 
@@ -8098,7 +7857,7 @@ abstract class AbstractPHPParser
      * @return ?ASTValue
      * @since 2.11.0
      */
-    private function parseVariableDefaultValue()
+    private function parseVariableDefaultValue(): ?ASTValue
     {
         if ($this->tokenizer->peek() === Tokens::T_NEW) {
             $defaultValue = new ASTValue();
@@ -8117,7 +7876,7 @@ abstract class AbstractPHPParser
      * @return ?ASTValue
      * @since 0.9.6
      */
-    private function parseStaticValueOrStaticArray()
+    private function parseStaticValueOrStaticArray(): ?ASTValue
     {
         $this->consumeComments();
 
@@ -8141,7 +7900,7 @@ abstract class AbstractPHPParser
      * @return ?ASTValue
      * @since 0.9.5
      */
-    private function parseStaticValue()
+    private function parseStaticValue(): ?ASTValue
     {
         $defaultValue = new ASTValue();
 
@@ -8528,10 +8287,9 @@ abstract class AbstractPHPParser
     /**
      * Parses fn operator of lambda function for syntax fn() => available since PHP 7.4.
      *
-     * @return ASTClosure
      * @throws UnexpectedTokenException
      */
-    private function parseLambdaFunctionDeclaration()
+    private function parseLambdaFunctionDeclaration(): ASTClosure
     {
         $this->tokenStack->push();
 
@@ -8558,10 +8316,9 @@ abstract class AbstractPHPParser
      * the PHP zend_language_parser.y definition.
      *
      * @param ASTNode $expr The context node instance.
-     * @return bool
      * @since 0.10.0
      */
-    private function isReadWriteVariable(ASTNode $expr)
+    private function isReadWriteVariable(ASTNode $expr): bool
     {
         return $expr instanceof ASTVariable
             || $expr instanceof ASTFunctionPostfix
@@ -8577,9 +8334,8 @@ abstract class AbstractPHPParser
      * parsed package annotation, when no namespace declaration was parsed.
      *
      * @param string $localName The local class or interface name.
-     * @return string
      */
-    private function createQualifiedTypeName(string $localName)
+    private function createQualifiedTypeName(string $localName): string
     {
         return ltrim($this->getNamespaceOrPackageName() . '\\' . $localName, '\\');
     }
@@ -8591,7 +8347,7 @@ abstract class AbstractPHPParser
      * @return ?string
      * @since 0.9.8
      */
-    private function getNamespaceOrPackageName()
+    private function getNamespaceOrPackageName(): ?string
     {
         if (!isset($this->namespaceName)) {
             return $this->packageName;
@@ -8603,10 +8359,9 @@ abstract class AbstractPHPParser
     /**
      * Returns the currently active package or namespace.
      *
-     * @return ASTNamespace
      * @since 1.0.0
      */
-    private function getNamespaceOrPackage()
+    private function getNamespaceOrPackage(): ASTNamespace
     {
         $namespace = $this->builder->buildNamespace((string) $this->getNamespaceOrPackageName());
         $namespace->setPackageAnnotation(null === $this->namespaceName);
@@ -8616,10 +8371,8 @@ abstract class AbstractPHPParser
 
     /**
      * Extracts the @package information from the given comment.
-     *
-     * @return string|null
      */
-    private function parsePackageAnnotation(string $comment)
+    private function parsePackageAnnotation(string $comment): ?string
     {
         if (getenv('DISMISS_PACKAGES')) {
             $this->packageName = null;
@@ -8654,10 +8407,8 @@ abstract class AbstractPHPParser
      *
      * This method checks that the previous token is an open tag and the following
      * token is not a class, a interface, final, abstract or a function.
-     *
-     * @return bool
      */
-    private function isFileComment()
+    private function isFileComment(): bool
     {
         if ($this->tokenizer->prev() !== Tokens::T_OPEN_TAG) {
             return false;
@@ -8682,7 +8433,7 @@ abstract class AbstractPHPParser
      * @param string $comment The context doc comment block.
      * @return array<int, string>
      */
-    private function parseThrowsAnnotations(string $comment)
+    private function parseThrowsAnnotations(string $comment): array
     {
         $throws = [];
 
@@ -8700,9 +8451,8 @@ abstract class AbstractPHPParser
      * it returns the found return type.
      *
      * @param string $comment A doc comment text.
-     * @return string|null
      */
-    private function parseReturnAnnotation(string $comment)
+    private function parseReturnAnnotation(string $comment): ?string
     {
         if (!preg_match(self::REGEXP_RETURN_TYPE, $comment, $match)) {
             return null;
@@ -8728,7 +8478,7 @@ abstract class AbstractPHPParser
      * @param string $comment A doc comment text.
      * @return array<string>
      */
-    private function parseVarAnnotation(string $comment)
+    private function parseVarAnnotation(string $comment): array
     {
         if (preg_match(self::REGEXP_VAR_TYPE, (string) $comment, $match) > 0) {
             $useSymbolTable = $this->useSymbolTable;
@@ -8747,10 +8497,9 @@ abstract class AbstractPHPParser
      * doc comment information. The returned value will be <b>null</b> when no
      * type information exists.
      *
-     * @return ASTType|null
      * @since 0.9.6
      */
-    private function parseFieldDeclarationType()
+    private function parseFieldDeclarationType(): ?ASTType
     {
         // Skip, if ignore annotations is set
         if ($this->ignoreAnnotations) {
@@ -8789,10 +8538,9 @@ abstract class AbstractPHPParser
      * Extracts non scalar types from a field doc comment and creates a
      * matching type instance.
      *
-     * @return ASTClassOrInterfaceReference|null
      * @since 0.9.6
      */
-    private function parseFieldDeclarationClassOrInterfaceReference()
+    private function parseFieldDeclarationClassOrInterfaceReference(): ?ASTClassOrInterfaceReference
     {
         if (!$this->docComment) {
             return null;
@@ -8816,9 +8564,8 @@ abstract class AbstractPHPParser
      *
      * @param bool $standalone Either yield is the statement (true), or nested in
      *                         an expression (false).
-     * @return ASTYieldStatement
      */
-    private function parseYield(bool $standalone)
+    private function parseYield(bool $standalone): ASTYieldStatement
     {
         $this->tokenStack->push();
 
@@ -8892,11 +8639,10 @@ abstract class AbstractPHPParser
      * <b>$tokenType</b>.
      *
      * @param int $tokenType The next expected token type.
-     * @return Token
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
-    protected function consumeToken(int $tokenType)
+    protected function consumeToken(int $tokenType): Token
     {
         assert($tokenType > 0);
 
@@ -8936,10 +8682,8 @@ abstract class AbstractPHPParser
      * Return the appropriate exception for either UnexpectedTokenException
      * configured with the next token, or TokenStreamEndException if there
      * is no more token.
-     *
-     * @return TokenStreamEndException|UnexpectedTokenException
      */
-    private function getUnexpectedNextTokenException()
+    private function getUnexpectedNextTokenException(): TokenStreamEndException|UnexpectedTokenException
     {
         return $this->getUnexpectedTokenException($this->tokenizer->next());
     }
@@ -8950,9 +8694,8 @@ abstract class AbstractPHPParser
      * null.
      *
      * @param Token|Tokenizer::T_*|null $token
-     * @return TokenStreamEndException|UnexpectedTokenException
      */
-    private function getUnexpectedTokenException($token)
+    private function getUnexpectedTokenException($token): TokenStreamEndException|UnexpectedTokenException
     {
         if ($token instanceof Token) {
             return new UnexpectedTokenException($token, $this->tokenizer->getSourceFile() ?? 'unknown');
@@ -8972,10 +8715,9 @@ abstract class AbstractPHPParser
      *  $value = $nullableValue ?? throw new InvalidArgumentException();
      *  $value = $falsableValue ?: throw new InvalidArgumentException();
      *
-     * @return ASTThrowStatement
      * @throws UnexpectedTokenException
      */
-    private function parseThrowExpression()
+    private function parseThrowExpression(): ASTThrowStatement
     {
         if ($this->tokenizer->peek() === Tokens::T_THROW) {
             return $this->parseThrowStatement([
@@ -8994,10 +8736,9 @@ abstract class AbstractPHPParser
      * Parses enum declaration. available since PHP 8.1. Ex.:
      *  enum Suit: string { case HEARTS = 'hearts'; }
      *
-     * @return ASTEnum
      * @throws UnexpectedTokenException
      */
-    private function parseEnumDeclaration()
+    private function parseEnumDeclaration(): ASTEnum
     {
         $this->tokenStack->push();
 
@@ -9013,10 +8754,8 @@ abstract class AbstractPHPParser
     /**
      * Parses enum declaration signature. available since PHP 8.1. Ex.:
      *  enum Suit: string
-     *
-     * @return ASTEnum
      */
-    private function parseEnumSignature()
+    private function parseEnumSignature(): ASTEnum
     {
         $this->tokenStack->add($this->requireNextToken());
         $this->consumeComments();
@@ -9069,10 +8808,8 @@ abstract class AbstractPHPParser
      * Peek the next token if it's of the given type, add it to current tokenStack, and return it if so.
      *
      * @psalm-param Tokens::T_* $type
-     *
-     * @return Token|null
      */
-    private function addTokenToStackIfType(int $type)
+    private function addTokenToStackIfType(int $type): ?Token
     {
         if ($this->tokenizer->peek() === $type) {
             $next = $this->tokenizer->next();
@@ -9087,10 +8824,8 @@ abstract class AbstractPHPParser
 
     /**
      * Return the next token if it exists, else throw a TokenStreamEndException.
-     *
-     * @return Token
      */
-    private function requireNextToken()
+    private function requireNextToken(): Token
     {
         $next = $this->tokenizer->next();
 
@@ -9103,9 +8838,8 @@ abstract class AbstractPHPParser
 
     /**
      * @param string $numberRepresentation integer number as it appears in the code, `0xfe4`, `1_000_000`
-     * @return int
      */
-    private function parseIntegerNumberImage(string $numberRepresentation)
+    private function parseIntegerNumberImage(string $numberRepresentation): int
     {
         $numberRepresentation = trim($numberRepresentation);
 
@@ -9116,10 +8850,7 @@ abstract class AbstractPHPParser
         return (int) $this->getNumberFromImage($numberRepresentation);
     }
 
-    /**
-     * @return float|int|string
-     */
-    private function getNumberFromImage(string $numberRepresentation)
+    private function getNumberFromImage(string $numberRepresentation): float|int|string
     {
         $numberRepresentation = str_replace('_', '', $numberRepresentation);
 
@@ -9141,10 +8872,7 @@ abstract class AbstractPHPParser
         }
     }
 
-    /**
-     * @return ASTEnumCase
-     */
-    private function parseEnumCase()
+    private function parseEnumCase(): ASTEnumCase
     {
         $this->tokenStack->add($this->requireNextToken());
         $this->tokenStack->push();
@@ -9164,10 +8892,7 @@ abstract class AbstractPHPParser
         return $this->setNodePositionsAndReturn($case);
     }
 
-    /**
-     * @return ASTNode|null
-     */
-    private function parseEnumCaseValue()
+    private function parseEnumCaseValue(): ?ASTNode
     {
         if ($this->tokenizer->peek() !== Tokens::T_EQUAL) {
             return null;
@@ -9187,10 +8912,8 @@ abstract class AbstractPHPParser
 
     /**
      * @psalm-param Tokens::T_* $type
-     *
-     * @return string
      */
-    private function parseNumber(int $type)
+    private function parseNumber(int $type): string
     {
         $token = $this->consumeToken($type);
         $number = (string) $token->image;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -292,10 +292,9 @@ class PHPBuilder implements Builder
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstClassOrInterfaceReference(string $qualifiedName)
+    public function buildAstClassOrInterfaceReference(string $qualifiedName): ASTClassOrInterfaceReference
     {
         $this->checkBuilderState();
 
@@ -314,10 +313,9 @@ class PHPBuilder implements Builder
      *
      * @param string $qualifiedName The qualified name of the referenced type.
      * @param bool $classReference true if class reference only.
-     * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstNeededReference(string $qualifiedName, bool $classReference)
+    public function buildAstNeededReference(string $qualifiedName, bool $classReference): ASTClassOrInterfaceReference
     {
         if ($classReference) {
             return $this->buildAstClassReference($qualifiedName);
@@ -331,10 +329,9 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @return AbstractASTClassOrInterface
      * @since  0.9.5
      */
-    public function getClassOrInterface(string $qualifiedName)
+    public function getClassOrInterface(string $qualifiedName): AbstractASTClassOrInterface
     {
         $classOrInterface = $this->findClass($qualifiedName);
         if ($classOrInterface !== null) {
@@ -353,10 +350,9 @@ class PHPBuilder implements Builder
      * Builds a new php trait instance.
      *
      * @param string $qualifiedName The full qualified trait name.
-     * @return ASTTrait
      * @since 1.0.0
      */
-    public function buildTrait(string $qualifiedName)
+    public function buildTrait(string $qualifiedName): ASTTrait
     {
         $this->checkBuilderState();
 
@@ -373,10 +369,9 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
-     * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait(string $qualifiedName)
+    public function getTrait(string $qualifiedName): ASTTrait
     {
         $trait = $this->findTrait($qualifiedName);
         if ($trait === null) {
@@ -390,10 +385,9 @@ class PHPBuilder implements Builder
      * Builds a new trait reference node.
      *
      * @param string $qualifiedName The full qualified trait name.
-     * @return ASTTraitReference
      * @since  1.0.0
      */
-    public function buildAstTraitReference(string $qualifiedName)
+    public function buildAstTraitReference(string $qualifiedName): ASTTraitReference
     {
         $this->checkBuilderState();
 
@@ -431,7 +425,7 @@ class PHPBuilder implements Builder
      * @param string $name The class name.
      * @return ASTClass The created class object.
      */
-    public function buildClass(string $name)
+    public function buildClass(string $name): ASTClass
     {
         $this->checkBuilderState();
 
@@ -449,10 +443,9 @@ class PHPBuilder implements Builder
      * instance when no matching type exists.
      *
      * @param string $qualifiedName The full qualified type identifier.
-     * @return ASTClass|ASTEnum
      * @since  0.9.5
      */
-    public function getClass(string $qualifiedName)
+    public function getClass(string $qualifiedName): ASTClass|ASTEnum
     {
         return $this->findClass($qualifiedName)
             ?: $this->buildClassInternal($qualifiedName);
@@ -460,10 +453,8 @@ class PHPBuilder implements Builder
 
     /**
      * Builds an anonymous class instance.
-     *
-     * @return ASTAnonymousClass
      */
-    public function buildAnonymousClass()
+    public function buildAnonymousClass(): ASTAnonymousClass
     {
         return $this->buildAstNodeInstance(ASTAnonymousClass::class)
             ->setCache($this->cache)
@@ -474,10 +465,9 @@ class PHPBuilder implements Builder
      * Builds a new code type reference instance.
      *
      * @param string $qualifiedName The qualified name of the referenced type.
-     * @return ASTClassReference
      * @since  0.9.5
      */
-    public function buildAstClassReference(string $qualifiedName)
+    public function buildAstClassReference(string $qualifiedName): ASTClassReference
     {
         $this->checkBuilderState();
 
@@ -520,9 +510,8 @@ class PHPBuilder implements Builder
      * </ol>
      *
      * @param string $name The interface name.
-     * @return ASTInterface
      */
-    public function buildInterface(string $name)
+    public function buildInterface(string $name): ASTInterface
     {
         $this->checkBuilderState();
 
@@ -539,10 +528,9 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTInterface}
      * instance when no matching type exists.
      *
-     * @return ASTInterface
      * @since  0.9.5
      */
-    public function getInterface(string $qualifiedName)
+    public function getInterface(string $qualifiedName): ASTInterface
     {
         $interface = $this->findInterface($qualifiedName);
         if ($interface === null) {
@@ -554,10 +542,8 @@ class PHPBuilder implements Builder
 
     /**
      * Builds a new method instance.
-     *
-     * @return ASTMethod
      */
-    public function buildMethod(string $name)
+    public function buildMethod(string $name): ASTMethod
     {
         $this->checkBuilderState();
 
@@ -575,9 +561,8 @@ class PHPBuilder implements Builder
      * Builds a new package instance.
      *
      * @param string $name The package name.
-     * @return ASTNamespace
      */
-    public function buildNamespace(string $name)
+    public function buildNamespace(string $name): ASTNamespace
     {
         if (!isset($this->namespaces[$name])) {
             // Debug package creation
@@ -595,9 +580,8 @@ class PHPBuilder implements Builder
      * Builds a new function instance.
      *
      * @param string $name The function name.
-     * @return ASTFunction
      */
-    public function buildFunction(string $name)
+    public function buildFunction(string $name): ASTFunction
     {
         $this->checkBuilderState();
 
@@ -616,10 +600,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new self reference instance.
      *
-     * @return ASTSelfReference
      * @since  0.9.6
      */
-    public function buildAstSelfReference(AbstractASTClassOrInterface $type)
+    public function buildAstSelfReference(AbstractASTClassOrInterface $type): ASTSelfReference
     {
         Log::debug(
             'Creating: \\PDepend\\Source\\AST\\ASTSelfReference(' . $type->getImage() . ')',
@@ -633,10 +616,9 @@ class PHPBuilder implements Builder
      *
      * @param ASTClassOrInterfaceReference $reference The type
      *                                                instance that reference the concrete target of parent.
-     * @return ASTParentReference
      * @since  0.9.6
      */
-    public function buildAstParentReference(ASTClassOrInterfaceReference $reference)
+    public function buildAstParentReference(ASTClassOrInterfaceReference $reference): ASTParentReference
     {
         Log::debug('Creating: \\PDepend\\Source\\AST\\ASTParentReference()');
 
@@ -646,10 +628,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new static reference instance.
      *
-     * @return ASTStaticReference
      * @since  0.9.6
      */
-    public function buildAstStaticReference(AbstractASTClassOrInterface $owner)
+    public function buildAstStaticReference(AbstractASTClassOrInterface $owner): ASTStaticReference
     {
         Log::debug('Creating: \\PDepend\\Source\\AST\\ASTStaticReference()');
 
@@ -659,10 +640,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new field declaration node.
      *
-     * @return ASTFieldDeclaration
      * @since  0.9.6
      */
-    public function buildAstFieldDeclaration()
+    public function buildAstFieldDeclaration(): ASTFieldDeclaration
     {
         return $this->buildAstNodeInstance(ASTFieldDeclaration::class);
     }
@@ -671,10 +651,9 @@ class PHPBuilder implements Builder
      * Builds a new variable declarator node.
      *
      * @param string $image The source image for the variable declarator.
-     * @return ASTVariableDeclarator
      * @since  0.9.6
      */
-    public function buildAstVariableDeclarator(string $image)
+    public function buildAstVariableDeclarator(string $image): ASTVariableDeclarator
     {
         return $this->buildAstNodeInstance(ASTVariableDeclarator::class, $image);
     }
@@ -683,10 +662,9 @@ class PHPBuilder implements Builder
      * Builds a new static variable declaration node.
      *
      * @param string $image The source image for the statuc declaration.
-     * @return ASTStaticVariableDeclaration
      * @since  0.9.6
      */
-    public function buildAstStaticVariableDeclaration(string $image)
+    public function buildAstStaticVariableDeclaration(string $image): ASTStaticVariableDeclaration
     {
         return $this->buildAstNodeInstance(ASTStaticVariableDeclaration::class, $image);
     }
@@ -695,10 +673,9 @@ class PHPBuilder implements Builder
      * Builds a new constant node.
      *
      * @param string $image The source image for the constant.
-     * @return ASTConstant
      * @since  0.9.6
      */
-    public function buildAstConstant(string $image)
+    public function buildAstConstant(string $image): ASTConstant
     {
         return $this->buildAstNodeInstance(ASTConstant::class, $image);
     }
@@ -707,10 +684,9 @@ class PHPBuilder implements Builder
      * Builds a new variable node.
      *
      * @param string $image The source image for the variable.
-     * @return ASTVariable
      * @since  0.9.6
      */
-    public function buildAstVariable(string $image)
+    public function buildAstVariable(string $image): ASTVariable
     {
         return $this->buildAstNodeInstance(ASTVariable::class, $image);
     }
@@ -719,10 +695,9 @@ class PHPBuilder implements Builder
      * Builds a new variable variable node.
      *
      * @param string $image The source image for the variable variable.
-     * @return ASTVariableVariable
      * @since  0.9.6
      */
-    public function buildAstVariableVariable(string $image)
+    public function buildAstVariableVariable(string $image): ASTVariableVariable
     {
         return $this->buildAstNodeInstance(ASTVariableVariable::class, $image);
     }
@@ -731,10 +706,9 @@ class PHPBuilder implements Builder
      * Builds a new compound variable node.
      *
      * @param string $image The source image for the compound variable.
-     * @return ASTCompoundVariable
      * @since  0.9.6
      */
-    public function buildAstCompoundVariable(string $image)
+    public function buildAstCompoundVariable(string $image): ASTCompoundVariable
     {
         return $this->buildAstNodeInstance(ASTCompoundVariable::class, $image);
     }
@@ -742,10 +716,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new compound expression node.
      *
-     * @return ASTCompoundExpression
      * @since  0.9.6
      */
-    public function buildAstCompoundExpression()
+    public function buildAstCompoundExpression(): ASTCompoundExpression
     {
         return $this->buildAstNodeInstance(ASTCompoundExpression::class);
     }
@@ -753,10 +726,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new closure node.
      *
-     * @return ASTClosure
      * @since  0.9.12
      */
-    public function buildAstClosure()
+    public function buildAstClosure(): ASTClosure
     {
         return $this->buildAstNodeInstance(ASTClosure::class);
     }
@@ -764,10 +736,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new formal parameters node.
      *
-     * @return ASTFormalParameters
      * @since  0.9.6
      */
-    public function buildAstFormalParameters()
+    public function buildAstFormalParameters(): ASTFormalParameters
     {
         return $this->buildAstNodeInstance(ASTFormalParameters::class);
     }
@@ -775,10 +746,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new formal parameter node.
      *
-     * @return ASTFormalParameter
      * @since  0.9.6
      */
-    public function buildAstFormalParameter()
+    public function buildAstFormalParameter(): ASTFormalParameter
     {
         return $this->buildAstNodeInstance(ASTFormalParameter::class);
     }
@@ -786,10 +756,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new expression node.
      *
-     * @return ASTExpression
      * @since 0.9.8
      */
-    public function buildAstExpression(?string $image = null)
+    public function buildAstExpression(?string $image = null): ASTExpression
     {
         return $this->buildAstNodeInstance(ASTExpression::class, $image);
     }
@@ -798,10 +767,9 @@ class PHPBuilder implements Builder
      * Builds a new assignment expression node.
      *
      * @param string $image The assignment operator.
-     * @return ASTAssignmentExpression
      * @since  0.9.8
      */
-    public function buildAstAssignmentExpression(string $image)
+    public function buildAstAssignmentExpression(string $image): ASTAssignmentExpression
     {
         return $this->buildAstNodeInstance(ASTAssignmentExpression::class, $image);
     }
@@ -810,10 +778,9 @@ class PHPBuilder implements Builder
      * Builds a new allocation expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTAllocationExpression
      * @since  0.9.6
      */
-    public function buildAstAllocationExpression(string $image)
+    public function buildAstAllocationExpression(string $image): ASTAllocationExpression
     {
         return $this->buildAstNodeInstance(ASTAllocationExpression::class, $image);
     }
@@ -822,10 +789,9 @@ class PHPBuilder implements Builder
      * Builds a new eval-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTEvalExpression
      * @since  0.9.12
      */
-    public function buildAstEvalExpression(string $image)
+    public function buildAstEvalExpression(string $image): ASTEvalExpression
     {
         return $this->buildAstNodeInstance(ASTEvalExpression::class, $image);
     }
@@ -834,10 +800,9 @@ class PHPBuilder implements Builder
      * Builds a new exit-expression instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTExitExpression
      * @since  0.9.12
      */
-    public function buildAstExitExpression(string $image)
+    public function buildAstExitExpression(string $image): ASTExitExpression
     {
         return $this->buildAstNodeInstance(ASTExitExpression::class, $image);
     }
@@ -846,10 +811,9 @@ class PHPBuilder implements Builder
      * Builds a new clone-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTCloneExpression
      * @since  0.9.12
      */
-    public function buildAstCloneExpression(string $image)
+    public function buildAstCloneExpression(string $image): ASTCloneExpression
     {
         return $this->buildAstNodeInstance(ASTCloneExpression::class, $image);
     }
@@ -858,10 +822,9 @@ class PHPBuilder implements Builder
      * Builds a new list-expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTListExpression
      * @since  0.9.12
      */
-    public function buildAstListExpression(string $image)
+    public function buildAstListExpression(string $image): ASTListExpression
     {
         return $this->buildAstNodeInstance(ASTListExpression::class, $image);
     }
@@ -869,10 +832,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new include- or include_once-expression.
      *
-     * @return ASTIncludeExpression
      * @since  0.9.12
      */
-    public function buildAstIncludeExpression()
+    public function buildAstIncludeExpression(): ASTIncludeExpression
     {
         return $this->buildAstNodeInstance(ASTIncludeExpression::class);
     }
@@ -880,10 +842,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new require- or require_once-expression.
      *
-     * @return ASTRequireExpression
      * @since  0.9.12
      */
-    public function buildAstRequireExpression()
+    public function buildAstRequireExpression(): ASTRequireExpression
     {
         return $this->buildAstNodeInstance(ASTRequireExpression::class);
     }
@@ -891,10 +852,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array-expression node.
      *
-     * @return ASTArrayIndexExpression
      * @since  0.9.12
      */
-    public function buildAstArrayIndexExpression()
+    public function buildAstArrayIndexExpression(): ASTArrayIndexExpression
     {
         return $this->buildAstNodeInstance(ASTArrayIndexExpression::class);
     }
@@ -908,10 +868,9 @@ class PHPBuilder implements Builder
      * //     --------
      * </code>
      *
-     * @return ASTStringIndexExpression
      * @since  0.9.12
      */
-    public function buildAstStringIndexExpression()
+    public function buildAstStringIndexExpression(): ASTStringIndexExpression
     {
         return $this->buildAstNodeInstance(ASTStringIndexExpression::class);
     }
@@ -919,10 +878,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new php array node.
      *
-     * @return ASTArray
      * @since  1.0.0
      */
-    public function buildAstArray()
+    public function buildAstArray(): ASTArray
     {
         return $this->buildAstNodeInstance(ASTArray::class);
     }
@@ -930,10 +888,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array element node.
      *
-     * @return ASTArrayElement
      * @since  1.0.0
      */
-    public function buildAstArrayElement()
+    public function buildAstArrayElement(): ASTArrayElement
     {
         return $this->buildAstNodeInstance(ASTArrayElement::class);
     }
@@ -942,10 +899,9 @@ class PHPBuilder implements Builder
      * Builds a new instanceof expression node.
      *
      * @param string $image The source image of this expression.
-     * @return ASTInstanceOfExpression
      * @since  0.9.6
      */
-    public function buildAstInstanceOfExpression(string $image)
+    public function buildAstInstanceOfExpression(string $image): ASTInstanceOfExpression
     {
         return $this->buildAstNodeInstance(ASTInstanceOfExpression::class, $image);
     }
@@ -965,10 +921,9 @@ class PHPBuilder implements Builder
      * }
      * </code>
      *
-     * @return ASTIssetExpression
      * @since  0.9.12
      */
-    public function buildAstIssetExpression()
+    public function buildAstIssetExpression(): ASTIssetExpression
     {
         return $this->buildAstNodeInstance(ASTIssetExpression::class);
     }
@@ -982,10 +937,9 @@ class PHPBuilder implements Builder
      *         --------------
      * </code>
      *
-     * @return ASTConditionalExpression
      * @since  0.9.8
      */
-    public function buildAstConditionalExpression()
+    public function buildAstConditionalExpression(): ASTConditionalExpression
     {
         return $this->buildAstNodeInstance(ASTConditionalExpression::class, '?');
     }
@@ -999,10 +953,9 @@ class PHPBuilder implements Builder
      * -------------
      * </code>
      *
-     * @return ASTPrintExpression
      * @since 2.3
      */
-    public function buildAstPrintExpression()
+    public function buildAstPrintExpression(): ASTPrintExpression
     {
         return $this->buildAstNodeInstance(ASTPrintExpression::class, 'print');
     }
@@ -1010,10 +963,9 @@ class PHPBuilder implements Builder
     /**
      * Build a new shift left expression.
      *
-     * @return ASTShiftLeftExpression
      * @since  1.0.1
      */
-    public function buildAstShiftLeftExpression()
+    public function buildAstShiftLeftExpression(): ASTShiftLeftExpression
     {
         return $this->buildAstNodeInstance(ASTShiftLeftExpression::class);
     }
@@ -1021,10 +973,9 @@ class PHPBuilder implements Builder
     /**
      * Build a new shift right expression.
      *
-     * @return ASTShiftRightExpression
      * @since  1.0.1
      */
-    public function buildAstShiftRightExpression()
+    public function buildAstShiftRightExpression(): ASTShiftRightExpression
     {
         return $this->buildAstNodeInstance(ASTShiftRightExpression::class);
     }
@@ -1032,10 +983,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new boolean and-expression.
      *
-     * @return ASTBooleanAndExpression
      * @since  0.9.8
      */
-    public function buildAstBooleanAndExpression()
+    public function buildAstBooleanAndExpression(): ASTBooleanAndExpression
     {
         return $this->buildAstNodeInstance(ASTBooleanAndExpression::class, '&&');
     }
@@ -1043,10 +993,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new boolean or-expression.
      *
-     * @return ASTBooleanOrExpression
      * @since  0.9.8
      */
-    public function buildAstBooleanOrExpression()
+    public function buildAstBooleanOrExpression(): ASTBooleanOrExpression
     {
         return $this->buildAstNodeInstance(ASTBooleanOrExpression::class, '||');
     }
@@ -1054,10 +1003,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>and</b>-expression.
      *
-     * @return ASTLogicalAndExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalAndExpression()
+    public function buildAstLogicalAndExpression(): ASTLogicalAndExpression
     {
         return $this->buildAstNodeInstance(ASTLogicalAndExpression::class, 'and');
     }
@@ -1065,10 +1013,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>or</b>-expression.
      *
-     * @return ASTLogicalOrExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalOrExpression()
+    public function buildAstLogicalOrExpression(): ASTLogicalOrExpression
     {
         return $this->buildAstNodeInstance(ASTLogicalOrExpression::class, 'or');
     }
@@ -1076,10 +1023,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new logical <b>xor</b>-expression.
      *
-     * @return ASTLogicalXorExpression
      * @since  0.9.8
      */
-    public function buildAstLogicalXorExpression()
+    public function buildAstLogicalXorExpression(): ASTLogicalXorExpression
     {
         return $this->buildAstNodeInstance(ASTLogicalXorExpression::class, 'xor');
     }
@@ -1087,10 +1033,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new trait use-statement node.
      *
-     * @return ASTTraitUseStatement
      * @since  1.0.0
      */
-    public function buildAstTraitUseStatement()
+    public function buildAstTraitUseStatement(): ASTTraitUseStatement
     {
         return $this->buildAstNodeInstance(ASTTraitUseStatement::class);
     }
@@ -1098,10 +1043,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new trait adaptation scope
      *
-     * @return ASTTraitAdaptation
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptation()
+    public function buildAstTraitAdaptation(): ASTTraitAdaptation
     {
         return $this->buildAstNodeInstance(ASTTraitAdaptation::class);
     }
@@ -1110,10 +1054,9 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation alias statement.
      *
      * @param string $image The trait method name.
-     * @return ASTTraitAdaptationAlias
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationAlias(string $image)
+    public function buildAstTraitAdaptationAlias(string $image): ASTTraitAdaptationAlias
     {
         return $this->buildAstNodeInstance(ASTTraitAdaptationAlias::class, $image);
     }
@@ -1122,10 +1065,9 @@ class PHPBuilder implements Builder
      * Builds a new trait adaptation precedence statement.
      *
      * @param string $image The trait method name.
-     * @return ASTTraitAdaptationPrecedence
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationPrecedence(string $image)
+    public function buildAstTraitAdaptationPrecedence(string $image): ASTTraitAdaptationPrecedence
     {
         return $this->buildAstNodeInstance(ASTTraitAdaptationPrecedence::class, $image);
     }
@@ -1133,10 +1075,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new switch-statement-node.
      *
-     * @return ASTSwitchStatement
      * @since  0.9.8
      */
-    public function buildAstSwitchStatement()
+    public function buildAstSwitchStatement(): ASTSwitchStatement
     {
         return $this->buildAstNodeInstance(ASTSwitchStatement::class);
     }
@@ -1145,10 +1086,9 @@ class PHPBuilder implements Builder
      * Builds a new switch-label node.
      *
      * @param string $image The source image of this label.
-     * @return ASTSwitchLabel
      * @since  0.9.8
      */
-    public function buildAstSwitchLabel(string $image)
+    public function buildAstSwitchLabel(string $image): ASTSwitchLabel
     {
         return $this->buildAstNodeInstance(ASTSwitchLabel::class, $image);
     }
@@ -1156,10 +1096,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new global-statement instance.
      *
-     * @return ASTGlobalStatement
      * @since  0.9.12
      */
-    public function buildAstGlobalStatement()
+    public function buildAstGlobalStatement(): ASTGlobalStatement
     {
         return $this->buildAstNodeInstance(ASTGlobalStatement::class);
     }
@@ -1167,10 +1106,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new unset-statement instance.
      *
-     * @return ASTUnsetStatement
      * @since  0.9.12
      */
-    public function buildAstUnsetStatement()
+    public function buildAstUnsetStatement(): ASTUnsetStatement
     {
         return $this->buildAstNodeInstance(ASTUnsetStatement::class);
     }
@@ -1178,10 +1116,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new catch-statement node.
      *
-     * @return ASTCatchStatement
      * @since  0.9.8
      */
-    public function buildAstCatchStatement(string $image)
+    public function buildAstCatchStatement(string $image): ASTCatchStatement
     {
         return $this->buildAstNodeInstance(ASTCatchStatement::class, $image);
     }
@@ -1189,10 +1126,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new finally-statement node.
      *
-     * @return ASTFinallyStatement
      * @since  2.0.0
      */
-    public function buildAstFinallyStatement()
+    public function buildAstFinallyStatement(): ASTFinallyStatement
     {
         return $this->buildAstNodeInstance(ASTFinallyStatement::class, 'finally');
     }
@@ -1201,10 +1137,9 @@ class PHPBuilder implements Builder
      * Builds a new if statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTIfStatement
      * @since  0.9.8
      */
-    public function buildAstIfStatement(string $image)
+    public function buildAstIfStatement(string $image): ASTIfStatement
     {
         return $this->buildAstNodeInstance(ASTIfStatement::class, $image);
     }
@@ -1213,10 +1148,9 @@ class PHPBuilder implements Builder
      * Builds a new elseif statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTElseIfStatement
      * @since  0.9.8
      */
-    public function buildAstElseIfStatement(string $image)
+    public function buildAstElseIfStatement(string $image): ASTElseIfStatement
     {
         return $this->buildAstNodeInstance(ASTElseIfStatement::class, $image);
     }
@@ -1225,10 +1159,9 @@ class PHPBuilder implements Builder
      * Builds a new for statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTForStatement
      * @since  0.9.8
      */
-    public function buildAstForStatement(string $image)
+    public function buildAstForStatement(string $image): ASTForStatement
     {
         return $this->buildAstNodeInstance(ASTForStatement::class, $image);
     }
@@ -1242,10 +1175,9 @@ class PHPBuilder implements Builder
      *      ------------------------
      * </code>
      *
-     * @return ASTForInit
      * @since  0.9.8
      */
-    public function buildAstForInit()
+    public function buildAstForInit(): ASTForInit
     {
         return $this->buildAstNodeInstance(ASTForInit::class);
     }
@@ -1259,10 +1191,9 @@ class PHPBuilder implements Builder
      *                                        -------------------------------
      * </code>
      *
-     * @return ASTForUpdate
      * @since  0.9.12
      */
-    public function buildAstForUpdate()
+    public function buildAstForUpdate(): ASTForUpdate
     {
         return $this->buildAstNodeInstance(ASTForUpdate::class);
     }
@@ -1271,10 +1202,9 @@ class PHPBuilder implements Builder
      * Builds a new foreach-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTForeachStatement
      * @since  0.9.8
      */
-    public function buildAstForeachStatement(string $image)
+    public function buildAstForeachStatement(string $image): ASTForeachStatement
     {
         return $this->buildAstNodeInstance(ASTForeachStatement::class, $image);
     }
@@ -1283,10 +1213,9 @@ class PHPBuilder implements Builder
      * Builds a new while-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTWhileStatement
      * @since  0.9.8
      */
-    public function buildAstWhileStatement(string $image)
+    public function buildAstWhileStatement(string $image): ASTWhileStatement
     {
         return $this->buildAstNodeInstance(ASTWhileStatement::class, $image);
     }
@@ -1295,10 +1224,9 @@ class PHPBuilder implements Builder
      * Builds a new do/while-statement node.
      *
      * @param string $image The source image of this statement.
-     * @return ASTDoWhileStatement
      * @since  0.9.12
      */
-    public function buildAstDoWhileStatement(string $image)
+    public function buildAstDoWhileStatement(string $image): ASTDoWhileStatement
     {
         return $this->buildAstNodeInstance(ASTDoWhileStatement::class, $image);
     }
@@ -1324,10 +1252,9 @@ class PHPBuilder implements Builder
      * -----------
      * </code>
      *
-     * @return ASTDeclareStatement
      * @since  0.10.0
      */
-    public function buildAstDeclareStatement()
+    public function buildAstDeclareStatement(): ASTDeclareStatement
     {
         return $this->buildAstNodeInstance(ASTDeclareStatement::class);
     }
@@ -1354,10 +1281,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source image of this expression.
-     * @return ASTMemberPrimaryPrefix
      * @since  0.9.6
      */
-    public function buildAstMemberPrimaryPrefix(string $image)
+    public function buildAstMemberPrimaryPrefix(string $image): ASTMemberPrimaryPrefix
     {
         return $this->buildAstNodeInstance(ASTMemberPrimaryPrefix::class, $image);
     }
@@ -1366,10 +1292,9 @@ class PHPBuilder implements Builder
      * Builds a new identifier node.
      *
      * @param string $image The image of this identifier.
-     * @return ASTIdentifier
      * @since  0.9.6
      */
-    public function buildAstIdentifier(string $image)
+    public function buildAstIdentifier(string $image): ASTIdentifier
     {
         return $this->buildAstNodeInstance(ASTIdentifier::class, $image);
     }
@@ -1388,10 +1313,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTFunctionPostfix
      * @since  0.9.6
      */
-    public function buildAstFunctionPostfix(string $image)
+    public function buildAstFunctionPostfix(string $image): ASTFunctionPostfix
     {
         return $this->buildAstNodeInstance(ASTFunctionPostfix::class, $image);
     }
@@ -1410,10 +1334,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTMethodPostfix
      * @since  0.9.6
      */
-    public function buildAstMethodPostfix(string $image)
+    public function buildAstMethodPostfix(string $image): ASTMethodPostfix
     {
         return $this->buildAstNodeInstance(ASTMethodPostfix::class, $image);
     }
@@ -1428,10 +1351,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTConstantPostfix
      * @since  0.9.6
      */
-    public function buildAstConstantPostfix(string $image)
+    public function buildAstConstantPostfix(string $image): ASTConstantPostfix
     {
         return $this->buildAstNodeInstance(ASTConstantPostfix::class, $image);
     }
@@ -1450,10 +1372,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The image of this node.
-     * @return ASTPropertyPostfix
      * @since  0.9.6
      */
-    public function buildAstPropertyPostfix(string $image)
+    public function buildAstPropertyPostfix(string $image): ASTPropertyPostfix
     {
         return $this->buildAstNodeInstance(ASTPropertyPostfix::class, $image);
     }
@@ -1471,10 +1392,9 @@ class PHPBuilder implements Builder
      * //       -----
      * </code>
      *
-     * @return ASTClassFqnPostfix
      * @since  2.0.0
      */
-    public function buildAstClassFqnPostfix()
+    public function buildAstClassFqnPostfix(): ASTClassFqnPostfix
     {
         return $this->buildAstNodeInstance(ASTClassFqnPostfix::class, 'class');
     }
@@ -1492,10 +1412,9 @@ class PHPBuilder implements Builder
      * //       ------------
      * </code>
      *
-     * @return ASTArguments
      * @since  0.9.6
      */
-    public function buildAstArguments()
+    public function buildAstArguments(): ASTArguments
     {
         return $this->buildAstNodeInstance(ASTArguments::class);
     }
@@ -1507,10 +1426,9 @@ class PHPBuilder implements Builder
      * match($x)
      * </code>
      *
-     * @return ASTMatchArgument
      * @since  0.9.6
      */
-    public function buildAstMatchArgument()
+    public function buildAstMatchArgument(): ASTMatchArgument
     {
         return $this->buildAstNodeInstance(ASTMatchArgument::class);
     }
@@ -1524,10 +1442,9 @@ class PHPBuilder implements Builder
      * }
      * </code>
      *
-     * @return ASTMatchBlock
      * @since  2.9.0
      */
-    public function buildAstMatchBlock()
+    public function buildAstMatchBlock(): ASTMatchBlock
     {
         return $this->buildAstNodeInstance(ASTMatchBlock::class);
     }
@@ -1539,10 +1456,9 @@ class PHPBuilder implements Builder
      * "foo" => "bar",
      * </code>
      *
-     * @return ASTMatchEntry
      * @since  2.9.0
      */
-    public function buildAstMatchEntry()
+    public function buildAstMatchEntry(): ASTMatchEntry
     {
         return $this->buildAstNodeInstance(ASTMatchEntry::class);
     }
@@ -1554,10 +1470,9 @@ class PHPBuilder implements Builder
      * number_format(5623, thousands_separator: ' ')
      * </code>
      *
-     * @return ASTNamedArgument
      * @since  2.9.0
      */
-    public function buildAstNamedArgument(string $name, ASTNode $value)
+    public function buildAstNamedArgument(string $name, ASTNode $value): ASTNamedArgument
     {
         Log::debug("Creating: \\PDepend\\Source\\AST\\ASTNamedArgument($name)");
 
@@ -1567,10 +1482,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new array type node.
      *
-     * @return ASTTypeArray
      * @since  0.9.6
      */
-    public function buildAstTypeArray()
+    public function buildAstTypeArray(): ASTTypeArray
     {
         return $this->buildAstNodeInstance(ASTTypeArray::class);
     }
@@ -1578,10 +1492,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the callable type.
      *
-     * @return ASTTypeCallable
      * @since  1.0.0
      */
-    public function buildAstTypeCallable()
+    public function buildAstTypeCallable(): ASTTypeCallable
     {
         return $this->buildAstNodeInstance(ASTTypeCallable::class);
     }
@@ -1589,10 +1502,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the iterable type.
      *
-     * @return ASTTypeIterable
      * @since  2.5.1
      */
-    public function buildAstTypeIterable()
+    public function buildAstTypeIterable(): ASTTypeIterable
     {
         return $this->buildAstNodeInstance(ASTTypeIterable::class);
     }
@@ -1601,10 +1513,9 @@ class PHPBuilder implements Builder
      * Builds a new primitive type node.
      *
      * @param string $image The source image for the primitive type.
-     * @return ASTScalarType
      * @since  0.9.6
      */
-    public function buildAstScalarType(string $image)
+    public function buildAstScalarType(string $image): ASTScalarType
     {
         return $this->buildAstNodeInstance(ASTScalarType::class, $image);
     }
@@ -1612,20 +1523,17 @@ class PHPBuilder implements Builder
     /**
      * Builds a new node for the union type.
      *
-     * @return ASTUnionType
      * @since  1.0.0
      */
-    public function buildAstUnionType()
+    public function buildAstUnionType(): ASTUnionType
     {
         return $this->buildAstNodeInstance(ASTUnionType::class);
     }
 
     /**
      * Builds a new node for the union type.
-     *
-     * @return ASTIntersectionType
      */
-    public function buildAstIntersectionType()
+    public function buildAstIntersectionType(): ASTIntersectionType
     {
         return $this->buildAstNodeInstance(ASTIntersectionType::class);
     }
@@ -1634,10 +1542,9 @@ class PHPBuilder implements Builder
      * Builds a new literal node.
      *
      * @param string $image The source image for the literal node.
-     * @return ASTLiteral
      * @since  0.9.6
      */
-    public function buildAstLiteral(string $image)
+    public function buildAstLiteral(string $image): ASTLiteral
     {
         return $this->buildAstNodeInstance(ASTLiteral::class, $image);
     }
@@ -1657,10 +1564,9 @@ class PHPBuilder implements Builder
      * // |-- ASTLiteral             -  ">"
      * </code>
      *
-     * @return ASTString
      * @since  0.9.10
      */
-    public function buildAstString()
+    public function buildAstString(): ASTString
     {
         return $this->buildAstNodeInstance(ASTString::class);
     }
@@ -1668,10 +1574,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new heredoc node.
      *
-     * @return ASTHeredoc
      * @since  0.9.12
      */
-    public function buildAstHeredoc()
+    public function buildAstHeredoc(): ASTHeredoc
     {
         return $this->buildAstNodeInstance(ASTHeredoc::class);
     }
@@ -1689,10 +1594,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source code image for this node.
-     * @return ASTConstantDefinition
      * @since  0.9.6
      */
-    public function buildAstConstantDefinition(string $image)
+    public function buildAstConstantDefinition(string $image): ASTConstantDefinition
     {
         return $this->buildAstNodeInstance(ASTConstantDefinition::class, $image);
     }
@@ -1729,10 +1633,9 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $image The source code image for this node.
-     * @return ASTConstantDeclarator
      * @since  0.9.6
      */
-    public function buildAstConstantDeclarator(string $image)
+    public function buildAstConstantDeclarator(string $image): ASTConstantDeclarator
     {
         return $this->buildAstNodeInstance(ASTConstantDeclarator::class, $image);
     }
@@ -1741,10 +1644,9 @@ class PHPBuilder implements Builder
      * Builds a new comment node instance.
      *
      * @param string $cdata The comment text.
-     * @return ASTComment
      * @since  0.9.8
      */
-    public function buildAstComment(string $cdata)
+    public function buildAstComment(string $cdata): ASTComment
     {
         return $this->buildAstNodeInstance(ASTComment::class, $cdata);
     }
@@ -1753,10 +1655,9 @@ class PHPBuilder implements Builder
      * Builds a new unary expression node instance.
      *
      * @param string $image The unary expression image/character.
-     * @return ASTUnaryExpression
      * @since  0.9.11
      */
-    public function buildAstUnaryExpression(string $image)
+    public function buildAstUnaryExpression(string $image): ASTUnaryExpression
     {
         return $this->buildAstNodeInstance(ASTUnaryExpression::class, $image);
     }
@@ -1765,10 +1666,9 @@ class PHPBuilder implements Builder
      * Builds a new cast-expression node instance.
      *
      * @param string $image The cast-expression image/character.
-     * @return ASTCastExpression
      * @since  0.10.0
      */
-    public function buildAstCastExpression(string $image)
+    public function buildAstCastExpression(string $image): ASTCastExpression
     {
         return $this->buildAstNodeInstance(ASTCastExpression::class, $image);
     }
@@ -1777,10 +1677,9 @@ class PHPBuilder implements Builder
      * Builds a new postfix-expression node instance.
      *
      * @param string $image The postfix-expression image/character.
-     * @return ASTPostfixExpression
      * @since  0.10.0
      */
-    public function buildAstPostfixExpression(string $image)
+    public function buildAstPostfixExpression(string $image): ASTPostfixExpression
     {
         return $this->buildAstNodeInstance(ASTPostfixExpression::class, $image);
     }
@@ -1788,10 +1687,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new pre-increment-expression node instance.
      *
-     * @return ASTPreIncrementExpression
      * @since  0.10.0
      */
-    public function buildAstPreIncrementExpression()
+    public function buildAstPreIncrementExpression(): ASTPreIncrementExpression
     {
         return $this->buildAstNodeInstance(ASTPreIncrementExpression::class);
     }
@@ -1799,10 +1697,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new pre-decrement-expression node instance.
      *
-     * @return ASTPreDecrementExpression
      * @since  0.10.0
      */
-    public function buildAstPreDecrementExpression()
+    public function buildAstPreDecrementExpression(): ASTPreDecrementExpression
     {
         return $this->buildAstNodeInstance(ASTPreDecrementExpression::class);
     }
@@ -1810,10 +1707,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new function/method scope instance.
      *
-     * @return ASTScope
      * @since  0.9.12
      */
-    public function buildAstScope()
+    public function buildAstScope(): ASTScope
     {
         return $this->buildAstNodeInstance(ASTScope::class);
     }
@@ -1821,10 +1717,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new statement instance.
      *
-     * @return ASTStatement
      * @since  0.9.12
      */
-    public function buildAstStatement()
+    public function buildAstStatement(): ASTStatement
     {
         return $this->buildAstNodeInstance(ASTStatement::class);
     }
@@ -1833,10 +1728,9 @@ class PHPBuilder implements Builder
      * Builds a new return statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTReturnStatement
      * @since  0.9.12
      */
-    public function buildAstReturnStatement(string $image)
+    public function buildAstReturnStatement(string $image): ASTReturnStatement
     {
         return $this->buildAstNodeInstance(ASTReturnStatement::class, $image);
     }
@@ -1845,10 +1739,9 @@ class PHPBuilder implements Builder
      * Builds a new break-statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTBreakStatement
      * @since  0.9.12
      */
-    public function buildAstBreakStatement(string $image)
+    public function buildAstBreakStatement(string $image): ASTBreakStatement
     {
         return $this->buildAstNodeInstance(ASTBreakStatement::class, $image);
     }
@@ -1857,10 +1750,9 @@ class PHPBuilder implements Builder
      * Builds a new continue-statement node instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTContinueStatement
      * @since  0.9.12
      */
-    public function buildAstContinueStatement(string $image)
+    public function buildAstContinueStatement(string $image): ASTContinueStatement
     {
         return $this->buildAstNodeInstance(ASTContinueStatement::class, $image);
     }
@@ -1868,10 +1760,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new scope-statement instance.
      *
-     * @return ASTScopeStatement
      * @since  0.9.12
      */
-    public function buildAstScopeStatement()
+    public function buildAstScopeStatement(): ASTScopeStatement
     {
         return $this->buildAstNodeInstance(ASTScopeStatement::class);
     }
@@ -1880,10 +1771,9 @@ class PHPBuilder implements Builder
      * Builds a new try-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTTryStatement
      * @since  0.9.12
      */
-    public function buildAstTryStatement(string $image)
+    public function buildAstTryStatement(string $image): ASTTryStatement
     {
         return $this->buildAstNodeInstance(ASTTryStatement::class, $image);
     }
@@ -1892,10 +1782,9 @@ class PHPBuilder implements Builder
      * Builds a new throw-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTThrowStatement
      * @since  0.9.12
      */
-    public function buildAstThrowStatement(string $image)
+    public function buildAstThrowStatement(string $image): ASTThrowStatement
     {
         return $this->buildAstNodeInstance(ASTThrowStatement::class, $image);
     }
@@ -1904,10 +1793,9 @@ class PHPBuilder implements Builder
      * Builds a new goto-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTGotoStatement
      * @since  0.9.12
      */
-    public function buildAstGotoStatement(string $image)
+    public function buildAstGotoStatement(string $image): ASTGotoStatement
     {
         return $this->buildAstNodeInstance(ASTGotoStatement::class, $image);
     }
@@ -1916,10 +1804,9 @@ class PHPBuilder implements Builder
      * Builds a new label-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTLabelStatement
      * @since  0.9.12
      */
-    public function buildAstLabelStatement(string $image)
+    public function buildAstLabelStatement(string $image): ASTLabelStatement
     {
         return $this->buildAstNodeInstance(ASTLabelStatement::class, $image);
     }
@@ -1928,10 +1815,9 @@ class PHPBuilder implements Builder
      * Builds a new exit-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTEchoStatement
      * @since  0.9.12
      */
-    public function buildAstEchoStatement(string $image)
+    public function buildAstEchoStatement(string $image): ASTEchoStatement
     {
         return $this->buildAstNodeInstance(ASTEchoStatement::class, $image);
     }
@@ -1940,10 +1826,9 @@ class PHPBuilder implements Builder
      * Builds a new yield-statement instance.
      *
      * @param string $image The source code image for this node.
-     * @return ASTYieldStatement
      * @since  $version$
      */
-    public function buildAstYieldStatement(string $image)
+    public function buildAstYieldStatement(string $image): ASTYieldStatement
     {
         return $this->buildAstNodeInstance(ASTYieldStatement::class, $image);
     }
@@ -1965,7 +1850,7 @@ class PHPBuilder implements Builder
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function getNamespaces()
+    public function getNamespaces(): ASTArtifactList
     {
         if (!isset($this->preparedNamespaces)) {
             $this->preparedNamespaces = $this->getPreparedNamespaces();
@@ -1981,7 +1866,7 @@ class PHPBuilder implements Builder
      * @return ASTNamespace[]
      * @since  0.9.12
      */
-    private function getPreparedNamespaces()
+    private function getPreparedNamespaces(): array
     {
         // Create a package array copy
         $namespaces = $this->namespaces;
@@ -2021,10 +1906,9 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @return ASTTrait
      * @since  0.9.5
      */
-    protected function buildTraitInternal(string $qualifiedName)
+    protected function buildTraitInternal(string $qualifiedName): ASTTrait
     {
         $this->internal = true;
 
@@ -2043,10 +1927,9 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @return ASTTrait|null
      * @since  0.9.5
      */
-    protected function findTrait(string $qualifiedName)
+    protected function findTrait(string $qualifiedName): ?ASTTrait
     {
         $this->freeze();
 
@@ -2093,10 +1976,9 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @return ASTInterface
      * @since  0.9.5
      */
-    protected function buildInterfaceInternal(string $qualifiedName)
+    protected function buildInterfaceInternal(string $qualifiedName): ASTInterface
     {
         $this->internal = true;
 
@@ -2115,10 +1997,9 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @return ASTInterface|null
      * @since  0.9.5
      */
-    protected function findInterface(string $qualifiedName)
+    protected function findInterface(string $qualifiedName): ?ASTInterface
     {
         $this->freeze();
 
@@ -2162,10 +2043,9 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @return ASTClass
      * @since  0.9.5
      */
-    protected function buildClassInternal(string $qualifiedName)
+    protected function buildClassInternal(string $qualifiedName): ASTClass
     {
         $this->internal = true;
 
@@ -2184,10 +2064,9 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @return ASTClass|ASTEnum|null
      * @since  0.9.5
      */
-    protected function findClass(string $qualifiedName)
+    protected function findClass(string $qualifiedName): null|ASTClass|ASTEnum
     {
         $this->freeze();
 
@@ -2278,7 +2157,7 @@ class PHPBuilder implements Builder
      *                                                                      parsing process.
      * @return array<string, array<string, array<string, T>>>
      */
-    private function copyTypesWithPackage(array $originalTypes)
+    private function copyTypesWithPackage(array $originalTypes): array
     {
         $copiedTypes = [];
         foreach ($originalTypes as $typeName => $namespaces) {
@@ -2366,7 +2245,7 @@ class PHPBuilder implements Builder
      * @param ?ASTScalarType $type The enum type ('string', 'int', or null if not backed).
      * @return ASTEnum The created class object.
      */
-    public function buildEnum(string $name, ?ASTScalarType $type = null)
+    public function buildEnum(string $name, ?ASTScalarType $type = null): ASTEnum
     {
         $this->checkBuilderState();
 
@@ -2385,7 +2264,7 @@ class PHPBuilder implements Builder
      * @param ?ASTNode $value The enum case value if backed.
      * @return ASTEnumCase The created class object.
      */
-    public function buildEnumCase(string $name, ?ASTNode $value = null)
+    public function buildEnumCase(string $name, ?ASTNode $value = null): ASTEnumCase
     {
         $this->checkBuilderState();
 
@@ -2496,9 +2375,8 @@ class PHPBuilder implements Builder
      * Returns <b>true</b> if the given package is the default package.
      *
      * @param string $namespaceName The package name.
-     * @return bool
      */
-    protected function isDefault(string $namespaceName)
+    protected function isDefault(string $namespaceName): bool
     {
         return ($namespaceName === self::DEFAULT_NAMESPACE);
     }
@@ -2514,9 +2392,8 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $qualifiedName The qualified PHP 5.3 type identifier.
-     * @return string
      */
-    protected function extractTypeName(string $qualifiedName)
+    protected function extractTypeName(string $qualifiedName): string
     {
         if (($pos = strrpos($qualifiedName, '\\')) !== false) {
             return substr($qualifiedName, $pos + 1);
@@ -2544,9 +2421,8 @@ class PHPBuilder implements Builder
      * </code>
      *
      * @param string $qualifiedName The qualified PHP 5.3 class identifier.
-     * @return string|null
      */
-    protected function extractNamespaceName(string $qualifiedName)
+    protected function extractNamespaceName(string $qualifiedName): ?string
     {
         if (($pos = strrpos($qualifiedName, '\\')) !== false) {
             return ltrim(substr($qualifiedName, 0, $pos), '\\');

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -61,10 +61,9 @@ class PHPParserGeneric extends PHPParserVersion83
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @return bool
      * @since 2.3
      */
-    protected function isFunctionName(int $tokenType)
+    protected function isFunctionName(int $tokenType): bool
     {
         return match ($tokenType) {
             Tokens::T_CLONE,

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -79,10 +79,8 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
 
     /**
      * Tests if the given image is a PHP 8.2 type hint.
-     *
-     * @return bool
      */
-    protected function isScalarOrCallableTypeHint(string $image)
+    protected function isScalarOrCallableTypeHint(string $image): bool
     {
         if (strtolower($image) === 'true') {
             return true;
@@ -101,11 +99,10 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
     }
 
     /**
-     * @return ASTType
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      */
-    protected function parseSingleTypeHint()
+    protected function parseSingleTypeHint(): ASTType
     {
         $this->consumeComments();
 
@@ -134,10 +131,7 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
         }
     }
 
-    /**
-     * @return bool
-     */
-    protected function canNotBeStandAloneType(ASTNode $type)
+    protected function canNotBeStandAloneType(ASTNode $type): bool
     {
         return false;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
@@ -61,12 +61,11 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
     /**
      * Parse a typed constant (PHP >= 8.3).
      *
-     * @return ASTConstantDeclarator
      * @throws UnexpectedTokenException
      * @throws TokenStreamEndException
      * @since  1.16.0
      */
-    protected function parseTypedConstantDeclarator()
+    protected function parseTypedConstantDeclarator(): ASTConstantDeclarator
     {
         $constantType = $this->parseTypeHint();
         $tokenType = $this->tokenizer->peek();
@@ -84,10 +83,9 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
     }
 
     /**
-     * @return bool
      * @since  2.16.3
      */
-    protected function isConstantName(int $tokenType)
+    protected function isConstantName(int $tokenType): bool
     {
         return parent::isConstantName($tokenType) || $tokenType === Tokens::T_BITWISE_OR;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -619,10 +619,8 @@ class PHPTokenizerInternal implements FullTokenizer
 
     /**
      * Returns the name of the source file.
-     *
-     * @return ASTCompilationUnit
      */
-    public function getSourceFile()
+    public function getSourceFile(): ASTCompilationUnit
     {
         return $this->sourceFile;
     }
@@ -640,10 +638,8 @@ class PHPTokenizerInternal implements FullTokenizer
 
     /**
      * Returns the previous token or null if there is no one yet.
-     *
-     * @return Token|null
      */
-    public function prevToken()
+    public function prevToken(): ?Token
     {
         $this->tokenize();
 
@@ -656,10 +652,8 @@ class PHPTokenizerInternal implements FullTokenizer
 
     /**
      * Returns the current token or null if there is no more.
-     *
-     * @return Token|null
      */
-    public function currentToken()
+    public function currentToken(): ?Token
     {
         $this->tokenize();
 
@@ -673,10 +667,8 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the next token or {@link Tokenizer::T_EOF} if
      * there is no next token.
-     *
-     * @return int|Token
      */
-    public function next()
+    public function next(): int|Token
     {
         $this->tokenize();
 
@@ -690,10 +682,8 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the next token type or {@link Tokenizer::T_EOF} if
      * there is no next token.
-     *
-     * @return int
      */
-    public function peek()
+    public function peek(): int
     {
         $this->tokenize();
 
@@ -708,9 +698,8 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the token type at the given position relatively to the current position.
      *
      * @param int $shift positive or negative to apply to the current index.
-     * @return int
      */
-    public function peekAt(int $shift)
+    public function peekAt(int $shift): int
     {
         $this->tokenize();
 
@@ -731,10 +720,9 @@ class PHPTokenizerInternal implements FullTokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return int|null
      * @since  0.9.12
      */
-    public function peekNext()
+    public function peekNext(): ?int
     {
         $this->tokenize();
 
@@ -756,10 +744,8 @@ class PHPTokenizerInternal implements FullTokenizer
     /**
      * Returns the previous token type or {@link Tokenizer::T_BOF}
      * if there is no previous token.
-     *
-     * @return int
      */
-    public function prev()
+    public function prev(): int
     {
         $this->tokenize();
 
@@ -776,7 +762,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array{int, string, int} $token
      * @return array<int, array<int, int|string>>
      */
-    private function splitQualifiedNameToken(array $token)
+    private function splitQualifiedNameToken(array $token): array
     {
         $result = [];
 
@@ -807,7 +793,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array<int|string> $token
      * @return array<int, array<int, int|string>>
      */
-    private function splitRelativeNameToken(array $token, string $namespace)
+    private function splitRelativeNameToken(array $token, string $namespace): array
     {
         $result = [
             [
@@ -844,7 +830,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array<array{int, string, int}|string> $tokens Unprepared array of php tokens.
      * @return array<array<int, int|string>|string>
      */
-    private function substituteTokens(array $tokens)
+    private function substituteTokens(array $tokens): array
     {
         $result = [];
         $attributeComment = null;
@@ -1062,9 +1048,8 @@ class PHPTokenizerInternal implements FullTokenizer
      * was no none php token.
      *
      * @param array<array<int, int|string>|string> $tokens Reference to the current token stream.
-     * @return string|null
      */
-    private function consumeNonePhpTokens(array &$tokens)
+    private function consumeNonePhpTokens(array &$tokens): ?string
     {
         // The collected token content
         $content = null;
@@ -1097,7 +1082,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param string $token The unknown string token.
      * @return array{int, string}
      */
-    private function generateUnknownToken(string $token)
+    private function generateUnknownToken(string $token): array
     {
         return [$this->unknownTokenID++, $token];
     }

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -127,10 +127,9 @@ class SymbolTable
      * value exists for the given key.
      *
      * @param string $key The key for a searched scope value.
-     * @return string|null
      * @throws NoActiveScopeException
      */
-    public function lookup(string $key)
+    public function lookup(string $key): ?string
     {
         $this->ensureActiveScopeExists();
 
@@ -157,7 +156,7 @@ class SymbolTable
      *
      * @return string normalized key
      */
-    private function normalizeKey(string $key)
+    private function normalizeKey(string $key): string
     {
         return strtolower($key);
     }

--- a/src/main/php/PDepend/Source/Parser/TokenStack.php
+++ b/src/main/php/PDepend/Source/Parser/TokenStack.php
@@ -89,7 +89,7 @@ class TokenStack
      *
      * @return Token[]
      */
-    public function pop()
+    public function pop(): array
     {
         $tokens = $this->tokens;
         $this->tokens = isset($this->stack[--$this->offset]) ? $this->stack[$this->offset] : [];
@@ -107,9 +107,8 @@ class TokenStack
      * This method will add a new token to the currently active token scope.
      *
      * @param Token $token The token to add.
-     * @return Token
      */
-    public function add(Token $token)
+    public function add(Token $token): Token
     {
         return ($this->tokens[] = $token);
     }

--- a/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
@@ -56,7 +56,6 @@ interface FullTokenizer extends Tokenizer
      * Returns the token type at the given position relatively to the current position.
      *
      * @param int $shift positive or negative to apply to the current index.
-     * @return int
      */
-    public function peekAt(int $shift);
+    public function peekAt(int $shift): int;
 }

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -61,10 +61,8 @@ interface Tokenizer
 
     /**
      * Returns the name of the source file.
-     *
-     * @return ASTCompilationUnit|null
      */
-    public function getSourceFile();
+    public function getSourceFile(): ?ASTCompilationUnit;
 
     /**
      * Sets a new php source file.
@@ -84,26 +82,22 @@ interface Tokenizer
     /**
      * Returns the previous token or null if there is no one yet.
      *
-     * @return Token|null
      * @since  2.6.0
      */
-    public function prevToken();
+    public function prevToken(): ?Token;
 
     /**
      * Returns the current token or null if there is no more.
      *
-     * @return Token|null
      * @since  2.6.0
      */
-    public function currentToken();
+    public function currentToken(): ?Token;
 
     /**
      * Returns the next token type or {@link Tokenizer::T_EOF} if
      * there is no next token.
-     *
-     * @return int
      */
-    public function peek();
+    public function peek(): int;
 
     /**
      * Returns the type of next token, after the current token. This method
@@ -112,13 +106,11 @@ interface Tokenizer
      * @return ?int
      * @since  0.9.12
      */
-    public function peekNext();
+    public function peekNext(): ?int;
 
     /**
      * Returns the previous token type or {@link Tokenizer::T_BOF}
      * if there is no previous token.
-     *
-     * @return int
      */
-    public function prev();
+    public function prev(): int;
 }

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -86,10 +86,8 @@ class Command
 
     /**
      * Performs the main cli process and returns the exit code.
-     *
-     * @return int
      */
-    public function run()
+    public function run(): int
     {
         $this->application = new Application();
 
@@ -481,10 +479,9 @@ class Command
      * Prints all available log options and returns the length of the longest
      * option.
      *
-     * @return int
      * @throws Exception
      */
-    protected function printLogOptions()
+    protected function printLogOptions(): int
     {
         $maxLength = 0;
         $options = [];
@@ -523,10 +520,9 @@ class Command
      * Prints the analyzer options.
      *
      * @param int $length Length of the longest option.
-     * @return int
      * @throws Exception
      */
-    protected function printAnalyzerOptions(int $length)
+    protected function printAnalyzerOptions(int $length): int
     {
         $options = $this->application->getAvailableAnalyzerOptions();
 
@@ -602,7 +598,7 @@ class Command
      *
      * @return int The exit code.
      */
-    public static function main()
+    public static function main(): int
     {
         $command = new self();
 
@@ -623,10 +619,7 @@ class Command
         echo PHP_EOL;
     }
 
-    /**
-     * @return string
-     */
-    private function getErrorTrace(Exception|Throwable $exception)
+    private function getErrorTrace(Exception|Throwable $exception): string
     {
         return $exception::class . '(' . $exception->getMessage() . ')' . PHP_EOL .
             '## ' . $exception->getFile() . '(' . $exception->getLine() . ')' . PHP_EOL .

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -217,11 +217,10 @@ class Runner
      * Starts the main PDepend process and returns <b>true</b> after a successful
      * execution.
      *
-     * @return int
      * @throws RuntimeException An exception with a readable error message and
      *                          an exit code.
      */
-    public function run()
+    public function run(): int
     {
         $engine = $this->engine;
         $engine->setOptions($this->options);
@@ -296,10 +295,8 @@ class Runner
     /**
      * This method will return <b>true</b> when there were errors during the
      * parse process.
-     *
-     * @return bool
      */
-    public function hasParseErrors()
+    public function hasParseErrors(): bool
     {
         return (count($this->parseErrors) > 0);
     }
@@ -310,7 +307,7 @@ class Runner
      *
      * @return array<string>
      */
-    public function getParseErrors()
+    public function getParseErrors(): array
     {
         return $this->parseErrors;
     }

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -85,12 +85,11 @@ class CacheFactory
      * identifier.
      *
      * @param string $cacheKey The name/identifier for the cache instance.
-     * @return CacheDriver
      * @throws InvalidArgumentException
      * @throws RandomException
      * @throws RuntimeException
      */
-    public function create(?string $cacheKey = null)
+    public function create(?string $cacheKey = null): CacheDriver
     {
         if (false === isset($this->caches[$cacheKey])) {
             $this->caches[$cacheKey] = $this->createCache($cacheKey);
@@ -103,12 +102,11 @@ class CacheFactory
      * Creates a cache instance based on the supplied configuration.
      *
      * @param string|null $cacheKey The name/identifier for the cache instance.
-     * @return CacheDriver
      * @throws InvalidArgumentException If the configured cache driver is unknown.
      * @throws RandomException
      * @throws RuntimeException
      */
-    protected function createCache(?string $cacheKey = null)
+    protected function createCache(?string $cacheKey = null): CacheDriver
     {
         assert($this->configuration->cache instanceof stdClass);
 
@@ -131,10 +129,9 @@ class CacheFactory
      * @param string $location Cache root directory.
      * @param int $ttl Cache ttl
      * @param string|null $cacheKey The name/identifier for the cache instance.
-     * @return FileCacheDriver
      * @throws RuntimeException
      */
-    protected function createFileCache(string $location, int $ttl = self::DEFAULT_TTL, ?string $cacheKey = null)
+    protected function createFileCache(string $location, int $ttl = self::DEFAULT_TTL, ?string $cacheKey = null): FileCacheDriver
     {
         return new FileCacheDriver($location, $ttl, $cacheKey);
     }
@@ -142,10 +139,9 @@ class CacheFactory
     /**
      * Creates an in memory cache instance.
      *
-     * @return MemoryCacheDriver
      * @throws RandomException
      */
-    protected function createMemoryCache()
+    protected function createMemoryCache(): MemoryCacheDriver
     {
         return new MemoryCacheDriver();
     }

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -84,9 +84,8 @@ class FileCacheDirectory
      * full qualified path for that cache directory.
      *
      * @param string $key The cache for an entry.
-     * @return string
      */
-    public function createCacheDirectory(string $key)
+    public function createCacheDirectory(string $key): string
     {
         return $this->createOrReturnCacheDirectory($key);
     }
@@ -97,9 +96,8 @@ class FileCacheDirectory
      * the full qualified path for that cache directory.
      *
      * @param string $key The cache for an entry.
-     * @return string
      */
-    protected function createOrReturnCacheDirectory(string $key)
+    protected function createOrReturnCacheDirectory(string $key): string
     {
         $path = $this->getCacheDir() . '/' . substr($key, 0, 2);
         if (false === file_exists($path)) {
@@ -113,9 +111,8 @@ class FileCacheDirectory
      * Ensures that the given <b>$cacheDir</b> really exists.
      *
      * @param string $cacheDir The cache root directory.
-     * @return string
      */
-    protected function ensureExists(string $cacheDir)
+    protected function ensureExists(string $cacheDir): string
     {
         if (false === file_exists($cacheDir)) {
             @mkdir($cacheDir, 0o775, true);
@@ -127,20 +124,16 @@ class FileCacheDirectory
     /**
      * Tests if the current software cache version is similar to the stored
      * file system cache version.
-     *
-     * @return bool
      */
-    protected function isValidVersion()
+    protected function isValidVersion(): bool
     {
         return (self::VERSION === $this->readVersion());
     }
 
     /**
      * Reads the stored cache version number from the cache root directory.
-     *
-     * @return string|null
      */
-    protected function readVersion()
+    protected function readVersion(): ?string
     {
         if (file_exists($this->getVersionFile())) {
             return trim(file_get_contents($this->getVersionFile()) ?: '');
@@ -160,20 +153,16 @@ class FileCacheDirectory
 
     /**
      * Returns the file name for the used version file.
-     *
-     * @return string
      */
-    protected function getVersionFile()
+    protected function getVersionFile(): string
     {
         return $this->getCacheDir() . '/_version';
     }
 
     /**
      * Returns the cache root directory.
-     *
-     * @return string
      */
-    protected function getCacheDir()
+    protected function getCacheDir(): string
     {
         return $this->cacheDir;
     }

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollector.php
@@ -71,10 +71,8 @@ class FileCacheGarbageCollector
     /**
      * Removes all outdated cache files and returns the number of garbage
      * collected files.
-     *
-     * @return int
      */
-    public function garbageCollect()
+    public function garbageCollect(): int
     {
         if (false === file_exists($this->cacheDir)) {
             return 0;
@@ -103,10 +101,8 @@ class FileCacheGarbageCollector
 
     /**
      * Checks if the given file can be removed.
-     *
-     * @return bool
      */
-    private function isCollectibleFile(SplFileInfo $file)
+    private function isCollectibleFile(SplFileInfo $file): bool
     {
         if (false === $file->isFile()) {
             return false;

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -193,9 +193,8 @@ class FileCacheDriver implements CacheDriver
      * This method reads the raw data from the given <em>$file</em>.
      *
      * @param string $file The cache file name.
-     * @return string
      */
-    protected function read(string $file)
+    protected function read(string $file): string
     {
         $handle = fopen($file, 'rb');
         if (!$handle) {
@@ -239,9 +238,8 @@ class FileCacheDriver implements CacheDriver
      * directory and the current entry type.
      *
      * @param string $key The cache key for the given data.
-     * @return string
      */
-    protected function getCacheFile(string $key)
+    protected function getCacheFile(string $key): string
     {
         $cacheFile = $this->getCacheFileWithoutExtension($key) .
                      '.' . $this->version .
@@ -259,9 +257,8 @@ class FileCacheDriver implements CacheDriver
      * extension.
      *
      * @param string $key The cache key for the given data.
-     * @return string
      */
-    protected function getCacheFileWithoutExtension(string $key)
+    protected function getCacheFileWithoutExtension(string $key): string
     {
         if (is_string($this->cacheKey)) {
             $key = md5($key . $this->cacheKey);

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -192,9 +192,8 @@ class MemoryCacheDriver implements CacheDriver
      * type, so that it is only valid for a single call.
      *
      * @param string $key The concrete object key.
-     * @return string
      */
-    protected function getCacheKey(string $key)
+    protected function getCacheKey(string $key): string
     {
         $type = $this->type;
         $this->type = self::ENTRY_TYPE;

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -113,10 +113,9 @@ class Configuration
      * for the given <b>$name</b> exists.
      *
      * @param string $name Name of the requested property.
-     * @return bool
      * @since  0.10.0
      */
-    public function __isset(string $name)
+    public function __isset(string $name): bool
     {
         return isset($this->settings->{$name});
     }

--- a/src/main/php/PDepend/Util/ConfigurationInstance.php
+++ b/src/main/php/PDepend/Util/ConfigurationInstance.php
@@ -56,10 +56,8 @@ class ConfigurationInstance
 
     /**
      * Returns a configured config instance or <b>null</b>.
-     *
-     * @return Configuration|null
      */
-    public static function get()
+    public static function get(): ?Configuration
     {
         return self::$configuration;
     }

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -103,10 +103,8 @@ class CloverReport implements Report
 
     /**
      * Returns the percentage code coverage for the given item instance.
-     *
-     * @return float
      */
-    public function getCoverage(AbstractASTArtifact $artifact)
+    public function getCoverage(AbstractASTArtifact $artifact): float
     {
         $lines = $this->getLines($artifact->getCompilationUnit()?->getFileName() ?? 'default');
 
@@ -141,7 +139,7 @@ class CloverReport implements Report
      * @param string $fileName The source file name.
      * @return array<bool>
      */
-    private function getLines(string $fileName)
+    private function getLines(string $fileName): array
     {
         return $this->fileLineCoverage[$fileName] ?? [];
     }

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -60,11 +60,10 @@ class Factory
      * path name.
      *
      * @param string $pathName Qualified path name of a coverage report file.
-     * @return CloverReport
      * @throws RuntimeException When the given path name does not point to a
      *                          valid coverage file or onto an unsupported coverage format.
      */
-    public function create(string $pathName)
+    public function create(string $pathName): CloverReport
     {
         $sxml = $this->loadXml($pathName);
         if (isset($sxml->project)) {
@@ -79,11 +78,10 @@ class Factory
      * the given path name.
      *
      * @param string $pathName Qualified path name of a coverage report file.
-     * @return SimpleXMLElement
      * @throws RuntimeException When the given path name does not point to a
      *                          valid xml file.
      */
-    private function loadXml(string $pathName)
+    private function loadXml(string $pathName): SimpleXMLElement
     {
         $mode = libxml_use_internal_errors(true);
         $sxml = simplexml_load_file($pathName);

--- a/src/main/php/PDepend/Util/Coverage/Report.php
+++ b/src/main/php/PDepend/Util/Coverage/Report.php
@@ -55,8 +55,6 @@ interface Report
 {
     /**
      * Returns the percentage code coverage for the given item instance.
-     *
-     * @return float
      */
-    public function getCoverage(AbstractASTArtifact $artifact);
+    public function getCoverage(AbstractASTArtifact $artifact): float;
 }

--- a/src/main/php/PDepend/Util/FileUtil.php
+++ b/src/main/php/PDepend/Util/FileUtil.php
@@ -55,10 +55,9 @@ final class FileUtil
      * Returns the home directory of the current user if it exists. Otherwise
      * this method will return the system temp directory.
      *
-     * @return string
      * @since  0.10.0
      */
-    public static function getUserHomeDirOrSysTempDir()
+    public static function getUserHomeDirOrSysTempDir(): string
     {
         $home = self::getUserHomeDir();
 
@@ -71,10 +70,8 @@ final class FileUtil
 
     /**
      * Returns the system temp directory.
-     *
-     * @return string
      */
-    public static function getSysTempDir()
+    public static function getSysTempDir(): string
     {
         return sys_get_temp_dir();
     }
@@ -82,10 +79,9 @@ final class FileUtil
     /**
      * Returns the home directory of the current user.
      *
-     * @return string
      * @since  0.10.0
      */
-    public static function getUserHomeDir()
+    public static function getUserHomeDir(): string
     {
         $userHomeDir = getenv('HOME');
 

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -65,30 +65,24 @@ class IdBuilder
 
     /**
      * Generates an identifier for the given file instance.
-     *
-     * @return string
      */
-    public function forFile(ASTCompilationUnit $compilationUnit)
+    public function forFile(ASTCompilationUnit $compilationUnit): string
     {
         return $this->hash($compilationUnit->getFileName() ?? 'default');
     }
 
     /**
      * Generates an identifier for the given function instance.
-     *
-     * @return string
      */
-    public function forFunction(ASTFunction $function)
+    public function forFunction(ASTFunction $function): string
     {
         return $this->forOffsetItem($function, 'function');
     }
 
     /**
      * Generates an identifier for the given class, interface or trait instance.
-     *
-     * @return string
      */
-    public function forClassOrInterface(AbstractASTType $type)
+    public function forClassOrInterface(AbstractASTType $type): string
     {
         return $this->forOffsetItem(
             $type,
@@ -100,9 +94,8 @@ class IdBuilder
      * Generates an identifier for the given source item.
      *
      * @param string $prefix The item type identifier.
-     * @return string
      */
-    protected function forOffsetItem(AbstractASTArtifact $artifact, string $prefix)
+    protected function forOffsetItem(AbstractASTArtifact $artifact, string $prefix): string
     {
         $fileHash = $artifact->getCompilationUnit()?->getId() ?? 'default';
         $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getImage()));
@@ -114,10 +107,8 @@ class IdBuilder
 
     /**
      * Generates an identifier for the given method instance.
-     *
-     * @return string
      */
-    public function forMethod(ASTMethod $method)
+    public function forMethod(ASTMethod $method): string
     {
         $hash = $this->hash(strtolower($method->getImage()));
 
@@ -133,9 +124,8 @@ class IdBuilder
      * Creates a base 36 hash for the given string.
      *
      * @param string $string The raw input identifier/string.
-     * @return string
      */
-    protected function hash(string $string)
+    protected function hash(string $string): string
     {
         return substr(base_convert(md5($string), 16, 36), 0, 11);
     }
@@ -146,9 +136,8 @@ class IdBuilder
      *
      * @param string $file The file identifier.
      * @param string $string The node identifier.
-     * @return string
      */
-    protected function getOffsetInFile(string $file, string $string)
+    protected function getOffsetInFile(string $file, string $string): string
     {
         if (isset($this->offsetInFile[$file][$string])) {
             $this->offsetInFile[$file][$string]++;

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -110,10 +110,8 @@ class ImageConvert
 
     /**
      * Tests that the ImageMagick CLI tool <b>convert</b> exists.
-     *
-     * @return bool
      */
-    protected static function hasImagickConvert()
+    protected static function hasImagickConvert(): bool
     {
         /** @codeCoverageIgnoreStart */
         $desc = [

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -233,10 +233,9 @@ final class Type
      * extension.
      *
      * @param string $typeName The type name.
-     * @return bool
      * @throws ReflectionException
      */
-    public static function isInternalType(string $typeName)
+    public static function isInternalType(string $typeName): bool
     {
         self::initTypeToExtension();
 
@@ -251,10 +250,9 @@ final class Type
      * exists, this method will return <b>null</b>.
      *
      * @param string $typeName The type name.
-     * @return string|null
      * @throws ReflectionException
      */
-    public static function getTypePackage(string $typeName)
+    public static function getTypePackage(string $typeName): ?string
     {
         self::initTypeToExtension();
 
@@ -270,7 +268,7 @@ final class Type
      * @return array<string>
      * @throws ReflectionException
      */
-    public static function getInternalNamespaces()
+    public static function getInternalNamespaces(): array
     {
         if (!isset(self::$internalNamespaces)) {
             self::$internalNamespaces = [];
@@ -287,10 +285,9 @@ final class Type
      * php extension.
      *
      * @param string $packageName Name of a package.
-     * @return bool
      * @throws ReflectionException
      */
-    public static function isInternalPackage(string $packageName)
+    public static function isInternalPackage(string $packageName): bool
     {
         $packageNames = self::getInternalNamespaces();
 
@@ -302,9 +299,8 @@ final class Type
      * the list of scalar/none-object types.
      *
      * @param string $image The type identifier.
-     * @return bool
      */
-    public static function isScalarType(string $image)
+    public static function isScalarType(string $image): bool
     {
         $image = strtolower($image);
         if (isset(self::$scalarTypes[$image])) {
@@ -323,10 +319,9 @@ final class Type
      * the list of primitive types.
      *
      * @param string $image The type image.
-     * @return bool
      * @since  0.9.6
      */
-    public static function isPrimitiveType(string $image)
+    public static function isPrimitiveType(string $image): bool
     {
         return (self::getPrimitiveType($image) !== null);
     }
@@ -336,10 +331,9 @@ final class Type
      * image.
      *
      * @param string $image The found primitive type image.
-     * @return string|null
      * @since  0.9.6
      */
-    public static function getPrimitiveType(string $image)
+    public static function getPrimitiveType(string $image): ?string
     {
         $image = strtolower($image);
         if (isset(self::$primitiveTypes[$image])) {
@@ -359,10 +353,9 @@ final class Type
      * php array type.
      *
      * @param string $image The found type image.
-     * @return bool
      * @since  0.9.6
      */
-    public static function isArrayType(string $image)
+    public static function isArrayType(string $image): bool
     {
         return (strtolower($image) === 'array');
     }
@@ -375,7 +368,7 @@ final class Type
      * @return array<string, string>
      * @throws ReflectionException
      */
-    private static function initTypeToExtension()
+    private static function initTypeToExtension(): array
     {
         // Skip when already done.
         if (isset(self::$typeNameToExtension)) {

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -54,10 +54,7 @@ namespace PDepend\Util;
  */
 final class Utf8Util
 {
-    /**
-     * @return string
-     */
-    public static function ensureEncoding(string $raw)
+    public static function ensureEncoding(string $raw): string
     {
         if (mb_check_encoding($raw, 'UTF-8')) {
             return $raw;

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -150,10 +150,9 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the working directory for the currently executed test.
      *
-     * @return string
      * @since 1.0.0
      */
-    protected function getTestWorkingDirectory()
+    protected function getTestWorkingDirectory(): string
     {
         $resource = $this->createCodeResourceUriForTest();
         if (is_file($resource)) {
@@ -180,9 +179,8 @@ abstract class AbstractTestCase extends TestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $nodeType The searched node class.
-     * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInFunction(string $nodeType)
+    protected function getFirstNodeOfTypeInFunction(string $nodeType): ASTNode
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -191,10 +189,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first function found in a test file associated with the
      * given test case.
-     *
-     * @return ASTFunction
      */
-    protected function getFirstFunctionForTestCase()
+    protected function getFirstFunctionForTestCase(): ASTFunction
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -202,10 +198,7 @@ abstract class AbstractTestCase extends TestCase
             ->current();
     }
 
-    /**
-     * @return ASTClosure
-     */
-    protected function getFirstClosureForTestCase()
+    protected function getFirstClosureForTestCase(): ASTClosure
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -216,10 +209,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Create a TextUi Runner
-     *
-     * @return TextUI\Runner
      */
-    protected function createTextUiRunner()
+    protected function createTextUiRunner(): TextUI\Runner
     {
         $application = $this->createTestApplication();
 
@@ -238,10 +229,9 @@ abstract class AbstractTestCase extends TestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $nodeType The searched node class.
-     * @return ASTNode
      * @since 1.0.0
      */
-    protected function getFirstNodeOfTypeInTrait(string $nodeType)
+    protected function getFirstNodeOfTypeInTrait(string $nodeType): ASTNode
     {
         return $this->getFirstTraitForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -251,9 +241,8 @@ abstract class AbstractTestCase extends TestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $nodeType The searched node class.
-     * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInClass(string $nodeType)
+    protected function getFirstNodeOfTypeInClass(string $nodeType): ASTNode
     {
         return $this->getFirstClassForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -263,9 +252,8 @@ abstract class AbstractTestCase extends TestCase
      * Returns a node instance for the currently executed test case.
      *
      * @param string $nodeType The searched node class.
-     * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInInterface(string $nodeType)
+    protected function getFirstNodeOfTypeInInterface(string $nodeType): ASTNode
     {
         return $this->getFirstInterfaceForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -275,10 +263,9 @@ abstract class AbstractTestCase extends TestCase
      * Returns the first trait found in a test file associated with the given
      * test case.
      *
-     * @return ASTTrait
      * @since 1.0.0
      */
-    protected function getFirstTraitForTestCase()
+    protected function getFirstTraitForTestCase(): ASTTrait
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -289,10 +276,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first class found in a test file associated with the given
      * test case.
-     *
-     * @return ASTClass
      */
-    protected function getFirstClassForTestCase()
+    protected function getFirstClassForTestCase(): ASTClass
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -303,10 +288,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first method that could be found in the source file
      * associated with the calling test case.
-     *
-     * @return ASTMethod
      */
-    protected function getFirstClassMethodForTestCase()
+    protected function getFirstClassMethodForTestCase(): ASTMethod
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -319,10 +302,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first interface that could be found in the source file
      * associated with the calling test case.
-     *
-     * @return ASTInterface
      */
-    protected function getFirstInterfaceForTestCase()
+    protected function getFirstInterfaceForTestCase(): ASTInterface
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -333,10 +314,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first method that could be found in the source file
      * associated with the calling test case.
-     *
-     * @return ASTMethod
      */
-    protected function getFirstInterfaceMethodForTestCase()
+    protected function getFirstInterfaceMethodForTestCase(): ASTMethod
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -349,10 +328,8 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
-     *
-     * @return AbstractASTClassOrInterface
      */
-    protected function getFirstTypeForTestCase()
+    protected function getFirstTypeForTestCase(): AbstractASTClassOrInterface
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -363,20 +340,15 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Returns the first method that could be found in the code under test for
      * the calling test case.
-     *
-     * @return ASTMethod
      */
-    protected function getFirstMethodForTestCase()
+    protected function getFirstMethodForTestCase(): ASTMethod
     {
         return $this->getFirstTypeForTestCase()
             ->getMethods()
             ->current();
     }
 
-    /**
-     * @return ASTFormalParameter
-     */
-    protected function getFirstFormalParameterForTestCase()
+    protected function getFirstFormalParameterForTestCase(): ASTFormalParameter
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType(
@@ -391,7 +363,7 @@ abstract class AbstractTestCase extends TestCase
      * @param array $actual Previous filled list.
      * @return array<string>
      */
-    protected static function collectChildNodes(ASTNode $node, array $actual = [])
+    protected static function collectChildNodes(ASTNode $node, array $actual = []): array
     {
         foreach ($node->getChildren() as $child) {
             $actual[] = $child::class;
@@ -416,9 +388,8 @@ abstract class AbstractTestCase extends TestCase
      * Collects all children from a given node.
      *
      * @param ASTNode $node The current root node.
-     * @return array
      */
-    protected static function collectGraph(ASTNode $node)
+    protected static function collectGraph(ASTNode $node): array
     {
         $graph = [];
         foreach ($node->getChildren() as $child) {
@@ -448,10 +419,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a mocked class instance without calling the constructor.
      *
      * @param string $className Name of the class to mock.
-     * @return ASTProperty
      * @since 0.10.0
      */
-    protected function getMockWithoutConstructor(string $className)
+    protected function getMockWithoutConstructor(string $className): ASTProperty
     {
         $mock = $this->getMockBuilder($className)
             ->onlyMethods(['__construct'])
@@ -487,10 +457,9 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Creates a test configuration instance.
      *
-     * @return Util\Configuration
      * @since 0.10.0
      */
-    protected function createConfigurationFixture()
+    protected function createConfigurationFixture(): Util\Configuration
     {
         $application = $this->createTestApplication();
 
@@ -509,10 +478,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a PDepend instance configured with the code resource associated
      * with the calling test case.
      *
-     * @return Engine
      * @since 0.10.0
      */
-    protected function createEngineFixture()
+    protected function createEngineFixture(): Engine
     {
         $this->changeWorkingDirectory(
             self::createCodeResourceURI('config/')
@@ -527,10 +495,7 @@ abstract class AbstractTestCase extends TestCase
         return new Engine($configuration, $cacheFactory, $analyzerFactory);
     }
 
-    /**
-     * @return int
-     */
-    protected function silentRun(TextUI\Runner $runner)
+    protected function silentRun(TextUI\Runner $runner): int
     {
         $error = null;
 
@@ -555,10 +520,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use class fixture.
      *
      * @param string $name Optional class name.
-     * @return ASTClass
      * @since 1.0.2
      */
-    protected function createClassFixture(?string $name = null)
+    protected function createClassFixture(?string $name = null): ASTClass
     {
         $name = $name ?: static::class;
 
@@ -576,10 +540,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use interface fixture.
      *
      * @param string $name Optional interface name.
-     * @return ASTInterface
      * @since 1.0.2
      */
-    protected function createInterfaceFixture(?string $name = null)
+    protected function createInterfaceFixture(?string $name = null): ASTInterface
     {
         $name = $name ?: static::class;
 
@@ -594,10 +557,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use trait fixture.
      *
      * @param string $name Optional trait name.
-     * @return ASTTrait
      * @since 1.0.2
      */
-    protected function createTraitFixture(?string $name = null)
+    protected function createTraitFixture(?string $name = null): ASTTrait
     {
         $name = $name ?: static::class;
 
@@ -611,10 +573,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use function fixture.
      *
      * @param string $name Optional function name.
-     * @return ASTFunction
      * @since 1.0.2
      */
-    protected function createFunctionFixture(?string $name = null)
+    protected function createFunctionFixture(?string $name = null): ASTFunction
     {
         $name = $name ?: static::class;
 
@@ -630,10 +591,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a ready to use method fixture.
      *
      * @param string $name Optional method name.
-     * @return ASTMethod
      * @since 1.0.2
      */
-    protected function createMethodFixture(?string $name = null)
+    protected function createMethodFixture(?string $name = null): ASTMethod
     {
         $name = $name ?: static::class;
 
@@ -646,10 +606,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Creates a temporary resource for the given file name.
-     *
-     * @return string
      */
-    protected function createRunResourceURI(?string $fileName = null)
+    protected function createRunResourceURI(?string $fileName = null): string
     {
         return tempnam(sys_get_temp_dir(), $fileName ?: uniqid());
     }
@@ -658,10 +616,9 @@ abstract class AbstractTestCase extends TestCase
      * Creates a code uri for the given file name.
      *
      * @param string $fileName The code file name.
-     * @return string
      * @throws ErrorException
      */
-    protected static function createCodeResourceURI(string $fileName)
+    protected static function createCodeResourceURI(string $fileName): string
     {
         $uri = realpath(__DIR__ . '/../../resources/files') . DIRECTORY_SEPARATOR . $fileName;
 
@@ -674,10 +631,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Creates a code uri for the calling test case.
-     *
-     * @return string
      */
-    protected function createCodeResourceUriForTest()
+    protected function createCodeResourceUriForTest(): string
     {
         [$class, $method] = explode('::', $this->getCallingTestMethod());
 
@@ -707,10 +662,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Returns the name of the calling test method.
-     *
-     * @return string
      */
-    protected function getCallingTestMethod()
+    protected function getCallingTestMethod(): string
     {
         foreach (debug_backtrace() as $frame) {
             if (str_starts_with($frame['function'], 'test')) {
@@ -764,7 +717,7 @@ abstract class AbstractTestCase extends TestCase
      * @param bool $ignoreAnnotations The parser should ignore annotations.
      * @return ASTArtifactList<ASTNamespace>
      */
-    protected function parseCodeResourceForTest(bool $ignoreAnnotations = false)
+    protected function parseCodeResourceForTest(bool $ignoreAnnotations = false): ASTArtifactList
     {
         return $this->parseSource(
             $this->createCodeResourceUriForTest(),
@@ -778,7 +731,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
 
@@ -800,7 +753,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseSource(string $fileOrDirectory, bool $ignoreAnnotations = false)
+    public function parseSource(string $fileOrDirectory, bool $ignoreAnnotations = false): ASTArtifactList
     {
         if (file_exists($fileOrDirectory) === false) {
             $fileOrDirectory = self::createCodeResourceURI($fileOrDirectory);
@@ -847,9 +800,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * @param Builder<mixed> $builder
-     * @return AbstractPHPParser
      */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return new PHPParserGeneric(
             $tokenizer,

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -60,10 +60,9 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Creates the PDepend summary report for the source associated with the
      * calling test case.
      *
-     * @return string
      * @since 0.10.0
      */
-    protected function createSummaryXmlForCallingTest()
+    protected function createSummaryXmlForCallingTest(): string
     {
         $this->changeWorkingDirectory(
             self::createCodeResourceURI('config/')
@@ -87,7 +86,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         return $this->parseSource(
             $this->getSourceFileForTestCase($testCase),
@@ -99,9 +98,8 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Returns the source file for the given test case.
      *
      * @param string $testCase The qualified test case name.
-     * @return string
      */
-    protected function getSourceFileForTestCase(string $testCase)
+    protected function getSourceFileForTestCase(string $testCase): string
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -86,10 +86,8 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
 
     /**
      * Returns the class names of all file aware logger classes.
-     *
-     * @return array
      */
-    public static function getLoggerClassNames()
+    public static function getLoggerClassNames(): array
     {
         return [
             [Chart::class, 'svg'],

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -106,7 +106,7 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
      *
      * @return ?ASTHeredoc
      */
-    protected function getFirstHeredocInClass()
+    protected function getFirstHeredocInClass(): ?ASTHeredoc
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -97,10 +97,8 @@ class ParserBug8927377Test extends AbstractRegressionTestCase
 
     /**
      * Returns the property postfix found in a class.
-     *
-     * @return ASTPropertyPostfix
      */
-    protected function getFirstPropertyPostfixInClass()
+    protected function getFirstPropertyPostfixInClass(): ASTPropertyPostfix
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -77,10 +77,8 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
 
     /**
      * Data provider for the reserved keyword as constant name test.
-     *
-     * @return array
      */
-    public static function dataProviderReservedKeywordAsTypeConstantName()
+    public static function dataProviderReservedKeywordAsTypeConstantName(): array
     {
         return [
             [

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -82,10 +82,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
     /**
      * Data provider for the substitution bug in object and class operator
      * chains.
-     *
-     * @return array
      */
-    public static function dataProviderTokenizerKeywordSubstitutionInOperatorChain()
+    public static function dataProviderTokenizerKeywordSubstitutionInOperatorChain(): array
     {
         return [
             [

--- a/src/test/php/PDepend/EngineTest.php
+++ b/src/test/php/PDepend/EngineTest.php
@@ -327,10 +327,8 @@ class EngineTest extends AbstractTestCase
 
     /**
      * Tests the newly added support for single file handling.
-     *
-     * @return ASTNamespace
      */
-    public function testSupportForSingleFileIssue90()
+    public function testSupportForSingleFileIssue90(): ASTNamespace
     {
         $engine = $this->createEngineFixture();
         $engine->addFile($this->createCodeResourceUriForTest());

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -194,7 +194,7 @@ class ExcludePathFilterTest extends AbstractTestCase
      * @param array<string> $excludes The filtered patterns
      * @return array<string>
      */
-    protected function createFilteredFileList(array $excludes)
+    protected function createFilteredFileList(array $excludes): array
     {
         $filter = new ExcludePathFilter($excludes);
 

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -94,7 +94,7 @@ class ExtensionFilterTest extends AbstractTestCase
      * @param array<string> $includes The file extensions
      * @return array<string>
      */
-    protected function createFilteredFileList(array $includes)
+    protected function createFilteredFileList(array $includes): array
     {
         $filter = new ExtensionFilter($includes);
 

--- a/src/test/php/PDepend/Input/IteratorTest.php
+++ b/src/test/php/PDepend/Input/IteratorTest.php
@@ -166,7 +166,7 @@ class IteratorTest extends AbstractTestCase
      * @param array<string> $extensions The accepted file extension.
      * @return array<string>
      */
-    protected function createFilteredFileList(array $extensions)
+    protected function createFilteredFileList(array $extensions): array
     {
         $files = new Iterator(
             new DirectoryIterator($this->createCodeResourceUriForTest()),

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -62,7 +62,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      *
      * @return ASTParameter[]
      */
-    protected function getParametersOfFirstFunction()
+    protected function getParametersOfFirstFunction(): array
     {
         return $this->getFirstFunctionForTestCase()
             ->getParameters();
@@ -73,7 +73,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    protected function parseTestCase(?string $testCase = null)
+    protected function parseTestCase(?string $testCase = null): ASTArtifactList
     {
         if ($testCase === null) {
             $testCase = $this->getTestCaseMethod();
@@ -88,7 +88,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
         if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0) {
@@ -100,10 +100,8 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
 
     /**
      * Returns a php callback for the calling test case method.
-     *
-     * @return string
      */
-    protected function getTestCaseMethod()
+    protected function getTestCaseMethod(): string
     {
         $trace = debug_backtrace();
         foreach ($trace as $frame) {

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -104,10 +104,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
     /**
      * Data provider that returns a list of actual input and expected output
      * primitive types.
-     *
-     * @return array
      */
-    public static function dataProviderParserSetsExpectedPrimitivePropertyType()
+    public static function dataProviderParserSetsExpectedPrimitivePropertyType(): array
     {
         return [
             ['int', 'integer'],

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -459,10 +459,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesQualifiedTypeNameInFunction()
+    public static function dataProviderParserResolvesQualifiedTypeNameInFunction(): array
     {
         return [
             ['issues/002-015-resolve-qualified-type-names.php', 'foo\bar'],
@@ -477,10 +475,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesQualifiedTypeNameInTypeSignature()
+    public static function dataProviderParserResolvesQualifiedTypeNameInTypeSignature(): array
     {
         return [
             ['issues/002-031-resolve-qualified-type-names.php', 'baz'],
@@ -494,10 +490,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserKeepsQualifiedTypeNameInFunction()
+    public static function dataProviderParserKeepsQualifiedTypeNameInFunction(): array
     {
         return [
             ['issues/002-016-resolve-qualified-type-names.php', ''],
@@ -512,10 +506,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserKeepsQualifiedTypeNameInTypeSignature()
+    public static function dataProviderParserKeepsQualifiedTypeNameInTypeSignature(): array
     {
         return [
             ['issues/002-032-resolve-qualified-type-names.php', 'foo\bar'],
@@ -527,10 +519,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax()
+    public static function dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax(): array
     {
         return [
             ['issues/002-017-resolve-qualified-type-names.php', 'foo\bar'],
@@ -544,10 +534,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax()
+    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax(): array
     {
         return [
             ['issues/002-033-resolve-qualified-type-names.php', 'baz\foo'],
@@ -560,10 +548,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax()
+    public static function dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax(): array
     {
         return [
             ['issues/002-018-resolve-qualified-type-names.php', ''],
@@ -577,10 +563,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     /**
      * Data provider method that returns test data for class name resolving
      * tests.
-     *
-     * @return array
      */
-    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax()
+    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax(): array
     {
         return [
             ['issues/002-034-resolve-qualified-type-names.php', 'baz\foo'],

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -164,10 +164,8 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * Executes PDepend's text ui command and returns the exit code and shell
      * output.
-     *
-     * @return array
      */
-    protected function runTextUICommand()
+    protected function runTextUICommand(): array
     {
         $command = new Command();
 

--- a/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/src/test/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -151,7 +151,7 @@ class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
      *
      * @return ASTParameter[]
      */
-    private function getParametersOfFirstMethod()
+    private function getParametersOfFirstMethod(): array
     {
         $namespaces = $this->parseTestCase();
 

--- a/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/src/test/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -599,10 +599,8 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Returns the first interface in the test case file.
-     *
-     * @return ASTInterface
      */
-    private function getFirstInterface()
+    private function getFirstInterface(): ASTInterface
     {
         $namespaces = $this->parseTestCase();
 
@@ -613,10 +611,8 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Returns the first class in the test case file.
-     *
-     * @return ASTClass
      */
-    private function getFirstClass()
+    private function getFirstClass(): ASTClass
     {
         $namespaces = $this->parseTestCase();
 
@@ -627,10 +623,8 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Returns the first method in the test case file.
-     *
-     * @return ASTMethod
      */
-    private function getFirstMethod()
+    private function getFirstMethod(): ASTMethod
     {
         $namespaces = $this->parseTestCase();
 
@@ -643,10 +637,8 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 
     /**
      * Returns the first function in the test case file.
-     *
-     * @return ASTFunction
      */
-    private function getFirstFunction()
+    private function getFirstFunction(): ASTFunction
     {
         $namespaces = $this->parseTestCase();
 

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -62,7 +62,7 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -410,7 +410,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @return array<string, mixed>
      */
-    private function calculateClassMetrics()
+    private function calculateClassMetrics(): array
     {
         $namespaces = $this->parseTestCaseSource($this->getCallingTestMethod());
 
@@ -427,10 +427,9 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testGetNodeMetricsForTrait
      *
-     * @return array
      * @since 1.0.6
      */
-    public function testGetNodeMetricsForTrait()
+    public function testGetNodeMetricsForTrait(): array
     {
         $metrics = $this->calculateTraitMetrics();
 
@@ -592,7 +591,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      * @return array<string, mixed>
      * @since 1.0.6
      */
-    private function calculateTraitMetrics()
+    private function calculateTraitMetrics(): array
     {
         $namespaces = $this->parseCodeResourceForTest();
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -503,10 +503,9 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testGetNodeMetricsForTrait
      *
-     * @return array
      * @since 1.0.6
      */
-    public function testGetNodeMetricsForTrait()
+    public function testGetNodeMetricsForTrait(): array
     {
         $metrics = $this->calculateTraitMetrics();
         static::assertIsArray($metrics);
@@ -569,10 +568,9 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * testGetProjectMetricsForTrait
      *
-     * @return array
      * @since 1.0.6
      */
-    public function testGetProjectMetricsForTrait()
+    public function testGetProjectMetricsForTrait(): array
     {
         $analyzer = new CouplingAnalyzer();
         $analyzer->analyze($this->parseCodeResourceForTest());
@@ -629,7 +627,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @return array<string, mixed>
      * @since 1.0.6
      */
-    private function calculateTraitMetrics()
+    private function calculateTraitMetrics(): array
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -666,7 +664,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @return array<string, mixed>
      * @since 0.10.2
      */
-    private function calculateProjectMetrics(?string $testCase = null)
+    private function calculateProjectMetrics(?string $testCase = null): array
     {
         $testCase = ($testCase ?: $this->getCallingTestMethod());
 
@@ -679,10 +677,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Data provider that returns different test files and the corresponding
      * invocation count value.
-     *
-     * @return array
      */
-    public static function dataProviderAnalyzerCalculatesExpectedCallCount()
+    public static function dataProviderAnalyzerCalculatesExpectedCallCount(): array
     {
         return [
             [__METHOD__ . '#01', 0, 0],

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -165,9 +165,8 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param string $testCase Name of the calling test case.
      * @param int $ccn The entire cyclomatic complexity number.
-     * @return array
      */
-    private function calculateCrapIndex(string $testCase, int $ccn)
+    private function calculateCrapIndex(string $testCase, int $ccn): array
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -197,10 +196,8 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Creates a temporary clover report file that can be used for a single test.
-     *
-     * @return string
      */
-    private function createCloverReportFile()
+    private function createCloverReportFile(): string
     {
         $pathName = $this->createRunResourceURI('clover.xml');
 
@@ -214,10 +211,8 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * Creates a mocked instance of the cyclomatic complexity analyzer.
-     *
-     * @return CyclomaticComplexityAnalyzer
      */
-    private function createCyclomaticComplexityAnalyzerMock(int $ccn = 42)
+    private function createCyclomaticComplexityAnalyzerMock(int $ccn = 42): CyclomaticComplexityAnalyzer
     {
         $mock = $this->getMockBuilder(CyclomaticComplexityAnalyzer::class)
             ->getMock();

--- a/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -341,10 +341,9 @@ class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return CyclomaticComplexityAnalyzer
      * @since 1.0.0
      */
-    private function createAnalyzer()
+    private function createAnalyzer(): CyclomaticComplexityAnalyzer
     {
         $analyzer = new CyclomaticComplexityAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -288,10 +288,9 @@ class HalsteadAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return HalsteadAnalyzer
      * @since 1.0.0
      */
-    private function createAnalyzer()
+    private function createAnalyzer(): HalsteadAnalyzer
     {
         $analyzer = new HalsteadAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -143,10 +143,7 @@ class HierarchyAnalyzerTest extends AbstractMetricsTestCase
         static::assertSame([], $analyzer->getNodeMetrics($class));
     }
 
-    /**
-     * @return HierarchyAnalyzer
-     */
-    private function createAnalyzer()
+    private function createAnalyzer(): HierarchyAnalyzer
     {
         return new HierarchyAnalyzer();
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -298,10 +298,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
         return $metrics[$metric];
     }
 
-    /**
-     * @return InheritanceAnalyzer
-     */
-    private function createAnalyzer()
+    private function createAnalyzer(): InheritanceAnalyzer
     {
         return new InheritanceAnalyzer();
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -192,10 +192,9 @@ class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Returns a pre configured ccn analyzer.
      *
-     * @return MaintainabilityIndexAnalyzer
      * @since 1.0.0
      */
-    private function createAnalyzer()
+    private function createAnalyzer(): MaintainabilityIndexAnalyzer
     {
         $analyzer = new MaintainabilityIndexAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -447,10 +447,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Returns the NPath Complexity of the first function found in source file
      * associated with the calling test case.
      *
-     * @return int
      * @since 0.9.12
      */
-    private function calculateFunctionMetric()
+    private function calculateFunctionMetric(): int
     {
         return $this->calculateNPathComplexity(
             $this->getFirstFunctionForTestCaseInternal()
@@ -461,10 +460,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Parses the source code associated with the calling test case and returns
      * the first function found in the test case source file.
      *
-     * @return ASTFunction
      * @since 0.9.12
      */
-    private function getFirstFunctionForTestCaseInternal()
+    private function getFirstFunctionForTestCaseInternal(): ASTFunction
     {
         return $this->parseTestCaseSource($this->getCallingTestMethod())
             ->current()
@@ -476,10 +474,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Returns the NPath Complexity of the first method found in source file
      * associated with the calling test case.
      *
-     * @return int
      * @since 0.9.12
      */
-    private function calculateMethodMetric()
+    private function calculateMethodMetric(): int
     {
         return $this->calculateNPathComplexity(
             $this->getFirstMethodForTestCaseInternal()
@@ -490,10 +487,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
      * Parses the source code associated with the calling test case and returns
      * the first method found in the test case source file.
      *
-     * @return ASTMethod
      * @since 0.9.12
      */
-    private function getFirstMethodForTestCaseInternal()
+    private function getFirstMethodForTestCaseInternal(): ASTMethod
     {
         return $this->parseTestCaseSource($this->getCallingTestMethod())
             ->current()
@@ -506,10 +502,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Calculates the NPath complexity for the given callable instance.
      *
-     * @return string
      * @since 0.9.12
      */
-    private function calculateNPathComplexity(AbstractASTCallable $callable)
+    private function calculateNPathComplexity(AbstractASTCallable $callable): string
     {
         $analyzer = $this->createAnalyzer();
         $analyzer->dispatch($callable);
@@ -522,10 +517,9 @@ class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a ready to use npath complexity analyzer.
      *
-     * @return NPathComplexityAnalyzer
      * @since 1.0.0
      */
-    private function createAnalyzer()
+    private function createAnalyzer(): NPathComplexityAnalyzer
     {
         $analyzer = new NPathComplexityAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -289,10 +289,7 @@ class NodeCountAnalyzerTest extends AbstractMetricsTestCase
         );
     }
 
-    /**
-     * @return NodeCountAnalyzer
-     */
-    private function createAnalyzer()
+    private function createAnalyzer(): NodeCountAnalyzer
     {
         return new NodeCountAnalyzer();
     }

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -662,10 +662,9 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a ready to use node loc analyzer.
      *
-     * @return NodeLocAnalyzer
      * @since 1.0.0
      */
-    private function createAnalyzer()
+    private function createAnalyzer(): NodeLocAnalyzer
     {
         $analyzer = new NodeLocAnalyzer();
         $analyzer->setCache($this->cache);

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -72,7 +72,7 @@ class ParserRegressionTest extends AbstractTestCase
      *
      * @return array<array>
      */
-    public static function dataProviderSourceFiles()
+    public static function dataProviderSourceFiles(): array
     {
         $files = [];
         foreach (new DirectoryIterator(self::createCodeResourceURI('parser_regression')) as $file) {

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -502,7 +502,7 @@ class ParserTest extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTFunction>
      */
-    public function testParserSetsCorrectFunctionReturnType()
+    public function testParserSetsCorrectFunctionReturnType(): ASTArtifactList
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -930,7 +930,7 @@ class ParserTest extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function testParserSetsFileLevelFunctionPackage()
+    public function testParserSetsFileLevelFunctionPackage(): ASTArtifactList
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -1442,10 +1442,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Returns an interface instance from the mixed code test file.
-     *
-     * @return ASTInterface
      */
-    protected function getInterfaceForTest()
+    protected function getInterfaceForTest(): ASTInterface
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -1457,7 +1455,7 @@ class ParserTest extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTMethod>
      */
-    protected function getInterfaceMethodsForTest()
+    protected function getInterfaceMethodsForTest(): ASTArtifactList
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -1469,10 +1467,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Returns a class instance from the mixed code test file.
-     *
-     * @return ASTClass
      */
-    protected function getClassForTest()
+    protected function getClassForTest(): ASTClass
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -1484,7 +1480,7 @@ class ParserTest extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTMethod>
      */
-    protected function getClassMethodsForTest()
+    protected function getClassMethodsForTest(): ASTArtifactList
     {
         $namespaces = $this->parseCodeResourceForTest();
 

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -85,7 +85,7 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      *
      * @return array<string>
      */
-    public function getAcceptedAnalyzers()
+    public function getAcceptedAnalyzers(): array
     {
         return [
             'pdepend.analyzer.cyclomatic_complexity',
@@ -115,9 +115,8 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      * with return <b>true</b>, otherwise the return value is <b>false</b>.
      *
      * @param Analyzer $analyzer The analyzer to log.
-     * @return bool
      */
-    public function log(Analyzer $analyzer)
+    public function log(Analyzer $analyzer): bool
     {
         $this->input['analyzers'][] = $analyzer;
 

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -309,7 +309,7 @@ class ChartTest extends AbstractTestCase
     /**
      * @return ASTNamespace[]
      */
-    private function createPackages()
+    private function createPackages(): array
     {
         $packages = [];
         foreach (func_get_args() as $i => $userDefined) {
@@ -322,10 +322,7 @@ class ChartTest extends AbstractTestCase
         return $packages;
     }
 
-    /**
-     * @return ASTNamespace
-     */
-    private function createPackage(bool $userDefined, string $packageName)
+    private function createPackage(bool $userDefined, string $packageName): ASTNamespace
     {
         $packageA = new ASTNamespace($packageName);
         $type = $this->getMockBuilder(ASTClass::class)

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -135,7 +135,7 @@ class XmlTest extends AbstractTestCase
      * @param string $fileName File name of the expected result document.
      * @return string The prepared xml document
      */
-    protected function getNormalizedPathXml(string $fileName)
+    protected function getNormalizedPathXml(string $fileName): string
     {
         $path = $this->createCodeResourceUriForTest();
 

--- a/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -127,10 +127,8 @@ class ASTAllocationExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a test allocation expression.
-     *
-     * @return ASTAllocationExpression
      */
-    private function getFirstAllocationExpressionInFunction()
+    private function getFirstAllocationExpressionInFunction(): ASTAllocationExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTAllocationExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -111,10 +111,7 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
         );
     }
 
-    /**
-     * @return ASTAnonymousClass
-     */
-    private function getFirstAnonymousClassInFunction()
+    private function getFirstAnonymousClassInFunction(): ASTAnonymousClass
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType(ASTAnonymousClass::class);

--- a/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -125,10 +125,8 @@ class ASTArgumentsTest extends ASTNodeTestCase
 
     /**
      * Returns an arguments instance for the currently executed test case.
-     *
-     * @return ASTArguments
      */
-    private function getFirstArgumentsOfFunction()
+    private function getFirstArgumentsOfFunction(): ASTArguments
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTArguments::class

--- a/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -295,10 +295,8 @@ class ASTArrayElementTest extends ASTNodeTestCase
 
     /**
      * Returns an array element for the currently executed test case.
-     *
-     * @return ASTArrayElement
      */
-    private function getFirstArrayElementInFunction()
+    private function getFirstArrayElementInFunction(): ASTArrayElement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTArrayElement::class

--- a/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -360,10 +360,8 @@ class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTArrayIndexExpression
      */
-    private function getFirstArrayIndexExpressionInFunction()
+    private function getFirstArrayIndexExpressionInFunction(): ASTArrayIndexExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTArrayIndexExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArrayTest.php
@@ -137,10 +137,8 @@ class ASTArrayTest extends ASTNodeTestCase
 
     /**
      * Returns an array instance for the currently executed test case.
-     *
-     * @return ASTArray
      */
-    private function getFirstArrayInFunction()
+    private function getFirstArrayInFunction(): ASTArray
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTArray::class

--- a/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -142,10 +142,8 @@ class ASTArtifactTest extends AbstractTestCase
 
     /**
      * Returns a mocked item instance.
-     *
-     * @return AbstractASTArtifact
      */
-    protected function getItemMock()
+    protected function getItemMock(): AbstractASTArtifact
     {
         return $this->getAbstractClassMock(
             AbstractASTArtifact::class,

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -272,10 +272,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testVariableAssignmentExpression
      *
-     * @return ASTAssignmentExpression
      * @since 1.0.1
      */
-    public function testVariableAssignmentExpression()
+    public function testVariableAssignmentExpression(): ASTAssignmentExpression
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
         static::assertInstanceOf(ASTAssignmentExpression::class, $expr);
@@ -326,10 +325,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testStaticPropertyAssignmentExpression
      *
-     * @return ASTAssignmentExpression
      * @since 1.0.1
      */
-    public function testStaticPropertyAssignmentExpression()
+    public function testStaticPropertyAssignmentExpression(): ASTAssignmentExpression
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
         static::assertInstanceOf(ASTAssignmentExpression::class, $expr);
@@ -380,10 +378,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testObjectPropertyAssignmentExpression
      *
-     * @return ASTAssignmentExpression
      * @since 1.0.1
      */
-    public function testObjectPropertyAssignmentExpression()
+    public function testObjectPropertyAssignmentExpression(): ASTAssignmentExpression
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
         static::assertInstanceOf(ASTAssignmentExpression::class, $expr);
@@ -434,10 +431,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * testChainedPropertyAssignmentExpression
      *
-     * @return ASTAssignmentExpression
      * @since 1.0.1
      */
-    public function testChainedPropertyAssignmentExpression()
+    public function testChainedPropertyAssignmentExpression(): ASTAssignmentExpression
     {
         $expr = $this->getFirstAssignmentExpressionInFunction();
         static::assertInstanceOf(ASTAssignmentExpression::class, $expr);
@@ -487,10 +483,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a test assignment-expression.
-     *
-     * @return ASTAssignmentExpression
      */
-    private function getFirstAssignmentExpressionInFunction()
+    private function getFirstAssignmentExpressionInFunction(): ASTAssignmentExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTAssignmentExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -93,10 +93,8 @@ class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTBooleanAndExpression
      */
-    private function getFirstBooleanAndExpressionInFunction()
+    private function getFirstBooleanAndExpressionInFunction(): ASTBooleanAndExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTBooleanAndExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -93,10 +93,8 @@ class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTBooleanOrExpression
      */
-    private function getFirstBooleanOrExpressionInFunction()
+    private function getFirstBooleanOrExpressionInFunction(): ASTBooleanOrExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTBooleanOrExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -93,10 +93,8 @@ class ASTBreakStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTBreakStatement
      */
-    private function getFirstBreakStatementInFunction()
+    private function getFirstBreakStatementInFunction(): ASTBreakStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTBreakStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCallableTest.php
@@ -255,20 +255,17 @@ class ASTCallableTest extends AbstractTestCase
      * Returns the first callable found in the test file for the calling test
      * method.
      *
-     * @return AbstractASTCallable
      * @since 0.10.0
      */
-    protected function getFirstCallableForTest()
+    protected function getFirstCallableForTest(): AbstractASTCallable
     {
         return $this->getFirstFunctionForTestCase();
     }
 
     /**
      * Returns a mocked instance of the callable class.
-     *
-     * @return AbstractASTCallable
      */
-    protected function getCallableMock()
+    protected function getCallableMock(): AbstractASTCallable
     {
         return $this->getAbstractClassMock(
             AbstractASTCallable::class,

--- a/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -290,10 +290,8 @@ class ASTCastExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTCastExpression
      */
-    private function getFirstCastExpressionInFunction()
+    private function getFirstCastExpressionInFunction(): ASTCastExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTCastExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -142,10 +142,8 @@ class ASTCatchStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTCatchStatement
      */
-    private function getFirstCatchStatementInFunction()
+    private function getFirstCatchStatementInFunction(): ASTCatchStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTCatchStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -303,10 +303,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTClassFqnPostfix
      */
-    private function getFirstClassFqnPostfixInClass()
+    private function getFirstClassFqnPostfixInClass(): ASTClassFqnPostfix
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTClassFqnPostfix::class
@@ -315,10 +313,8 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInClass()
+    private function getFirstMemberPrimaryPrefixInClass(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTMemberPrimaryPrefix::class

--- a/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -249,10 +249,8 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTClassOrInterfaceReference
      */
-    private function getFirstReferenceInFunction()
+    private function getFirstReferenceInFunction(): ASTClassOrInterfaceReference
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTClassOrInterfaceReference::class
@@ -262,10 +260,9 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return ASTClassOrInterfaceReference
      * @since 0.10.5
      */
-    private function getFirstReferenceInClass()
+    private function getFirstReferenceInClass(): ASTClassOrInterfaceReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTClassOrInterfaceReference::class
@@ -275,10 +272,9 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return ASTClassOrInterfaceReference
      * @since 0.10.5
      */
-    private function getFirstReferenceInInterface()
+    private function getFirstReferenceInInterface(): ASTClassOrInterfaceReference
     {
         return $this->getFirstNodeOfTypeInInterface(
             ASTClassOrInterfaceReference::class

--- a/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -192,10 +192,8 @@ class ASTClassReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTClassReference
      */
-    private function getFirstReferenceInFunction()
+    private function getFirstReferenceInFunction(): ASTClassReference
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTClassReference::class
@@ -205,10 +203,9 @@ class ASTClassReferenceTest extends ASTNodeTestCase
     /**
      * Returns the first reference node for the currently executed test case.
      *
-     * @return ASTClassReference
      * @since 0.10.5
      */
-    private function getFirstReferenceInClass()
+    private function getFirstReferenceInClass(): ASTClassReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTClassReference::class

--- a/src/test/php/PDepend/Source/AST/ASTClassTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClassTest.php
@@ -1483,10 +1483,8 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * Creates an abstract item instance.
-     *
-     * @return AbstractASTArtifact
      */
-    protected function createItem()
+    protected function createItem(): AbstractASTArtifact
     {
         $class = new ASTClass(__CLASS__);
         $class->setCompilationUnit(new ASTCompilationUnit(__FILE__));

--- a/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -93,10 +93,8 @@ class ASTCloneExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTCloneExpression
      */
-    private function getFirstCloneExpressionInFunction()
+    private function getFirstCloneExpressionInFunction(): ASTCloneExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTCloneExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTClosureTest.php
@@ -257,10 +257,8 @@ class ASTClosureTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTClosure
      */
-    private function getFirstClosureInFunction()
+    private function getFirstClosureInFunction(): ASTClosure
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTClosure::class

--- a/src/test/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCommentTest.php
@@ -165,10 +165,8 @@ class ASTCommentTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTComment
      */
-    private function getFirstCommentInClass()
+    private function getFirstCommentInClass(): ASTComment
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTComment::class

--- a/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -93,10 +93,8 @@ class ASTCompoundExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTCompoundExpression
      */
-    private function getFirstExpressionInFunction()
+    private function getFirstExpressionInFunction(): ASTCompoundExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTCompoundExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -155,10 +155,8 @@ class ASTCompoundVariableTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTCompoundVariable
      */
-    private function getFirstVariableInFunction()
+    private function getFirstVariableInFunction(): ASTCompoundVariable
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTCompoundVariable::class

--- a/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -93,10 +93,8 @@ class ASTConditionalExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTConditionalExpression
      */
-    private function getFirstConditionalExpressionInFunction()
+    private function getFirstConditionalExpressionInFunction(): ASTConditionalExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTConditionalExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -104,10 +104,9 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclarator
      *
-     * @return ASTConstantDeclarator
      * @since 1.0.2
      */
-    public function testConstantDeclarator()
+    public function testConstantDeclarator(): ASTConstantDeclarator
     {
         $declarator = $this->getFirstConstantDeclaratorInClass();
         static::assertInstanceOf(ASTConstantDeclarator::class, $declarator);
@@ -157,10 +156,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTConstantDeclarator
      */
-    private function getFirstConstantDeclaratorInClass()
+    private function getFirstConstantDeclaratorInClass(): ASTConstantDeclarator
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTConstantDeclarator::class

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -189,10 +189,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinition
      *
-     * @return ASTConstantDefinition
      * @since 1.0.2
      */
-    public function testConstantDefinition()
+    public function testConstantDefinition(): ASTConstantDefinition
     {
         $constant = $this->getFirstConstantDefinitionInClass();
         static::assertInstanceOf(ASTConstantDefinition::class, $constant);
@@ -243,10 +242,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclarators
      *
-     * @return ASTConstantDefinition
      * @since 1.0.2
      */
-    public function testConstantDefinitionWithDeclarators()
+    public function testConstantDefinitionWithDeclarators(): ASTConstantDefinition
     {
         $constant = $this->getFirstConstantDefinitionInClass();
         static::assertInstanceOf(ASTConstantDefinition::class, $constant);
@@ -324,10 +322,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTConstantDefinition
      */
-    private function getFirstConstantDefinitionInClass()
+    private function getFirstConstantDefinitionInClass(): ASTConstantDefinition
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTConstantDefinition::class
@@ -336,10 +332,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * Returns valid field declation modifiers.
-     *
-     * @return array
      */
-    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations()
+    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
     {
         return [
             [State::IS_PRIVATE],
@@ -350,10 +344,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * Returns invalid field declation modifiers.
-     *
-     * @return array
      */
-    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers()
+    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
     {
         return [
             [State::IS_ABSTRACT],

--- a/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -111,10 +111,8 @@ class ASTConstantPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTConstantPostfix
      */
-    private function getFirstConstantPostfixInFunction()
+    private function getFirstConstantPostfixInFunction(): ASTConstantPostfix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTConstantPostfix::class

--- a/src/test/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantTest.php
@@ -120,10 +120,8 @@ class ASTConstantTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTConstant
      */
-    private function getFirstConstantInFunction()
+    private function getFirstConstantInFunction(): ASTConstant
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTConstant::class

--- a/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -93,10 +93,8 @@ class ASTContinueStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTContinueStatement
      */
-    private function getFirstContinueStatementInFunction()
+    private function getFirstContinueStatementInFunction(): ASTContinueStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTContinueStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -202,10 +202,8 @@ class ASTDeclareStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTDeclareStatement
      */
-    private function getFirstDeclareStatementInFunction()
+    private function getFirstDeclareStatementInFunction(): ASTDeclareStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTDeclareStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -129,10 +129,8 @@ class ASTDoWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTDoWhileStatement
      */
-    private function getFirstDoWhileStatementInFunction()
+    private function getFirstDoWhileStatementInFunction(): ASTDoWhileStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTDoWhileStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -93,10 +93,8 @@ class ASTEchoStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTEchoStatement
      */
-    private function getFirstEchoStatementInFunction()
+    private function getFirstEchoStatementInFunction(): ASTEchoStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTEchoStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -201,10 +201,8 @@ class ASTElseIfStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTElseIfStatement
      */
-    private function getFirstElseIfStatementInFunction()
+    private function getFirstElseIfStatementInFunction(): ASTElseIfStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTElseIfStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -93,10 +93,8 @@ class ASTEvalExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTEvalExpression
      */
-    private function getFirstEvalExpressionInFunction()
+    private function getFirstEvalExpressionInFunction(): ASTEvalExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTEvalExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -58,10 +58,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCode
      *
-     * @return ASTExitExpression
      * @since 1.0.1
      */
-    public function testExitExpressionWithExitCode()
+    public function testExitExpressionWithExitCode(): ASTExitExpression
     {
         $expr = $this->getFirstExitExpressionInFunction();
         static::assertInstanceOf(ASTExitExpression::class, $expr);
@@ -120,10 +119,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgs
      *
-     * @return ASTExitExpression
      * @since 1.0.1
      */
-    public function testExitExpressionWithEmptyArgs()
+    public function testExitExpressionWithEmptyArgs(): ASTExitExpression
     {
         $expr = $this->getFirstExitExpressionInFunction();
         static::assertInstanceOf(ASTExitExpression::class, $expr);
@@ -182,10 +180,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgs
      *
-     * @return ASTExitExpression
      * @since 1.0.1
      */
-    public function testExitExpressionWithoutArgs()
+    public function testExitExpressionWithoutArgs(): ASTExitExpression
     {
         $expr = $this->getFirstExitExpressionInFunction();
         static::assertInstanceOf(ASTExitExpression::class, $expr);
@@ -235,10 +232,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTExitExpression
      */
-    private function getFirstExitExpressionInFunction()
+    private function getFirstExitExpressionInFunction(): ASTExitExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTExitExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -120,10 +120,8 @@ class ASTExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTExpression
      */
-    private function getFirstExpressionInFunction()
+    private function getFirstExpressionInFunction(): ASTExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -89,10 +89,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * testClassReferenceForJavaStyleArrayNotation
-     *
-     * @return AbstractASTClassOrInterface
      */
-    public function testClassReferenceForJavaStyleArrayNotation()
+    public function testClassReferenceForJavaStyleArrayNotation(): AbstractASTClassOrInterface
     {
         $declaration = $this->getFirstFieldDeclarationInClass();
         $reference = $declaration->getFirstChildOfType(
@@ -293,10 +291,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTFieldDeclaration
      */
-    private function getFirstFieldDeclarationInClass()
+    private function getFirstFieldDeclarationInClass(): ASTFieldDeclaration
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTFieldDeclaration::class
@@ -305,10 +301,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * Returns valid field declation modifiers.
-     *
-     * @return array
      */
-    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations()
+    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
     {
         return [
             [State::IS_PRIVATE],
@@ -331,10 +325,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
 
     /**
      * Returns invalid field declation modifiers.
-     *
-     * @return array
      */
-    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers()
+    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
     {
         return [
             [State::IS_ABSTRACT],

--- a/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -138,10 +138,8 @@ class ASTFinallyStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTFinallyStatement
      */
-    private function getFirstFinallyStatementInFunction()
+    private function getFirstFinallyStatementInFunction(): ASTFinallyStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTFinallyStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForInitTest.php
@@ -93,10 +93,8 @@ class ASTForInitTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTForInit
      */
-    private function getFirstForInitInFunction()
+    private function getFirstForInitInFunction(): ASTForInit
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTForInit::class

--- a/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -317,10 +317,8 @@ class ASTForStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTForStatement
      */
-    private function getFirstForStatementInFunction()
+    private function getFirstForStatementInFunction(): ASTForStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTForStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -93,10 +93,8 @@ class ASTForUpdateTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTForUpdate
      */
-    private function getFirstForUpdateInFunction()
+    private function getFirstForUpdateInFunction(): ASTForUpdate
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTForUpdate::class

--- a/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -293,10 +293,8 @@ class ASTForeachStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTForeachStatement
      */
-    private function getFirstForeachStatementInFunction()
+    private function getFirstForeachStatementInFunction(): ASTForeachStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTForeachStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -267,10 +267,8 @@ class ASTFormalParameterTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTFormalParameter
      */
-    private function getFirstFormalParameterInFunction()
+    private function getFirstFormalParameterInFunction(): ASTFormalParameter
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTFormalParameter::class

--- a/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -95,10 +95,8 @@ class ASTFormalParametersTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTFormalParameters
      */
-    private function getFirstFormalParametersInFunction()
+    private function getFirstFormalParametersInFunction(): ASTFormalParameters
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTFormalParameters::class

--- a/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -244,10 +244,8 @@ class ASTFunctionPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTFunctionPostfix
      */
-    private function getFirstFunctionPostfixInFunction()
+    private function getFirstFunctionPostfixInFunction(): ASTFunctionPostfix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTFunctionPostfix::class

--- a/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -155,10 +155,8 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
 
     /**
      * testClassReferenceForJavaStyleArrayNotation
-     *
-     * @return ASTClass
      */
-    public function testClassReferenceForJavaStyleArrayNotation()
+    public function testClassReferenceForJavaStyleArrayNotation(): ASTClass
     {
         $function = $this->getFirstFunctionForTestCaseInternal();
         $type = $function->getReturnClass();
@@ -573,10 +571,8 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
     /**
      * This method will return the first function instance within the source
      * file of the calling test case.
-     *
-     * @return ASTFunction
      */
-    private function getFirstFunctionForTestCaseInternal()
+    private function getFirstFunctionForTestCaseInternal(): ASTFunction
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -93,10 +93,8 @@ class ASTGlobalStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTGlobalStatement
      */
-    private function getFirstGlobalStatementInFunction()
+    private function getFirstGlobalStatementInFunction(): ASTGlobalStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTGlobalStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -93,10 +93,8 @@ class ASTGotoStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTGotoStatement
      */
-    private function getFirstGotoStatementInFunction()
+    private function getFirstGotoStatementInFunction(): ASTGotoStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTGotoStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -106,10 +106,8 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTHeredoc
      */
-    private function getFirstHeredocInFunction()
+    private function getFirstHeredocInFunction(): ASTHeredoc
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTHeredoc::class
@@ -118,10 +116,8 @@ class ASTHeredocTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTHeredoc
      */
-    private function getFirstHeredocInClass()
+    private function getFirstHeredocInClass(): ASTHeredoc
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTHeredoc::class

--- a/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -93,10 +93,8 @@ class ASTIdentifierTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTIdentifier
      */
-    private function getFirstIdentifierInFunction()
+    private function getFirstIdentifierInFunction(): ASTIdentifier
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTIdentifier::class

--- a/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -312,10 +312,8 @@ class ASTIfStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTIfStatement
      */
-    private function getFirstIfStatementInFunction()
+    private function getFirstIfStatementInFunction(): ASTIfStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTIfStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -166,10 +166,8 @@ class ASTIncludeExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTIncludeExpression
      */
-    private function getFirstIncludeExpressionInFunction()
+    private function getFirstIncludeExpressionInFunction(): ASTIncludeExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTIncludeExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -808,10 +808,8 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
     /**
      * Creates an abstract item instance.
-     *
-     * @return ASTInterface
      */
-    protected function createItem()
+    protected function createItem(): ASTInterface
     {
         $interface = new ASTInterface(__CLASS__);
         $interface->setCompilationUnit(new ASTCompilationUnit(__FILE__));

--- a/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -125,10 +125,8 @@ class ASTIssetExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTIssetExpression
      */
-    private function getFirstIssetExpressionInFunction()
+    private function getFirstIssetExpressionInFunction(): ASTIssetExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTIssetExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -93,10 +93,8 @@ class ASTLabelStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTLabelStatement
      */
-    private function getFirstLabelStatementInFunction()
+    private function getFirstLabelStatementInFunction(): ASTLabelStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTLabelStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -60,10 +60,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpression
      *
-     * @return ASTListExpression
      * @since 1.0.2
      */
-    public function testListExpression()
+    public function testListExpression(): ASTListExpression
     {
         $expr = $this->getFirstListExpressionInFunction();
         static::assertInstanceOf(ASTListExpression::class, $expr);
@@ -114,10 +113,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedList
      *
-     * @return ASTListExpression
      * @since 1.0.2
      */
-    public function testListExpressionWithNestedList()
+    public function testListExpressionWithNestedList(): ASTListExpression
     {
         $expr = $this->getFirstListExpressionInFunction();
         static::assertInstanceOf(ASTListExpression::class, $expr);
@@ -334,10 +332,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithKeys
      *
-     * @return ASTListExpression
      * @since 1.0.2
      */
-    public function testListExpressionWithKeys()
+    public function testListExpressionWithKeys(): ASTListExpression
     {
         $expr = $this->getFirstListExpressionInFunction();
         static::assertInstanceOf(ASTListExpression::class, $expr);
@@ -348,10 +345,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithKeysAndNestedList
      *
-     * @return ASTListExpression
      * @since 1.0.2
      */
-    public function testListExpressionWithKeysAndNestedList()
+    public function testListExpressionWithKeysAndNestedList(): ASTListExpression
     {
         $expr = $this->getFirstListExpressionInFunction();
         static::assertInstanceOf(ASTListExpression::class, $expr);
@@ -361,10 +357,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTListExpression
      */
-    private function getFirstListExpressionInFunction()
+    private function getFirstListExpressionInFunction(): ASTListExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTListExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -247,10 +247,8 @@ class ASTLiteralTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTLiteral
      */
-    private function getFirstLiteralInFunction()
+    private function getFirstLiteralInFunction(): ASTLiteral
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTLiteral::class

--- a/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -95,10 +95,8 @@ class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTLogicalAndExpression
      */
-    private function getFirstLogicalAndExpressionInFunction()
+    private function getFirstLogicalAndExpressionInFunction(): ASTLogicalAndExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTLogicalAndExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -95,10 +95,8 @@ class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTLogicalOrExpression
      */
-    private function getFirstLogicalOrExpressionInFunction()
+    private function getFirstLogicalOrExpressionInFunction(): ASTLogicalOrExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTLogicalOrExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -93,10 +93,8 @@ class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTLogicalXorExpression
      */
-    private function getFirstLogicalXorExpressionInFunction()
+    private function getFirstLogicalXorExpressionInFunction(): ASTLogicalXorExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTLogicalXorExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -741,10 +741,8 @@ class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 
     /**
      * Returns a test member primary prefix.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInFunction()
+    private function getFirstMemberPrimaryPrefixInFunction(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTMemberPrimaryPrefix::class

--- a/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -661,10 +661,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMethodPostfix
      */
-    private function getFirstMethodPostfixInFunction()
+    private function getFirstMethodPostfixInFunction(): ASTMethodPostfix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTMethodPostfix::class
@@ -673,10 +671,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInFunction()
+    private function getFirstMemberPrimaryPrefixInFunction(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTMemberPrimaryPrefix::class
@@ -685,10 +681,8 @@ class ASTMethodPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInClass()
+    private function getFirstMemberPrimaryPrefixInClass(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTMemberPrimaryPrefix::class

--- a/src/test/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTMethodTest.php
@@ -687,10 +687,8 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
     /**
      * Returns the first method defined in a source file associated with the
      * given test case.
-     *
-     * @return ASTMethod
      */
-    protected function getFirstMethodInClass()
+    protected function getFirstMethodInClass(): ASTMethod
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -702,10 +700,8 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * Creates an abstract item instance.
-     *
-     * @return AbstractASTArtifact
      */
-    protected function createItem()
+    protected function createItem(): AbstractASTArtifact
     {
         $method = new ASTMethod('method');
         $method->setCompilationUnit(new ASTCompilationUnit(__FILE__));

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -688,7 +688,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParameterTest.php
@@ -204,10 +204,9 @@ class ASTParameterTest extends AbstractTestCase
      * Returns the first class method found in the test file associated with the
      * calling test method.
      *
-     * @return ASTMethod
      * @since 1.0.0
      */
-    private function getFirstMethodInClass()
+    private function getFirstMethodInClass(): ASTMethod
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -182,10 +182,8 @@ class ASTParentReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTParentReference
      */
-    private function getFirstParentReferenceInClass()
+    private function getFirstParentReferenceInClass(): ASTParentReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTParentReference::class

--- a/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -322,10 +322,8 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPostfixExpression
      */
-    private function getFirstPostfixExpressionInClass()
+    private function getFirstPostfixExpressionInClass(): ASTPostfixExpression
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTPostfixExpression::class
@@ -334,10 +332,8 @@ class ASTPostfixExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPostfixExpression
      */
-    private function getFirstPostfixExpressionInFunction()
+    private function getFirstPostfixExpressionInFunction(): ASTPostfixExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTPostfixExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -177,10 +177,8 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPreDecrementExpression
      */
-    private function getFirstPreDecrementExpressionInClass()
+    private function getFirstPreDecrementExpressionInClass(): ASTPreDecrementExpression
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTPreDecrementExpression::class
@@ -189,10 +187,8 @@ class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPreDecrementExpression
      */
-    private function getFirstPreDecrementExpressionInFunction()
+    private function getFirstPreDecrementExpressionInFunction(): ASTPreDecrementExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTPreDecrementExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -191,10 +191,8 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPreIncrementExpression
      */
-    private function getFirstPreIncrementExpressionInClass()
+    private function getFirstPreIncrementExpressionInClass(): ASTPreIncrementExpression
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTPreIncrementExpression::class
@@ -203,10 +201,8 @@ class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPreIncrementExpression
      */
-    private function getFirstPreIncrementExpressionInFunction()
+    private function getFirstPreIncrementExpressionInFunction(): ASTPreIncrementExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTPreIncrementExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -55,10 +55,7 @@ namespace PDepend\Source\AST;
  */
 class ASTPrintExpressionTest extends ASTNodeTestCase
 {
-    /**
-     * @return ASTPrintExpression
-     */
-    public function testSimplePrintExpression()
+    public function testSimplePrintExpression(): ASTPrintExpression
     {
         $print = $this->getFirstPrintInFunction();
         static::assertInstanceOf(ASTPrintExpression::class, $print);
@@ -98,10 +95,7 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
         static::assertSame(9, $expr->getEndColumn());
     }
 
-    /**
-     * @return ASTPrintExpression
-     */
-    private function getFirstPrintInFunction()
+    private function getFirstPrintInFunction(): ASTPrintExpression
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType(ASTPrintExpression::class);

--- a/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -396,10 +396,8 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTPropertyPostfix
      */
-    private function getFirstPropertyPostfixInFunction()
+    private function getFirstPropertyPostfixInFunction(): ASTPropertyPostfix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTPropertyPostfix::class
@@ -408,10 +406,8 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInFunction()
+    private function getFirstMemberPrimaryPrefixInFunction(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTMemberPrimaryPrefix::class
@@ -420,10 +416,8 @@ class ASTPropertyPostfixTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTMemberPrimaryPrefix
      */
-    private function getFirstMemberPrimaryPrefixInClass()
+    private function getFirstMemberPrimaryPrefixInClass(): ASTMemberPrimaryPrefix
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTMemberPrimaryPrefix::class

--- a/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -434,10 +434,8 @@ class ASTPropertyTest extends AbstractTestCase
 
     /**
      * Returns the first property found in the corresponding test file.
-     *
-     * @return ASTProperty
      */
-    private function getFirstPropertyInClass()
+    private function getFirstPropertyInClass(): ASTProperty
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -95,10 +95,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpression
      *
-     * @return ASTRequireExpression
      * @since 1.0.2
      */
-    public function testRequireExpression()
+    public function testRequireExpression(): ASTRequireExpression
     {
         $expr = $this->getFirstRequireExpressionInFunction();
         static::assertInstanceOf(ASTRequireExpression::class, $expr);
@@ -149,10 +148,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesis
      *
-     * @return ASTRequireExpression
      * @since 1.0.2
      */
-    public function testRequireExpressionWithParenthesis()
+    public function testRequireExpressionWithParenthesis(): ASTRequireExpression
     {
         $expr = $this->getFirstRequireExpressionInFunction();
         static::assertInstanceOf(ASTRequireExpression::class, $expr);
@@ -202,10 +200,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTRequireExpression
      */
-    private function getFirstRequireExpressionInFunction()
+    private function getFirstRequireExpressionInFunction(): ASTRequireExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTRequireExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -58,10 +58,9 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatement
      *
-     * @return ASTReturnStatement
      * @since 1.0.2
      */
-    public function testReturnStatement()
+    public function testReturnStatement(): ASTReturnStatement
     {
         $stmt = $this->getFirstReturnStatementInFunction();
         static::assertInstanceOf(ASTReturnStatement::class, $stmt);
@@ -129,10 +128,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTReturnStatement
      */
-    private function getFirstReturnStatementInFunction()
+    private function getFirstReturnStatementInFunction(): ASTReturnStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTReturnStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -58,10 +58,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testParserHandlesInlineScopeStatement
      *
-     * @return ASTScopeStatement
      * @since 1.0.0
      */
-    public function testParserHandlesInlineScopeStatement()
+    public function testParserHandlesInlineScopeStatement(): ASTScopeStatement
     {
         $stmt = $this->getFirstScopeStatementInFunction();
         static::assertCount(1, $stmt->getChildren());
@@ -72,12 +71,11 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartLine
      *
-     * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testParserHandlesInlineScopeStatement
      */
-    public function testInlineScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt)
+    public function testInlineScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(4, $stmt->getStartLine());
 
@@ -87,12 +85,11 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartColumn
      *
-     * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartLine
      */
-    public function testInlineScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt)
+    public function testInlineScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(5, $stmt->getStartColumn());
 
@@ -102,12 +99,11 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedEndLine
      *
-     * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartColumn
      */
-    public function testInlineScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt)
+    public function testInlineScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(5, $stmt->getEndLine());
 
@@ -129,10 +125,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatement
      *
-     * @return ASTScopeStatement
      * @since 1.0.2
      */
-    public function testScopeStatement()
+    public function testScopeStatement(): ASTScopeStatement
     {
         $stmt = $this->getFirstScopeStatementInFunction();
         static::assertInstanceOf(ASTScopeStatement::class, $stmt);
@@ -183,10 +178,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternative
      *
-     * @return ASTScopeStatement
      * @since 1.0.2
      */
-    public function testScopeStatementWithAlternative()
+    public function testScopeStatementWithAlternative(): ASTScopeStatement
     {
         $stmt = $this->getFirstScopeStatementInFunction();
         static::assertInstanceOf(ASTScopeStatement::class, $stmt);
@@ -236,10 +230,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTScopeStatement
      */
-    private function getFirstScopeStatementInFunction()
+    private function getFirstScopeStatementInFunction(): ASTScopeStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTScopeStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -58,10 +58,9 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * testScope
      *
-     * @return ASTScope
      * @since 1.0.2
      */
-    public function testScope()
+    public function testScope(): ASTScope
     {
         $scope = $this->getFirstScopeInFunction();
         static::assertInstanceOf(ASTScope::class, $scope);
@@ -111,10 +110,8 @@ class ASTScopeTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTScope
      */
-    private function getFirstScopeInFunction()
+    private function getFirstScopeInFunction(): ASTScope
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTScope::class

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -150,10 +150,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReference
      *
-     * @return ASTSelfReference
      * @since 1.0.2
      */
-    public function testSelfReference()
+    public function testSelfReference(): ASTSelfReference
     {
         $reference = $this->getFirstSelfReferenceInClass();
         static::assertInstanceOf(ASTSelfReference::class, $reference);
@@ -217,10 +216,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTSelfReference
      */
-    private function getFirstSelfReferenceInClass()
+    private function getFirstSelfReferenceInClass(): ASTSelfReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTSelfReference::class

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -68,10 +68,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftLeftExpression
-     *
-     * @return ASTShiftLeftExpression
      */
-    public function testShiftLeftExpression()
+    public function testShiftLeftExpression(): ASTShiftLeftExpression
     {
         $expr = $this->getFirstShiftLeftExpressionInFunction();
         static::assertInstanceOf(ASTShiftLeftExpression::class, $expr);
@@ -121,10 +119,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTShiftLeftExpression
      */
-    private function getFirstShiftLeftExpressionInFunction()
+    private function getFirstShiftLeftExpressionInFunction(): ASTShiftLeftExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTShiftLeftExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -68,10 +68,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftRightExpression
-     *
-     * @return ASTShiftRightExpression
      */
-    public function testShiftRightExpression()
+    public function testShiftRightExpression(): ASTShiftRightExpression
     {
         $expr = $this->getFirstShiftRightExpressionInFunction();
         static::assertInstanceOf(ASTShiftRightExpression::class, $expr);
@@ -121,10 +119,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTShiftRightExpression
      */
-    private function getFirstShiftRightExpressionInFunction()
+    private function getFirstShiftRightExpressionInFunction(): ASTShiftRightExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTShiftRightExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -58,10 +58,9 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatement
      *
-     * @return ASTStatement
      * @since 1.0.2
      */
-    public function testStatement()
+    public function testStatement(): ASTStatement
     {
         $stmt = $this->getFirstStatementInFunction();
         static::assertInstanceOf(ASTStatement::class, $stmt);
@@ -111,10 +110,8 @@ class ASTStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTStatement
      */
-    private function getFirstStatementInFunction()
+    private function getFirstStatementInFunction(): ASTStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -160,10 +160,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReference
      *
-     * @return ASTStaticReference
      * @since 1.0.2
      */
-    public function testStaticReference()
+    public function testStaticReference(): ASTStaticReference
     {
         $reference = $this->getFirstStaticReferenceInClass();
         static::assertInstanceOf(ASTStaticReference::class, $reference);
@@ -230,10 +229,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTStaticReference
      */
-    private function getFirstStaticReferenceInClass()
+    private function getFirstStaticReferenceInClass(): ASTStaticReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTStaticReference::class

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -58,10 +58,9 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * testStaticVariableDeclaration
      *
-     * @return ASTStaticVariableDeclaration
      * @since 1.0.2
      */
-    public function testStaticVariableDeclaration()
+    public function testStaticVariableDeclaration(): ASTStaticVariableDeclaration
     {
         $declaration = $this->getFirstStaticVariableDeclarationInFunction();
         static::assertInstanceOf(ASTStaticVariableDeclaration::class, $declaration);
@@ -111,10 +110,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTStaticVariableDeclaration
      */
-    private function getFirstStaticVariableDeclarationInFunction()
+    private function getFirstStaticVariableDeclarationInFunction(): ASTStaticVariableDeclaration
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTStaticVariableDeclaration::class

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -61,10 +61,9 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpression
      *
-     * @return ASTStringIndexExpression
      * @since 1.0.2
      */
-    public function testStringIndexExpression()
+    public function testStringIndexExpression(): ASTStringIndexExpression
     {
         $expr = $this->getFirstStringIndexExpressionInFunction();
         static::assertInstanceOf(ASTStringIndexExpression::class, $expr);
@@ -114,10 +113,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTStringIndexExpression
      */
-    private function getFirstStringIndexExpressionInFunction()
+    private function getFirstStringIndexExpressionInFunction(): ASTStringIndexExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTStringIndexExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTStringTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringTest.php
@@ -242,10 +242,8 @@ class ASTStringTest extends ASTNodeTestCase
 
     /**
      * Returns a test member primary prefix.
-     *
-     * @return ASTString
      */
-    private function getFirstStringInFunction()
+    private function getFirstStringInFunction(): ASTString
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTString::class

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -97,10 +97,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabel
      *
-     * @return ASTSwitchLabel
      * @since 1.0.2
      */
-    public function testSwitchLabel()
+    public function testSwitchLabel(): ASTSwitchLabel
     {
         $label = $this->getFirstSwitchLabelInFunction();
         static::assertInstanceOf(ASTSwitchLabel::class, $label);
@@ -180,10 +179,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCode
      *
-     * @return ASTSwitchLabel
      * @since 2.1.0
      */
-    public function testSwitchLabelWithNestedNonePhpCode()
+    public function testSwitchLabelWithNestedNonePhpCode(): ASTSwitchLabel
     {
         $label = $this->getFirstSwitchLabelInFunction();
         static::assertInstanceOf(ASTSwitchLabel::class, $label);
@@ -242,10 +240,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelDefault
      *
-     * @return ASTSwitchLabel
      * @since 1.0.2
      */
-    public function testSwitchLabelDefault()
+    public function testSwitchLabelDefault(): ASTSwitchLabel
     {
         $label = $this->getFirstSwitchLabelInFunction();
         static::assertInstanceOf(ASTSwitchLabel::class, $label);
@@ -324,10 +321,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * testSwitchLabelWithNestedNonePhpCode
      *
-     * @return ASTSwitchLabel
      * @since 2.1.0
      */
-    public function testSwitchLabelDefaultWithNestedNonePhpCode()
+    public function testSwitchLabelDefaultWithNestedNonePhpCode(): ASTSwitchLabel
     {
         $label = $this->getFirstSwitchLabelInFunction();
         static::assertInstanceOf(ASTSwitchLabel::class, $label);
@@ -403,10 +399,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTSwitchLabel
      */
-    private function getFirstSwitchLabelInFunction()
+    private function getFirstSwitchLabelInFunction(): ASTSwitchLabel
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTSwitchLabel::class

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -84,10 +84,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatement
      *
-     * @return ASTSwitchStatement
      * @since 1.0.2
      */
-    public function testSwitchStatement()
+    public function testSwitchStatement(): ASTSwitchStatement
     {
         $stmt = $this->getFirstSwitchStatementInFunction();
         static::assertInstanceOf(ASTSwitchStatement::class, $stmt);
@@ -174,10 +173,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithAlternativeScope
      *
-     * @return ASTSwitchStatement
      * @since 1.0.2
      */
-    public function testSwitchStatementWithAlternativeScope()
+    public function testSwitchStatementWithAlternativeScope(): ASTSwitchStatement
     {
         $stmt = $this->getFirstSwitchStatementInFunction();
         static::assertInstanceOf(ASTSwitchStatement::class, $stmt);
@@ -237,10 +235,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementWithNestedNonePhpCode
      *
-     * @return ASTSwitchStatement
      * @since 2.1.0
      */
-    public function testSwitchStatementWithNestedNonePhpCode()
+    public function testSwitchStatementWithNestedNonePhpCode(): ASTSwitchStatement
     {
         $switch = $this->getFirstSwitchStatementInFunction();
         static::assertInstanceOf(ASTSwitchStatement::class, $switch);
@@ -298,10 +295,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTSwitchStatement
      */
-    private function getFirstSwitchStatementInFunction()
+    private function getFirstSwitchStatementInFunction(): ASTSwitchStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTSwitchStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -58,10 +58,9 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatement
      *
-     * @return ASTThrowStatement
      * @since 1.0.2
      */
-    public function testThrowStatement()
+    public function testThrowStatement(): ASTThrowStatement
     {
         $stmt = $this->getFirstThrowStatementInFunction();
         static::assertInstanceOf(ASTThrowStatement::class, $stmt);
@@ -111,10 +110,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTThrowStatement
      */
-    private function getFirstThrowStatementInFunction()
+    private function getFirstThrowStatementInFunction(): ASTThrowStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTThrowStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -138,10 +138,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAlias
      *
-     * @return ASTTraitAdaptationAlias
      * @since 1.0.2
      */
-    public function testTraitAdaptationAlias()
+    public function testTraitAdaptationAlias(): ASTTraitAdaptationAlias
     {
         $alias = $this->getFirstTraitAdaptationAliasInClass();
         static::assertInstanceOf(ASTTraitAdaptationAlias::class, $alias);
@@ -191,10 +190,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitAdaptationAlias
      */
-    private function getFirstTraitAdaptationAliasInClass()
+    private function getFirstTraitAdaptationAliasInClass(): ASTTraitAdaptationAlias
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTTraitAdaptationAlias::class
@@ -204,10 +201,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReference
      *
-     * @return ASTTraitReference
      * @since 1.0.2
      */
-    public function testTraitReference()
+    public function testTraitReference(): ASTTraitReference
     {
         $reference = $this->getFirstTraitReferenceInClass();
         static::assertInstanceOf(ASTTraitReference::class, $reference);
@@ -257,10 +253,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitReference
      */
-    private function getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass(): ASTTraitReference
     {
         return $this->getFirstTraitAdaptationAliasInClass()
             ->getFirstChildOfType(ASTTraitReference::class);

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -86,10 +86,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedence
      *
-     * @return ASTTraitAdaptationPrecedence
      * @since 1.0.2
      */
-    public function testTraitAdaptationPrecedence()
+    public function testTraitAdaptationPrecedence(): ASTTraitAdaptationPrecedence
     {
         $precedence = $this->getFirstTraitAdaptationPrecedenceInClass();
         static::assertInstanceOf(ASTTraitAdaptationPrecedence::class, $precedence);
@@ -139,10 +138,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitAdaptationPrecedence
      */
-    private function getFirstTraitAdaptationPrecedenceInClass()
+    private function getFirstTraitAdaptationPrecedenceInClass(): ASTTraitAdaptationPrecedence
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTTraitAdaptationPrecedence::class
@@ -152,10 +149,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReference
      *
-     * @return ASTTraitReference
      * @since 1.0.2
      */
-    public function testTraitReference()
+    public function testTraitReference(): ASTTraitReference
     {
         $reference = $this->getFirstTraitReferenceInClass();
         static::assertInstanceOf(ASTTraitReference::class, $reference);
@@ -205,10 +201,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitReference
      */
-    private function getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass(): ASTTraitReference
     {
         return $this->getFirstTraitAdaptationPrecedenceInClass()
             ->getFirstChildOfType(ASTTraitReference::class);

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -60,10 +60,9 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptation
      *
-     * @return ASTTraitAdaptation
      * @since 1.0.2
      */
-    public function testTraitAdaptation()
+    public function testTraitAdaptation(): ASTTraitAdaptation
     {
         $scope = $this->getFirstTraitAdaptationInClass();
         static::assertInstanceOf(ASTTraitAdaptation::class, $scope);
@@ -113,10 +112,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitAdaptation
      */
-    private function getFirstTraitAdaptationInClass()
+    private function getFirstTraitAdaptationInClass(): ASTTraitAdaptation
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTTraitAdaptation::class

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -77,10 +77,9 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReference
      *
-     * @return ASTTraitReference
      * @since 1.0.2
      */
-    public function testTraitReference()
+    public function testTraitReference(): ASTTraitReference
     {
         $reference = $this->getFirstTraitReferenceInClass();
         static::assertInstanceOf(ASTTraitReference::class, $reference);
@@ -130,10 +129,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitReference
      */
-    private function getFirstTraitReferenceInClass()
+    private function getFirstTraitReferenceInClass(): ASTTraitReference
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTTraitReference::class
@@ -153,10 +150,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * Returns a mocked builder context instance.
-     *
-     * @return BuilderContext
      */
-    protected function getBuilderContextMock()
+    protected function getBuilderContextMock(): BuilderContext
     {
         $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();

--- a/src/test/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitTest.php
@@ -381,20 +381,16 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * Returns the first trait found the code under test.
-     *
-     * @return ASTTrait
      */
-    protected function getFirstTraitForTest()
+    protected function getFirstTraitForTest(): ASTTrait
     {
         return parent::getFirstTraitForTestCase();
     }
 
     /**
      * Creates an item instance.
-     *
-     * @return AbstractASTArtifact
      */
-    protected function createItem()
+    protected function createItem(): AbstractASTArtifact
     {
         return new ASTTrait(__CLASS__);
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -381,10 +381,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatement
      *
-     * @return ASTTraitUseStatement
      * @since 1.0.2
      */
-    public function testTraitUseStatement()
+    public function testTraitUseStatement(): ASTTraitUseStatement
     {
         $stmt = $this->getFirstTraitUseStatementInClass();
         static::assertInstanceOf(ASTTraitUseStatement::class, $stmt);
@@ -435,10 +434,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTrait
      *
-     * @return ASTTraitUseStatement
      * @since 1.0.2
      */
-    public function testTraitUseStatementInTrait()
+    public function testTraitUseStatementInTrait(): ASTTraitUseStatement
     {
         $stmt = $this->getFirstTraitUseStatementInTrait();
         static::assertInstanceOf(ASTTraitUseStatement::class, $stmt);
@@ -488,10 +486,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitUseStatement
      */
-    private function getFirstTraitUseStatementInClass()
+    private function getFirstTraitUseStatementInClass(): ASTTraitUseStatement
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTTraitUseStatement::class
@@ -500,10 +496,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTraitUseStatement
      */
-    private function getFirstTraitUseStatementInTrait()
+    private function getFirstTraitUseStatementInTrait(): ASTTraitUseStatement
     {
         return $this->getFirstNodeOfTypeInTrait(
             ASTTraitUseStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -60,10 +60,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testTryStatement
      *
-     * @return ASTTryStatement
      * @since 1.0.2
      */
-    public function testTryStatement()
+    public function testTryStatement(): ASTTryStatement
     {
         $stmt = $this->getFirstTryStatementInFunction();
         static::assertInstanceOf(ASTTryStatement::class, $stmt);
@@ -164,10 +163,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTryStatement
      */
-    private function getFirstTryStatementInFunction()
+    private function getFirstTryStatementInFunction(): ASTTryStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTTryStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -58,10 +58,9 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayType
      *
-     * @return ASTTypeArray
      * @since 1.0.2
      */
-    public function testArrayType()
+    public function testArrayType(): ASTTypeArray
     {
         $type = $this->getFirstArrayTypeInFunction();
         static::assertInstanceOf(ASTTypeArray::class, $type);
@@ -129,10 +128,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTypeArray
      */
-    private function getFirstArrayTypeInFunction()
+    private function getFirstArrayTypeInFunction(): ASTTypeArray
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTTypeArray::class

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -68,10 +68,9 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableType
      *
-     * @return ASTTypeCallable
      * @since 1.0.2
      */
-    public function testCallableType()
+    public function testCallableType(): ASTTypeCallable
     {
         $type = $this->getFirstCallableTypeInFunction();
         static::assertInstanceOf(ASTTypeCallable::class, $type);
@@ -121,10 +120,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTypeCallable
      */
-    private function getFirstCallableTypeInFunction()
+    private function getFirstCallableTypeInFunction(): ASTTypeCallable
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTTypeCallable::class

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -58,10 +58,9 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableType
      *
-     * @return ASTTypeIterable
      * @since 2.5.1
      */
-    public function testIterableType()
+    public function testIterableType(): ASTTypeIterable
     {
         $type = $this->getFirstArrayTypeInFunction();
         static::assertInstanceOf(ASTTypeIterable::class, $type);
@@ -129,10 +128,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTTypeIterable
      */
-    private function getFirstArrayTypeInFunction()
+    private function getFirstArrayTypeInFunction(): ASTTypeIterable
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTTypeIterable::class

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -58,10 +58,9 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpression
      *
-     * @return ASTUnaryExpression
      * @since 1.0.2
      */
-    public function testUnaryExpression()
+    public function testUnaryExpression(): ASTUnaryExpression
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
         static::assertInstanceOf(ASTUnaryExpression::class, $expr);
@@ -109,10 +108,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
         static::assertSame(14, $expr->getEndColumn());
     }
 
-    /**
-     * @return ASTUnaryExpression
-     */
-    public function testUnaryExpressionNot()
+    public function testUnaryExpressionNot(): ASTUnaryExpression
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
         static::assertInstanceOf(ASTUnaryExpression::class, $expr);
@@ -152,10 +148,7 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
         static::assertSame(5, $expr->getEndColumn());
     }
 
-    /**
-     * @return ASTUnaryExpression
-     */
-    public function testUnaryExpressionSuppressWarning()
+    public function testUnaryExpressionSuppressWarning(): ASTUnaryExpression
     {
         $expr = $this->getFirstUnaryExpressionInFunction();
         static::assertInstanceOf(ASTUnaryExpression::class, $expr);
@@ -197,10 +190,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTUnaryExpression
      */
-    private function getFirstUnaryExpressionInFunction()
+    private function getFirstUnaryExpressionInFunction(): ASTUnaryExpression
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTUnaryExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -58,10 +58,9 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatement
      *
-     * @return ASTUnsetStatement
      * @since 1.0.2
      */
-    public function testUnsetStatement()
+    public function testUnsetStatement(): ASTUnsetStatement
     {
         $stmt = $this->getFirstUnsetStatementInFunction();
         static::assertInstanceOf(ASTUnsetStatement::class, $stmt);
@@ -111,10 +110,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTUnsetStatement
      */
-    private function getFirstUnsetStatementInFunction()
+    private function getFirstUnsetStatementInFunction(): ASTUnsetStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTUnsetStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -95,10 +95,9 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
     /**
      * testVariableDeclarator
      *
-     * @return ASTVariableDeclarator
      * @since 1.0.2
      */
-    public function testVariableDeclarator()
+    public function testVariableDeclarator(): ASTVariableDeclarator
     {
         $declarator = $this->getFirstVariableDeclaratorInFunction();
         static::assertInstanceOf(ASTVariableDeclarator::class, $declarator);
@@ -148,10 +147,8 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTVariableDeclarator
      */
-    private function getFirstVariableDeclaratorInFunction()
+    private function getFirstVariableDeclaratorInFunction(): ASTVariableDeclarator
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTVariableDeclarator::class

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -93,10 +93,9 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariable
      *
-     * @return ASTVariable
      * @since 1.0.2
      */
-    public function testVariable()
+    public function testVariable(): ASTVariable
     {
         $variable = $this->getFirstVariableInClass();
         static::assertInstanceOf(ASTVariable::class, $variable);
@@ -146,10 +145,8 @@ class ASTVariableTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTVariable
      */
-    private function getFirstVariableInClass()
+    private function getFirstVariableInClass(): ASTVariable
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTVariable::class

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -58,10 +58,9 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariable
      *
-     * @return ASTVariableVariable
      * @since 1.0.2
      */
-    public function testVariableVariable()
+    public function testVariableVariable(): ASTVariableVariable
     {
         $variable = $this->getFirstVariableVariableInClass();
         static::assertInstanceOf(ASTVariableVariable::class, $variable);
@@ -111,10 +110,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTVariableVariable
      */
-    private function getFirstVariableVariableInClass()
+    private function getFirstVariableVariableInClass(): ASTVariableVariable
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTVariableVariable::class

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -85,10 +85,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatement
      *
-     * @return ASTWhileStatement
      * @since 1.0.2
      */
-    public function testWhileStatement()
+    public function testWhileStatement(): ASTWhileStatement
     {
         $stmt = $this->getFirstWhileStatementInFunction();
         static::assertInstanceOf(ASTWhileStatement::class, $stmt);
@@ -139,10 +138,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementWithAlternativeScope
      *
-     * @return ASTWhileStatement
      * @since 1.0.2
      */
-    public function testWhileStatementWithAlternativeScope()
+    public function testWhileStatementWithAlternativeScope(): ASTWhileStatement
     {
         $stmt = $this->getFirstWhileStatementInFunction();
         static::assertInstanceOf(ASTWhileStatement::class, $stmt);
@@ -201,10 +199,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTWhileStatement
      */
-    private function getFirstWhileStatementInFunction()
+    private function getFirstWhileStatementInFunction(): ASTWhileStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTWhileStatement::class

--- a/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -134,7 +134,7 @@ class ASTYieldStatementTest extends ASTNodeTestCase
      *
      * @return \PDepend\Source\AST\ASTExpression[]
      */
-    public function testYieldKeyValue()
+    public function testYieldKeyValue(): array
     {
         $stmt = $this->getFirstYieldStatementInFunction();
         $nodes = $stmt->getChildren();
@@ -159,10 +159,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldValueAssignmentSimple
-     *
-     * @return ASTYieldStatement
      */
-    public function testYieldValueAssignmentSimple()
+    public function testYieldValueAssignmentSimple(): ASTYieldStatement
     {
         $yield = $this->getFirstYieldStatementInFunction();
         $nodes = $yield->getChildren();
@@ -187,10 +185,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldValueAssignmentKeyValue
-     *
-     * @return ASTYieldStatement
      */
-    public function testYieldValueAssignmentKeyValue()
+    public function testYieldValueAssignmentKeyValue(): ASTYieldStatement
     {
         $yield = $this->getFirstYieldStatementInFunction();
         $nodes = $yield->getChildren();
@@ -228,10 +224,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * Returns a node instance for the currently executed test case.
-     *
-     * @return ASTYieldStatement
      */
-    private function getFirstYieldStatementInFunction()
+    private function getFirstYieldStatementInFunction(): ASTYieldStatement
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTYieldStatement::class

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -75,7 +75,7 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      *
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
 
@@ -89,8 +89,6 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
 
     /**
      * Creates an abstract item instance.
-     *
-     * @return AbstractASTArtifact
      */
-    abstract protected function createItem();
+    abstract protected function createItem(): AbstractASTArtifact;
 }

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -55,10 +55,7 @@ use PDepend\Util\Cache\CacheDriver;
  */
 abstract class PHPParserVersion81TestCase extends AbstractTestCase
 {
-    /**
-     * @return AbstractPHPParser
-     */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return $this->getAbstractClassMock(
             'PDepend\\Source\\Language\\PHP\\AbstractPHPParser',

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -56,10 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
  */
 abstract class PHPParserVersion82TestCase extends AbstractTestCase
 {
-    /**
-     * @return AbstractPHPParser
-     */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return $this->getAbstractClassMock(
             'PDepend\\Source\\Language\\PHP\\PHPParserVersion82',

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -56,10 +56,7 @@ use PDepend\Util\Cache\CacheDriver;
  */
 abstract class PHPParserVersion83TestCase extends AbstractTestCase
 {
-    /**
-     * @return AbstractPHPParser
-     */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return $this->getAbstractClassMock(
             'PDepend\\Source\\Language\\PHP\\PHPParserVersion83',

--- a/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -1869,10 +1869,8 @@ class PHPBuilderTest extends AbstractTestCase
 
     /**
      * Creates a clean builder test instance.
-     *
-     * @return PHPBuilder
      */
-    protected function createBuilder()
+    protected function createBuilder(): PHPBuilder
     {
         $builder = new PHPBuilder();
         $builder->setCache($this->createCacheFixture());

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -702,10 +702,8 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.
-     *
-     * @return AbstractASTClassOrInterface
      */
-    protected function getFirstTypeForTestCase()
+    protected function getFirstTypeForTestCase(): AbstractASTClassOrInterface
     {
         return $this->parseCodeResourceForTest()
             ->current()
@@ -716,10 +714,8 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * Returns the first method that could be found in the code under test for
      * the calling test case.
-     *
-     * @return ASTMethod
      */
-    protected function getFirstMethodForTestCase()
+    protected function getFirstMethodForTestCase(): ASTMethod
     {
         return $this->getFirstTypeForTestCase()
             ->getMethods()
@@ -729,10 +725,8 @@ class PHPParserGenericTest extends AbstractTestCase
     /**
      * Returns the first property that could be found in the code under test for
      * the calling test case.
-     *
-     * @return ASTProperty
      */
-    protected function getFirstPropertyForTestCase()
+    protected function getFirstPropertyForTestCase(): ASTProperty
     {
         $class = $this->getFirstTypeForTestCase();
         static::assertInstanceOf(ASTClass::class, $class);
@@ -1161,10 +1155,8 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithArrays
-     *
-     * @return \PDepend\Source\AST\ASTNode
      */
-    public function testSpaceshipOperatorWithArrays()
+    public function testSpaceshipOperatorWithArrays(): \PDepend\Source\AST\ASTNode
     {
         $expr = $this->getFirstClassMethodForTestCase()
             ->getFirstChildOfType('PDepend\\Source\\AST\\ASTExpression')
@@ -1232,10 +1224,7 @@ class PHPParserGenericTest extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return ASTNamespace
-     */
-    public function testGroupUseStatement()
+    public function testGroupUseStatement(): ASTNamespace
     {
         $namespaces = $this->parseCodeResourceForTest();
         static::assertNotNull($namespaces);

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -109,7 +109,7 @@ class PHPParserVersion81Test extends AbstractTestCase
     /**
      * @return \PDepend\Source\AST\AbstractASTClassOrInterface[]
      */
-    public function testParserResolvesDependenciesInDocComments()
+    public function testParserResolvesDependenciesInDocComments(): array
     {
         $namespaces = $this->parseCodeResourceForTest();
         $classes = $namespaces[0]->getClasses();
@@ -648,10 +648,8 @@ class PHPParserVersion81Test extends AbstractTestCase
 
     /**
      * testSpaceshipOperatorWithArrays
-     *
-     * @return ASTExpression
      */
-    public function testSpaceshipOperatorWithArrays()
+    public function testSpaceshipOperatorWithArrays(): ASTExpression
     {
         $expr = $this->getFirstClassMethodForTestCase()
             ->getFirstChildOfType(ASTExpression::class)
@@ -719,10 +717,7 @@ class PHPParserVersion81Test extends AbstractTestCase
         $this->parseCodeResourceForTest();
     }
 
-    /**
-     * @return ASTNamespace
-     */
-    public function testGroupUseStatement()
+    public function testGroupUseStatement(): ASTNamespace
     {
         $namespaces = $this->parseCodeResourceForTest();
         static::assertNotNull($namespaces);
@@ -1506,10 +1501,7 @@ class PHPParserVersion81Test extends AbstractTestCase
         }
     }
 
-    /**
-     * @return AbstractPHPParser
-     */
-    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache)
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
         return $this->getAbstractClassMock(
             'PDepend\\Source\\Language\\PHP\\AbstractPHPParser',

--- a/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -586,7 +586,7 @@ class PHPTokenizerInternalTest extends AbstractTestCase
      *
      * @return array<int>
      */
-    private function getTokenTypesForTest()
+    private function getTokenTypesForTest(): array
     {
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile($this->createCodeResourceUriForTest());

--- a/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -261,10 +261,9 @@ class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
      * Returns the first allocation expression found in the test file associated
      * with the calling test method.
      *
-     * @return ASTAllocationExpression
      * @since 1.0.1
      */
-    private function getFirstAllocationInClass()
+    private function getFirstAllocationInClass(): ASTAllocationExpression
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTAllocationExpression::class

--- a/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -229,10 +229,8 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
 
     /**
      * Returns an arguments instance for the currently executed test case.
-     *
-     * @return ASTArguments
      */
-    private function getFirstArgumentsOfFunction()
+    private function getFirstArgumentsOfFunction(): ASTArguments
     {
         return $this->getFirstNodeOfTypeInFunction(
             ASTArguments::class
@@ -241,10 +239,8 @@ class ASTArgumentsParsingTest extends AbstractParserTestCase
 
     /**
      * Returns an arguments instance for the currently executed test case.
-     *
-     * @return ASTArguments
      */
-    private function getFirstArgumentsOfMethod()
+    private function getFirstArgumentsOfMethod(): ASTArguments
     {
         return $this->getFirstNodeOfTypeInClass(
             ASTArguments::class

--- a/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/src/test/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -90,10 +90,8 @@ class ASTFormalParameterParsingTest extends AbstractParserTestCase
 
     /**
      * Returns the first formal parameter found in the associated test file.
-     *
-     * @return ASTFormalParameter
      */
-    private function getFirstMethodFormalParameter()
+    private function getFirstMethodFormalParameter(): ASTFormalParameter
     {
         return $this->parseCodeResourceForTest()
             ->current()

--- a/src/test/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/src/test/php/PDepend/Source/Parser/TokenStackTest.php
@@ -128,10 +128,8 @@ class TokenStackTest extends AbstractParserTestCase
 
     /**
      * Returns a test token instance.
-     *
-     * @return Token
      */
-    protected function createToken()
+    protected function createToken(): Token
     {
         return new Token(1, __CLASS__, 13, 17, 23, 42);
     }

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -291,10 +291,8 @@ class CommandTest extends AbstractTestCase
 
     /**
      * Executes the command class and returns an array with namespace statistics.
-     *
-     * @return array
      */
-    private function runCommandAndReturnStatistics(array $argv, string $pathName)
+    private function runCommandAndReturnStatistics(array $argv, string $pathName): array
     {
         $logFile = $this->createRunResourceURI();
 
@@ -584,7 +582,7 @@ class CommandTest extends AbstractTestCase
      * @param ?array $argv The cli parameters.
      * @return array<mixed>
      */
-    private function executeCommand(?array $argv = null)
+    private function executeCommand(?array $argv = null): array
     {
         $this->prepareArgv($argv);
 

--- a/src/test/php/PDepend/TextUI/RunnerTest.php
+++ b/src/test/php/PDepend/TextUI/RunnerTest.php
@@ -316,9 +316,8 @@ class RunnerTest extends AbstractTestCase
      *
      * @param Runner $runner The runner instance.
      * @param $pathName The source path.
-     * @return array
      */
-    private function runRunnerAndReturnStatistics(Runner $runner, $pathName)
+    private function runRunnerAndReturnStatistics(Runner $runner, $pathName): array
     {
         $logFile = $this->createRunResourceURI();
 

--- a/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
+++ b/src/test/php/PDepend/Util/Cache/AbstractDriverTestCase.php
@@ -192,8 +192,6 @@ abstract class AbstractDriverTestCase extends AbstractTestCase
 
     /**
      * Creates a test fixture.
-     *
-     * @return CacheDriver
      */
-    abstract protected function createDriver();
+    abstract protected function createDriver(): CacheDriver;
 }

--- a/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/src/test/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -143,10 +143,8 @@ class CacheFactoryTest extends AbstractTestCase
 
     /**
      * Creates a prepared factory instance.
-     *
-     * @return CacheFactory
      */
-    protected function createFactoryFixture()
+    protected function createFactoryFixture(): CacheFactory
     {
         $application = new Application();
         $application->setConfigurationFile(getcwd() . '/pdepend.xml');

--- a/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -77,10 +77,8 @@ class FileCacheDriverTest extends AbstractDriverTestCase
 
     /**
      * Creates a test fixture.
-     *
-     * @return CacheDriver
      */
-    protected function createDriver()
+    protected function createDriver(): CacheDriver
     {
         return new FileCacheDriver($this->cacheDir, $this->cacheTtl);
     }

--- a/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/src/test/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -59,10 +59,8 @@ class MemoryCacheDriverTest extends AbstractDriverTestCase
 {
     /**
      * Creates a test fixture.
-     *
-     * @return CacheDriver
      */
-    protected function createDriver()
+    protected function createDriver(): CacheDriver
     {
         return new MemoryCacheDriver();
     }

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -159,10 +159,8 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * Creates a clover coverage report instance.
-     *
-     * @return CloverReport
      */
-    private function createCloverReport()
+    private function createCloverReport(): CloverReport
     {
         $sxml = simplexml_load_file(__DIR__ . '/_files/clover.xml');
 
@@ -171,10 +169,8 @@ class CloverReportTest extends AbstractTestCase
 
     /**
      * Creates a clover coverage report instance.
-     *
-     * @return CloverReport
      */
-    private function createNamespacedCloverReport()
+    private function createNamespacedCloverReport(): CloverReport
     {
         $sxml = simplexml_load_file(__DIR__ . '/_files/clover-namespaced.xml');
 
@@ -185,9 +181,8 @@ class CloverReportTest extends AbstractTestCase
      * Creates a mocked method instance.
      *
      * @param string $name Name of the mock method.
-     * @return ASTMethod
      */
-    private function createMethodMock(string $name, int $startLine = 1, int $endLine = 4)
+    private function createMethodMock(string $name, int $startLine = 1, int $endLine = 4): ASTMethod
     {
         $file = $this->getMockBuilder(ASTCompilationUnit::class)
             ->setConstructorArgs([null])

--- a/src/test/php/PDepend/Util/ImageConvertTest.php
+++ b/src/test/php/PDepend/Util/ImageConvertTest.php
@@ -163,10 +163,8 @@ class ImageConvertTest extends AbstractTestCase
 
     /**
      * Returns a temporary input svg fixture.
-     *
-     * @return string
      */
-    protected function createInputSvg()
+    protected function createInputSvg(): string
     {
         $input = $this->createRunResourceURI(uniqid('input_')) . '.svg';
         copy(__DIR__ . '/_input/pyramid.svg', $input);


### PR DESCRIPTION
Type: refactoring / documentation update
Breaking change: yes

Simply ran:
```php
vendor/bin/php-cs-fixer fix --rules=phpdoc_to_return_type
vendor/bin/php-cs-fixer fix
```