### PR TITLE
Add remaning native hints to application

### DIFF
--- a/src/main/php/PDepend/DependencyInjection/PdependExtension.php
+++ b/src/main/php/PDepend/DependencyInjection/PdependExtension.php
@@ -135,7 +135,7 @@ class PdependExtension extends SymfonyExtension
         return $settings;
     }
 
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return 'http://pdepend.org/schema/dic/pdepend';
     }

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -195,10 +195,8 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * Adds the given type to this namespace and returns the input type instance.
-     *
-     * @param AbstractASTClassOrInterface $type
      */
-    public function addType(AbstractASTType $type): AbstractASTClassOrInterface
+    public function addType(AbstractASTClassOrInterface $type): AbstractASTClassOrInterface
     {
         // Skip if this namespace already contains this type
         if (in_array($type, $this->types, true)) {

--- a/src/main/php/PDepend/Util/MathUtil.php
+++ b/src/main/php/PDepend/Util/MathUtil.php
@@ -60,7 +60,7 @@ final class MathUtil
      * @param numeric-string $right The right arithmetic operand.
      * @return numeric-string
      */
-    public static function mul($left, $right)
+    public static function mul(string $left, string $right): string
     {
         if (function_exists('bcmul')) {
             return bcmul($left, $right);
@@ -77,7 +77,7 @@ final class MathUtil
      * @param string $right The right arithmetic operand.
      * @return numeric-string
      */
-    public static function add(string $left, string $right)
+    public static function add(string $left, string $right): string
     {
         if (function_exists('bcadd')) {
             return bcadd($left, $right);


### PR DESCRIPTION
Type: refactoring / documentation update

A few places that didn't get native type hints from converting PHPDoc, found via phanalist