### PR TITLE
Apply BC type hints

### DIFF
--- a/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/AbstractCachingAnalyzer.php
@@ -44,7 +44,6 @@
 
 namespace PDepend\Metrics;
 
-use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
@@ -101,10 +100,8 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      * Tries to restore the metrics for a cached node. If this method has
      * restored the metrics it will return <b>TRUE</b>, otherwise the return
      * value will be <b>FALSE</b>.
-     *
-     * @param ASTClass|ASTCompilationUnit|ASTFunction|ASTInterface|ASTMethod $node
      */
-    protected function restoreFromCache(AbstractASTArtifact $node): bool
+    protected function restoreFromCache(ASTClass|ASTCompilationUnit|ASTFunction|ASTInterface|ASTMethod $node): bool
     {
         $id = $node->getId();
         if ($node->isCached() && isset($this->metricsCached[$id])) {

--- a/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -302,7 +302,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      *
      * @param ASTClass|ASTEnum|ASTTrait $class The context class instance.
      */
-    private function calculateVarsi(AbstractASTClassOrInterface $class): int
+    private function calculateVarsi(ASTClass|ASTEnum|ASTTrait $class): int
     {
         // List of properties, this method only counts not overwritten properties
         $properties = [];
@@ -372,10 +372,7 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         return $ccn;
     }
 
-    /**
-     * @param ASTClass|ASTEnum $class
-     */
-    private function calculateAbstractASTClassOrInterfaceMetrics(AbstractASTClassOrInterface $class): void
+    private function calculateAbstractASTClassOrInterfaceMetrics(ASTClass|ASTEnum|ASTTrait $class): void
     {
         $impl = count($class->getInterfaces());
         $varsi = $this->calculateVarsi($class);

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList.php
@@ -119,7 +119,7 @@ class ASTArtifactList implements ArrayAccess, Countable, Iterator
      * @return T
      * @throws OutOfBoundsException
      */
-    public function current(): ASTArtifact|false
+    public function current(): ASTArtifact
     {
         if ($this->offset >= $this->count) {
             throw new OutOfBoundsException('The offset does not exist.');

--- a/src/main/php/PDepend/Source/AST/ASTNamespace.php
+++ b/src/main/php/PDepend/Source/AST/ASTNamespace.php
@@ -218,10 +218,8 @@ class ASTNamespace extends AbstractASTArtifact
 
     /**
      * Removes the given type instance from this namespace.
-     *
-     * @param AbstractASTClassOrInterface $type
      */
-    public function removeType(AbstractASTType $type): void
+    public function removeType(AbstractASTClassOrInterface $type): void
     {
         if (($index = array_search($type, $this->types, true)) !== false) {
             // Remove class from internal list

--- a/src/main/php/PDepend/Source/Builder/Builder.php
+++ b/src/main/php/PDepend/Source/Builder/Builder.php
@@ -178,7 +178,7 @@ interface Builder extends IteratorAggregate
      * @return $this
      * @since  0.10.0
      */
-    public function setCache(CacheDriver $cache);
+    public function setCache(CacheDriver $cache): self;
 
     /**
      * Restores a function within the internal type scope.

--- a/src/main/php/PDepend/Source/Builder/BuilderContext.php
+++ b/src/main/php/PDepend/Source/Builder/BuilderContext.php
@@ -102,10 +102,8 @@ interface BuilderContext
 
     /**
      * Returns the class instance for the given qualified name.
-     *
-     * @return ASTClass|ASTEnum;
      */
-    public function getClass(string $qualifiedName);
+    public function getClass(string $qualifiedName): ASTClass|ASTEnum;
 
     /**
      * Returns a class or an interface instance for the given qualified name.

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -2736,7 +2736,7 @@ abstract class AbstractPHPParser
      * @return T
      * @throws ParserException
      */
-    private function parseExpressionTypeReference(ASTNode $expr, bool $classRef): AbstractASTNode
+    private function parseExpressionTypeReference(AbstractASTNode $expr, bool $classRef): AbstractASTNode
     {
         $expr->addChild(
             $this->parseOptionalMemberPrimaryPrefix(
@@ -3146,7 +3146,7 @@ abstract class AbstractPHPParser
      * @return T
      * @since 1.0.0
      */
-    private function parseExpressionList(ASTNode $exprList): AbstractASTNode
+    private function parseExpressionList(AbstractASTNode $exprList): AbstractASTNode
     {
         $this->consumeComments();
 
@@ -3160,9 +3160,10 @@ abstract class AbstractPHPParser
     /**
      * Return true if children remain to be added, false else.
      *
-     * @param AbstractASTNode $exprList
+     * @throws TokenStreamEndException
+     * @throws UnexpectedTokenException
      */
-    private function addChildToList(ASTNode $exprList, ASTNode $expr): bool
+    private function addChildToList(AbstractASTNode $exprList, ASTNode $expr): bool
     {
         $exprList->addChild($expr);
 
@@ -4690,7 +4691,7 @@ abstract class AbstractPHPParser
      * @return AbstractASTNode The original input node or this node wrapped with a function postfix instance.
      * @since 1.0.0
      */
-    private function parseOptionalFunctionPostfix(ASTNode $node): AbstractASTNode
+    private function parseOptionalFunctionPostfix(AbstractASTNode $node): AbstractASTNode
     {
         $this->consumeComments();
         if (Tokens::T_PARENTHESIS_OPEN === $this->tokenizer->peek()) {

--- a/src/main/php/PDepend/Util/Cache/CacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/CacheDriver.php
@@ -66,7 +66,7 @@ interface CacheDriver
      *
      * @return $this
      */
-    public function type(string $type);
+    public function type(string $type): self;
 
     /**
      * This method will store the given <em>$data</em> under <em>$key</em>. This

--- a/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/File/FileCacheDirectory.php
@@ -47,7 +47,6 @@ namespace PDepend\Util\Cache\Driver\File;
 use DirectoryIterator;
 use PDepend\Util\Cache\CacheDriver;
 use RuntimeException;
-use SplFileInfo;
 
 /**
  * Directory helper for the file system based cache implementation.
@@ -196,10 +195,9 @@ class FileCacheDirectory
      * Flushes the cache record for the given file info instance, independent if
      * it is a file, directory or symlink.
      *
-     * @param DirectoryIterator $file
      * @throws RuntimeException
      */
-    protected function flushEntry(SplFileInfo $file): void
+    protected function flushEntry(DirectoryIterator $file): void
     {
         $path = $file->getRealPath();
         if ($file->isDot()) {


### PR DESCRIPTION
Type: refactoring
Breaking change: yes

These are types that we have previously overridden via PHPDoc to not be BC but still correct the wrong native hint.