### PR TITLE
Convert PHPDoc to argument type hints

### DIFF
--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -69,10 +69,9 @@ class Application
     private string $configurationFile;
 
     /**
-     * @param string $configurationFile
      * @throws InvalidArgumentException
      */
-    public function setConfigurationFile($configurationFile): void
+    public function setConfigurationFile(string $configurationFile): void
     {
         if (!file_exists($configurationFile)) {
             throw new InvalidArgumentException(
@@ -206,11 +205,10 @@ class Application
     }
 
     /**
-     * @param string $serviceTag
      * @return array<string, array<string, string>>
      * @throws Exception
      */
-    private function getAvailableOptionsFor($serviceTag)
+    private function getAvailableOptionsFor(string $serviceTag)
     {
         $container = $this->getContainer();
 

--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -117,7 +117,7 @@ class PdependExtension extends SymfonyExtension
      * @param array<string, array<string, string>> $config
      * @return stdClass
      */
-    private function createSettings($config)
+    private function createSettings(array $config)
     {
         $settings = new stdClass();
 

--- a/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
+++ b/src/main/php/PDepend/DependencyInjection/TreeBuilder.php
@@ -57,10 +57,8 @@ class TreeBuilder
 
     /**
      * TreeBuilder constructor.
-     *
-     * @param string $name
      */
-    public function __construct($name = 'pdepend')
+    public function __construct(string $name = 'pdepend')
     {
         $this->treeBuilder = new BaseTreeBuilder($name, 'array');
         $rootNode = $this->treeBuilder->getRootNode();

--- a/src/main/php/PDepend/Engine.php
+++ b/src/main/php/PDepend/Engine.php
@@ -178,7 +178,7 @@ class Engine
      * @param string $directory The php source directory.
      * @throws InvalidArgumentException
      */
-    public function addDirectory($directory): void
+    public function addDirectory(string $directory): void
     {
         $dir = realpath($directory);
 
@@ -195,7 +195,7 @@ class Engine
      * @param string $file The source file name.
      * @throws InvalidArgumentException
      */
-    public function addFile($file): void
+    public function addFile(string $file): void
     {
         if ($file === '-') {
             $file = $this->phpStreamPrefix . 'stdin';
@@ -375,12 +375,11 @@ class Engine
     /**
      * Returns the analyzed namespace for the given name.
      *
-     * @param string $name
      * @return ASTNamespace
      * @throws OutOfBoundsException
      * @throws RuntimeException
      */
-    public function getNamespace($name)
+    public function getNamespace(string $name)
     {
         if (!isset($this->namespaces)) {
             $msg = 'getNamespace() doesn\'t work before the source was analyzed.';
@@ -648,7 +647,7 @@ class Engine
      * @return Analyzer[]
      * @throws InvalidArgumentException
      */
-    private function createAnalyzers($options)
+    private function createAnalyzers(array $options)
     {
         $analyzers = $this->analyzerFactory->createRequiredForGenerators($this->generators);
 
@@ -674,10 +673,9 @@ class Engine
     }
 
     /**
-     * @param string $path
      * @return bool
      */
-    private function isPhpStream($path)
+    private function isPhpStream(string $path)
     {
         return str_starts_with($path, $this->phpStreamPrefix);
     }

--- a/src/main/php/PDepend/Input/CompositeFilter.php
+++ b/src/main/php/PDepend/Input/CompositeFilter.php
@@ -76,7 +76,7 @@ class CompositeFilter implements Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      */
-    public function accept($relative, $absolute): bool
+    public function accept(string $relative, string $absolute): bool
     {
         foreach ($this->filters as $filter) {
             if (!$filter->accept($relative, $absolute)) {

--- a/src/main/php/PDepend/Input/ExcludePathFilter.php
+++ b/src/main/php/PDepend/Input/ExcludePathFilter.php
@@ -81,7 +81,7 @@ class ExcludePathFilter implements Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      */
-    public function accept($relative, $absolute): bool
+    public function accept(string $relative, string $absolute): bool
     {
         return $this->notRelative($relative) && $this->notAbsolute($absolute);
     }
@@ -94,7 +94,7 @@ class ExcludePathFilter implements Filter
      * @return bool
      * @since  0.10.0
      */
-    protected function notAbsolute($path)
+    protected function notAbsolute(string $path)
     {
         return !preg_match($this->pattern, str_replace('\\', '/', $path));
     }
@@ -107,7 +107,7 @@ class ExcludePathFilter implements Filter
      * @return bool
      * @since  0.10.0
      */
-    protected function notRelative($path)
+    protected function notRelative(string $path)
     {
         $subPath = str_replace('\\', '/', $path);
 

--- a/src/main/php/PDepend/Input/ExtensionFilter.php
+++ b/src/main/php/PDepend/Input/ExtensionFilter.php
@@ -68,7 +68,7 @@ class ExtensionFilter implements Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      */
-    public function accept($relative, $absolute): bool
+    public function accept(string $relative, string $absolute): bool
     {
         if (str_starts_with($absolute, 'php://')) {
             return true;

--- a/src/main/php/PDepend/Input/Filter.php
+++ b/src/main/php/PDepend/Input/Filter.php
@@ -57,5 +57,5 @@ interface Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      */
-    public function accept($relative, $absolute): bool;
+    public function accept(string $relative, string $absolute): bool;
 }

--- a/src/main/php/PDepend/Metrics/Analyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer.php
@@ -74,7 +74,7 @@ interface Analyzer
      *
      * @param ASTArtifactList<ASTNamespace> $namespaces
      */
-    public function analyze($namespaces): void;
+    public function analyze(ASTArtifactList $namespaces): void;
 
     /**
      * An analyzer that is active must return <b>true</b> to recognized by

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -195,7 +195,7 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
      * @param string $id2 Identifier for the outgoing edges.
      * @return array<string, float>
      */
-    protected function computeCodeRank($id1, $id2)
+    protected function computeCodeRank(string $id1, string $id2)
     {
         $dampingFactory = self::DAMPING_FACTOR;
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactory.php
@@ -94,7 +94,7 @@ class StrategyFactory
      * @throws InvalidArgumentException If the given <b>$id</b> is not valid or
      *                                  no matching class declaration exists.
      */
-    public function createStrategy($strategyName)
+    public function createStrategy(string $strategyName)
     {
         if (!isset($this->validStrategies[$strategyName])) {
             throw new InvalidArgumentException(

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -182,7 +182,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
      * @param ASTArtifactList<ASTNamespace> $namespaces
      * @since  0.10.2
      */
-    private function doAnalyze($namespaces): void
+    private function doAnalyze(ASTArtifactList $namespaces): void
     {
         $this->fireStartAnalyzer();
         $this->reset();

--- a/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzer.php
@@ -144,7 +144,7 @@ class CrapIndexAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, A
      *
      * @param ASTArtifactList<ASTNamespace> $namespaces
      */
-    private function doAnalyze($namespaces): void
+    private function doAnalyze(ASTArtifactList $namespaces): void
     {
         $this->metrics = [];
 

--- a/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzer.php
@@ -225,7 +225,7 @@ class CyclomaticComplexityAnalyzer extends AbstractCachingAnalyzer implements An
      * @param string $nodeId Identifier of the analyzed item.
      * @since  1.0.0
      */
-    private function updateProjectMetrics($nodeId): void
+    private function updateProjectMetrics(string $nodeId): void
     {
         $this->ccn += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_1] ?? 0;
         $this->ccn2 += $this->metrics[$nodeId][self::M_CYCLOMATIC_COMPLEXITY_2] ?? 0;

--- a/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/InheritanceAnalyzer.php
@@ -165,7 +165,7 @@ class InheritanceAnalyzer extends AbstractAnalyzer implements
      * @param ASTArtifactList<ASTNamespace> $namespaces
      * @since  0.9.10
      */
-    private function doAnalyze($namespaces): void
+    private function doAnalyze(ASTArtifactList $namespaces): void
     {
         foreach ($namespaces as $namespace) {
             $this->dispatch($namespace);

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -385,7 +385,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      *
      * @param string $id The unique identifier of a node.
      */
-    private function updateProjectMetrics($id): void
+    private function updateProjectMetrics(string $id): void
     {
         foreach ($this->metrics[$id] as $metric => $value) {
             $this->projectMetrics[$metric] += $value;
@@ -409,7 +409,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
      * @param bool $search Optional boolean flag, search start.
      * @return array<int, int>
      */
-    private function linesOfCode(array $tokens, $search = false)
+    private function linesOfCode(array $tokens, bool $search = false)
     {
         $clines = [];
         $elines = [];

--- a/src/main/php/PDepend/Report/Dependencies/Xml.php
+++ b/src/main/php/PDepend/Report/Dependencies/Xml.php
@@ -103,7 +103,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }
@@ -197,11 +197,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param string $typeIdentifier
-     *
      * @throws RuntimeException
      */
-    private function generateTypeXml(AbstractASTClassOrInterface $type, $typeIdentifier): void
+    private function generateTypeXml(AbstractASTClassOrInterface $type, string $typeIdentifier): void
     {
         if (!$type->isUserDefined()) {
             return;

--- a/src/main/php/PDepend/Report/FileAwareGenerator.php
+++ b/src/main/php/PDepend/Report/FileAwareGenerator.php
@@ -56,5 +56,5 @@ interface FileAwareGenerator extends ReportGenerator
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void;
+    public function setLogFile(string $logFile): void;
 }

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -83,7 +83,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -120,7 +120,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -107,7 +107,7 @@ class Pyramid implements FileAwareGenerator
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }
@@ -221,7 +221,7 @@ class Pyramid implements FileAwareGenerator
      * @param mixed $value The metric/field value.
      * @return string|null
      */
-    private function computeThreshold($name, $value)
+    private function computeThreshold(string $name, mixed $value)
     {
         if (!isset($this->thresholds[$name])) {
             return null;

--- a/src/main/php/PDepend/Report/ReportGeneratorFactory.php
+++ b/src/main/php/PDepend/Report/ReportGeneratorFactory.php
@@ -83,7 +83,7 @@ class ReportGeneratorFactory
      * @return ReportGenerator
      * @throws RuntimeException
      */
-    public function createGenerator($identifier, $fileName)
+    public function createGenerator(string $identifier, string $fileName)
     {
         if (!isset($this->instances[$identifier])) {
             $loggerServices = $this->container->findTaggedServiceIds('pdepend.logger');

--- a/src/main/php/PDepend/Report/Summary/Xml.php
+++ b/src/main/php/PDepend/Report/Summary/Xml.php
@@ -118,7 +118,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }
@@ -269,10 +269,9 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
     /**
      * Generates the XML for a class or trait node.
      *
-     * @param string $typeIdentifier
      * @throws RuntimeException
      */
-    private function generateTypeXml(ASTClass $type, $typeIdentifier): void
+    private function generateTypeXml(ASTClass $type, string $typeIdentifier): void
     {
         if (!$type->isUserDefined()) {
             return;

--- a/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTAnonymousClass.php
@@ -91,10 +91,7 @@ class ASTAnonymousClass extends ASTClass
         parent::__wakeup();
     }
 
-    /**
-     * @param string $image
-     */
-    public function setImage($image): void
+    public function setImage(string $image): void
     {
         $this->setName($image);
     }
@@ -172,11 +169,10 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @param int $index
      * @return int
      * @since 0.10.4
      */
-    protected function getMetadataInteger($index)
+    protected function getMetadataInteger(int $index)
     {
         return (int) $this->getMetadata($index);
     }
@@ -185,11 +181,9 @@ class ASTAnonymousClass extends ASTClass
      * Stores an integer value under the given index in the internally used data
      * string.
      *
-     * @param int $index
-     * @param int $value
      * @since 0.10.4
      */
-    protected function setMetadataInteger($index, $value): void
+    protected function setMetadataInteger(int $index, int $value): void
     {
         $this->setMetadata($index, (string) $value);
     }
@@ -197,11 +191,10 @@ class ASTAnonymousClass extends ASTClass
     /**
      * Returns the value that was stored under the given index.
      *
-     * @param int $index
      * @return string
      * @since 0.10.4
      */
-    protected function getMetadata($index)
+    protected function getMetadata(int $index)
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
 
@@ -212,11 +205,9 @@ class ASTAnonymousClass extends ASTClass
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int $index
-     * @param string $value
      * @since 0.10.4
      */
-    protected function setMetadata($index, $value): void
+    protected function setMetadata(int $index, string $value): void
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
         $metadata[$index] = $value;

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -169,7 +169,7 @@ class ASTArtifactList implements ArrayAccess, Countable, Iterator
      * @link   http://php.net/manual/en/arrayaccess.offsetexists.php
      * @since  1.0.0
      */
-    public function offsetExists($offset): bool
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->artifacts[$offset]);
     }

--- a/src/main/php/PDepend/Source/AST/ASTCastExpression.php
+++ b/src/main/php/PDepend/Source/AST/ASTCastExpression.php
@@ -88,7 +88,7 @@ class ASTCastExpression extends ASTUnaryExpression
      *
      * @param string $image The original cast image.
      */
-    public function __construct($image)
+    public function __construct(string $image)
     {
         parent::__construct(preg_replace('(\s+)', '', strtolower($image)));
     }

--- a/src/main/php/PDepend/Source/AST/ASTClass.php
+++ b/src/main/php/PDepend/Source/AST/ASTClass.php
@@ -189,12 +189,11 @@ class ASTClass extends AbstractASTClassOrInterface
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param int $modifiers
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
      * @since  0.9.4
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(

--- a/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/main/php/PDepend/Source/AST/ASTClassOrInterfaceReference.php
@@ -65,10 +65,8 @@ class ASTClassOrInterfaceReference extends ASTType
 
     /**
      * Constructs a new type holder instance.
-     *
-     * @param string $qualifiedName
      */
-    public function __construct(BuilderContext $context, $qualifiedName)
+    public function __construct(BuilderContext $context, string $qualifiedName)
     {
         parent::__construct($qualifiedName);
 

--- a/src/main/php/PDepend/Source/AST/ASTClosure.php
+++ b/src/main/php/PDepend/Source/AST/ASTClosure.php
@@ -83,7 +83,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      *
      * @param bool $returnsReference Does this closure return by reference?
      */
-    public function setReturnsByReference($returnsReference): void
+    public function setReturnsByReference(bool $returnsReference): void
     {
         $this->setMetadataBoolean(5, (bool) $returnsReference);
     }
@@ -122,7 +122,7 @@ class ASTClosure extends AbstractASTNode implements ASTCallable
      * @param bool $static Whether this closure is static or not.
      * @since  1.0.0
      */
-    public function setStatic($static): void
+    public function setStatic(bool $static): void
     {
         $this->setMetadataBoolean(6, (bool) $static);
     }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -89,7 +89,7 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      *
      * @param string|null $fileName The source file name/path.
      */
-    public function __construct($fileName)
+    public function __construct(?string $fileName)
     {
         if ($fileName && str_starts_with($fileName, 'php://')) {
             $this->fileName = $fileName;

--- a/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
+++ b/src/main/php/PDepend/Source/AST/ASTConstantDefinition.php
@@ -84,7 +84,7 @@ class ASTConstantDefinition extends AbstractASTNode
      * @param int $modifiers The declared modifiers for this node.
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         $expected = ~State::IS_PUBLIC
             & ~State::IS_PROTECTED

--- a/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
+++ b/src/main/php/PDepend/Source/AST/ASTDeclareStatement.php
@@ -103,10 +103,8 @@ class ASTDeclareStatement extends ASTStatement
 
     /**
      * Adds a parameter/value for this declare-statement.
-     *
-     * @param string $name
      */
-    public function addValue($name, ASTValue $value): void
+    public function addValue(string $name, ASTValue $value): void
     {
         $this->values[$name] = $value;
     }

--- a/src/main/php/PDepend/Source/AST/ASTEnum.php
+++ b/src/main/php/PDepend/Source/AST/ASTEnum.php
@@ -263,12 +263,11 @@ class ASTEnum extends AbstractASTClassOrInterface
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param int $modifiers
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
      * @since  0.9.4
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(

--- a/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
+++ b/src/main/php/PDepend/Source/AST/ASTFieldDeclaration.php
@@ -117,7 +117,7 @@ class ASTFieldDeclaration extends AbstractASTNode
      * @param int $modifiers The declared modifiers for this node.
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         $expected = ~State::IS_PUBLIC
                   & ~State::IS_PROTECTED

--- a/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTFormalParameter.php
@@ -165,12 +165,11 @@ class ASTFormalParameter extends AbstractASTNode
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param int $modifiers
      * @throws BadMethodCallException
      * @throws InvalidArgumentException
      * @since  0.9.4
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         if ($this->modifiers !== 0) {
             throw new BadMethodCallException(

--- a/src/main/php/PDepend/Source/AST/ASTHeredoc.php
+++ b/src/main/php/PDepend/Source/AST/ASTHeredoc.php
@@ -61,7 +61,7 @@ class ASTHeredoc extends ASTExpression
      *
      * @param string $delimiter The heredoc delimiter.
      */
-    public function setDelimiter($delimiter): void
+    public function setDelimiter(string $delimiter): void
     {
         $this->delimiter = $delimiter;
     }

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -90,11 +90,10 @@ class ASTMethod extends AbstractASTCallable
      * This method will throw an exception when the value of given <b>$modifiers</b>
      * contains an invalid/unexpected modifier
      *
-     * @param int $modifiers
      * @throws InvalidArgumentException If the given modifier contains unexpected values.
      * @since  0.9.4
      */
-    public function setModifiers($modifiers): void
+    public function setModifiers(int $modifiers): void
     {
         $expected = ~State::IS_PUBLIC
                   & ~State::IS_PROTECTED

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -74,10 +74,8 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * Constructs a new namespace for the given <b>$name</b>
-     *
-     * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         parent::__construct($name);
         $this->id = spl_object_hash($this);
@@ -289,10 +287,7 @@ class ASTNamespace extends AbstractASTArtifact
         return $this->packageAnnotation;
     }
 
-    /**
-     * @param bool $packageAnnotation
-     */
-    public function setPackageAnnotation($packageAnnotation): void
+    public function setPackageAnnotation(bool $packageAnnotation): void
     {
         $this->packageAnnotation = $packageAnnotation;
     }

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -159,7 +159,7 @@ interface ASTNode
      *
      * @param ?string $comment The doc comment block for this node.
      */
-    public function setComment($comment): void;
+    public function setComment(?string $comment): void;
 
     /**
      * For better performance we have moved the single setter methods for the

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -231,7 +231,7 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      *
      * @param int $position The parameter position.
      */
-    public function setPosition($position): void
+    public function setPosition(int $position): void
     {
         $this->position = $position;
     }
@@ -333,7 +333,7 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
      *                       optional or not.
      * @since  0.9.5
      */
-    public function setOptional($optional): void
+    public function setOptional(bool $optional): void
     {
         $this->optional = (bool) $optional;
     }
@@ -382,10 +382,9 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
     }
 
     /**
-     * @param ASTNode $node
      * @return bool
      */
-    private function isTypeAllowingNull($node)
+    private function isTypeAllowingNull(ASTNode $node)
     {
         if ($node instanceof ASTUnionType) {
             foreach ($node->getChildren() as $child) {

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -78,7 +78,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      *
      * @param int $newModifier The new method modifier.
      */
-    public function setNewModifier($newModifier): void
+    public function setNewModifier(int $newModifier): void
     {
         $this->newModifier = $newModifier;
     }
@@ -99,7 +99,7 @@ class ASTTraitAdaptationAlias extends ASTStatement
      *
      * @param string $newName The new aliased method name.
      */
-    public function setNewName($newName): void
+    public function setNewName(string $newName): void
     {
         $this->newName = $newName;
     }

--- a/src/main/php/PDepend/Source/AST/ASTValue.php
+++ b/src/main/php/PDepend/Source/AST/ASTValue.php
@@ -76,7 +76,7 @@ class ASTValue
      *
      * @param mixed $value The parsed PHP-value.
      */
-    public function setValue($value): void
+    public function setValue(mixed $value): void
     {
         if (!$this->valueAvailable) {
             $this->value = $value;

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -107,7 +107,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * @param string $name The item name.
      * @since  1.0.0
      */
-    public function setName($name): void
+    public function setName(string $name): void
     {
         $this->name = $name;
     }
@@ -132,7 +132,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      * @param string $id Identifier for this node.
      * @since  0.9.12
      */
-    public function setId($id): void
+    public function setId(string $id): void
     {
         $this->id = $id;
     }
@@ -247,7 +247,7 @@ abstract class AbstractASTArtifact implements ASTArtifact
      *
      * @param ?string $comment
      */
-    public function setComment($comment): void
+    public function setComment(?string $comment): void
     {
         $this->comment = $comment;
     }

--- a/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTClassOrInterface.php
@@ -246,7 +246,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @return bool
      * @since  0.9.6
      */
-    public function hasConstant($name)
+    public function hasConstant(string $name)
     {
         if ($this->constants === null) {
             $this->constants = $this->initConstants();
@@ -262,7 +262,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * @param string $name Name of the searched constant.
      * @since  0.9.6
      */
-    public function getConstant($name): mixed
+    public function getConstant(string $name): mixed
     {
         if ($this->hasConstant($name)) {
             return $this->constants[$name];

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -85,7 +85,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param ?string $image The source image for this node.
      */
-    public function __construct($image = null)
+    public function __construct(?string $image = null)
     {
         $this->metadata = str_repeat(':', $this->getMetadataSize() - 1);
 
@@ -128,7 +128,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param ?string $image
      */
-    public function setImage($image): void
+    public function setImage(?string $image): void
     {
         $this->setMetadata(4, $image ?? '');
     }
@@ -212,11 +212,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns an integer value that was stored under the given index.
      *
-     * @param int $index
      * @return int
      * @since 0.10.4
      */
-    protected function getMetadataInteger($index)
+    protected function getMetadataInteger(int $index)
     {
         return (int) $this->getMetadata($index);
     }
@@ -225,11 +224,9 @@ abstract class AbstractASTNode implements ASTNode
      * Stores an integer value under the given index in the internally used data
      * string.
      *
-     * @param int $index
-     * @param int $value
      * @since 0.10.4
      */
-    protected function setMetadataInteger($index, $value): void
+    protected function setMetadataInteger(int $index, int $value): void
     {
         $this->setMetadata($index, (string) $value);
     }
@@ -237,11 +234,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns a boolean value that was stored under the given index.
      *
-     * @param int $index
      * @return bool
      * @since 0.10.4
      */
-    protected function getMetadataBoolean($index)
+    protected function getMetadataBoolean(int $index)
     {
         return (bool) $this->getMetadata($index);
     }
@@ -250,11 +246,9 @@ abstract class AbstractASTNode implements ASTNode
      * Stores a boolean value under the given index in the internally used data
      * string.
      *
-     * @param int $index
-     * @param bool $value
      * @since 0.10.4
      */
-    protected function setMetadataBoolean($index, $value): void
+    protected function setMetadataBoolean(int $index, bool $value): void
     {
         $this->setMetadata($index, $value ? '1' : '0');
     }
@@ -262,11 +256,10 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns the value that was stored under the given index.
      *
-     * @param int $index
      * @return string
      * @since 0.10.4
      */
-    protected function getMetadata($index)
+    protected function getMetadata(int $index)
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
 
@@ -277,11 +270,9 @@ abstract class AbstractASTNode implements ASTNode
      * Stores the given value under the given index in an internal storage
      * container.
      *
-     * @param int $index
-     * @param string $value
      * @since 0.10.4
      */
-    protected function setMetadata($index, $value): void
+    protected function setMetadata(int $index, string $value): void
     {
         $metadata = explode(':', $this->metadata, $this->getMetadataSize());
         $metadata[$index] = $value;
@@ -451,7 +442,7 @@ abstract class AbstractASTNode implements ASTNode
      *
      * @param ?string $comment The doc comment block for this node.
      */
-    public function setComment($comment): void
+    public function setComment(?string $comment): void
     {
         $this->comment = $comment;
     }

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -192,11 +192,10 @@ interface Builder extends IteratorAggregate
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return AbstractASTClassOrInterface
      * @since  0.9.5
      */
-    public function getClassOrInterface($qualifiedName);
+    public function getClassOrInterface(string $qualifiedName);
 
     /**
      * Builds a new code type reference instance.
@@ -205,16 +204,15 @@ interface Builder extends IteratorAggregate
      * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstClassOrInterfaceReference($qualifiedName);
+    public function buildAstClassOrInterfaceReference(string $qualifiedName);
 
     /**
      * Builds a new php trait instance.
      *
-     * @param string $qualifiedName
      * @return ASTTrait
      * @since  1.0.0
      */
-    public function buildTrait($qualifiedName);
+    public function buildTrait(string $qualifiedName);
 
     /**
      * Restores an existing trait instance within the context of this builder.
@@ -228,19 +226,17 @@ interface Builder extends IteratorAggregate
      * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait($qualifiedName);
+    public function getTrait(string $qualifiedName);
 
     /**
      * Builds a new code class instance.
      *
-     * @param string $qualifiedName
      * @return ASTClass
      */
-    public function buildClass($qualifiedName);
+    public function buildClass(string $qualifiedName);
 
     /**
      * Builds an anonymous class instance.
@@ -254,11 +250,10 @@ interface Builder extends IteratorAggregate
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return ASTClass|ASTEnum
      * @since  0.9.5
      */
-    public function getClass($qualifiedName);
+    public function getClass(string $qualifiedName);
 
     /**
      * Restores an existing class instance within the context of this builder.
@@ -281,15 +276,14 @@ interface Builder extends IteratorAggregate
      * @return ASTClassReference
      * @since  0.9.5
      */
-    public function buildAstClassReference($qualifiedName);
+    public function buildAstClassReference(string $qualifiedName);
 
     /**
      * Builds a new new interface instance.
      *
-     * @param string $qualifiedName
      * @return ASTInterface
      */
-    public function buildInterface($qualifiedName);
+    public function buildInterface(string $qualifiedName);
 
     /**
      * Restores an existing interface instance within the context of this builder.
@@ -307,31 +301,28 @@ interface Builder extends IteratorAggregate
      * @return ASTInterface
      * @since  0.9.5
      */
-    public function getInterface($qualifiedName);
+    public function getInterface(string $qualifiedName);
 
     /**
      * Builds a new namespace instance.
      *
-     * @param string $name
      * @return ASTNamespace
      */
-    public function buildNamespace($name);
+    public function buildNamespace(string $name);
 
     /**
      * Builds a new method instance.
      *
-     * @param string $name
      * @return ASTMethod
      */
-    public function buildMethod($name);
+    public function buildMethod(string $name);
 
     /**
      * Builds a new function instance.
      *
-     * @param string $name
      * @return ASTFunction
      */
-    public function buildFunction($name);
+    public function buildFunction(string $name);
 
     /**
      * Builds a new self reference instance.
@@ -373,7 +364,7 @@ interface Builder extends IteratorAggregate
      * @return ASTVariableDeclarator
      * @since  0.9.6
      */
-    public function buildAstVariableDeclarator($image);
+    public function buildAstVariableDeclarator(string $image);
 
     /**
      * Builds a new constant node.
@@ -382,7 +373,7 @@ interface Builder extends IteratorAggregate
      * @return ASTConstant
      * @since  0.9.6
      */
-    public function buildAstConstant($image);
+    public function buildAstConstant(string $image);
 
     /**
      * Builds a new variable node.
@@ -391,7 +382,7 @@ interface Builder extends IteratorAggregate
      * @return ASTVariable
      * @since  0.9.6
      */
-    public function buildAstVariable($image);
+    public function buildAstVariable(string $image);
 
     /**
      * Builds a new variable variable node.
@@ -400,7 +391,7 @@ interface Builder extends IteratorAggregate
      * @return ASTVariableVariable
      * @since  0.9.6
      */
-    public function buildAstVariableVariable($image);
+    public function buildAstVariableVariable(string $image);
 
     /**
      * Builds a new compound variable node.
@@ -409,7 +400,7 @@ interface Builder extends IteratorAggregate
      * @return ASTCompoundVariable
      * @since  0.9.6
      */
-    public function buildAstCompoundVariable($image);
+    public function buildAstCompoundVariable(string $image);
 
     /**
      * Builds a new compound expression node.
@@ -426,7 +417,7 @@ interface Builder extends IteratorAggregate
      * @return ASTStaticVariableDeclaration
      * @since  0.9.6
      */
-    public function buildAstStaticVariableDeclaration($image);
+    public function buildAstStaticVariableDeclaration(string $image);
 
     /**
      * Builds a new closure node.
@@ -455,11 +446,10 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new expression node.
      *
-     * @param string $image
      * @return ASTExpression
      * @since 0.9.8
      */
-    public function buildAstExpression($image = null);
+    public function buildAstExpression(?string $image = null);
 
     /**
      * Builds a new assignment expression node.
@@ -468,7 +458,7 @@ interface Builder extends IteratorAggregate
      * @return ASTAssignmentExpression
      * @since  0.9.8
      */
-    public function buildAstAssignmentExpression($image);
+    public function buildAstAssignmentExpression(string $image);
 
     /**
      * Builds a new allocation expression node.
@@ -477,7 +467,7 @@ interface Builder extends IteratorAggregate
      * @return ASTAllocationExpression
      * @since  0.9.6
      */
-    public function buildAstAllocationExpression($image);
+    public function buildAstAllocationExpression(string $image);
 
     /**
      * Builds a new eval-expression node.
@@ -486,7 +476,7 @@ interface Builder extends IteratorAggregate
      * @return ASTEvalExpression
      * @since  0.9.12
      */
-    public function buildAstEvalExpression($image);
+    public function buildAstEvalExpression(string $image);
 
     /**
      * Builds a new exit-expression instance.
@@ -495,7 +485,7 @@ interface Builder extends IteratorAggregate
      * @return ASTExitExpression
      * @since  0.9.12
      */
-    public function buildAstExitExpression($image);
+    public function buildAstExitExpression(string $image);
 
     /**
      * Builds a new clone-expression node.
@@ -504,7 +494,7 @@ interface Builder extends IteratorAggregate
      * @return ASTCloneExpression
      * @since  0.9.12
      */
-    public function buildAstCloneExpression($image);
+    public function buildAstCloneExpression(string $image);
 
     /**
      * Builds a new list-expression node.
@@ -513,7 +503,7 @@ interface Builder extends IteratorAggregate
      * @return ASTListExpression
      * @since  0.9.12
      */
-    public function buildAstListExpression($image);
+    public function buildAstListExpression(string $image);
 
     /**
      * Builds a new include- or include_once-expression.
@@ -560,7 +550,7 @@ interface Builder extends IteratorAggregate
      * @return ASTInstanceOfExpression
      * @since  0.9.6
      */
-    public function buildAstInstanceOfExpression($image);
+    public function buildAstInstanceOfExpression(string $image);
 
     /**
      * Builds a new isset-expression node.
@@ -689,7 +679,7 @@ interface Builder extends IteratorAggregate
      * @return ASTTraitAdaptationAlias
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationAlias($image);
+    public function buildAstTraitAdaptationAlias(string $image);
 
     /**
      * Builds a new trait adaptation precedence statement.
@@ -698,7 +688,7 @@ interface Builder extends IteratorAggregate
      * @return ASTTraitAdaptationPrecedence
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationPrecedence($image);
+    public function buildAstTraitAdaptationPrecedence(string $image);
 
     /**
      * Builds a new trait reference node.
@@ -707,7 +697,7 @@ interface Builder extends IteratorAggregate
      * @return ASTTraitReference
      * @since  1.0.0
      */
-    public function buildAstTraitReference($qualifiedName);
+    public function buildAstTraitReference(string $qualifiedName);
 
     /**
      * Builds a new switch-statement-node.
@@ -724,7 +714,7 @@ interface Builder extends IteratorAggregate
      * @return ASTSwitchLabel
      * @since  0.9.8
      */
-    public function buildAstSwitchLabel($image);
+    public function buildAstSwitchLabel(string $image);
 
     /**
      * Builds a new catch-statement node.
@@ -733,7 +723,7 @@ interface Builder extends IteratorAggregate
      * @return ASTCatchStatement
      * @since  0.9.8
      */
-    public function buildAstCatchStatement($image);
+    public function buildAstCatchStatement(string $image);
 
     /**
      * Builds a new finally-statement node.
@@ -750,7 +740,7 @@ interface Builder extends IteratorAggregate
      * @return ASTIfStatement
      * @since  0.9.8
      */
-    public function buildAstIfStatement($image);
+    public function buildAstIfStatement(string $image);
 
     /**
      * Builds a new elseif-statement node.
@@ -759,7 +749,7 @@ interface Builder extends IteratorAggregate
      * @return ASTElseIfStatement
      * @since  0.9.8
      */
-    public function buildAstElseIfStatement($image);
+    public function buildAstElseIfStatement(string $image);
 
     /**
      * Builds a new for-statement node.
@@ -768,7 +758,7 @@ interface Builder extends IteratorAggregate
      * @return ASTForStatement
      * @since  0.9.8
      */
-    public function buildAstForStatement($image);
+    public function buildAstForStatement(string $image);
 
     /**
      * Builds a new for-init node.
@@ -805,7 +795,7 @@ interface Builder extends IteratorAggregate
      * @return ASTForeachStatement
      * @since  0.9.8
      */
-    public function buildAstForeachStatement($image);
+    public function buildAstForeachStatement(string $image);
 
     /**
      * Builds a new while-statement node.
@@ -814,7 +804,7 @@ interface Builder extends IteratorAggregate
      * @return ASTWhileStatement
      * @since  0.9.8
      */
-    public function buildAstWhileStatement($image);
+    public function buildAstWhileStatement(string $image);
 
     /**
      * Builds a new do/while-statement node.
@@ -823,7 +813,7 @@ interface Builder extends IteratorAggregate
      * @return ASTDoWhileStatement
      * @since  0.9.12
      */
-    public function buildAstDoWhileStatement($image);
+    public function buildAstDoWhileStatement(string $image);
 
     /**
      * Builds a new declare-statement node.
@@ -876,7 +866,7 @@ interface Builder extends IteratorAggregate
      * @return ASTMemberPrimaryPrefix
      * @since  0.9.6
      */
-    public function buildAstMemberPrimaryPrefix($image);
+    public function buildAstMemberPrimaryPrefix(string $image);
 
     /**
      * Builds a new identifier node.
@@ -885,7 +875,7 @@ interface Builder extends IteratorAggregate
      * @return ASTIdentifier
      * @since  0.9.6
      */
-    public function buildAstIdentifier($image);
+    public function buildAstIdentifier(string $image);
 
     /**
      * Builds a new function postfix expression.
@@ -904,7 +894,7 @@ interface Builder extends IteratorAggregate
      * @return ASTFunctionPostfix
      * @since  0.9.6
      */
-    public function buildAstFunctionPostfix($image);
+    public function buildAstFunctionPostfix(string $image);
 
     /**
      * Builds a new method postfix expression.
@@ -923,7 +913,7 @@ interface Builder extends IteratorAggregate
      * @return ASTMethodPostfix
      * @since  0.9.6
      */
-    public function buildAstMethodPostfix($image);
+    public function buildAstMethodPostfix(string $image);
 
     /**
      * Builds a new constant postfix expression.
@@ -938,7 +928,7 @@ interface Builder extends IteratorAggregate
      * @return ASTConstantPostfix
      * @since  0.9.6
      */
-    public function buildAstConstantPostfix($image);
+    public function buildAstConstantPostfix(string $image);
 
     /**
      * Builds a new property postfix expression.
@@ -957,7 +947,7 @@ interface Builder extends IteratorAggregate
      * @return ASTPropertyPostfix
      * @since  0.9.6
      */
-    public function buildAstPropertyPostfix($image);
+    public function buildAstPropertyPostfix(string $image);
 
     /**
      * Builds a new full qualified class name postfix expression.
@@ -1040,11 +1030,10 @@ interface Builder extends IteratorAggregate
      * number_format(5623, thousands_separator: ' ')
      * </code>
      *
-     * @param string $name
      * @return ASTNamedArgument
      * @since  2.9.0
      */
-    public function buildAstNamedArgument($name, ASTNode $value);
+    public function buildAstNamedArgument(string $name, ASTNode $value);
 
     /**
      * Builds a new array type node.
@@ -1073,11 +1062,10 @@ interface Builder extends IteratorAggregate
     /**
      * Builds a new primitive type node.
      *
-     * @param string $image
      * @return ASTScalarType
      * @since  0.9.6
      */
-    public function buildAstScalarType($image);
+    public function buildAstScalarType(string $image);
 
     /**
      * Builds a new node for the union type.
@@ -1101,7 +1089,7 @@ interface Builder extends IteratorAggregate
      * @return ASTLiteral
      * @since  0.9.6
      */
-    public function buildAstLiteral($image);
+    public function buildAstLiteral(string $image);
 
     /**
      * Builds a new php string node.
@@ -1163,7 +1151,7 @@ interface Builder extends IteratorAggregate
      * @return ASTConstantDefinition
      * @since  0.9.6
      */
-    public function buildAstConstantDefinition($image);
+    public function buildAstConstantDefinition(string $image);
 
     /**
      * Builds a new constant declarator node.
@@ -1200,7 +1188,7 @@ interface Builder extends IteratorAggregate
      * @return ASTConstantDeclarator
      * @since  0.9.6
      */
-    public function buildAstConstantDeclarator($image);
+    public function buildAstConstantDeclarator(string $image);
 
     /**
      * Builds a new comment node instance.
@@ -1209,7 +1197,7 @@ interface Builder extends IteratorAggregate
      * @return ASTComment
      * @since  0.9.8
      */
-    public function buildAstComment($cdata);
+    public function buildAstComment(string $cdata);
 
     /**
      * Builds a new unary expression node instance.
@@ -1218,7 +1206,7 @@ interface Builder extends IteratorAggregate
      * @return ASTUnaryExpression
      * @since  0.9.11
      */
-    public function buildAstUnaryExpression($image);
+    public function buildAstUnaryExpression(string $image);
 
     /**
      * Builds a new cast-expression node instance.
@@ -1227,7 +1215,7 @@ interface Builder extends IteratorAggregate
      * @return ASTCastExpression
      * @since  0.10.0
      */
-    public function buildAstCastExpression($image);
+    public function buildAstCastExpression(string $image);
 
     /**
      * Builds a new postfix-expression node instance.
@@ -1236,7 +1224,7 @@ interface Builder extends IteratorAggregate
      * @return ASTPostfixExpression
      * @since  0.10.0
      */
-    public function buildAstPostfixExpression($image);
+    public function buildAstPostfixExpression(string $image);
 
     /**
      * Builds a new pre-increment-expression node instance.
@@ -1277,7 +1265,7 @@ interface Builder extends IteratorAggregate
      * @return ASTReturnStatement
      * @since  0.9.12
      */
-    public function buildAstReturnStatement($image);
+    public function buildAstReturnStatement(string $image);
 
     /**
      * Builds a new break-statement node instance.
@@ -1286,7 +1274,7 @@ interface Builder extends IteratorAggregate
      * @return ASTBreakStatement
      * @since  0.9.12
      */
-    public function buildAstBreakStatement($image);
+    public function buildAstBreakStatement(string $image);
 
     /**
      * Builds a new continue-statement node instance.
@@ -1295,7 +1283,7 @@ interface Builder extends IteratorAggregate
      * @return ASTContinueStatement
      * @since  0.9.12
      */
-    public function buildAstContinueStatement($image);
+    public function buildAstContinueStatement(string $image);
 
     /**
      * Builds a new scope-statement instance.
@@ -1312,7 +1300,7 @@ interface Builder extends IteratorAggregate
      * @return ASTTryStatement
      * @since  0.9.12
      */
-    public function buildAstTryStatement($image);
+    public function buildAstTryStatement(string $image);
 
     /**
      * Builds a new throw-statement instance.
@@ -1321,7 +1309,7 @@ interface Builder extends IteratorAggregate
      * @return ASTThrowStatement
      * @since  0.9.12
      */
-    public function buildAstThrowStatement($image);
+    public function buildAstThrowStatement(string $image);
 
     /**
      * Builds a new goto-statement instance.
@@ -1330,7 +1318,7 @@ interface Builder extends IteratorAggregate
      * @return ASTGotoStatement
      * @since  0.9.12
      */
-    public function buildAstGotoStatement($image);
+    public function buildAstGotoStatement(string $image);
 
     /**
      * Builds a new label-statement instance.
@@ -1339,7 +1327,7 @@ interface Builder extends IteratorAggregate
      * @return ASTLabelStatement
      * @since  0.9.12
      */
-    public function buildAstLabelStatement($image);
+    public function buildAstLabelStatement(string $image);
 
     /**
      * Builds a new global-statement instance.
@@ -1364,7 +1352,7 @@ interface Builder extends IteratorAggregate
      * @return ASTEchoStatement
      * @since  0.9.12
      */
-    public function buildAstEchoStatement($image);
+    public function buildAstEchoStatement(string $image);
 
     /**
      * Builds a new yield-statement instance.
@@ -1373,5 +1361,5 @@ interface Builder extends IteratorAggregate
      * @return ASTYieldStatement
      * @since  $version$
      */
-    public function buildAstYieldStatement($image);
+    public function buildAstYieldStatement(string $image);
 }

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -99,21 +99,19 @@ interface BuilderContext
      * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait($qualifiedName);
+    public function getTrait(string $qualifiedName);
 
     /**
      * Returns the class instance for the given qualified name.
      *
-     * @param string $qualifiedName
      * @return ASTClass|ASTEnum;
      */
-    public function getClass($qualifiedName);
+    public function getClass(string $qualifiedName);
 
     /**
      * Returns a class or an interface instance for the given qualified name.
      *
-     * @param string $qualifiedName
      * @return AbstractASTClassOrInterface
      */
-    public function getClassOrInterface($qualifiedName);
+    public function getClassOrInterface(string $qualifiedName);
 }

--- a/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContext.php
@@ -136,11 +136,10 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the trait instance for the given qualified name.
      *
-     * @param string $qualifiedName
      * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait($qualifiedName)
+    public function getTrait(string $qualifiedName)
     {
         return $this->getBuilder()->getTrait($qualifiedName);
     }
@@ -148,10 +147,9 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns the class instance for the given qualified name.
      *
-     * @param string $qualifiedName
      * @return ASTClass|ASTEnum
      */
-    public function getClass($qualifiedName)
+    public function getClass(string $qualifiedName)
     {
         return $this->getBuilder()->getClass($qualifiedName);
     }
@@ -159,10 +157,9 @@ class GlobalBuilderContext implements BuilderContext
     /**
      * Returns a class or an interface instance for the given qualified name.
      *
-     * @param string $qualifiedName
      * @return AbstractASTClassOrInterface
      */
-    public function getClassOrInterface($qualifiedName)
+    public function getClassOrInterface(string $qualifiedName)
     {
         return $this->getBuilder()->getClassOrInterface($qualifiedName);
     }

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -374,7 +374,7 @@ abstract class AbstractPHPParser
      * @param int $maxNestingLevel The maximum allowed nesting level.
      * @since 0.9.12
      */
-    public function setMaxNestingLevel($maxNestingLevel): void
+    public function setMaxNestingLevel(int $maxNestingLevel): void
     {
         $this->maxNestingLevel = $maxNestingLevel;
     }
@@ -405,11 +405,10 @@ abstract class AbstractPHPParser
     /**
      * Parses a scalar type hint or a callable type hint.
      *
-     * @param string $image
      * @return ASTType
      * @throws ParserException
      */
-    private function parseScalarOrCallableTypeHint($image)
+    private function parseScalarOrCallableTypeHint(string $image)
     {
         return match (strtolower($image)) {
             'int',
@@ -432,12 +431,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $tokenType
-     * @param int $modifiers
-     *
      * @return int
      */
-    private function getModifiersForConstantDefinition($tokenType, $modifiers)
+    private function getModifiersForConstantDefinition(int $tokenType, int $modifiers)
     {
         $allowed = State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE;
         $modifiers &= $allowed;
@@ -806,7 +802,7 @@ abstract class AbstractPHPParser
      * @param int $modifiers Optional default modifiers.
      * @param bool $echoing True if current statement is echoing (such as after <?=).
      */
-    private function reset($modifiers = 0, $echoing = false): void
+    private function reset(int $modifiers = 0, bool $echoing = false): void
     {
         $this->packageName = Builder::DEFAULT_NAMESPACE;
         $this->docComment = null;
@@ -818,11 +814,10 @@ abstract class AbstractPHPParser
      * Tests if the given token type is a reserved keyword in the supported PHP
      * version.
      *
-     * @param int $tokenType
      * @return bool
      * @since 1.1.1
      */
-    private function isKeyword($tokenType)
+    private function isKeyword(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_CLASS,
@@ -861,7 +856,7 @@ abstract class AbstractPHPParser
      * @return bool
      * @since 0.10.6
      */
-    private function isClassName($tokenType)
+    private function isClassName(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_DIR,
@@ -905,10 +900,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $tokenType
      * @return bool
      */
-    protected function isConstantName($tokenType)
+    protected function isConstantName(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_CALLABLE,
@@ -986,11 +980,10 @@ abstract class AbstractPHPParser
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @param int $tokenType
      * @return bool
      * @since 2.3
      */
-    protected function isFunctionName($tokenType)
+    protected function isFunctionName(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_STRING,
@@ -1020,10 +1013,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $tokenType
      * @return bool
      */
-    private function isMethodName($tokenType)
+    private function isMethodName(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_CLASS => true,
@@ -1425,11 +1417,10 @@ abstract class AbstractPHPParser
      * This method will parse a list of modifiers and a following property or
      * method.
      *
-     * @param int $modifiers
      * @return ASTNode
      * @since 0.9.6
      */
-    private function parseMethodOrFieldDeclaration($modifiers = 0)
+    private function parseMethodOrFieldDeclaration(int $modifiers = 0)
     {
         $this->tokenStack->push();
         $tokenType = $this->tokenizer->peek();
@@ -1505,12 +1496,10 @@ abstract class AbstractPHPParser
     /**
      * Override this in later PHPParserVersions as necessary
      *
-     * @param int $tokenType
-     * @param int $modifiers
      * @return AbstractASTNode
      * @throws UnexpectedTokenException
      */
-    private function parseUnknownDeclaration($tokenType, $modifiers)
+    private function parseUnknownDeclaration(int $tokenType, int $modifiers)
     {
         /**
          * Typed properties
@@ -2186,11 +2175,8 @@ abstract class AbstractPHPParser
 
     /**
      * Throws an exception if the given token is not a valid list unpacking opening token for current PHP level.
-     *
-     * @param int $tokenType
-     * @param Token $unexpectedToken
      */
-    private function ensureTokenIsListUnpackingOpening($tokenType, $unexpectedToken = null): void
+    private function ensureTokenIsListUnpackingOpening(int $tokenType, ?Token $unexpectedToken = null): void
     {
         if (!$this->isListUnpacking($tokenType)) {
             throw $this->getUnexpectedTokenException($unexpectedToken ?: $this->tokenizer->prevToken());
@@ -2344,11 +2330,10 @@ abstract class AbstractPHPParser
      * @template T of ASTExpression
      *
      * @param T $expr
-     * @param int $type
      * @return T
      * @since 0.9.12
      */
-    private function parseRequireOrIncludeExpression(ASTExpression $expr, $type): ASTExpression
+    private function parseRequireOrIncludeExpression(ASTExpression $expr, int $type): ASTExpression
     {
         $this->tokenStack->push();
 
@@ -2570,8 +2555,8 @@ abstract class AbstractPHPParser
     private function parseIndexExpression(
         ASTNode $node,
         ASTExpression $expr,
-        $open,
-        $close,
+        int $open,
+        int $close,
     ): AbstractASTNode {
         $this->consumeToken($open);
 
@@ -2789,10 +2774,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $tokenType
      * @return ASTClassOrInterfaceReference
      */
-    private function parseStandAloneExpressionTypeReference($tokenType)
+    private function parseStandAloneExpressionTypeReference(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_SELF => $this->parseSelfReference($this->consumeToken(Tokens::T_SELF)),
@@ -2803,11 +2787,10 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param bool $classRef
      * @return AbstractASTNode
      * @throws ParserException
      */
-    private function parseStandAloneExpressionType($classRef)
+    private function parseStandAloneExpressionType(bool $classRef)
     {
         // Peek next token and look for a static type identifier
         $this->consumeComments();
@@ -2832,11 +2815,10 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTNode
      *
      * @param T $expr
-     * @param bool $classRef
      * @return T
      * @throws ParserException
      */
-    private function parseExpressionTypeReference(ASTNode $expr, $classRef): AbstractASTNode
+    private function parseExpressionTypeReference(ASTNode $expr, bool $classRef): AbstractASTNode
     {
         $expr->addChild(
             $this->parseOptionalMemberPrimaryPrefix(
@@ -3032,7 +3014,7 @@ abstract class AbstractPHPParser
      * @return ASTClassOrInterfaceReference
      * @since 0.9.8
      */
-    private function parseClassOrInterfaceReference($classReference)
+    private function parseClassOrInterfaceReference(bool $classReference)
     {
         $this->tokenStack->push();
 
@@ -3070,8 +3052,6 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTNode
      *
      * @param T $node
-     * @param int $closeToken
-     * @param int|null $separatorToken
      * @return T
      * @throws TokenStreamEndException
      * @since 0.9.6
@@ -3079,8 +3059,8 @@ abstract class AbstractPHPParser
     private function parseBraceExpression(
         ASTNode $node,
         Token $start,
-        $closeToken,
-        $separatorToken = null,
+        int $closeToken,
+        ?int $separatorToken = null,
     ): AbstractASTNode {
         if (is_object($expr = $this->parseOptionalExpression())) {
             $node->addChild($expr);
@@ -3217,7 +3197,7 @@ abstract class AbstractPHPParser
      * @return bool
      * @since 0.10.0
      */
-    private function isAlternativeScopeTermination($tokenType)
+    private function isAlternativeScopeTermination(int $tokenType)
     {
         return in_array(
             $tokenType,
@@ -3239,7 +3219,7 @@ abstract class AbstractPHPParser
      * @param int $tokenType The token type identifier.
      * @since 0.10.0
      */
-    private function parseAlternativeScopeTermination($tokenType): void
+    private function parseAlternativeScopeTermination(int $tokenType): void
     {
         $this->consumeToken($tokenType);
         $this->consumeComments();
@@ -4376,11 +4356,10 @@ abstract class AbstractPHPParser
     /**
      * This methods return true if the token matches a list opening in the current PHP version level.
      *
-     * @param int $tokenType
      * @return bool
      * @since 2.6.0
      */
-    private function isListUnpacking($tokenType = null)
+    private function isListUnpacking(?int $tokenType = null)
     {
         return in_array($tokenType ?: $this->tokenizer->peek(), [Tokens::T_LIST, Tokens::T_SQUARED_BRACKET_OPEN], true);
     }
@@ -5695,11 +5674,10 @@ abstract class AbstractPHPParser
      * @template T of AbstractASTNode
      *
      * @param T $node The context parent node.
-     * @param bool $inCall
      * @return T The prepared entire node.
      * @since 0.9.12
      */
-    private function parseVariableList(ASTNode $node, $inCall = false): AbstractASTNode
+    private function parseVariableList(ASTNode $node, bool $inCall = false): AbstractASTNode
     {
         $this->consumeComments();
         while ($this->tokenizer->peek() !== Tokenizer::T_EOF) {
@@ -5938,11 +5916,10 @@ abstract class AbstractPHPParser
      * Parses a static identifier expression, as it is used for method and
      * function names.
      *
-     * @param int $tokenType
      * @return ASTIdentifier
      * @since 0.9.12
      */
-    private function parseIdentifier($tokenType = Tokens::T_STRING)
+    private function parseIdentifier(int $tokenType = Tokens::T_STRING)
     {
         $token = $this->consumeToken($tokenType);
 
@@ -6047,11 +6024,10 @@ abstract class AbstractPHPParser
     /**
      * Parses an array structure.
      *
-     * @param bool $static
      * @return ASTArray
      * @since 1.0.0
      */
-    private function doParseArray($static = false)
+    private function doParseArray(bool $static = false)
     {
         $this->tokenStack->push();
 
@@ -6084,11 +6060,10 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTArray
      * @param T $array
-     * @param bool $static
      * @return T
      * @since 1.0.0
      */
-    private function parseArray(ASTArray $array, $static = false): ASTArray
+    private function parseArray(ASTArray $array, bool $static = false): ASTArray
     {
         switch ($this->tokenizer->peek()) {
             case Tokens::T_SQUARED_BRACKET_OPEN:
@@ -6119,12 +6094,10 @@ abstract class AbstractPHPParser
      *
      * @template T of ASTArray
      * @param T $array
-     * @param int $endDelimiter
-     * @param bool $static
      * @return T
      * @since 1.0.0
      */
-    private function parseArrayElements(ASTArray $array, $endDelimiter, $static = false): ASTArray
+    private function parseArrayElements(ASTArray $array, int $endDelimiter, bool $static = false): ASTArray
     {
         $consecutiveComma = null;
         $openingToken = $this->tokenizer->prevToken();
@@ -6166,12 +6139,9 @@ abstract class AbstractPHPParser
      * Check if the given array/list is a value and so does not have consecutive commas in it,
      * or if it's a destructuring list and so check the syntax is valid in the current PHP level.
      *
-     * @param bool $useSquaredBrackets
-     * @param Token|null $openingToken
-     * @param Token|null $consecutiveComma
      * @throws UnexpectedTokenException
      */
-    private function ensureArrayIsValid($useSquaredBrackets, $openingToken, $consecutiveComma): void
+    private function ensureArrayIsValid(bool $useSquaredBrackets, ?Token $openingToken, ?Token $consecutiveComma): void
     {
         // If this array is followed by =, it's in fact a destructuring list
         if ($this->tokenizer->peekNext() === Tokens::T_EQUAL) {
@@ -6268,11 +6238,10 @@ abstract class AbstractPHPParser
      * An array element can have a simple value, a key/value pair, a value by
      * reference or a key/value pair with a referenced value.
      *
-     * @param bool $static
      * @return ASTArrayElement
      * @since 1.0.0
      */
-    private function parseArrayElement($static = false)
+    private function parseArrayElement(bool $static = false)
     {
         $this->consumeComments();
 
@@ -6337,7 +6306,7 @@ abstract class AbstractPHPParser
      * @return string
      * @since 0.9.10
      */
-    private function parseStringSequence($tokenType)
+    private function parseStringSequence(int $tokenType)
     {
         $type = $tokenType;
         $string = '';
@@ -6370,7 +6339,7 @@ abstract class AbstractPHPParser
      * @throws UnexpectedTokenException
      * @since 0.9.10
      */
-    private function parseString($delimiterType)
+    private function parseString(int $delimiterType)
     {
         $token = $this->consumeToken($delimiterType);
 
@@ -6402,11 +6371,10 @@ abstract class AbstractPHPParser
      *
      * @template T of AbstractASTNode
      * @param T $node
-     * @param int $stopToken
      * @return T
      * @since 0.9.12
      */
-    private function parseStringExpressions(AbstractASTNode $node, $stopToken): AbstractASTNode
+    private function parseStringExpressions(AbstractASTNode $node, int $stopToken): AbstractASTNode
     {
         while (($tokenType = $this->tokenizer->peek()) !== Tokenizer::T_EOF) {
             switch ($tokenType) {
@@ -6656,10 +6624,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $tokenType
      * @return ASTFormalParameter
      */
-    private function parseFormalParameterFromType($tokenType)
+    private function parseFormalParameterFromType(int $tokenType)
     {
         if ($this->isTypeHint($tokenType)) {
             $typeHint = $this->parseOptionalTypeHint();
@@ -7064,11 +7031,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param ASTType $firstType
-     *
      * @return ASTUnionType
      */
-    private function parseUnionTypeHint($firstType)
+    private function parseUnionTypeHint(ASTType $firstType)
     {
         $types = [$firstType];
 
@@ -7088,11 +7053,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param ASTType $firstType
-     *
      * @return ASTIntersectionType
      */
-    private function parseIntersectionTypeHint($firstType)
+    private function parseIntersectionTypeHint(ASTType $firstType)
     {
         $token = $this->tokenizer->currentToken();
         $types = [$firstType];
@@ -7119,11 +7082,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param ASTType $type
-     *
      * @return ASTType
      */
-    private function parseTypeHintCombination($type)
+    private function parseTypeHintCombination(ASTType $type)
     {
         $peek = $this->tokenizer->peek();
 
@@ -7141,11 +7102,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param ASTNode $type
-     *
      * @return bool
      */
-    protected function canNotBeStandAloneType($type)
+    protected function canNotBeStandAloneType(ASTNode $type)
     {
         return $type instanceof ASTScalarType && ($type->isFalse() || $type->isNull());
     }
@@ -7621,10 +7580,9 @@ abstract class AbstractPHPParser
     /**
      * Determines if the given image is a PHP 7 type hint.
      *
-     * @param string $image
      * @return bool
      */
-    protected function isScalarOrCallableTypeHint($image)
+    protected function isScalarOrCallableTypeHint(string $image)
     {
         return match (strtolower($image)) {
             'int',
@@ -8603,7 +8561,7 @@ abstract class AbstractPHPParser
      * @return bool
      * @since 0.10.0
      */
-    private function isReadWriteVariable($expr)
+    private function isReadWriteVariable(ASTNode $expr)
     {
         return $expr instanceof ASTVariable
             || $expr instanceof ASTFunctionPostfix
@@ -8621,7 +8579,7 @@ abstract class AbstractPHPParser
      * @param string $localName The local class or interface name.
      * @return string
      */
-    private function createQualifiedTypeName($localName)
+    private function createQualifiedTypeName(string $localName)
     {
         return ltrim($this->getNamespaceOrPackageName() . '\\' . $localName, '\\');
     }
@@ -8659,10 +8617,9 @@ abstract class AbstractPHPParser
     /**
      * Extracts the @package information from the given comment.
      *
-     * @param string $comment
      * @return string|null
      */
-    private function parsePackageAnnotation($comment)
+    private function parsePackageAnnotation(string $comment)
     {
         if (getenv('DISMISS_PACKAGES')) {
             $this->packageName = null;
@@ -8725,7 +8682,7 @@ abstract class AbstractPHPParser
      * @param string $comment The context doc comment block.
      * @return array<int, string>
      */
-    private function parseThrowsAnnotations($comment)
+    private function parseThrowsAnnotations(string $comment)
     {
         $throws = [];
 
@@ -8745,7 +8702,7 @@ abstract class AbstractPHPParser
      * @param string $comment A doc comment text.
      * @return string|null
      */
-    private function parseReturnAnnotation($comment)
+    private function parseReturnAnnotation(string $comment)
     {
         if (!preg_match(self::REGEXP_RETURN_TYPE, $comment, $match)) {
             return null;
@@ -8771,7 +8728,7 @@ abstract class AbstractPHPParser
      * @param string $comment A doc comment text.
      * @return array<string>
      */
-    private function parseVarAnnotation($comment)
+    private function parseVarAnnotation(string $comment)
     {
         if (preg_match(self::REGEXP_VAR_TYPE, (string) $comment, $match) > 0) {
             $useSymbolTable = $this->useSymbolTable;
@@ -8861,7 +8818,7 @@ abstract class AbstractPHPParser
      *                         an expression (false).
      * @return ASTYieldStatement
      */
-    private function parseYield($standalone)
+    private function parseYield(bool $standalone)
     {
         $this->tokenStack->push();
 
@@ -8939,7 +8896,7 @@ abstract class AbstractPHPParser
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      */
-    protected function consumeToken($tokenType)
+    protected function consumeToken(int $tokenType)
     {
         assert($tokenType > 0);
 
@@ -9111,13 +9068,11 @@ abstract class AbstractPHPParser
     /**
      * Peek the next token if it's of the given type, add it to current tokenStack, and return it if so.
      *
-     * @param int $type
-     *
      * @psalm-param Tokens::T_* $type
      *
      * @return Token|null
      */
-    private function addTokenToStackIfType($type)
+    private function addTokenToStackIfType(int $type)
     {
         if ($this->tokenizer->peek() === $type) {
             $next = $this->tokenizer->next();
@@ -9150,7 +9105,7 @@ abstract class AbstractPHPParser
      * @param string $numberRepresentation integer number as it appears in the code, `0xfe4`, `1_000_000`
      * @return int
      */
-    private function parseIntegerNumberImage($numberRepresentation)
+    private function parseIntegerNumberImage(string $numberRepresentation)
     {
         $numberRepresentation = trim($numberRepresentation);
 
@@ -9162,10 +9117,9 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param string $numberRepresentation
      * @return float|int|string
      */
-    private function getNumberFromImage($numberRepresentation)
+    private function getNumberFromImage(string $numberRepresentation)
     {
         $numberRepresentation = str_replace('_', '', $numberRepresentation);
 
@@ -9232,13 +9186,11 @@ abstract class AbstractPHPParser
     }
 
     /**
-     * @param int $type
-     *
      * @psalm-param Tokens::T_* $type
      *
      * @return string
      */
-    private function parseNumber($type)
+    private function parseNumber(int $type)
     {
         $token = $this->consumeToken($type);
         $number = (string) $token->image;

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -295,7 +295,7 @@ class PHPBuilder implements Builder
      * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstClassOrInterfaceReference($qualifiedName)
+    public function buildAstClassOrInterfaceReference(string $qualifiedName)
     {
         $this->checkBuilderState();
 
@@ -317,7 +317,7 @@ class PHPBuilder implements Builder
      * @return ASTClassOrInterfaceReference
      * @since  0.9.5
      */
-    public function buildAstNeededReference($qualifiedName, $classReference)
+    public function buildAstNeededReference(string $qualifiedName, bool $classReference)
     {
         if ($classReference) {
             return $this->buildAstClassReference($qualifiedName);
@@ -331,11 +331,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTClass}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return AbstractASTClassOrInterface
      * @since  0.9.5
      */
-    public function getClassOrInterface($qualifiedName)
+    public function getClassOrInterface(string $qualifiedName)
     {
         $classOrInterface = $this->findClass($qualifiedName);
         if ($classOrInterface !== null) {
@@ -357,7 +356,7 @@ class PHPBuilder implements Builder
      * @return ASTTrait
      * @since 1.0.0
      */
-    public function buildTrait($qualifiedName)
+    public function buildTrait(string $qualifiedName)
     {
         $this->checkBuilderState();
 
@@ -374,11 +373,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTTrait}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return ASTTrait
      * @since  1.0.0
      */
-    public function getTrait($qualifiedName)
+    public function getTrait(string $qualifiedName)
     {
         $trait = $this->findTrait($qualifiedName);
         if ($trait === null) {
@@ -395,7 +393,7 @@ class PHPBuilder implements Builder
      * @return ASTTraitReference
      * @since  1.0.0
      */
-    public function buildAstTraitReference($qualifiedName)
+    public function buildAstTraitReference(string $qualifiedName)
     {
         $this->checkBuilderState();
 
@@ -433,7 +431,7 @@ class PHPBuilder implements Builder
      * @param string $name The class name.
      * @return ASTClass The created class object.
      */
-    public function buildClass($name)
+    public function buildClass(string $name)
     {
         $this->checkBuilderState();
 
@@ -454,7 +452,7 @@ class PHPBuilder implements Builder
      * @return ASTClass|ASTEnum
      * @since  0.9.5
      */
-    public function getClass($qualifiedName)
+    public function getClass(string $qualifiedName)
     {
         return $this->findClass($qualifiedName)
             ?: $this->buildClassInternal($qualifiedName);
@@ -479,7 +477,7 @@ class PHPBuilder implements Builder
      * @return ASTClassReference
      * @since  0.9.5
      */
-    public function buildAstClassReference($qualifiedName)
+    public function buildAstClassReference(string $qualifiedName)
     {
         $this->checkBuilderState();
 
@@ -524,7 +522,7 @@ class PHPBuilder implements Builder
      * @param string $name The interface name.
      * @return ASTInterface
      */
-    public function buildInterface($name)
+    public function buildInterface(string $name)
     {
         $this->checkBuilderState();
 
@@ -541,11 +539,10 @@ class PHPBuilder implements Builder
      * qualified name. It will create a new {@link ASTInterface}
      * instance when no matching type exists.
      *
-     * @param string $qualifiedName
      * @return ASTInterface
      * @since  0.9.5
      */
-    public function getInterface($qualifiedName)
+    public function getInterface(string $qualifiedName)
     {
         $interface = $this->findInterface($qualifiedName);
         if ($interface === null) {
@@ -558,10 +555,9 @@ class PHPBuilder implements Builder
     /**
      * Builds a new method instance.
      *
-     * @param string $name
      * @return ASTMethod
      */
-    public function buildMethod($name)
+    public function buildMethod(string $name)
     {
         $this->checkBuilderState();
 
@@ -581,7 +577,7 @@ class PHPBuilder implements Builder
      * @param string $name The package name.
      * @return ASTNamespace
      */
-    public function buildNamespace($name)
+    public function buildNamespace(string $name)
     {
         if (!isset($this->namespaces[$name])) {
             // Debug package creation
@@ -601,7 +597,7 @@ class PHPBuilder implements Builder
      * @param string $name The function name.
      * @return ASTFunction
      */
-    public function buildFunction($name)
+    public function buildFunction(string $name)
     {
         $this->checkBuilderState();
 
@@ -678,7 +674,7 @@ class PHPBuilder implements Builder
      * @return ASTVariableDeclarator
      * @since  0.9.6
      */
-    public function buildAstVariableDeclarator($image)
+    public function buildAstVariableDeclarator(string $image)
     {
         return $this->buildAstNodeInstance(ASTVariableDeclarator::class, $image);
     }
@@ -690,7 +686,7 @@ class PHPBuilder implements Builder
      * @return ASTStaticVariableDeclaration
      * @since  0.9.6
      */
-    public function buildAstStaticVariableDeclaration($image)
+    public function buildAstStaticVariableDeclaration(string $image)
     {
         return $this->buildAstNodeInstance(ASTStaticVariableDeclaration::class, $image);
     }
@@ -702,7 +698,7 @@ class PHPBuilder implements Builder
      * @return ASTConstant
      * @since  0.9.6
      */
-    public function buildAstConstant($image)
+    public function buildAstConstant(string $image)
     {
         return $this->buildAstNodeInstance(ASTConstant::class, $image);
     }
@@ -714,7 +710,7 @@ class PHPBuilder implements Builder
      * @return ASTVariable
      * @since  0.9.6
      */
-    public function buildAstVariable($image)
+    public function buildAstVariable(string $image)
     {
         return $this->buildAstNodeInstance(ASTVariable::class, $image);
     }
@@ -726,7 +722,7 @@ class PHPBuilder implements Builder
      * @return ASTVariableVariable
      * @since  0.9.6
      */
-    public function buildAstVariableVariable($image)
+    public function buildAstVariableVariable(string $image)
     {
         return $this->buildAstNodeInstance(ASTVariableVariable::class, $image);
     }
@@ -738,7 +734,7 @@ class PHPBuilder implements Builder
      * @return ASTCompoundVariable
      * @since  0.9.6
      */
-    public function buildAstCompoundVariable($image)
+    public function buildAstCompoundVariable(string $image)
     {
         return $this->buildAstNodeInstance(ASTCompoundVariable::class, $image);
     }
@@ -790,11 +786,10 @@ class PHPBuilder implements Builder
     /**
      * Builds a new expression node.
      *
-     * @param string $image
      * @return ASTExpression
      * @since 0.9.8
      */
-    public function buildAstExpression($image = null)
+    public function buildAstExpression(?string $image = null)
     {
         return $this->buildAstNodeInstance(ASTExpression::class, $image);
     }
@@ -806,7 +801,7 @@ class PHPBuilder implements Builder
      * @return ASTAssignmentExpression
      * @since  0.9.8
      */
-    public function buildAstAssignmentExpression($image)
+    public function buildAstAssignmentExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTAssignmentExpression::class, $image);
     }
@@ -818,7 +813,7 @@ class PHPBuilder implements Builder
      * @return ASTAllocationExpression
      * @since  0.9.6
      */
-    public function buildAstAllocationExpression($image)
+    public function buildAstAllocationExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTAllocationExpression::class, $image);
     }
@@ -830,7 +825,7 @@ class PHPBuilder implements Builder
      * @return ASTEvalExpression
      * @since  0.9.12
      */
-    public function buildAstEvalExpression($image)
+    public function buildAstEvalExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTEvalExpression::class, $image);
     }
@@ -842,7 +837,7 @@ class PHPBuilder implements Builder
      * @return ASTExitExpression
      * @since  0.9.12
      */
-    public function buildAstExitExpression($image)
+    public function buildAstExitExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTExitExpression::class, $image);
     }
@@ -854,7 +849,7 @@ class PHPBuilder implements Builder
      * @return ASTCloneExpression
      * @since  0.9.12
      */
-    public function buildAstCloneExpression($image)
+    public function buildAstCloneExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTCloneExpression::class, $image);
     }
@@ -866,7 +861,7 @@ class PHPBuilder implements Builder
      * @return ASTListExpression
      * @since  0.9.12
      */
-    public function buildAstListExpression($image)
+    public function buildAstListExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTListExpression::class, $image);
     }
@@ -950,7 +945,7 @@ class PHPBuilder implements Builder
      * @return ASTInstanceOfExpression
      * @since  0.9.6
      */
-    public function buildAstInstanceOfExpression($image)
+    public function buildAstInstanceOfExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTInstanceOfExpression::class, $image);
     }
@@ -1118,7 +1113,7 @@ class PHPBuilder implements Builder
      * @return ASTTraitAdaptationAlias
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationAlias($image)
+    public function buildAstTraitAdaptationAlias(string $image)
     {
         return $this->buildAstNodeInstance(ASTTraitAdaptationAlias::class, $image);
     }
@@ -1130,7 +1125,7 @@ class PHPBuilder implements Builder
      * @return ASTTraitAdaptationPrecedence
      * @since  1.0.0
      */
-    public function buildAstTraitAdaptationPrecedence($image)
+    public function buildAstTraitAdaptationPrecedence(string $image)
     {
         return $this->buildAstNodeInstance(ASTTraitAdaptationPrecedence::class, $image);
     }
@@ -1153,7 +1148,7 @@ class PHPBuilder implements Builder
      * @return ASTSwitchLabel
      * @since  0.9.8
      */
-    public function buildAstSwitchLabel($image)
+    public function buildAstSwitchLabel(string $image)
     {
         return $this->buildAstNodeInstance(ASTSwitchLabel::class, $image);
     }
@@ -1183,11 +1178,10 @@ class PHPBuilder implements Builder
     /**
      * Builds a new catch-statement node.
      *
-     * @param string $image
      * @return ASTCatchStatement
      * @since  0.9.8
      */
-    public function buildAstCatchStatement($image)
+    public function buildAstCatchStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTCatchStatement::class, $image);
     }
@@ -1210,7 +1204,7 @@ class PHPBuilder implements Builder
      * @return ASTIfStatement
      * @since  0.9.8
      */
-    public function buildAstIfStatement($image)
+    public function buildAstIfStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTIfStatement::class, $image);
     }
@@ -1222,7 +1216,7 @@ class PHPBuilder implements Builder
      * @return ASTElseIfStatement
      * @since  0.9.8
      */
-    public function buildAstElseIfStatement($image)
+    public function buildAstElseIfStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTElseIfStatement::class, $image);
     }
@@ -1234,7 +1228,7 @@ class PHPBuilder implements Builder
      * @return ASTForStatement
      * @since  0.9.8
      */
-    public function buildAstForStatement($image)
+    public function buildAstForStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTForStatement::class, $image);
     }
@@ -1280,7 +1274,7 @@ class PHPBuilder implements Builder
      * @return ASTForeachStatement
      * @since  0.9.8
      */
-    public function buildAstForeachStatement($image)
+    public function buildAstForeachStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTForeachStatement::class, $image);
     }
@@ -1292,7 +1286,7 @@ class PHPBuilder implements Builder
      * @return ASTWhileStatement
      * @since  0.9.8
      */
-    public function buildAstWhileStatement($image)
+    public function buildAstWhileStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTWhileStatement::class, $image);
     }
@@ -1304,7 +1298,7 @@ class PHPBuilder implements Builder
      * @return ASTDoWhileStatement
      * @since  0.9.12
      */
-    public function buildAstDoWhileStatement($image)
+    public function buildAstDoWhileStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTDoWhileStatement::class, $image);
     }
@@ -1363,7 +1357,7 @@ class PHPBuilder implements Builder
      * @return ASTMemberPrimaryPrefix
      * @since  0.9.6
      */
-    public function buildAstMemberPrimaryPrefix($image)
+    public function buildAstMemberPrimaryPrefix(string $image)
     {
         return $this->buildAstNodeInstance(ASTMemberPrimaryPrefix::class, $image);
     }
@@ -1375,7 +1369,7 @@ class PHPBuilder implements Builder
      * @return ASTIdentifier
      * @since  0.9.6
      */
-    public function buildAstIdentifier($image)
+    public function buildAstIdentifier(string $image)
     {
         return $this->buildAstNodeInstance(ASTIdentifier::class, $image);
     }
@@ -1397,7 +1391,7 @@ class PHPBuilder implements Builder
      * @return ASTFunctionPostfix
      * @since  0.9.6
      */
-    public function buildAstFunctionPostfix($image)
+    public function buildAstFunctionPostfix(string $image)
     {
         return $this->buildAstNodeInstance(ASTFunctionPostfix::class, $image);
     }
@@ -1419,7 +1413,7 @@ class PHPBuilder implements Builder
      * @return ASTMethodPostfix
      * @since  0.9.6
      */
-    public function buildAstMethodPostfix($image)
+    public function buildAstMethodPostfix(string $image)
     {
         return $this->buildAstNodeInstance(ASTMethodPostfix::class, $image);
     }
@@ -1437,7 +1431,7 @@ class PHPBuilder implements Builder
      * @return ASTConstantPostfix
      * @since  0.9.6
      */
-    public function buildAstConstantPostfix($image)
+    public function buildAstConstantPostfix(string $image)
     {
         return $this->buildAstNodeInstance(ASTConstantPostfix::class, $image);
     }
@@ -1459,7 +1453,7 @@ class PHPBuilder implements Builder
      * @return ASTPropertyPostfix
      * @since  0.9.6
      */
-    public function buildAstPropertyPostfix($image)
+    public function buildAstPropertyPostfix(string $image)
     {
         return $this->buildAstNodeInstance(ASTPropertyPostfix::class, $image);
     }
@@ -1560,11 +1554,10 @@ class PHPBuilder implements Builder
      * number_format(5623, thousands_separator: ' ')
      * </code>
      *
-     * @param string $name
      * @return ASTNamedArgument
      * @since  2.9.0
      */
-    public function buildAstNamedArgument($name, ASTNode $value)
+    public function buildAstNamedArgument(string $name, ASTNode $value)
     {
         Log::debug("Creating: \\PDepend\\Source\\AST\\ASTNamedArgument($name)");
 
@@ -1611,7 +1604,7 @@ class PHPBuilder implements Builder
      * @return ASTScalarType
      * @since  0.9.6
      */
-    public function buildAstScalarType($image)
+    public function buildAstScalarType(string $image)
     {
         return $this->buildAstNodeInstance(ASTScalarType::class, $image);
     }
@@ -1644,7 +1637,7 @@ class PHPBuilder implements Builder
      * @return ASTLiteral
      * @since  0.9.6
      */
-    public function buildAstLiteral($image)
+    public function buildAstLiteral(string $image)
     {
         return $this->buildAstNodeInstance(ASTLiteral::class, $image);
     }
@@ -1699,7 +1692,7 @@ class PHPBuilder implements Builder
      * @return ASTConstantDefinition
      * @since  0.9.6
      */
-    public function buildAstConstantDefinition($image)
+    public function buildAstConstantDefinition(string $image)
     {
         return $this->buildAstNodeInstance(ASTConstantDefinition::class, $image);
     }
@@ -1739,7 +1732,7 @@ class PHPBuilder implements Builder
      * @return ASTConstantDeclarator
      * @since  0.9.6
      */
-    public function buildAstConstantDeclarator($image)
+    public function buildAstConstantDeclarator(string $image)
     {
         return $this->buildAstNodeInstance(ASTConstantDeclarator::class, $image);
     }
@@ -1751,7 +1744,7 @@ class PHPBuilder implements Builder
      * @return ASTComment
      * @since  0.9.8
      */
-    public function buildAstComment($cdata)
+    public function buildAstComment(string $cdata)
     {
         return $this->buildAstNodeInstance(ASTComment::class, $cdata);
     }
@@ -1763,7 +1756,7 @@ class PHPBuilder implements Builder
      * @return ASTUnaryExpression
      * @since  0.9.11
      */
-    public function buildAstUnaryExpression($image)
+    public function buildAstUnaryExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTUnaryExpression::class, $image);
     }
@@ -1775,7 +1768,7 @@ class PHPBuilder implements Builder
      * @return ASTCastExpression
      * @since  0.10.0
      */
-    public function buildAstCastExpression($image)
+    public function buildAstCastExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTCastExpression::class, $image);
     }
@@ -1787,7 +1780,7 @@ class PHPBuilder implements Builder
      * @return ASTPostfixExpression
      * @since  0.10.0
      */
-    public function buildAstPostfixExpression($image)
+    public function buildAstPostfixExpression(string $image)
     {
         return $this->buildAstNodeInstance(ASTPostfixExpression::class, $image);
     }
@@ -1843,7 +1836,7 @@ class PHPBuilder implements Builder
      * @return ASTReturnStatement
      * @since  0.9.12
      */
-    public function buildAstReturnStatement($image)
+    public function buildAstReturnStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTReturnStatement::class, $image);
     }
@@ -1855,7 +1848,7 @@ class PHPBuilder implements Builder
      * @return ASTBreakStatement
      * @since  0.9.12
      */
-    public function buildAstBreakStatement($image)
+    public function buildAstBreakStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTBreakStatement::class, $image);
     }
@@ -1867,7 +1860,7 @@ class PHPBuilder implements Builder
      * @return ASTContinueStatement
      * @since  0.9.12
      */
-    public function buildAstContinueStatement($image)
+    public function buildAstContinueStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTContinueStatement::class, $image);
     }
@@ -1890,7 +1883,7 @@ class PHPBuilder implements Builder
      * @return ASTTryStatement
      * @since  0.9.12
      */
-    public function buildAstTryStatement($image)
+    public function buildAstTryStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTTryStatement::class, $image);
     }
@@ -1902,7 +1895,7 @@ class PHPBuilder implements Builder
      * @return ASTThrowStatement
      * @since  0.9.12
      */
-    public function buildAstThrowStatement($image)
+    public function buildAstThrowStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTThrowStatement::class, $image);
     }
@@ -1914,7 +1907,7 @@ class PHPBuilder implements Builder
      * @return ASTGotoStatement
      * @since  0.9.12
      */
-    public function buildAstGotoStatement($image)
+    public function buildAstGotoStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTGotoStatement::class, $image);
     }
@@ -1926,7 +1919,7 @@ class PHPBuilder implements Builder
      * @return ASTLabelStatement
      * @since  0.9.12
      */
-    public function buildAstLabelStatement($image)
+    public function buildAstLabelStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTLabelStatement::class, $image);
     }
@@ -1938,7 +1931,7 @@ class PHPBuilder implements Builder
      * @return ASTEchoStatement
      * @since  0.9.12
      */
-    public function buildAstEchoStatement($image)
+    public function buildAstEchoStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTEchoStatement::class, $image);
     }
@@ -1950,7 +1943,7 @@ class PHPBuilder implements Builder
      * @return ASTYieldStatement
      * @since  $version$
      */
-    public function buildAstYieldStatement($image)
+    public function buildAstYieldStatement(string $image)
     {
         return $this->buildAstNodeInstance(ASTYieldStatement::class, $image);
     }
@@ -2028,11 +2021,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param string $qualifiedName
      * @return ASTTrait
      * @since  0.9.5
      */
-    protected function buildTraitInternal($qualifiedName)
+    protected function buildTraitInternal(string $qualifiedName)
     {
         $this->internal = true;
 
@@ -2051,11 +2043,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param string $qualifiedName
      * @return ASTTrait|null
      * @since  0.9.5
      */
-    protected function findTrait($qualifiedName)
+    protected function findTrait(string $qualifiedName)
     {
         $this->freeze();
 
@@ -2102,11 +2093,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param string $qualifiedName
      * @return ASTInterface
      * @since  0.9.5
      */
-    protected function buildInterfaceInternal($qualifiedName)
+    protected function buildInterfaceInternal(string $qualifiedName)
     {
         $this->internal = true;
 
@@ -2125,11 +2115,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param string $qualifiedName
      * @return ASTInterface|null
      * @since  0.9.5
      */
-    protected function findInterface($qualifiedName)
+    protected function findInterface(string $qualifiedName)
     {
         $this->freeze();
 
@@ -2173,11 +2162,10 @@ class PHPBuilder implements Builder
      *   <li>Create a new instance for the specified package.</li>
      * </ol>
      *
-     * @param string $qualifiedName
      * @return ASTClass
      * @since  0.9.5
      */
-    protected function buildClassInternal($qualifiedName)
+    protected function buildClassInternal(string $qualifiedName)
     {
         $this->internal = true;
 
@@ -2196,11 +2184,10 @@ class PHPBuilder implements Builder
      * qualified name in all scopes already processed. It will return the best
      * matching instance or <b>null</b> if no match exists.
      *
-     * @param string $qualifiedName
      * @return ASTClass|ASTEnum|null
      * @since  0.9.5
      */
-    protected function findClass($qualifiedName)
+    protected function findClass(string $qualifiedName)
     {
         $this->freeze();
 
@@ -2225,11 +2212,10 @@ class PHPBuilder implements Builder
      * @template T of AbstractASTType
      *
      * @param array<string, array<string, array<string, T>>> $instances
-     * @param string $qualifiedName
      * @return T|null
      * @since  0.9.5
      */
-    protected function findType(array $instances, $qualifiedName): ?AbstractASTType
+    protected function findType(array $instances, string $qualifiedName): ?AbstractASTType
     {
         $classOrInterfaceName = $this->extractTypeName($qualifiedName);
         $caseInsensitiveName = strtolower($classOrInterfaceName);
@@ -2380,7 +2366,7 @@ class PHPBuilder implements Builder
      * @param ?ASTScalarType $type The enum type ('string', 'int', or null if not backed).
      * @return ASTEnum The created class object.
      */
-    public function buildEnum($name, ?ASTScalarType $type = null)
+    public function buildEnum(string $name, ?ASTScalarType $type = null)
     {
         $this->checkBuilderState();
 
@@ -2399,7 +2385,7 @@ class PHPBuilder implements Builder
      * @param ?ASTNode $value The enum case value if backed.
      * @return ASTEnumCase The created class object.
      */
-    public function buildEnumCase($name, ?ASTNode $value = null)
+    public function buildEnumCase(string $name, ?ASTNode $value = null)
     {
         $this->checkBuilderState();
 
@@ -2419,7 +2405,7 @@ class PHPBuilder implements Builder
      * @param ?string $namespaceName
      * @since 1.0.0
      */
-    protected function storeTrait($traitName, $namespaceName, ASTTrait $trait): void
+    protected function storeTrait(?string $traitName, ?string $namespaceName, ASTTrait $trait): void
     {
         $traitName = strtolower($traitName ?? '');
         if (!isset($this->traits[$traitName][$namespaceName])) {
@@ -2438,7 +2424,7 @@ class PHPBuilder implements Builder
      * @param ?string $namespaceName
      * @since 0.9.5
      */
-    protected function storeClass($className, $namespaceName, ASTClass $class): void
+    protected function storeClass(?string $className, ?string $namespaceName, ASTClass $class): void
     {
         $className = strtolower($className ?? '');
         if (!isset($this->classes[$className][$namespaceName])) {
@@ -2457,7 +2443,7 @@ class PHPBuilder implements Builder
      * @param ?string $namespaceName
      * @since 2.11.0
      */
-    protected function storeEnum($enumName, $namespaceName, ASTEnum $enum): void
+    protected function storeEnum(?string $enumName, ?string $namespaceName, ASTEnum $enum): void
     {
         $enumName = strtolower($enumName ?? '');
         if (!isset($this->classes[$enumName][$namespaceName])) {
@@ -2476,7 +2462,7 @@ class PHPBuilder implements Builder
      * @param ?string $namespaceName
      * @since 0.9.5
      */
-    protected function storeInterface($interfaceName, $namespaceName, ASTInterface $interface): void
+    protected function storeInterface(?string $interfaceName, ?string $namespaceName, ASTInterface $interface): void
     {
         $interfaceName = strtolower($interfaceName ?? '');
         if (!isset($this->interfaces[$interfaceName][$namespaceName])) {
@@ -2496,7 +2482,7 @@ class PHPBuilder implements Builder
      * @throws BadMethodCallException
      * @since  0.9.5
      */
-    protected function checkBuilderState($internal = false): void
+    protected function checkBuilderState(bool $internal = false): void
     {
         if ($this->frozen && !$this->internal) {
             throw new BadMethodCallException(
@@ -2512,7 +2498,7 @@ class PHPBuilder implements Builder
      * @param string $namespaceName The package name.
      * @return bool
      */
-    protected function isDefault($namespaceName)
+    protected function isDefault(string $namespaceName)
     {
         return ($namespaceName === self::DEFAULT_NAMESPACE);
     }
@@ -2530,7 +2516,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The qualified PHP 5.3 type identifier.
      * @return string
      */
-    protected function extractTypeName($qualifiedName)
+    protected function extractTypeName(string $qualifiedName)
     {
         if (($pos = strrpos($qualifiedName, '\\')) !== false) {
             return substr($qualifiedName, $pos + 1);
@@ -2560,7 +2546,7 @@ class PHPBuilder implements Builder
      * @param string $qualifiedName The qualified PHP 5.3 class identifier.
      * @return string|null
      */
-    protected function extractNamespaceName($qualifiedName)
+    protected function extractNamespaceName(string $qualifiedName)
     {
         if (($pos = strrpos($qualifiedName, '\\')) !== false) {
             return ltrim(substr($qualifiedName, 0, $pos), '\\');
@@ -2582,7 +2568,7 @@ class PHPBuilder implements Builder
      * @return T
      * @since 0.9.12
      */
-    private function buildAstNodeInstance($className, $image = null): ASTNode
+    private function buildAstNodeInstance($className, ?string $image = null): ASTNode
     {
         Log::debug("Creating: {$className}({$image})");
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserGeneric.php
@@ -61,11 +61,10 @@ class PHPParserGeneric extends PHPParserVersion83
      * Tests if the give token is a valid function name in the supported PHP
      * version.
      *
-     * @param int $tokenType
      * @return bool
      * @since 2.3
      */
-    protected function isFunctionName($tokenType)
+    protected function isFunctionName(int $tokenType)
     {
         return match ($tokenType) {
             Tokens::T_CLONE,

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion82.php
@@ -80,10 +80,9 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
     /**
      * Tests if the given image is a PHP 8.2 type hint.
      *
-     * @param string $image
      * @return bool
      */
-    protected function isScalarOrCallableTypeHint($image)
+    protected function isScalarOrCallableTypeHint(string $image)
     {
         if (strtolower($image) === 'true') {
             return true;
@@ -136,10 +135,9 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
     }
 
     /**
-     * @param ASTNode $type
      * @return bool
      */
-    protected function canNotBeStandAloneType($type)
+    protected function canNotBeStandAloneType(ASTNode $type)
     {
         return false;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPParserVersion83.php
@@ -84,11 +84,10 @@ abstract class PHPParserVersion83 extends PHPParserVersion82
     }
 
     /**
-     * @param int $tokenType
      * @return bool
      * @since  2.16.3
      */
-    protected function isConstantName($tokenType)
+    protected function isConstantName(int $tokenType)
     {
         return parent::isConstantName($tokenType) || $tokenType === Tokens::T_BITWISE_OR;
     }

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -632,7 +632,7 @@ class PHPTokenizerInternal implements FullTokenizer
      *
      * @param string $sourceFile A php source file.
      */
-    public function setSourceFile($sourceFile): void
+    public function setSourceFile(string $sourceFile): void
     {
         unset($this->tokens);
         $this->sourceFile = new ASTCompilationUnit($sourceFile);
@@ -710,7 +710,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param int $shift positive or negative to apply to the current index.
      * @return int
      */
-    public function peekAt($shift)
+    public function peekAt(int $shift)
     {
         $this->tokenize();
 
@@ -776,7 +776,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param array{int, string, int} $token
      * @return array<int, array<int, int|string>>
      */
-    private function splitQualifiedNameToken($token)
+    private function splitQualifiedNameToken(array $token)
     {
         $result = [];
 
@@ -805,10 +805,9 @@ class PHPTokenizerInternal implements FullTokenizer
      * Split PHP 8 T_NAME_RELATIVE token into PHP 7 compatible tokens.
      *
      * @param array<int|string> $token
-     * @param string $namespace
      * @return array<int, array<int, int|string>>
      */
-    private function splitRelativeNameToken($token, $namespace)
+    private function splitRelativeNameToken(array $token, string $namespace)
     {
         $result = [
             [
@@ -1098,7 +1097,7 @@ class PHPTokenizerInternal implements FullTokenizer
      * @param string $token The unknown string token.
      * @return array{int, string}
      */
-    private function generateUnknownToken($token)
+    private function generateUnknownToken(string $token)
     {
         return [$this->unknownTokenID++, $token];
     }

--- a/src/main/php/PDepend/Source/Parser/InvalidStateException.php
+++ b/src/main/php/PDepend/Source/Parser/InvalidStateException.php
@@ -59,7 +59,7 @@ class InvalidStateException extends ParserException
      * @param string $fileName The source file where this exception occurred.
      * @param string $reason Short description what has happened.
      */
-    public function __construct($lineNumber, $fileName, $reason)
+    public function __construct(int $lineNumber, string $fileName, string $reason)
     {
         parent::__construct(
             sprintf(

--- a/src/main/php/PDepend/Source/Parser/SymbolTable.php
+++ b/src/main/php/PDepend/Source/Parser/SymbolTable.php
@@ -104,7 +104,7 @@ class SymbolTable
      * @param string $value A new scope value.
      * @throws NoActiveScopeException
      */
-    public function add($key, $value): void
+    public function add(string $key, string $value): void
     {
         $this->ensureActiveScopeExists();
         $this->scope[$this->normalizeKey($key)] = $value;
@@ -130,7 +130,7 @@ class SymbolTable
      * @return string|null
      * @throws NoActiveScopeException
      */
-    public function lookup($key)
+    public function lookup(string $key)
     {
         $this->ensureActiveScopeExists();
 
@@ -155,10 +155,9 @@ class SymbolTable
      * Normalizes the <code>$key</code>, so it's the same for
      * <code>add()</code> and <code>lookup()</code> operations.
      *
-     * @param string $key
      * @return string normalized key
      */
-    private function normalizeKey($key)
+    private function normalizeKey(string $key)
     {
         return strtolower($key);
     }

--- a/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
+++ b/src/main/php/PDepend/Source/Parser/UnexpectedTokenException.php
@@ -60,7 +60,7 @@ class UnexpectedTokenException extends TokenException
      * @param Token $token The last parsed token instance.
      * @param string $fileName The file where the exception occurred.
      */
-    public function __construct(Token $token, $fileName)
+    public function __construct(Token $token, string $fileName)
     {
         $exception = new Exception();
         $message = sprintf(

--- a/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/FullTokenizer.php
@@ -58,5 +58,5 @@ interface FullTokenizer extends Tokenizer
      * @param int $shift positive or negative to apply to the current index.
      * @return int
      */
-    public function peekAt($shift);
+    public function peekAt(int $shift);
 }

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -71,7 +71,7 @@ interface Tokenizer
      *
      * @param string $sourceFile A php source file.
      */
-    public function setSourceFile($sourceFile): void;
+    public function setSourceFile(string $sourceFile): void;
 
     /**
      * Returns the next token or {@link Tokenizer::T_EOF} if

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -526,7 +526,7 @@ class Command
      * @return int
      * @throws Exception
      */
-    protected function printAnalyzerOptions($length)
+    protected function printAnalyzerOptions(int $length)
     {
         $options = $this->application->getAvailableAnalyzerOptions();
 
@@ -557,7 +557,7 @@ class Command
      * @param string $message The option help message.
      * @param int $length The length of the longest option.
      */
-    private function printOption($option, $message, $length): void
+    private function printOption(string $option, string $message, int $length): void
     {
         // Ignore the phpunit xml option
         if (str_starts_with($option, '--phpunit-xml=')) {
@@ -585,7 +585,7 @@ class Command
      *
      * @param int $length Padding length for the option.
      */
-    private function printDbusOption($length): void
+    private function printDbusOption(int $length): void
     {
         if (!extension_loaded('dbus')) {
             return;
@@ -609,10 +609,7 @@ class Command
         return $command->run();
     }
 
-    /**
-     * @param int $startTime
-     */
-    private function printStatistics($startTime): void
+    private function printStatistics(int $startTime): void
     {
         $duration = time() - $startTime;
         $hours = (int) ($duration / 3600);
@@ -627,10 +624,9 @@ class Command
     }
 
     /**
-     * @param Exception|Throwable $exception
      * @return string
      */
-    private function getErrorTrace($exception)
+    private function getErrorTrace(Exception|Throwable $exception)
     {
         return $exception::class . '(' . $exception->getMessage() . ')' . PHP_EOL .
             '## ' . $exception->getFile() . '(' . $exception->getLine() . ')' . PHP_EOL .

--- a/src/main/php/PDepend/TextUI/ResultPrinter.php
+++ b/src/main/php/PDepend/TextUI/ResultPrinter.php
@@ -165,10 +165,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
 
     /**
      * Prints a single dot for the current step.
-     *
-     * @param int $size
      */
-    protected function step($size = 1): void
+    protected function step(int $size = 1): void
     {
         if ($this->count > 0 && $this->count % $size === 0) {
             echo '.';
@@ -181,10 +179,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
 
     /**
      * Closes the current dot line.
-     *
-     * @param int $size
      */
-    protected function finish($size = 1): void
+    protected function finish(int $size = 1): void
     {
         $diff = ($this->count % ($size * 60));
 

--- a/src/main/php/PDepend/TextUI/Runner.php
+++ b/src/main/php/PDepend/TextUI/Runner.php
@@ -188,11 +188,8 @@ class Runner
 
     /**
      * Adds a logger to this runner.
-     *
-     * @param string $generatorId
-     * @param string $reportFile
      */
-    public function addReportGenerator($generatorId, $reportFile): void
+    public function addReportGenerator(string $generatorId, string $reportFile): void
     {
         $this->loggerMap[$generatorId] = $reportFile;
     }
@@ -200,10 +197,9 @@ class Runner
     /**
      * Adds a logger or analyzer option.
      *
-     * @param string $identifier
      * @param array<int, string>|string $value
      */
-    public function addOption($identifier, $value): void
+    public function addOption(string $identifier, array|string $value): void
     {
         $this->options[$identifier] = $value;
     }

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -64,10 +64,9 @@ interface CacheDriver
      * you must invoke right before every call to <em>restore()</em> or
      * <em>store()</em>.
      *
-     * @param string $type
      * @return $this
      */
-    public function type($type);
+    public function type(string $type);
 
     /**
      * This method will store the given <em>$data</em> under <em>$key</em>. This
@@ -80,7 +79,7 @@ interface CacheDriver
      * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
-    public function store($key, $data, $hash = null): void;
+    public function store(string $key, mixed $data, ?string $hash = null): void;
 
     /**
      * This method tries to restore an existing cache entry for the given
@@ -92,7 +91,7 @@ interface CacheDriver
      * @param string $key The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
      */
-    public function restore($key, $hash = null): mixed;
+    public function restore(string $key, ?string $hash = null): mixed;
 
     /**
      * This method will remove an existing cache entry for the given identifier.
@@ -102,5 +101,5 @@ interface CacheDriver
      *
      * @param string $pattern The cache key pattern.
      */
-    public function remove($pattern): void;
+    public function remove(string $pattern): void;
 }

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -90,7 +90,7 @@ class CacheFactory
      * @throws RandomException
      * @throws RuntimeException
      */
-    public function create($cacheKey = null)
+    public function create(?string $cacheKey = null)
     {
         if (false === isset($this->caches[$cacheKey])) {
             $this->caches[$cacheKey] = $this->createCache($cacheKey);
@@ -108,7 +108,7 @@ class CacheFactory
      * @throws RandomException
      * @throws RuntimeException
      */
-    protected function createCache($cacheKey = null)
+    protected function createCache(?string $cacheKey = null)
     {
         assert($this->configuration->cache instanceof stdClass);
 
@@ -134,7 +134,7 @@ class CacheFactory
      * @return FileCacheDriver
      * @throws RuntimeException
      */
-    protected function createFileCache($location, $ttl = self::DEFAULT_TTL, $cacheKey = null)
+    protected function createFileCache(string $location, int $ttl = self::DEFAULT_TTL, ?string $cacheKey = null)
     {
         return new FileCacheDriver($location, $ttl, $cacheKey);
     }

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -70,7 +70,7 @@ class FileCacheDirectory
      * @param string $cacheDir The cache root directory.
      * @throws RuntimeException
      */
-    public function __construct($cacheDir)
+    public function __construct(string $cacheDir)
     {
         $this->cacheDir = $this->ensureExists($cacheDir);
 
@@ -86,7 +86,7 @@ class FileCacheDirectory
      * @param string $key The cache for an entry.
      * @return string
      */
-    public function createCacheDirectory($key)
+    public function createCacheDirectory(string $key)
     {
         return $this->createOrReturnCacheDirectory($key);
     }
@@ -99,7 +99,7 @@ class FileCacheDirectory
      * @param string $key The cache for an entry.
      * @return string
      */
-    protected function createOrReturnCacheDirectory($key)
+    protected function createOrReturnCacheDirectory(string $key)
     {
         $path = $this->getCacheDir() . '/' . substr($key, 0, 2);
         if (false === file_exists($path)) {
@@ -115,7 +115,7 @@ class FileCacheDirectory
      * @param string $cacheDir The cache root directory.
      * @return string
      */
-    protected function ensureExists($cacheDir)
+    protected function ensureExists(string $cacheDir)
     {
         if (false === file_exists($cacheDir)) {
             @mkdir($cacheDir, 0o775, true);
@@ -196,7 +196,7 @@ class FileCacheDirectory
      * @param string $cacheDir A cache directory.
      * @throws RuntimeException
      */
-    protected function flushDirectory($cacheDir): void
+    protected function flushDirectory(string $cacheDir): void
     {
         foreach (new DirectoryIterator($cacheDir) as $child) {
             $this->flushEntry($child);

--- a/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/FileCacheDriver.php
@@ -86,8 +86,8 @@ class FileCacheDriver implements CacheDriver
      * @throws RuntimeException
      */
     public function __construct(
-        $root,
-        $ttl = self::DEFAULT_TTL,
+        string $root,
+        int $ttl = self::DEFAULT_TTL,
         private readonly ?string $cacheKey = null
     ) {
         $this->directory = new FileCacheDirectory($root);
@@ -107,7 +107,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $type The name or object type for the next storage method call.
      * @return $this
      */
-    public function type($type): self
+    public function type(string $type): self
     {
         $this->type = $type;
 
@@ -125,7 +125,7 @@ class FileCacheDriver implements CacheDriver
      * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
-    public function store($key, $data, $hash = null): void
+    public function store(string $key, mixed $data, ?string $hash = null): void
     {
         $file = $this->getCacheFile($key);
         $this->write($file, serialize(['hash' => $hash, 'data' => $data]));
@@ -137,7 +137,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $file The cache file name.
      * @param string $data Serialized cache data.
      */
-    protected function write($file, $data): void
+    protected function write(string $file, string $data): void
     {
         $handle = fopen($file, 'wb');
         if (!$handle) {
@@ -159,7 +159,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $key The cache key for the given data.
      * @param ?string $hash Optional hash that will be used for verification.
      */
-    public function restore($key, $hash = null): mixed
+    public function restore(string $key, ?string $hash = null): mixed
     {
         $file = $this->getCacheFile($key);
         if (file_exists($file)) {
@@ -177,7 +177,7 @@ class FileCacheDriver implements CacheDriver
      * @param string  $file The cache file name.
      * @param ?string $hash The verification hash.
      */
-    protected function restoreFile($file, $hash): mixed
+    protected function restoreFile(string $file, ?string $hash): mixed
     {
         // unserialize() throws E_NOTICE when data is corrupt
         /** @var array{hash: ?string, data: mixed} */
@@ -195,7 +195,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $file The cache file name.
      * @return string
      */
-    protected function read($file)
+    protected function read(string $file)
     {
         $handle = fopen($file, 'rb');
         if (!$handle) {
@@ -223,7 +223,7 @@ class FileCacheDriver implements CacheDriver
      *
      * @param string $pattern The cache key pattern.
      */
-    public function remove($pattern): void
+    public function remove(string $pattern): void
     {
         $file = $this->getCacheFileWithoutExtension($pattern);
         $glob = glob("{$file}*.*") ?: [];
@@ -241,7 +241,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $key The cache key for the given data.
      * @return string
      */
-    protected function getCacheFile($key)
+    protected function getCacheFile(string $key)
     {
         $cacheFile = $this->getCacheFileWithoutExtension($key) .
                      '.' . $this->version .
@@ -261,7 +261,7 @@ class FileCacheDriver implements CacheDriver
      * @param string $key The cache key for the given data.
      * @return string
      */
-    protected function getCacheFileWithoutExtension($key)
+    protected function getCacheFileWithoutExtension(string $key)
     {
         if (is_string($this->cacheKey)) {
             $key = md5($key . $this->cacheKey);
@@ -274,11 +274,8 @@ class FileCacheDriver implements CacheDriver
 
     /**
      * Cleans old cache files.
-     *
-     * @param string $root
-     * @param int $ttl
      */
-    protected function garbageCollect($root, $ttl): void
+    protected function garbageCollect(string $root, int $ttl): void
     {
         $garbageCollector = new FileCacheGarbageCollector($root, $ttl);
         $garbageCollector->garbageCollect();

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -126,7 +126,7 @@ class MemoryCacheDriver implements CacheDriver
      * @param string $type The name or object type for the next storage method call.
      * @return $this
      */
-    public function type($type): self
+    public function type(string $type): self
     {
         $this->type = $type;
 
@@ -144,7 +144,7 @@ class MemoryCacheDriver implements CacheDriver
      * @param mixed $data Any data that should be cached.
      * @param string $hash Optional hash that will be used for verification.
      */
-    public function store($key, $data, $hash = null): void
+    public function store(string $key, mixed $data, ?string $hash = null): void
     {
         $this->cache[$this->getCacheKey($key)] = [$hash, $data];
     }
@@ -159,7 +159,7 @@ class MemoryCacheDriver implements CacheDriver
      * @param string $key The cache key for the given data.
      * @param string $hash Optional hash that will be used for verification.
      */
-    public function restore($key, $hash = null): mixed
+    public function restore(string $key, ?string $hash = null): mixed
     {
         $cacheKey = $this->getCacheKey($key);
         if (isset($this->cache[$cacheKey]) && $this->cache[$cacheKey][0] === $hash) {
@@ -177,7 +177,7 @@ class MemoryCacheDriver implements CacheDriver
      *
      * @param string $pattern The cache key pattern.
      */
-    public function remove($pattern): void
+    public function remove(string $pattern): void
     {
         foreach (array_keys($this->cache) as $key) {
             if (str_starts_with($key, $pattern)) {
@@ -194,7 +194,7 @@ class MemoryCacheDriver implements CacheDriver
      * @param string $key The concrete object key.
      * @return string
      */
-    protected function getCacheKey($key)
+    protected function getCacheKey(string $key)
     {
         $type = $this->type;
         $this->type = self::ENTRY_TYPE;

--- a/src/main/php/PDepend/Util/Configuration.php
+++ b/src/main/php/PDepend/Util/Configuration.php
@@ -77,7 +77,7 @@ class Configuration
      * @throws OutOfRangeException If no matching configuration value exists.
      * @since  0.10.0
      */
-    public function __get($name): mixed
+    public function __get(string $name): mixed
     {
         if (isset($this->settings->{$name})) {
             return $this->settings->{$name};
@@ -99,7 +99,7 @@ class Configuration
      * @throws OutOfRangeException Whenever this method is called.
      * @since  0.10.0
      */
-    public function __set($name, $value): void
+    public function __set(string $name, mixed $value): void
     {
         throw new OutOfRangeException(
             sprintf("A configuration option '%s' not exists.", $name),
@@ -116,7 +116,7 @@ class Configuration
      * @return bool
      * @since  0.10.0
      */
-    public function __isset($name)
+    public function __isset(string $name)
     {
         return isset($this->settings->{$name});
     }

--- a/src/main/php/PDepend/Util/Coverage/CloverReport.php
+++ b/src/main/php/PDepend/Util/Coverage/CloverReport.php
@@ -141,7 +141,7 @@ class CloverReport implements Report
      * @param string $fileName The source file name.
      * @return array<bool>
      */
-    private function getLines($fileName)
+    private function getLines(string $fileName)
     {
         return $this->fileLineCoverage[$fileName] ?? [];
     }

--- a/src/main/php/PDepend/Util/Coverage/Factory.php
+++ b/src/main/php/PDepend/Util/Coverage/Factory.php
@@ -64,7 +64,7 @@ class Factory
      * @throws RuntimeException When the given path name does not point to a
      *                          valid coverage file or onto an unsupported coverage format.
      */
-    public function create($pathName)
+    public function create(string $pathName)
     {
         $sxml = $this->loadXml($pathName);
         if (isset($sxml->project)) {
@@ -83,7 +83,7 @@ class Factory
      * @throws RuntimeException When the given path name does not point to a
      *                          valid xml file.
      */
-    private function loadXml($pathName)
+    private function loadXml(string $pathName)
     {
         $mode = libxml_use_internal_errors(true);
         $sxml = simplexml_load_file($pathName);

--- a/src/main/php/PDepend/Util/IdBuilder.php
+++ b/src/main/php/PDepend/Util/IdBuilder.php
@@ -102,7 +102,7 @@ class IdBuilder
      * @param string $prefix The item type identifier.
      * @return string
      */
-    protected function forOffsetItem(AbstractASTArtifact $artifact, $prefix)
+    protected function forOffsetItem(AbstractASTArtifact $artifact, string $prefix)
     {
         $fileHash = $artifact->getCompilationUnit()?->getId() ?? 'default';
         $itemHash = $this->hash($prefix . ':' . strtolower($artifact->getImage()));
@@ -135,7 +135,7 @@ class IdBuilder
      * @param string $string The raw input identifier/string.
      * @return string
      */
-    protected function hash($string)
+    protected function hash(string $string)
     {
         return substr(base_convert(md5($string), 16, 36), 0, 11);
     }
@@ -148,7 +148,7 @@ class IdBuilder
      * @param string $string The node identifier.
      * @return string
      */
-    protected function getOffsetInFile($file, $string)
+    protected function getOffsetInFile(string $file, string $string)
     {
         if (isset($this->offsetInFile[$file][$string])) {
             $this->offsetInFile[$file][$string]++;

--- a/src/main/php/PDepend/Util/ImageConvert.php
+++ b/src/main/php/PDepend/Util/ImageConvert.php
@@ -66,7 +66,7 @@ class ImageConvert
      * @throws ImagickException
      * @throws InvalidArgumentException
      */
-    public static function convert($input, $output): void
+    public static function convert(string $input, string $output): void
     {
         $inputType = strtolower(pathinfo($input, PATHINFO_EXTENSION));
         $outputType = strtolower(pathinfo($output, PATHINFO_EXTENSION));
@@ -144,7 +144,7 @@ class ImageConvert
      * @param string $input The input svg file.
      * @throws InvalidArgumentException
      */
-    protected static function prepareSvg($input): void
+    protected static function prepareSvg(string $input): void
     {
         // Check for a configuration instance
         if (($config = ConfigurationInstance::get()) === null) {

--- a/src/main/php/PDepend/Util/Log.php
+++ b/src/main/php/PDepend/Util/Log.php
@@ -70,7 +70,7 @@ final class Log
      *
      * @param int $severity The log severity levels.
      */
-    public static function setSeverity($severity): void
+    public static function setSeverity(int $severity): void
     {
         self::$debug = ((self::DEBUG & $severity) === $severity);
     }
@@ -80,7 +80,7 @@ final class Log
      *
      * @param string $message The debug log message.
      */
-    public static function debug($message): void
+    public static function debug(string $message): void
     {
         if (self::$debug) {
             self::log($message);
@@ -92,7 +92,7 @@ final class Log
      *
      * @param string $message The log message.
      */
-    public static function log($message): void
+    public static function log(string $message): void
     {
         fwrite(self::$stream, PHP_EOL . $message);
     }

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -77,7 +77,7 @@ final class MathUtil
      * @param string $right The right arithmetic operand.
      * @return numeric-string
      */
-    public static function add($left, $right)
+    public static function add(string $left, string $right)
     {
         if (function_exists('bcadd')) {
             return bcadd($left, $right);

--- a/src/main/php/PDepend/Util/Type.php
+++ b/src/main/php/PDepend/Util/Type.php
@@ -236,7 +236,7 @@ final class Type
      * @return bool
      * @throws ReflectionException
      */
-    public static function isInternalType($typeName)
+    public static function isInternalType(string $typeName)
     {
         self::initTypeToExtension();
 
@@ -254,7 +254,7 @@ final class Type
      * @return string|null
      * @throws ReflectionException
      */
-    public static function getTypePackage($typeName)
+    public static function getTypePackage(string $typeName)
     {
         self::initTypeToExtension();
 
@@ -290,7 +290,7 @@ final class Type
      * @return bool
      * @throws ReflectionException
      */
-    public static function isInternalPackage($packageName)
+    public static function isInternalPackage(string $packageName)
     {
         $packageNames = self::getInternalNamespaces();
 
@@ -304,7 +304,7 @@ final class Type
      * @param string $image The type identifier.
      * @return bool
      */
-    public static function isScalarType($image)
+    public static function isScalarType(string $image)
     {
         $image = strtolower($image);
         if (isset(self::$scalarTypes[$image])) {
@@ -326,7 +326,7 @@ final class Type
      * @return bool
      * @since  0.9.6
      */
-    public static function isPrimitiveType($image)
+    public static function isPrimitiveType(string $image)
     {
         return (self::getPrimitiveType($image) !== null);
     }
@@ -339,7 +339,7 @@ final class Type
      * @return string|null
      * @since  0.9.6
      */
-    public static function getPrimitiveType($image)
+    public static function getPrimitiveType(string $image)
     {
         $image = strtolower($image);
         if (isset(self::$primitiveTypes[$image])) {
@@ -362,7 +362,7 @@ final class Type
      * @return bool
      * @since  0.9.6
      */
-    public static function isArrayType($image)
+    public static function isArrayType(string $image)
     {
         return (strtolower($image) === 'array');
     }

--- a/src/main/php/PDepend/Util/Utf8Util.php
+++ b/src/main/php/PDepend/Util/Utf8Util.php
@@ -55,10 +55,9 @@ namespace PDepend\Util;
 final class Utf8Util
 {
     /**
-     * @param string $raw
      * @return string
      */
-    public static function ensureEncoding($raw)
+    public static function ensureEncoding(string $raw)
     {
         if (mb_check_encoding($raw, 'UTF-8')) {
             return $raw;

--- a/src/test/php/PDepend/AbstractTestCase.php
+++ b/src/test/php/PDepend/AbstractTestCase.php
@@ -136,7 +136,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $directory Optional working directory.
      * @since 0.10.0
      */
-    protected function changeWorkingDirectory($directory = null): void
+    protected function changeWorkingDirectory(?string $directory = null): void
     {
         if (null === $directory) {
             $directory = $this->getTestWorkingDirectory();
@@ -181,7 +181,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $nodeType The searched node class.
      * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInFunction($nodeType)
+    protected function getFirstNodeOfTypeInFunction(string $nodeType)
     {
         return $this->getFirstFunctionForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -240,7 +240,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTNode
      * @since 1.0.0
      */
-    protected function getFirstNodeOfTypeInTrait($nodeType)
+    protected function getFirstNodeOfTypeInTrait(string $nodeType)
     {
         return $this->getFirstTraitForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -252,7 +252,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $nodeType The searched node class.
      * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInClass($nodeType)
+    protected function getFirstNodeOfTypeInClass(string $nodeType)
     {
         return $this->getFirstClassForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -264,7 +264,7 @@ abstract class AbstractTestCase extends TestCase
      * @param string $nodeType The searched node class.
      * @return ASTNode
      */
-    protected function getFirstNodeOfTypeInInterface($nodeType)
+    protected function getFirstNodeOfTypeInInterface(string $nodeType)
     {
         return $this->getFirstInterfaceForTestCase()
             ->getFirstChildOfType($nodeType);
@@ -437,7 +437,7 @@ abstract class AbstractTestCase extends TestCase
      * @param ASTNode $node The root node.
      * @param array $graph Expected class structure.
      */
-    protected static function assertGraph(ASTNode $node, $graph): void
+    protected static function assertGraph(ASTNode $node, array $graph): void
     {
         $actual = self::collectGraph($node);
         static::assertEquals($graph, $actual);
@@ -450,7 +450,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTProperty
      * @since 0.10.0
      */
-    protected function getMockWithoutConstructor($className)
+    protected function getMockWithoutConstructor(string $className)
     {
         $mock = $this->getMockBuilder($className)
             ->onlyMethods(['__construct'])
@@ -462,10 +462,8 @@ abstract class AbstractTestCase extends TestCase
 
     /**
      * Clears all temporary resources.
-     *
-     * @param string $dir
      */
-    private function clearRunResources($dir = null): void
+    private function clearRunResources(?string $dir = null): void
     {
         if ($dir === null) {
             $dir = __DIR__ . '/_run';
@@ -532,10 +530,9 @@ abstract class AbstractTestCase extends TestCase
     }
 
     /**
-     * @param TextUI\Runner $runner
      * @return int
      */
-    protected function silentRun($runner)
+    protected function silentRun(TextUI\Runner $runner)
     {
         $error = null;
 
@@ -563,7 +560,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTClass
      * @since 1.0.2
      */
-    protected function createClassFixture($name = null)
+    protected function createClassFixture(?string $name = null)
     {
         $name = $name ?: static::class;
 
@@ -584,7 +581,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTInterface
      * @since 1.0.2
      */
-    protected function createInterfaceFixture($name = null)
+    protected function createInterfaceFixture(?string $name = null)
     {
         $name = $name ?: static::class;
 
@@ -602,7 +599,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTTrait
      * @since 1.0.2
      */
-    protected function createTraitFixture($name = null)
+    protected function createTraitFixture(?string $name = null)
     {
         $name = $name ?: static::class;
 
@@ -619,7 +616,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTFunction
      * @since 1.0.2
      */
-    protected function createFunctionFixture($name = null)
+    protected function createFunctionFixture(?string $name = null)
     {
         $name = $name ?: static::class;
 
@@ -638,7 +635,7 @@ abstract class AbstractTestCase extends TestCase
      * @return ASTMethod
      * @since 1.0.2
      */
-    protected function createMethodFixture($name = null)
+    protected function createMethodFixture(?string $name = null)
     {
         $name = $name ?: static::class;
 
@@ -652,10 +649,9 @@ abstract class AbstractTestCase extends TestCase
     /**
      * Creates a temporary resource for the given file name.
      *
-     * @param string $fileName
      * @return string
      */
-    protected function createRunResourceURI($fileName = null)
+    protected function createRunResourceURI(?string $fileName = null)
     {
         return tempnam(sys_get_temp_dir(), $fileName ?: uniqid());
     }
@@ -667,7 +663,7 @@ abstract class AbstractTestCase extends TestCase
      * @return string
      * @throws ErrorException
      */
-    protected static function createCodeResourceURI($fileName)
+    protected static function createCodeResourceURI(string $fileName)
     {
         $uri = realpath(__DIR__ . '/../../resources/files') . DIRECTORY_SEPARATOR . $fileName;
 
@@ -753,7 +749,7 @@ abstract class AbstractTestCase extends TestCase
      *
      * @param string $className Name of the missing class.
      */
-    public static function autoload($className): void
+    public static function autoload(string $className): void
     {
         $file = strtr($className, '\\', DIRECTORY_SEPARATOR) . '.php';
         if (is_file(__DIR__ . '/../../../main/php/PDepend/Engine.php')) {
@@ -770,7 +766,7 @@ abstract class AbstractTestCase extends TestCase
      * @param bool $ignoreAnnotations The parser should ignore annotations.
      * @return ASTArtifactList<ASTNamespace>
      */
-    protected function parseCodeResourceForTest($ignoreAnnotations = false)
+    protected function parseCodeResourceForTest(bool $ignoreAnnotations = false)
     {
         return $this->parseSource(
             $this->createCodeResourceUriForTest(),
@@ -782,11 +778,9 @@ abstract class AbstractTestCase extends TestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
 
@@ -806,11 +800,9 @@ abstract class AbstractTestCase extends TestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $fileOrDirectory
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseSource($fileOrDirectory, $ignoreAnnotations = false)
+    public function parseSource(string $fileOrDirectory, bool $ignoreAnnotations = false)
     {
         if (file_exists($fileOrDirectory) === false) {
             $fileOrDirectory = self::createCodeResourceURI($fileOrDirectory);

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -85,11 +85,9 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
     /**
      * Parses the source of a test case file.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         return $this->parseSource(
             $this->getSourceFileForTestCase($testCase),
@@ -103,7 +101,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * @param string $testCase The qualified test case name.
      * @return string
      */
-    protected function getSourceFileForTestCase($testCase)
+    protected function getSourceFileForTestCase(string $testCase)
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/src/test/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -69,7 +69,7 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
      * @param string $extension Log file extension.
      * @dataProvider getLoggerClassNames
      */
-    public function testLogFileIsCreatedForUnstructuredCode($className, $extension): void
+    public function testLogFileIsCreatedForUnstructuredCode(string $className, string $extension): void
     {
         $file = $this->createRunResourceURI() . '.' . $extension;
 

--- a/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/src/test/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -63,7 +63,7 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
      * @param string $constantName Name of the expected constant
      * @dataProvider dataProviderReservedKeywordAsTypeConstantName
      */
-    public function testReservedKeywordAsTypeConstantName($sourceFile, $constantName): void
+    public function testReservedKeywordAsTypeConstantName(string $sourceFile, string $constantName): void
     {
         $namespaces = $this->parseSource($sourceFile);
 

--- a/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/src/test/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -66,7 +66,7 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
      * @param array<int> $tokenTypes List of all expected token types.
      * @dataProvider dataProviderTokenizerKeywordSubstitutionInOperatorChain
      */
-    public function testTokenizerKeywordSubstitutionInOperatorChain($sourceFile, array $tokenTypes): void
+    public function testTokenizerKeywordSubstitutionInOperatorChain(string $sourceFile, array $tokenTypes): void
     {
         $tokenizer = new PHPTokenizerInternal();
         $tokenizer->setSourceFile(self::createCodeResourceURI($sourceFile));

--- a/src/test/php/PDepend/Input/DummyFilter.php
+++ b/src/test/php/PDepend/Input/DummyFilter.php
@@ -62,7 +62,7 @@ class DummyFilter implements Filter
      *
      * @param bool $returnValue The pre defined return value for this filter.
      */
-    public function __construct($returnValue)
+    public function __construct(bool $returnValue)
     {
         $this->returnValue = $returnValue;
     }
@@ -73,7 +73,7 @@ class DummyFilter implements Filter
      * @param string $relative The relative path to the specified root.
      * @param string $absolute The absolute path to a source file.
      */
-    public function accept($relative, $absolute): bool
+    public function accept(string $relative, string $absolute): bool
     {
         $this->invoked = true;
 

--- a/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/src/test/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -115,7 +115,7 @@ class BuilderParserCacheTest extends AbstractTestCase
      * @param string $file Relative path to a test file for the calling test.
      * @return Builder
      */
-    protected function parseSourceAndReturnBuilder($file)
+    protected function parseSourceAndReturnBuilder(string $file)
     {
         copy($this->createCodeResourceUriForTest() . '/' . $file, $this->testFile);
 

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -71,10 +71,9 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
     /**
      * Parses the source for the calling test case.
      *
-     * @param string $testCase
      * @return ASTArtifactList<ASTNamespace>
      */
-    protected function parseTestCase($testCase = null)
+    protected function parseTestCase(?string $testCase = null)
     {
         if ($testCase === null) {
             $testCase = $this->getTestCaseMethod();
@@ -87,11 +86,9 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
         if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0) {

--- a/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/src/test/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -65,7 +65,7 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
      * @param string $expected The expected primitive type image.
      * @dataProvider dataProviderParserSetsExpectedPrimitivePropertyType
      */
-    public function testParserSetsExpectedPrimitivePropertyType($actual, $expected): void
+    public function testParserSetsExpectedPrimitivePropertyType(string $actual, string $expected): void
     {
         $type = $this->parseTestCase(__METHOD__ . '_' . $actual)
             ->current()

--- a/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/src/test/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -299,7 +299,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInTypeSignature
      */
-    public function testParserResolvesQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
+    public function testParserResolvesQualifiedTypeNameInTypeSignature(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -319,7 +319,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesQualifiedTypeNameInFunction
      */
-    public function testParserResolvesQualifiedTypeNameInFunction($fileName, $namespaceName): void
+    public function testParserResolvesQualifiedTypeNameInFunction(string $fileName, string $namespaceName): void
     {
         $namespaces = $this->parseSource($fileName);
         $function = $namespaces->current()
@@ -344,7 +344,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInTypeSignature
      */
-    public function testParserKeepsQualifiedTypeNameInTypeSignature($fileName, $namespaceName): void
+    public function testParserKeepsQualifiedTypeNameInTypeSignature(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -364,7 +364,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserKeepsQualifiedTypeNameInFunction
      */
-    public function testParserKeepsQualifiedTypeNameInFunction($fileName, $namespaceName): void
+    public function testParserKeepsQualifiedTypeNameInFunction(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -384,7 +384,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax
      */
-    public function testParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax($fileName, $namespaceName): void
+    public function testParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -404,7 +404,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax
      */
-    public function testParserResolvesNamespaceKeywordInFunctionSemicolonSyntax($fileName, $namespaceName): void
+    public function testParserResolvesNamespaceKeywordInFunctionSemicolonSyntax(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -424,7 +424,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax
      */
-    public function testParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax($fileName, $namespaceName): void
+    public function testParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()
@@ -444,7 +444,7 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      * @param string $namespaceName Name of the expected namespace.
      * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax
      */
-    public function testParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax($fileName, $namespaceName): void
+    public function testParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
             ->current()

--- a/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/src/test/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -154,7 +154,7 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
      *
      * @param array<string> $argv The temporary command line argument vector
      */
-    protected function prepareArgv($argv): void
+    protected function prepareArgv(array $argv): void
     {
         array_unshift($argv, __FILE__);
 

--- a/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
+++ b/src/test/php/PDepend/Metrics/AbstractMetricsTestCase.php
@@ -60,11 +60,9 @@ abstract class AbstractMetricsTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -397,7 +397,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param string $name Name of the searched metric.
      */
-    private function calculateClassMetric($name): mixed
+    private function calculateClassMetric(string $name): mixed
     {
         $metrics = $this->calculateClassMetrics();
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -416,7 +416,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param string $name Name of the requested software metric.
      */
-    private function calculateTypeMetric($name): mixed
+    private function calculateTypeMetric(string $name): mixed
     {
         $namespaces = $this->parseCodeResourceForTest();
         $types = $namespaces[0]->getTypes();
@@ -648,9 +648,9 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @dataProvider dataProviderAnalyzerCalculatesExpectedCallCount
      */
     public function testAnalyzerCalculatesExpectedCallCount(
-        $testCase,
-        $calls,
-        $fanout
+        string $testCase,
+        int $calls,
+        int $fanout
     ): void {
         $expected = ['calls' => $calls, 'fanout' => $fanout];
         $actual = $this->calculateProjectMetrics($testCase);
@@ -666,7 +666,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @return array<string, mixed>
      * @since 0.10.2
      */
-    private function calculateProjectMetrics($testCase = null)
+    private function calculateProjectMetrics(?string $testCase = null)
     {
         $testCase = ($testCase ?: $this->getCallingTestMethod());
 

--- a/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -154,7 +154,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      * @param int $ccn The entire cyclomatic complexity number.
      * @param int $crapIndex The expected crap index.
      */
-    private function doTestCrapIndexCalculation($testCase, $ccn, $crapIndex): void
+    private function doTestCrapIndexCalculation(string $testCase, int $ccn, int $crapIndex): void
     {
         $metrics = $this->calculateCrapIndex($testCase, $ccn);
         static::assertEqualsWithDelta($crapIndex, $metrics['crap'], 0.005);
@@ -167,7 +167,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
      * @param int $ccn The entire cyclomatic complexity number.
      * @return array
      */
-    private function calculateCrapIndex($testCase, $ccn)
+    private function calculateCrapIndex(string $testCase, int $ccn)
     {
         $namespaces = $this->parseCodeResourceForTest();
 
@@ -215,10 +215,9 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Creates a mocked instance of the cyclomatic complexity analyzer.
      *
-     * @param int $ccn
      * @return CyclomaticComplexityAnalyzer
      */
-    private function createCyclomaticComplexityAnalyzerMock($ccn = 42)
+    private function createCyclomaticComplexityAnalyzerMock(int $ccn = 42)
     {
         $mock = $this->getMockBuilder(CyclomaticComplexityAnalyzer::class)
             ->getMock();

--- a/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -285,7 +285,7 @@ class InheritanceAnalyzerTest extends AbstractMetricsTestCase
      * @param string $testCase Name of the calling test case.
      * @param string $metric Name of the searched metric.
      */
-    private function getCalculatedMetric($testCase, $metric): mixed
+    private function getCalculatedMetric(string $testCase, string $metric): mixed
     {
         $namespaces = $this->parseTestCaseSource($testCase);
         $namespace = $namespaces->current();

--- a/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/src/test/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -644,7 +644,7 @@ class NodeLocAnalyzerTest extends AbstractMetricsTestCase
      * @param string $name The name of the requested metric.
      * @since 0.10.2
      */
-    private function calculateFunctionMetric($name): mixed
+    private function calculateFunctionMetric(string $name): mixed
     {
         $namespaces = $this->parseTestCaseSource($this->getCallingTestMethod());
         $function = $namespaces->current()

--- a/src/test/php/PDepend/ParserRegressionTest.php
+++ b/src/test/php/PDepend/ParserRegressionTest.php
@@ -62,7 +62,7 @@ class ParserRegressionTest extends AbstractTestCase
      * @param string $pathName Name of the file to parse.
      * @dataProvider dataProviderSourceFiles
      */
-    public function testParserHandlesSourceFileWithoutException($pathName): void
+    public function testParserHandlesSourceFileWithoutException(string $pathName): void
     {
         $this->parseSource($pathName);
     }

--- a/src/test/php/PDepend/ParserTest.php
+++ b/src/test/php/PDepend/ParserTest.php
@@ -517,7 +517,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
-    public function testParserSetsFunctionReturnTypeToNull($functions): void
+    public function testParserSetsFunctionReturnTypeToNull(ASTArtifactList $functions): void
     {
         static::assertSame(
             [
@@ -536,7 +536,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
-    public function testParserSetsExpectedFunctionReturnTypeOfFunctionTwo($functions): void
+    public function testParserSetsExpectedFunctionReturnTypeOfFunctionTwo(ASTArtifactList $functions): void
     {
         static::assertSame(
             [
@@ -555,7 +555,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsCorrectFunctionReturnType
      */
-    public function testParserSetsExpectedFunctionReturnTypeOfFunctionThree($functions): void
+    public function testParserSetsExpectedFunctionReturnTypeOfFunctionThree(ASTArtifactList $functions): void
     {
         static::assertSame(
             [
@@ -938,7 +938,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
-    public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInFirstNamespace($namespaces): void
+    public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInFirstNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[0]->getFunctions();
         static::assertCount(2, $functions);
@@ -949,7 +949,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
-    public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInSecondNamespace($namespaces): void
+    public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInSecondNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[1]->getFunctions();
         static::assertCount(1, $functions);
@@ -960,7 +960,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
-    public function testParserSetsFileExpectedPackageForFirstFunctionInFirstNamespace($namespaces): void
+    public function testParserSetsFileExpectedPackageForFirstFunctionInFirstNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[0]->getFunctions();
 
@@ -972,7 +972,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
-    public function testParserSetsFileExpectedPackageForSecondFunctionInFirstNamespace($namespaces): void
+    public function testParserSetsFileExpectedPackageForSecondFunctionInFirstNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[0]->getFunctions();
 
@@ -984,7 +984,7 @@ class ParserTest extends AbstractTestCase
      *
      * @depends testParserSetsFileLevelFunctionPackage
      */
-    public function testParserSetsFileExpectedPackageForFirstFunctionInSecondNamespace($namespaces): void
+    public function testParserSetsFileExpectedPackageForFirstFunctionInSecondNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[1]->getFunctions();
 
@@ -1487,10 +1487,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * Generic comment test method.
-     *
-     * @param int $indent
      */
-    protected function doTestParserSetsCorrectDocComment(ASTArtifactList $nodes, $indent = 1): void
+    protected function doTestParserSetsCorrectDocComment(ASTArtifactList $nodes, int $indent = 1): void
     {
         $ws = str_repeat(' ', 4 * $indent);
 

--- a/src/test/php/PDepend/Report/Dummy/Logger.php
+++ b/src/test/php/PDepend/Report/Dummy/Logger.php
@@ -74,7 +74,7 @@ class Logger implements CodeAwareGenerator, FileAwareGenerator
      *
      * @param string $logFile The output log file.
      */
-    public function setLogFile($logFile): void
+    public function setLogFile(string $logFile): void
     {
         $this->logFile = $logFile;
     }

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -320,11 +320,9 @@ class ChartTest extends AbstractTestCase
     }
 
     /**
-     * @param bool $userDefined
-     * @param string $packageName
      * @return ASTNamespace
      */
-    private function createPackage($userDefined, $packageName)
+    private function createPackage(bool $userDefined, string $packageName)
     {
         $packageA = new ASTNamespace($packageName);
         $type = $this->getMockBuilder(ASTClass::class)

--- a/src/test/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/XmlTest.php
@@ -135,7 +135,7 @@ class XmlTest extends AbstractTestCase
      * @param string $fileName File name of the expected result document.
      * @return string The prepared xml document
      */
-    protected function getNormalizedPathXml($fileName)
+    protected function getNormalizedPathXml(string $fileName)
     {
         $path = $this->createCodeResourceUriForTest();
 

--- a/src/test/php/PDepend/Report/Summary/XmlTest.php
+++ b/src/test/php/PDepend/Report/Summary/XmlTest.php
@@ -237,11 +237,9 @@ class XmlTest extends AbstractTestCase
     }
 
     /**
-     * @param string $fixture
-     * @param string $expectation
      * @dataProvider dataProviderNodeAware
      */
-    public function testNodeAwareAnalyzer($fixture, $expectation): void
+    public function testNodeAwareAnalyzer(string $fixture, string $expectation): void
     {
         $this->namespaces = $this->parseSource($fixture);
 

--- a/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -286,11 +286,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testVariableAssignmentExpression
      */
-    public function testVariableAssignmentExpressionHasExpectedStartLine($expr): void
+    public function testVariableAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -298,11 +296,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testVariableAssignmentExpression
      */
-    public function testVariableAssignmentExpressionHasExpectedStartColumn($expr): void
+    public function testVariableAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -310,11 +306,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testVariableAssignmentExpression
      */
-    public function testVariableAssignmentExpressionHasExpectedEndLine($expr): void
+    public function testVariableAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
     }
@@ -322,11 +316,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testVariableAssignmentExpression
      */
-    public function testVariableAssignmentExpressionHasExpectedEndColumn($expr): void
+    public function testVariableAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());
     }
@@ -348,11 +340,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testStaticPropertyAssignmentExpression
      */
-    public function testStaticPropertyAssignmentExpressionHasExpectedStartLine($expr): void
+    public function testStaticPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -360,11 +350,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testStaticPropertyAssignmentExpression
      */
-    public function testStaticPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
+    public function testStaticPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -372,11 +360,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testStaticPropertyAssignmentExpression
      */
-    public function testStaticPropertyAssignmentExpressionHasExpectedEndLine($expr): void
+    public function testStaticPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -384,11 +370,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testStaticPropertyAssignmentExpression
      */
-    public function testStaticPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
+    public function testStaticPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(60, $expr->getEndColumn());
     }
@@ -410,11 +394,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testObjectPropertyAssignmentExpression
      */
-    public function testObjectPropertyAssignmentExpressionHasExpectedStartLine($expr): void
+    public function testObjectPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -422,11 +404,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testObjectPropertyAssignmentExpression
      */
-    public function testObjectPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
+    public function testObjectPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -434,11 +414,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testObjectPropertyAssignmentExpression
      */
-    public function testObjectPropertyAssignmentExpressionHasExpectedEndLine($expr): void
+    public function testObjectPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndLine());
     }
@@ -446,11 +424,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testObjectPropertyAssignmentExpression
      */
-    public function testObjectPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
+    public function testObjectPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(15, $expr->getEndColumn());
     }
@@ -472,11 +448,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testChainedPropertyAssignmentExpression
      */
-    public function testChainedPropertyAssignmentExpressionHasExpectedStartLine($expr): void
+    public function testChainedPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -484,11 +458,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testChainedPropertyAssignmentExpression
      */
-    public function testChainedPropertyAssignmentExpressionHasExpectedStartColumn($expr): void
+    public function testChainedPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -496,11 +468,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testChainedPropertyAssignmentExpression
      */
-    public function testChainedPropertyAssignmentExpressionHasExpectedEndColumn($expr): void
+    public function testChainedPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(23, $expr->getEndColumn());
     }
@@ -508,11 +478,9 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line of an assignment-expression.
      *
-     * @param ASTAssignmentExpression $expr
-     *
      * @depends testChainedPropertyAssignmentExpression
      */
-    public function testChainedPropertyAssignmentExpressionHasExpectedEndLine($expr): void
+    public function testChainedPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(8, $expr->getEndLine());
     }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -118,11 +118,9 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedStartLine
      *
-     * @param ASTConstantDeclarator $declarator
-     *
      * @depends testConstantDeclarator
      */
-    public function testConstantDeclaratorHasExpectedStartLine($declarator): void
+    public function testConstantDeclaratorHasExpectedStartLine(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(5, $declarator->getStartLine());
     }
@@ -130,11 +128,9 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedStartColumn
      *
-     * @param ASTConstantDeclarator $declarator
-     *
      * @depends testConstantDeclarator
      */
-    public function testConstantDeclaratorHasExpectedStartColumn($declarator): void
+    public function testConstantDeclaratorHasExpectedStartColumn(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(7, $declarator->getStartColumn());
     }
@@ -142,11 +138,9 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedEndLine
      *
-     * @param ASTConstantDeclarator $declarator
-     *
      * @depends testConstantDeclarator
      */
-    public function testConstantDeclaratorHasExpectedEndLine($declarator): void
+    public function testConstantDeclaratorHasExpectedEndLine(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(7, $declarator->getEndLine());
     }
@@ -154,11 +148,9 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
     /**
      * testConstantDeclaratorHasExpectedEndColumn
      *
-     * @param ASTConstantDeclarator $declarator
-     *
      * @depends testConstantDeclarator
      */
-    public function testConstantDeclaratorHasExpectedEndColumn($declarator): void
+    public function testConstantDeclaratorHasExpectedEndColumn(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(14, $declarator->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -62,7 +62,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * @param int $modifiers Combinations of valid modifiers.
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
-    public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
+    public function testSetModifiersAcceptsExpectedModifierCombinations(int $modifiers): void
     {
         $definition = new ASTConstantDefinition();
 
@@ -77,7 +77,7 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * @param int $modifiers Combinations of invalid modifiers.
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
-    public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void
+    public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers(int $modifiers): void
     {
         $definition = new ASTConstantDefinition();
 
@@ -197,11 +197,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedStartLine
      *
-     * @param ASTConstantDefinition $constant
-     *
      * @depends testConstantDefinition
      */
-    public function testConstantDefinitionHasExpectedStartLine($constant): void
+    public function testConstantDefinitionHasExpectedStartLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(4, $constant->getStartLine());
     }
@@ -209,11 +207,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedStartColumn
      *
-     * @param ASTConstantDefinition $constant
-     *
      * @depends testConstantDefinition
      */
-    public function testConstantDefinitionHasExpectedStartColumn($constant): void
+    public function testConstantDefinitionHasExpectedStartColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(5, $constant->getStartColumn());
     }
@@ -221,11 +217,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedEndLine
      *
-     * @param ASTConstantDefinition $constant
-     *
      * @depends testConstantDefinition
      */
-    public function testConstantDefinitionHasExpectedEndLine($constant): void
+    public function testConstantDefinitionHasExpectedEndLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(7, $constant->getEndLine());
     }
@@ -233,11 +227,9 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionHasExpectedEndColumn
      *
-     * @param ASTConstantDefinition $constant
-     *
      * @depends testConstantDefinition
      */
-    public function testConstantDefinitionHasExpectedEndColumn($constant): void
+    public function testConstantDefinitionHasExpectedEndColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(12, $constant->getEndColumn());
     }
@@ -259,12 +251,11 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedStartLine
      *
-     * @param ASTConstantDefinition $constant
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
      */
-    public function testConstantDefinitionWithDeclaratorsHasExpectedStartLine($constant): void
+    public function testConstantDefinitionWithDeclaratorsHasExpectedStartLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(4, $constant->getStartLine());
     }
@@ -272,12 +263,11 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedStartColumn
      *
-     * @param ASTConstantDefinition $constant
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
      */
-    public function testConstantDefinitionWithDeclaratorsHasExpectedStartColumn($constant): void
+    public function testConstantDefinitionWithDeclaratorsHasExpectedStartColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(5, $constant->getStartColumn());
     }
@@ -285,12 +275,11 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedEndLine
      *
-     * @param ASTConstantDefinition $constant
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
      */
-    public function testConstantDefinitionWithDeclaratorsHasExpectedEndLine($constant): void
+    public function testConstantDefinitionWithDeclaratorsHasExpectedEndLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(6, $constant->getEndLine());
     }
@@ -298,12 +287,11 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     /**
      * testConstantDefinitionWithDeclaratorsHasExpectedEndColumn
      *
-     * @param ASTConstantDefinition $constant
      * @since 1.0.2
      *
      * @depends testConstantDefinitionWithDeclarators
      */
-    public function testConstantDefinitionWithDeclaratorsHasExpectedEndColumn($constant): void
+    public function testConstantDefinitionWithDeclaratorsHasExpectedEndColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(18, $constant->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -72,12 +72,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedStartLine
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
      */
-    public function testExitExpressionWithExitCodeHasExpectedStartLine($expr): void
+    public function testExitExpressionWithExitCodeHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -85,12 +84,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedEndLine
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
      */
-    public function testExitExpressionWithExitCodeHasExpectedEndLine($expr): void
+    public function testExitExpressionWithExitCodeHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
     }
@@ -98,12 +96,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedStartColumn
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
      */
-    public function testExitExpressionWithExitCodeHasExpectedStartColumn($expr): void
+    public function testExitExpressionWithExitCodeHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -111,12 +108,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithExitCodeHasExpectedEndColumn
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithExitCode
      */
-    public function testExitExpressionWithExitCodeHasExpectedEndColumn($expr): void
+    public function testExitExpressionWithExitCodeHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());
     }
@@ -138,12 +134,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedStartLine
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
      */
-    public function testExitExpressionWithEmptyArgsHasExpectedStartLine($expr): void
+    public function testExitExpressionWithEmptyArgsHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -151,12 +146,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedEndLine
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
      */
-    public function testExitExpressionWithEmptyArgsHasExpectedEndLine($expr): void
+    public function testExitExpressionWithEmptyArgsHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -164,12 +158,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedStartColumn
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
      */
-    public function testExitExpressionWithEmptyArgsHasExpectedStartColumn($expr): void
+    public function testExitExpressionWithEmptyArgsHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -177,12 +170,11 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithEmptyArgsHasExpectedEndColumn
      *
-     * @param ASTExitExpression $expr
      * @since 1.0.1
      *
      * @depends testExitExpressionWithEmptyArgs
      */
-    public function testExitExpressionWithEmptyArgsHasExpectedEndColumn($expr): void
+    public function testExitExpressionWithEmptyArgsHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(10, $expr->getEndColumn());
     }
@@ -204,11 +196,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgsHasExpectedStartLine
      *
-     * @param ASTExitExpression $expr
-     *
      * @depends testExitExpressionWithoutArgs
      */
-    public function testExitExpressionWithoutArgsHasExpectedStartLine($expr): void
+    public function testExitExpressionWithoutArgsHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -216,11 +206,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionWithoutArgsHasExpectedStartColumn
      *
-     * @param ASTExitExpression $expr
-     *
      * @depends testExitExpressionWithoutArgs
      */
-    public function testExitExpressionWithoutArgsHasExpectedStartColumn($expr): void
+    public function testExitExpressionWithoutArgsHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -228,11 +216,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionHasExpectedEndLineWithoutArgs
      *
-     * @param ASTExitExpression $expr
-     *
      * @depends testExitExpressionWithoutArgs
      */
-    public function testExitExpressionWithoutArgsHasExpectedEndLine($expr): void
+    public function testExitExpressionWithoutArgsHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -240,11 +226,9 @@ class ASTExitExpressionTest extends ASTNodeTestCase
     /**
      * testExitExpressionHasExpectedEndColumnWithoutArgs
      *
-     * @param ASTExitExpression $expr
-     *
      * @depends testExitExpressionWithoutArgs
      */
-    public function testExitExpressionWithoutArgsHasExpectedEndColumn($expr): void
+    public function testExitExpressionWithoutArgsHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(8, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -120,7 +120,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * @param int $modifiers Combinations of valid modifiers.
      * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
-    public function testSetModifiersAcceptsExpectedModifierCombinations($modifiers): void
+    public function testSetModifiersAcceptsExpectedModifierCombinations(int $modifiers): void
     {
         $declaration = new ASTFieldDeclaration();
         $declaration->setModifiers($modifiers);
@@ -134,7 +134,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * @param int $modifiers Combinations of invalid modifiers.
      * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
-    public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers($modifiers): void
+    public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers(int $modifiers): void
     {
         $declaration = new ASTFieldDeclaration();
 

--- a/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -159,7 +159,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * @param object $parent The parent ast node.
      * @param string $image The expected type image.
      */
-    protected function assertInstanceOfGraphStatic($parent, $image): void
+    protected function assertInstanceOfGraphStatic(object $parent, string $image): void
     {
         $this->assertInstanceOfGraph(
             $parent,
@@ -174,7 +174,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * @param object $parent The parent ast node.
      * @param string $image The expected type image.
      */
-    protected function assertInstanceOfGraphProperty($parent, $image): void
+    protected function assertInstanceOfGraphProperty(object $parent, string $image): void
     {
         $this->assertInstanceOfGraph(
             $parent,
@@ -190,7 +190,7 @@ class ASTInstanceOfExpressionTest extends ASTNodeTestCase
      * @param string $image The expected type image.
      * @param string $type The expected class or interface type.
      */
-    protected function assertInstanceOfGraph($parent, $image, $type): void
+    protected function assertInstanceOfGraph(object $parent, string $image, string $type): void
     {
         $instanceOf = $parent->getFirstChildOfType(
             ASTInstanceOfExpression::class

--- a/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -74,11 +74,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param ASTListExpression $expr
-     *
      * @depends testListExpression
      */
-    public function testListExpressionHasExpectedStartLine($expr): void
+    public function testListExpressionHasExpectedStartLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -86,11 +84,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param ASTListExpression $expr
-     *
      * @depends testListExpression
      */
-    public function testListExpressionHasExpectedStartColumn($expr): void
+    public function testListExpressionHasExpectedStartColumn(ASTListExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -98,11 +94,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param ASTListExpression $expr
-     *
      * @depends testListExpression
      */
-    public function testListExpressionHasExpectedEndLine($expr): void
+    public function testListExpressionHasExpectedEndLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -110,11 +104,9 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param ASTListExpression $expr
-     *
      * @depends testListExpression
      */
-    public function testListExpressionHasExpectedEndColumn($expr): void
+    public function testListExpressionHasExpectedEndColumn(ASTListExpression $expr): void
     {
         static::assertEquals(16, $expr->getEndColumn());
     }
@@ -136,12 +128,11 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedListHasExpectedStartLine
      *
-     * @param ASTListExpression $expr
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
      */
-    public function testListExpressionWithNestedListHasExpectedStartLine($expr): void
+    public function testListExpressionWithNestedListHasExpectedStartLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -149,12 +140,11 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedListHasExpectedStartColumn
      *
-     * @param ASTListExpression $expr
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
      */
-    public function testListExpressionWithNestedListHasExpectedStartColumn($expr): void
+    public function testListExpressionWithNestedListHasExpectedStartColumn(ASTListExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -162,12 +152,11 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedListHasExpectedEndLine
      *
-     * @param ASTListExpression $expr
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
      */
-    public function testListExpressionWithNestedListHasExpectedEndLine($expr): void
+    public function testListExpressionWithNestedListHasExpectedEndLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -175,12 +164,11 @@ class ASTListExpressionTest extends ASTNodeTestCase
     /**
      * testListExpressionWithNestedListHasExpectedEndColumn
      *
-     * @param ASTListExpression $expr
      * @since 1.0.2
      *
      * @depends testListExpressionWithNestedList
      */
-    public function testListExpressionWithNestedListHasExpectedEndColumn($expr): void
+    public function testListExpressionWithNestedListHasExpectedEndColumn(ASTListExpression $expr): void
     {
         static::assertEquals(42, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/src/test/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -690,11 +690,9 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -109,11 +109,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedStartLine
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpression
      */
-    public function testRequireExpressionHasExpectedStartLine($expr): void
+    public function testRequireExpressionHasExpectedStartLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -121,11 +119,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedStartColumn
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpression
      */
-    public function testRequireExpressionHasExpectedStartColumn($expr): void
+    public function testRequireExpressionHasExpectedStartColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -133,11 +129,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedEndLine
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpression
      */
-    public function testRequireExpressionHasExpectedEndLine($expr): void
+    public function testRequireExpressionHasExpectedEndLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -145,11 +139,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionHasExpectedEndColumn
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpression
      */
-    public function testRequireExpressionHasExpectedEndColumn($expr): void
+    public function testRequireExpressionHasExpectedEndColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(35, $expr->getEndColumn());
     }
@@ -171,11 +163,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartLine
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpressionWithParenthesis
      */
-    public function testRequireExpressionWithParenthesisHasExpectedStartLine($expr): void
+    public function testRequireExpressionWithParenthesisHasExpectedStartLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -183,11 +173,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartColumn
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpressionWithParenthesis
      */
-    public function testRequireExpressionWithParenthesisHasExpectedStartColumn($expr): void
+    public function testRequireExpressionWithParenthesisHasExpectedStartColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
     }
@@ -195,11 +183,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndLine
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpressionWithParenthesis
      */
-    public function testRequireExpressionWithParenthesisHasExpectedEndLine($expr): void
+    public function testRequireExpressionWithParenthesisHasExpectedEndLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
     }
@@ -207,11 +193,9 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndColumn
      *
-     * @param ASTRequireExpression $expr
-     *
      * @depends testRequireExpressionWithParenthesis
      */
-    public function testRequireExpressionWithParenthesisHasExpectedEndColumn($expr): void
+    public function testRequireExpressionWithParenthesisHasExpectedEndColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -72,11 +72,9 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedStartLine
      *
-     * @param ASTReturnStatement $stmt
-     *
      * @depends testReturnStatement
      */
-    public function testReturnStatementHasExpectedStartLine($stmt): void
+    public function testReturnStatementHasExpectedStartLine(ASTReturnStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedStartColumn
      *
-     * @param ASTReturnStatement $stmt
-     *
      * @depends testReturnStatement
      */
-    public function testReturnStatementHasExpectedStartColumn($stmt): void
+    public function testReturnStatementHasExpectedStartColumn(ASTReturnStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedEndLine
      *
-     * @param ASTReturnStatement $stmt
-     *
      * @depends testReturnStatement
      */
-    public function testReturnStatementHasExpectedEndLine($stmt): void
+    public function testReturnStatementHasExpectedEndLine(ASTReturnStatement $stmt): void
     {
         static::assertEquals(7, $stmt->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTReturnStatementTest extends ASTNodeTestCase
     /**
      * testReturnStatementHasExpectedEndColumn
      *
-     * @param ASTReturnStatement $stmt
-     *
      * @depends testReturnStatement
      */
-    public function testReturnStatementHasExpectedEndColumn($stmt): void
+    public function testReturnStatementHasExpectedEndColumn(ASTReturnStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -72,13 +72,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartLine
      *
-     * @param ASTScopeStatement $stmt
      * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testParserHandlesInlineScopeStatement
      */
-    public function testInlineScopeStatementHasExpectedStartLine($stmt)
+    public function testInlineScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt)
     {
         static::assertEquals(4, $stmt->getStartLine());
 
@@ -88,13 +87,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedStartColumn
      *
-     * @param ASTScopeStatement $stmt
      * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartLine
      */
-    public function testInlineScopeStatementHasExpectedStartColumn($stmt)
+    public function testInlineScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt)
     {
         static::assertEquals(5, $stmt->getStartColumn());
 
@@ -104,13 +102,12 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedEndLine
      *
-     * @param ASTScopeStatement $stmt
      * @return ASTScopeStatement
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedStartColumn
      */
-    public function testInlineScopeStatementHasExpectedEndLine($stmt)
+    public function testInlineScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt)
     {
         static::assertEquals(5, $stmt->getEndLine());
 
@@ -120,12 +117,11 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testInlineScopeStatementHasExpectedEndColumn
      *
-     * @param ASTScopeStatement $stmt
      * @since 1.0.0
      *
      * @depends testInlineScopeStatementHasExpectedEndLine
      */
-    public function testInlineScopeStatementHasExpectedEndColumn($stmt): void
+    public function testInlineScopeStatementHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(20, $stmt->getEndColumn());
     }
@@ -147,11 +143,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start line value.
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatement
      */
-    public function testScopeStatementHasExpectedStartLine($stmt): void
+    public function testScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -159,11 +153,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start column value.
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatement
      */
-    public function testScopeStatementHasExpectedStartColumn($stmt): void
+    public function testScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(34, $stmt->getStartColumn());
     }
@@ -171,11 +163,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end line value.
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatement
      */
-    public function testScopeStatementHasExpectedEndLine($stmt): void
+    public function testScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
     }
@@ -183,11 +173,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end column value.
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatement
      */
-    public function testScopeStatementHasExpectedEndColumn($stmt): void
+    public function testScopeStatementHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
     }
@@ -209,11 +197,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedStartLine
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatementWithAlternative
      */
-    public function testScopeStatementWithAlternativeHasExpectedStartLine($stmt): void
+    public function testScopeStatementWithAlternativeHasExpectedStartLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getStartLine());
     }
@@ -221,11 +207,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedStartColumn
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatementWithAlternative
      */
-    public function testScopeStatementWithAlternativeHasExpectedStartColumn($stmt): void
+    public function testScopeStatementWithAlternativeHasExpectedStartColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getStartColumn());
     }
@@ -233,11 +217,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedEndLine
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatementWithAlternative
      */
-    public function testScopeStatementWithAlternativeHasExpectedEndLine($stmt): void
+    public function testScopeStatementWithAlternativeHasExpectedEndLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(17, $stmt->getEndLine());
     }
@@ -245,11 +227,9 @@ class ASTScopeStatementTest extends ASTNodeTestCase
     /**
      * testScopeStatementWithAlternativeHasExpectedEndColumn
      *
-     * @param ASTScopeStatement $stmt
-     *
      * @depends testScopeStatementWithAlternative
      */
-    public function testScopeStatementWithAlternativeHasExpectedEndColumn($stmt): void
+    public function testScopeStatementWithAlternativeHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(15, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTScopeTest.php
@@ -72,11 +72,9 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start line value.
      *
-     * @param ASTScope $scope
-     *
      * @depends testScope
      */
-    public function testScopeHasExpectedStartLine($scope): void
+    public function testScopeHasExpectedStartLine(ASTScope $scope): void
     {
         static::assertEquals(3, $scope->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected start column value.
      *
-     * @param ASTScope $scope
-     *
      * @depends testScope
      */
-    public function testScopeHasExpectedStartColumn($scope): void
+    public function testScopeHasExpectedStartColumn(ASTScope $scope): void
     {
         static::assertEquals(1, $scope->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end line value.
      *
-     * @param ASTScope $scope
-     *
      * @depends testScope
      */
-    public function testScopeHasExpectedEndLine($scope): void
+    public function testScopeHasExpectedEndLine(ASTScope $scope): void
     {
         static::assertEquals(8, $scope->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTScopeTest extends ASTNodeTestCase
     /**
      * Tests that the scope-statement has the expected end column value.
      *
-     * @param ASTScope $scope
-     *
      * @depends testScope
      */
-    public function testScopeHasExpectedEndColumn($scope): void
+    public function testScopeHasExpectedEndColumn(ASTScope $scope): void
     {
         static::assertEquals(1, $scope->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -164,11 +164,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedStartLine
      *
-     * @param ASTSelfReference $reference
-     *
      * @depends testSelfReference
      */
-    public function testSelfReferenceHasExpectedStartLine($reference): void
+    public function testSelfReferenceHasExpectedStartLine(ASTSelfReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
     }
@@ -176,11 +174,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedStartColumn
      *
-     * @param ASTSelfReference $reference
-     *
      * @depends testSelfReference
      */
-    public function testSelfReferenceHasExpectedStartColumn($reference): void
+    public function testSelfReferenceHasExpectedStartColumn(ASTSelfReference $reference): void
     {
         static::assertEquals(13, $reference->getStartColumn());
     }
@@ -188,11 +184,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedEndLine
      *
-     * @param ASTSelfReference $reference
-     *
      * @depends testSelfReference
      */
-    public function testSelfReferenceHasExpectedEndLine($reference): void
+    public function testSelfReferenceHasExpectedEndLine(ASTSelfReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
     }
@@ -200,11 +194,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
     /**
      * testSelfReferenceHasExpectedEndColumn
      *
-     * @param ASTSelfReference $reference
-     *
      * @depends testSelfReference
      */
-    public function testSelfReferenceHasExpectedEndColumn($reference): void
+    public function testSelfReferenceHasExpectedEndColumn(ASTSelfReference $reference): void
     {
         static::assertEquals(16, $reference->getEndColumn($reference));
     }

--- a/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -82,11 +82,9 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedStartLine
      *
-     * @param ASTShiftLeftExpression $expr
-     *
      * @depends testShiftLeftExpression
      */
-    public function testShiftLeftExpressionHasExpectedStartLine($expr): void
+    public function testShiftLeftExpressionHasExpectedStartLine(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(6, $expr->getStartLine());
     }
@@ -94,11 +92,9 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedStartColumn
      *
-     * @param ASTShiftLeftExpression $expr
-     *
      * @depends testShiftLeftExpression
      */
-    public function testShiftLeftExpressionHasExpectedStartColumn($expr): void
+    public function testShiftLeftExpressionHasExpectedStartColumn(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(13, $expr->getStartColumn());
     }
@@ -106,11 +102,9 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedEndLine
      *
-     * @param ASTShiftLeftExpression $expr
-     *
      * @depends testShiftLeftExpression
      */
-    public function testShiftLeftExpressionHasExpectedEndLine($expr): void
+    public function testShiftLeftExpressionHasExpectedEndLine(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
     }
@@ -118,11 +112,9 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
     /**
      * testShiftLeftExpressionHasExpectedEndColumn
      *
-     * @param ASTShiftLeftExpression $expr
-     *
      * @depends testShiftLeftExpression
      */
-    public function testShiftLeftExpressionHasExpectedEndColumn($expr): void
+    public function testShiftLeftExpressionHasExpectedEndColumn(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(14, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -82,11 +82,9 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedStartLine
      *
-     * @param ASTShiftRightExpression $expr
-     *
      * @depends testShiftRightExpression
      */
-    public function testShiftRightExpressionHasExpectedStartLine($expr): void
+    public function testShiftRightExpressionHasExpectedStartLine(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(6, $expr->getStartLine());
     }
@@ -94,11 +92,9 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedStartColumn
      *
-     * @param ASTShiftRightExpression $expr
-     *
      * @depends testShiftRightExpression
      */
-    public function testShiftRightExpressionHasExpectedStartColumn($expr): void
+    public function testShiftRightExpressionHasExpectedStartColumn(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(13, $expr->getStartColumn());
     }
@@ -106,11 +102,9 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedEndLine
      *
-     * @param ASTShiftRightExpression $expr
-     *
      * @depends testShiftRightExpression
      */
-    public function testShiftRightExpressionHasExpectedEndLine($expr): void
+    public function testShiftRightExpressionHasExpectedEndLine(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
     }
@@ -118,11 +112,9 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
     /**
      * testShiftRightExpressionHasExpectedEndColumn
      *
-     * @param ASTShiftRightExpression $expr
-     *
      * @depends testShiftRightExpression
      */
-    public function testShiftRightExpressionHasExpectedEndColumn($expr): void
+    public function testShiftRightExpressionHasExpectedEndColumn(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(14, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStatementTest.php
@@ -72,11 +72,9 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedStartLine
      *
-     * @param ASTStatement $stmt
-     *
      * @depends testStatement
      */
-    public function testStatementHasExpectedStartLine($stmt): void
+    public function testStatementHasExpectedStartLine(ASTStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedStartColumn
      *
-     * @param ASTStatement $stmt
-     *
      * @depends testStatement
      */
-    public function testStatementHasExpectedStartColumn($stmt): void
+    public function testStatementHasExpectedStartColumn(ASTStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedEndLine
      *
-     * @param ASTStatement $stmt
-     *
      * @depends testStatement
      */
-    public function testStatementHasExpectedEndLine($stmt): void
+    public function testStatementHasExpectedEndLine(ASTStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTStatementTest extends ASTNodeTestCase
     /**
      * testStatementHasExpectedEndColumn
      *
-     * @param ASTStatement $stmt
-     *
      * @depends testStatement
      */
-    public function testStatementHasExpectedEndColumn($stmt): void
+    public function testStatementHasExpectedEndColumn(ASTStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -174,11 +174,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedStartLine
      *
-     * @param ASTStaticReference $reference
-     *
      * @depends testStaticReference
      */
-    public function testStaticReferenceHasExpectedStartLine($reference): void
+    public function testStaticReferenceHasExpectedStartLine(ASTStaticReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
     }
@@ -186,11 +184,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedStartColumn
      *
-     * @param ASTStaticReference $reference
-     *
      * @depends testStaticReference
      */
-    public function testStaticReferenceHasExpectedStartColumn($reference): void
+    public function testStaticReferenceHasExpectedStartColumn(ASTStaticReference $reference): void
     {
         static::assertEquals(13, $reference->getStartColumn());
     }
@@ -198,11 +194,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedEndLine
      *
-     * @param ASTStaticReference $reference
-     *
      * @depends testStaticReference
      */
-    public function testStaticReferenceHasExpectedEndLine($reference): void
+    public function testStaticReferenceHasExpectedEndLine(ASTStaticReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
     }
@@ -210,11 +204,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     /**
      * testStaticReferenceHasExpectedEndColumn
      *
-     * @param ASTStaticReference $reference
-     *
      * @depends testStaticReference
      */
-    public function testStaticReferenceHasExpectedEndColumn($reference): void
+    public function testStaticReferenceHasExpectedEndColumn(ASTStaticReference $reference): void
     {
         static::assertEquals(18, $reference->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -72,11 +72,9 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected start line value.
      *
-     * @param ASTStaticVariableDeclaration $declaration
-     *
      * @depends testStaticVariableDeclaration
      */
-    public function testStaticVariableDeclarationHasExpectedStartLine($declaration): void
+    public function testStaticVariableDeclarationHasExpectedStartLine(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(4, $declaration->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected start column value.
      *
-     * @param ASTStaticVariableDeclaration $declaration
-     *
      * @depends testStaticVariableDeclaration
      */
-    public function testStaticVariableDeclarationHasExpectedStartColumn($declaration): void
+    public function testStaticVariableDeclarationHasExpectedStartColumn(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(5, $declaration->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected end line value.
      *
-     * @param ASTStaticVariableDeclaration $declaration
-     *
      * @depends testStaticVariableDeclaration
      */
-    public function testStaticVariableDeclarationHasExpectedEndLine($declaration): void
+    public function testStaticVariableDeclarationHasExpectedEndLine(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(5, $declaration->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
     /**
      * Tests that the declaration has the expected end column value.
      *
-     * @param ASTStaticVariableDeclaration $declaration
-     *
      * @depends testStaticVariableDeclaration
      */
-    public function testStaticVariableDeclarationHasExpectedEndColumn($declaration): void
+    public function testStaticVariableDeclarationHasExpectedEndColumn(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(23, $declaration->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -75,11 +75,9 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedStartLine
      *
-     * @param ASTStringIndexExpression $expr
-     *
      * @depends testStringIndexExpression
      */
-    public function testStringIndexExpressionHasExpectedStartLine($expr): void
+    public function testStringIndexExpressionHasExpectedStartLine(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
     }
@@ -87,11 +85,9 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedStartColumn
      *
-     * @param ASTStringIndexExpression $expr
-     *
      * @depends testStringIndexExpression
      */
-    public function testStringIndexExpressionHasExpectedStartColumn($expr): void
+    public function testStringIndexExpressionHasExpectedStartColumn(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(23, $expr->getStartColumn());
     }
@@ -99,11 +95,9 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedEndLine
      *
-     * @param ASTStringIndexExpression $expr
-     *
      * @depends testStringIndexExpression
      */
-    public function testStringIndexExpressionHasExpectedEndLine($expr): void
+    public function testStringIndexExpressionHasExpectedEndLine(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
     }
@@ -111,11 +105,9 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
     /**
      * testStringIndexExpressionHasExpectedEndColumn
      *
-     * @param ASTStringIndexExpression $expr
-     *
      * @depends testStringIndexExpression
      */
-    public function testStringIndexExpressionHasExpectedEndColumn($expr): void
+    public function testStringIndexExpressionHasExpectedEndColumn(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(28, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -111,11 +111,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabel
      */
-    public function testSwitchLabelHasExpectedStartLine($label): void
+    public function testSwitchLabelHasExpectedStartLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(6, $label->getStartLine());
     }
@@ -123,11 +121,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabel
      */
-    public function testSwitchLabelHasExpectedStartColumn($label): void
+    public function testSwitchLabelHasExpectedStartColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(9, $label->getStartColumn());
     }
@@ -135,11 +131,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabel
      */
-    public function testSwitchLabelHasExpectedEndLine($label): void
+    public function testSwitchLabelHasExpectedEndLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(7, $label->getEndLine());
     }
@@ -147,11 +141,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabel
      */
-    public function testSwitchLabelHasExpectedEndColumn($label): void
+    public function testSwitchLabelHasExpectedEndColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(18, $label->getEndColumn());
     }
@@ -264,11 +256,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabelDefault
      */
-    public function testSwitchLabelDefaultHasExpectedStartLine($label): void
+    public function testSwitchLabelDefaultHasExpectedStartLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(6, $label->getStartLine());
     }
@@ -276,11 +266,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabelDefault
      */
-    public function testSwitchLabelDefaultHasExpectedStartColumn($label): void
+    public function testSwitchLabelDefaultHasExpectedStartColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(9, $label->getStartColumn());
     }
@@ -288,11 +276,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabelDefault
      */
-    public function testSwitchLabelDefaultHasExpectedEndLine($label): void
+    public function testSwitchLabelDefaultHasExpectedEndLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(7, $label->getEndLine());
     }
@@ -300,11 +286,9 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param ASTSwitchLabel $label
-     *
      * @depends testSwitchLabelDefault
      */
-    public function testSwitchLabelDefaultHasExpectedEndColumn($label): void
+    public function testSwitchLabelDefaultHasExpectedEndColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(18, $label->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -98,11 +98,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the start line value.
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatement
      */
-    public function testSwitchStatementHasExpectedStartLine($stmt): void
+    public function testSwitchStatementHasExpectedStartLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -110,11 +108,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the start column value.
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatement
      */
-    public function testSwitchStatementHasExpectedStartColumn($stmt): void
+    public function testSwitchStatementHasExpectedStartColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -122,11 +118,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the end line value.
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatement
      */
-    public function testSwitchStatementHasExpectedEndLine($stmt): void
+    public function testSwitchStatementHasExpectedEndLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
     }
@@ -134,11 +128,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * Tests the end column value.
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatement
      */
-    public function testSwitchStatementHasExpectedEndColumn($stmt): void
+    public function testSwitchStatementHasExpectedEndColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
     }
@@ -196,11 +188,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartLine
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatementWithAlternativeScope
      */
-    public function testSwitchStatementAlternativeScopeHasExpectedStartLine($stmt): void
+    public function testSwitchStatementAlternativeScopeHasExpectedStartLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -208,11 +198,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartColumn
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatementWithAlternativeScope
      */
-    public function testSwitchStatementAlternativeScopeHasExpectedStartColumn($stmt): void
+    public function testSwitchStatementAlternativeScopeHasExpectedStartColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -220,11 +208,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndLine
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatementWithAlternativeScope
      */
-    public function testSwitchStatementAlternativeScopeHasExpectedEndLine($stmt): void
+    public function testSwitchStatementAlternativeScopeHasExpectedEndLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(25, $stmt->getEndLine());
     }
@@ -232,11 +218,9 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndColumn
      *
-     * @param ASTSwitchStatement $stmt
-     *
      * @depends testSwitchStatementWithAlternativeScope
      */
-    public function testSwitchStatementAlternativeScopeHasExpectedEndColumn($stmt): void
+    public function testSwitchStatementAlternativeScopeHasExpectedEndColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(14, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -72,11 +72,9 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedStartLine
      *
-     * @param ASTThrowStatement $stmt
-     *
      * @depends testThrowStatement
      */
-    public function testThrowStatementHasExpectedStartLine($stmt): void
+    public function testThrowStatementHasExpectedStartLine(ASTThrowStatement $stmt): void
     {
         static::assertSame(4, $stmt->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedStartColumn
      *
-     * @param ASTThrowStatement $stmt
-     *
      * @depends testThrowStatement
      */
-    public function testThrowStatementHasExpectedStartColumn($stmt): void
+    public function testThrowStatementHasExpectedStartColumn(ASTThrowStatement $stmt): void
     {
         static::assertSame(5, $stmt->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedEndLine
      *
-     * @param ASTThrowStatement $stmt
-     *
      * @depends testThrowStatement
      */
-    public function testThrowStatementHasExpectedEndLine($stmt): void
+    public function testThrowStatementHasExpectedEndLine(ASTThrowStatement $stmt): void
     {
         static::assertSame(5, $stmt->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTThrowStatementTest extends ASTNodeTestCase
     /**
      * testThrowStatementHasExpectedEndColumn
      *
-     * @param ASTThrowStatement $stmt
-     *
      * @depends testThrowStatement
      */
-    public function testThrowStatementHasExpectedEndColumn($stmt): void
+    public function testThrowStatementHasExpectedEndColumn(ASTThrowStatement $stmt): void
     {
         static::assertSame(38, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -152,11 +152,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedStartLine
      *
-     * @param ASTTraitAdaptationAlias $alias
-     *
      * @depends testTraitAdaptationAlias
      */
-    public function testTraitAdaptationAliasHasExpectedStartLine($alias): void
+    public function testTraitAdaptationAliasHasExpectedStartLine(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(6, $alias->getStartLine());
     }
@@ -164,11 +162,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedStartColumn
      *
-     * @param ASTTraitAdaptationAlias $alias
-     *
      * @depends testTraitAdaptationAlias
      */
-    public function testTraitAdaptationAliasHasExpectedStartColumn($alias): void
+    public function testTraitAdaptationAliasHasExpectedStartColumn(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(9, $alias->getStartColumn());
     }
@@ -176,11 +172,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedEndLine
      *
-     * @param ASTTraitAdaptationAlias $alias
-     *
      * @depends testTraitAdaptationAlias
      */
-    public function testTraitAdaptationAliasHasExpectedEndLine($alias): void
+    public function testTraitAdaptationAliasHasExpectedEndLine(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(6, $alias->getEndLine());
     }
@@ -188,11 +182,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationAliasHasExpectedEndColumn
      *
-     * @param ASTTraitAdaptationAlias $alias
-     *
      * @depends testTraitAdaptationAlias
      */
-    public function testTraitAdaptationAliasHasExpectedEndColumn($alias): void
+    public function testTraitAdaptationAliasHasExpectedEndColumn(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(46, $alias->getEndColumn());
     }
@@ -226,11 +218,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartLine($reference): void
+    public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(7, $reference->getStartLine());
     }
@@ -238,11 +228,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartColumn($reference): void
+    public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
     }
@@ -250,11 +238,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndLine($reference): void
+    public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(7, $reference->getEndLine());
     }
@@ -262,11 +248,9 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndColumn($reference): void
+    public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(36, $reference->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -100,11 +100,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartLine
      *
-     * @param ASTTraitAdaptationPrecedence $precedence
-     *
      * @depends testTraitAdaptationPrecedence
      */
-    public function testTraitAdaptationPrecedenceHasExpectedStartLine($precedence): void
+    public function testTraitAdaptationPrecedenceHasExpectedStartLine(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(6, $precedence->getStartLine());
     }
@@ -112,11 +110,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartColumn
      *
-     * @param ASTTraitAdaptationPrecedence $precedence
-     *
      * @depends testTraitAdaptationPrecedence
      */
-    public function testTraitAdaptationPrecedenceHasExpectedStartColumn($precedence): void
+    public function testTraitAdaptationPrecedenceHasExpectedStartColumn(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(9, $precedence->getStartColumn());
     }
@@ -124,11 +120,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndLine
      *
-     * @param ASTTraitAdaptationPrecedence $precedence
-     *
      * @depends testTraitAdaptationPrecedence
      */
-    public function testTraitAdaptationPrecedenceHasExpectedEndLine($precedence): void
+    public function testTraitAdaptationPrecedenceHasExpectedEndLine(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(8, $precedence->getEndLine());
     }
@@ -136,11 +130,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndColumn
      *
-     * @param ASTTraitAdaptationPrecedence $precedence
-     *
      * @depends testTraitAdaptationPrecedence
      */
-    public function testTraitAdaptationPrecedenceHasExpectedEndColumn($precedence): void
+    public function testTraitAdaptationPrecedenceHasExpectedEndColumn(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(56, $precedence->getEndColumn());
     }
@@ -174,11 +166,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartLine($reference): void
+    public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(6, $reference->getStartLine());
     }
@@ -186,11 +176,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartColumn($reference): void
+    public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
     }
@@ -198,11 +186,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndLine($reference): void
+    public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(6, $reference->getEndLine());
     }
@@ -210,11 +196,9 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndColumn($reference): void
+    public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(36, $reference->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -74,11 +74,9 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedStartLine
      *
-     * @param ASTTraitAdaptation $scope
-     *
      * @depends testTraitAdaptation
      */
-    public function testTraitAdaptationHasExpectedStartLine($scope): void
+    public function testTraitAdaptationHasExpectedStartLine(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(5, $scope->getStartLine());
     }
@@ -86,11 +84,9 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedStartColumn
      *
-     * @param ASTTraitAdaptation $scope
-     *
      * @depends testTraitAdaptation
      */
-    public function testTraitAdaptationHasExpectedStartColumn($scope): void
+    public function testTraitAdaptationHasExpectedStartColumn(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(32, $scope->getStartColumn());
     }
@@ -98,11 +94,9 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedEndLine
      *
-     * @param ASTTraitAdaptation $scope
-     *
      * @depends testTraitAdaptation
      */
-    public function testTraitAdaptationHasExpectedEndLine($scope): void
+    public function testTraitAdaptationHasExpectedEndLine(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(9, $scope->getEndLine());
     }
@@ -110,11 +104,9 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
     /**
      * testTraitAdaptationHasExpectedEndColumn
      *
-     * @param ASTTraitAdaptation $scope
-     *
      * @depends testTraitAdaptation
      */
-    public function testTraitAdaptationHasExpectedEndColumn($scope): void
+    public function testTraitAdaptationHasExpectedEndColumn(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(5, $scope->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -91,11 +91,9 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartLine($reference): void
+    public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
     }
@@ -103,11 +101,9 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedStartColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedStartColumn($reference): void
+    public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
     }
@@ -115,11 +111,9 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndLine
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndLine($reference): void
+    public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
     }
@@ -127,11 +121,9 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
     /**
      * testTraitReferenceHasExpectedEndColumn
      *
-     * @param ASTTraitReference $reference
-     *
      * @depends testTraitReference
      */
-    public function testTraitReferenceHasExpectedEndColumn($reference): void
+    public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(27, $reference->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -395,11 +395,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedStartLine
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatement
      */
-    public function testTraitUseStatementHasExpectedStartLine($stmt): void
+    public function testTraitUseStatementHasExpectedStartLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -407,11 +405,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedStartColumn
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatement
      */
-    public function testTraitUseStatementHasExpectedStartColumn($stmt): void
+    public function testTraitUseStatementHasExpectedStartColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -419,11 +415,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedEndLine
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatement
      */
-    public function testTraitUseStatementHasExpectedEndLine($stmt): void
+    public function testTraitUseStatementHasExpectedEndLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(9, $stmt->getEndLine());
     }
@@ -431,11 +425,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementHasExpectedEndColumn
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatement
      */
-    public function testTraitUseStatementHasExpectedEndColumn($stmt): void
+    public function testTraitUseStatementHasExpectedEndColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getEndColumn());
     }
@@ -457,11 +449,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedStartLine
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatementInTrait
      */
-    public function testTraitUseStatementInTraitHasExpectedStartLine($stmt): void
+    public function testTraitUseStatementInTraitHasExpectedStartLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -469,11 +459,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedStartColumn
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatementInTrait
      */
-    public function testTraitUseStatementInTraitHasExpectedStartColumn($stmt): void
+    public function testTraitUseStatementInTraitHasExpectedStartColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -481,11 +469,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedEndLine
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatementInTrait
      */
-    public function testTraitUseStatementInTraitHasExpectedEndLine($stmt): void
+    public function testTraitUseStatementInTraitHasExpectedEndLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getEndLine());
     }
@@ -493,11 +479,9 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
     /**
      * testTraitUseStatementInTraitHasExpectedEndColumn
      *
-     * @param ASTTraitUseStatement $stmt
-     *
      * @depends testTraitUseStatementInTrait
      */
-    public function testTraitUseStatementInTraitHasExpectedEndColumn($stmt): void
+    public function testTraitUseStatementInTraitHasExpectedEndColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(19, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -74,11 +74,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected start line value.
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testTryStatementHasExpectedStartLine($stmt): void
+    public function testTryStatementHasExpectedStartLine(ASTTryStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -86,11 +84,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected start column value.
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testTryStatementHasExpectedStartColumn($stmt): void
+    public function testTryStatementHasExpectedStartColumn(ASTTryStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -98,11 +94,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected end line value.
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testTryStatementHasExpectedEndLine($stmt): void
+    public function testTryStatementHasExpectedEndLine(ASTTryStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
     }
@@ -110,11 +104,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * Tests that the try-statement has the expected end column value.
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testTryStatementHasExpectedEndColumn($stmt): void
+    public function testTryStatementHasExpectedEndColumn(ASTTryStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
     }
@@ -122,11 +114,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testFirstChildOfTryStatementIsInstanceOfScopeStatement
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testFirstChildOfTryStatementIsInstanceOfScopeStatement($stmt): void
+    public function testFirstChildOfTryStatementIsInstanceOfScopeStatement(ASTTryStatement $stmt): void
     {
         static::assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(0));
     }
@@ -134,11 +124,9 @@ class ASTTryStatementTest extends ASTNodeTestCase
     /**
      * testSecondChildOfTryStatementIsInstanceOfCatchStatement
      *
-     * @param ASTTryStatement $stmt
-     *
      * @depends testTryStatement
      */
-    public function testSecondChildOfTryStatementIsInstanceOfCatchStatement($stmt): void
+    public function testSecondChildOfTryStatementIsInstanceOfCatchStatement(ASTTryStatement $stmt): void
     {
         static::assertInstanceOf(ASTCatchStatement::class, $stmt->getChild(1));
     }

--- a/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -72,11 +72,9 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedStartLine
      *
-     * @param ASTTypeArray $type
-     *
      * @depends testArrayType
      */
-    public function testArrayTypeHasExpectedStartLine($type): void
+    public function testArrayTypeHasExpectedStartLine(ASTTypeArray $type): void
     {
         static::assertEquals(2, $type->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedStartColumn
      *
-     * @param ASTTypeArray $type
-     *
      * @depends testArrayType
      */
-    public function testArrayTypeHasExpectedStartColumn($type): void
+    public function testArrayTypeHasExpectedStartColumn(ASTTypeArray $type): void
     {
         static::assertEquals(14, $type->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedEndLine
      *
-     * @param ASTTypeArray $type
-     *
      * @depends testArrayType
      */
-    public function testArrayTypeHasExpectedEndLine($type): void
+    public function testArrayTypeHasExpectedEndLine(ASTTypeArray $type): void
     {
         static::assertEquals(2, $type->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTTypeArrayTest extends ASTNodeTestCase
     /**
      * testArrayTypeHasExpectedEndColumn
      *
-     * @param ASTTypeArray $type
-     *
      * @depends testArrayType
      */
-    public function testArrayTypeHasExpectedEndColumn($type): void
+    public function testArrayTypeHasExpectedEndColumn(ASTTypeArray $type): void
     {
         static::assertEquals(18, $type->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -82,11 +82,9 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedStartLine
      *
-     * @param ASTTypeCallable $type
-     *
      * @depends testCallableType
      */
-    public function testCallableTypeHasExpectedStartLine($type): void
+    public function testCallableTypeHasExpectedStartLine(ASTTypeCallable $type): void
     {
         static::assertEquals(2, $type->getStartLine());
     }
@@ -94,11 +92,9 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedEndLine
      *
-     * @param ASTTypeCallable $type
-     *
      * @depends testCallableType
      */
-    public function testCallableTypeHasExpectedEndLine($type): void
+    public function testCallableTypeHasExpectedEndLine(ASTTypeCallable $type): void
     {
         static::assertEquals(2, $type->getEndLine());
     }
@@ -106,11 +102,9 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedStartColumn
      *
-     * @param ASTTypeCallable $type
-     *
      * @depends testCallableType
      */
-    public function testCallableTypeHasExpectedStartColumn($type): void
+    public function testCallableTypeHasExpectedStartColumn(ASTTypeCallable $type): void
     {
         static::assertEquals(27, $type->getStartColumn());
     }
@@ -118,11 +112,9 @@ class ASTTypeCallableTest extends ASTNodeTestCase
     /**
      * testCallableTypeHasExpectedEndColumn
      *
-     * @param ASTTypeCallable $type
-     *
      * @depends testCallableType
      */
-    public function testCallableTypeHasExpectedEndColumn($type): void
+    public function testCallableTypeHasExpectedEndColumn(ASTTypeCallable $type): void
     {
         static::assertEquals(34, $type->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -72,11 +72,9 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedStartLine
      *
-     * @param ASTTypeIterable $type
-     *
      * @depends testIterableType
      */
-    public function testIterableTypeHasExpectedStartLine($type): void
+    public function testIterableTypeHasExpectedStartLine(ASTTypeIterable $type): void
     {
         static::assertEquals(2, $type->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedStartColumn
      *
-     * @param ASTTypeIterable $type
-     *
      * @depends testIterableType
      */
-    public function testIterableTypeHasExpectedStartColumn($type): void
+    public function testIterableTypeHasExpectedStartColumn(ASTTypeIterable $type): void
     {
         static::assertEquals(24, $type->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedEndLine
      *
-     * @param ASTTypeIterable $type
-     *
      * @depends testIterableType
      */
-    public function testIterableTypeHasExpectedEndLine($type): void
+    public function testIterableTypeHasExpectedEndLine(ASTTypeIterable $type): void
     {
         static::assertEquals(2, $type->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTTypeIterableTest extends ASTNodeTestCase
     /**
      * testIterableTypeHasExpectedEndColumn
      *
-     * @param ASTTypeIterable $type
-     *
      * @depends testIterableType
      */
-    public function testIterableTypeHasExpectedEndColumn($type): void
+    public function testIterableTypeHasExpectedEndColumn(ASTTypeIterable $type): void
     {
         static::assertEquals(31, $type->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -72,11 +72,9 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedStartLine
      *
-     * @param ASTUnaryExpression $expr
-     *
      * @depends testUnaryExpression
      */
-    public function testUnaryExpressionHasExpectedStartLine($expr): void
+    public function testUnaryExpressionHasExpectedStartLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(4, $expr->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedEndLine
      *
-     * @param ASTUnaryExpression $expr
-     *
      * @depends testUnaryExpression
      */
-    public function testUnaryExpressionHasExpectedEndLine($expr): void
+    public function testUnaryExpressionHasExpectedEndLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(5, $expr->getEndLine());
     }
@@ -96,11 +92,9 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedStartColumn
      *
-     * @param ASTUnaryExpression $expr
-     *
      * @depends testUnaryExpression
      */
-    public function testUnaryExpressionHasExpectedStartColumn($expr): void
+    public function testUnaryExpressionHasExpectedStartColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(22, $expr->getStartColumn());
     }
@@ -108,11 +102,9 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
     /**
      * testUnaryExpressionHasExpectedEndColumn
      *
-     * @param ASTUnaryExpression $expr
-     *
      * @depends testUnaryExpression
      */
-    public function testUnaryExpressionHasExpectedEndColumn($expr): void
+    public function testUnaryExpressionHasExpectedEndColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(14, $expr->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -72,11 +72,9 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedStartLine
      *
-     * @param ASTUnsetStatement $stmt
-     *
      * @depends testUnsetStatement
      */
-    public function testUnsetStatementHasExpectedStartLine($stmt): void
+    public function testUnsetStatementHasExpectedStartLine(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedStartColumn
      *
-     * @param ASTUnsetStatement $stmt
-     *
      * @depends testUnsetStatement
      */
-    public function testUnsetStatementHasExpectedStartColumn($stmt): void
+    public function testUnsetStatementHasExpectedStartColumn(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedEndLine
      *
-     * @param ASTUnsetStatement $stmt
-     *
      * @depends testUnsetStatement
      */
-    public function testUnsetStatementHasExpectedEndLine($stmt): void
+    public function testUnsetStatementHasExpectedEndLine(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
     /**
      * testUnsetStatementHasExpectedEndColumn
      *
-     * @param ASTUnsetStatement $stmt
-     *
      * @depends testUnsetStatement
      */
-    public function testUnsetStatementHasExpectedEndColumn($stmt): void
+    public function testUnsetStatementHasExpectedEndColumn(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(22, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableTest.php
@@ -107,11 +107,9 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedStartLine
      *
-     * @param ASTVariable $variable
-     *
      * @depends testVariable
      */
-    public function testVariableHasExpectedStartLine($variable): void
+    public function testVariableHasExpectedStartLine(ASTVariable $variable): void
     {
         static::assertEquals(6, $variable->getStartLine());
     }
@@ -119,11 +117,9 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedStartColumn
      *
-     * @param ASTVariable $variable
-     *
      * @depends testVariable
      */
-    public function testVariableHasExpectedStartColumn($variable): void
+    public function testVariableHasExpectedStartColumn(ASTVariable $variable): void
     {
         static::assertEquals(9, $variable->getStartColumn());
     }
@@ -131,11 +127,9 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedEndLine
      *
-     * @param ASTVariable $variable
-     *
      * @depends testVariable
      */
-    public function testVariableHasExpectedEndLine($variable): void
+    public function testVariableHasExpectedEndLine(ASTVariable $variable): void
     {
         static::assertEquals(6, $variable->getEndLine());
     }
@@ -143,11 +137,9 @@ class ASTVariableTest extends ASTNodeTestCase
     /**
      * testVariableHasExpectedEndColumn
      *
-     * @param ASTVariable $variable
-     *
      * @depends testVariable
      */
-    public function testVariableHasExpectedEndColumn($variable): void
+    public function testVariableHasExpectedEndColumn(ASTVariable $variable): void
     {
         static::assertEquals(10, $variable->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -72,11 +72,9 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedStartLine
      *
-     * @param ASTVariableVariable $variable
-     *
      * @depends testVariableVariable
      */
-    public function testVariableVariableHasExpectedStartLine($variable): void
+    public function testVariableVariableHasExpectedStartLine(ASTVariableVariable $variable): void
     {
         static::assertEquals(6, $variable->getStartLine());
     }
@@ -84,11 +82,9 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedStartColumn
      *
-     * @param ASTVariableVariable $variable
-     *
      * @depends testVariableVariable
      */
-    public function testVariableVariableHasExpectedStartColumn($variable): void
+    public function testVariableVariableHasExpectedStartColumn(ASTVariableVariable $variable): void
     {
         static::assertEquals(9, $variable->getStartColumn());
     }
@@ -96,11 +92,9 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedEndLine
      *
-     * @param ASTVariableVariable $variable
-     *
      * @depends testVariableVariable
      */
-    public function testVariableVariableHasExpectedEndLine($variable): void
+    public function testVariableVariableHasExpectedEndLine(ASTVariableVariable $variable): void
     {
         static::assertEquals(8, $variable->getEndLine());
     }
@@ -108,11 +102,9 @@ class ASTVariableVariableTest extends ASTNodeTestCase
     /**
      * testVariableVariableHasExpectedEndColumn
      *
-     * @param ASTVariableVariable $variable
-     *
      * @depends testVariableVariable
      */
-    public function testVariableVariableHasExpectedEndColumn($variable): void
+    public function testVariableVariableHasExpectedEndColumn(ASTVariableVariable $variable): void
     {
         static::assertEquals(12, $variable->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/src/test/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -99,11 +99,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedStartLine
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatement
      */
-    public function testWhileStatementHasExpectedStartLine($stmt): void
+    public function testWhileStatementHasExpectedStartLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -111,11 +109,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedStartColumn
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatement
      */
-    public function testWhileStatementHasExpectedStartColumn($stmt): void
+    public function testWhileStatementHasExpectedStartColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -123,11 +119,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedEndLine
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatement
      */
-    public function testWhileStatementHasExpectedEndLine($stmt): void
+    public function testWhileStatementHasExpectedEndLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
     }
@@ -135,11 +129,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementHasExpectedEndColumn
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatement
      */
-    public function testWhileStatementHasExpectedEndColumn($stmt): void
+    public function testWhileStatementHasExpectedEndColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
     }
@@ -161,11 +153,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartLine
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatementWithAlternativeScope
      */
-    public function testWhileStatementAlternativeScopeHasExpectedStartLine($stmt): void
+    public function testWhileStatementAlternativeScopeHasExpectedStartLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
     }
@@ -173,11 +163,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartColumn
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatementWithAlternativeScope
      */
-    public function testWhileStatementAlternativeScopeHasExpectedStartColumn($stmt): void
+    public function testWhileStatementAlternativeScopeHasExpectedStartColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
     }
@@ -185,11 +173,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndLine
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatementWithAlternativeScope
      */
-    public function testWhileStatementAlternativeScopeHasExpectedEndLine($stmt): void
+    public function testWhileStatementAlternativeScopeHasExpectedEndLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
     }
@@ -197,11 +183,9 @@ class ASTWhileStatementTest extends ASTNodeTestCase
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndColumn
      *
-     * @param ASTWhileStatement $stmt
-     *
      * @depends testWhileStatementWithAlternativeScope
      */
-    public function testWhileStatementAlternativeScopeHasExpectedEndColumn($stmt): void
+    public function testWhileStatementAlternativeScopeHasExpectedEndColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getEndColumn());
     }

--- a/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/src/test/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -73,11 +73,9 @@ abstract class AbstractASTArtifactTestCase extends AbstractTestCase
      * Parses the given source file or directory with the default tokenizer
      * and node builder implementations.
      *
-     * @param string $testCase
-     * @param bool $ignoreAnnotations
      * @return ASTArtifactList<ASTNamespace>
      */
-    public function parseTestCaseSource($testCase, $ignoreAnnotations = false)
+    public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false)
     {
         [$class, $method] = explode('::', $testCase);
 

--- a/src/test/php/PDepend/TextUI/CommandTest.php
+++ b/src/test/php/PDepend/TextUI/CommandTest.php
@@ -292,10 +292,9 @@ class CommandTest extends AbstractTestCase
     /**
      * Executes the command class and returns an array with namespace statistics.
      *
-     * @param string $pathName
      * @return array
      */
-    private function runCommandAndReturnStatistics(array $argv, $pathName)
+    private function runCommandAndReturnStatistics(array $argv, string $pathName)
     {
         $logFile = $this->createRunResourceURI();
 
@@ -561,7 +560,7 @@ class CommandTest extends AbstractTestCase
      * @param string $actual The cli output.
      * @param string $prologText Optional prolog text.
      */
-    protected function assertHelpOutput($actual, $prologText = ''): void
+    protected function assertHelpOutput(string $actual, string $prologText = ''): void
     {
         $startsWith = $prologText . $this->versionOutput . $this->usageOutput;
         $startsWith = '/^' . preg_quote($startsWith) . '/';

--- a/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/src/test/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -185,11 +185,9 @@ class CloverReportTest extends AbstractTestCase
      * Creates a mocked method instance.
      *
      * @param string $name Name of the mock method.
-     * @param int $startLine
-     * @param int $endLine
      * @return ASTMethod
      */
-    private function createMethodMock($name, $startLine = 1, $endLine = 4)
+    private function createMethodMock(string $name, int $startLine = 1, int $endLine = 4)
     {
         $file = $this->getMockBuilder(ASTCompilationUnit::class)
             ->setConstructorArgs([null])


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

Simply ran:
```php
vendor/bin/php-cs-fixer fix --rules=phpdoc_to_param_type
vendor/bin/php-cs-fixer fix
```