### PR TITLE
Parallel parsing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=8.1",
         "php-64bit": "*",
+        "fidry/cpu-core-counter": "^1.1",
         "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0 || ^8.0",
@@ -30,6 +31,11 @@
     "autoload": {
         "psr-4": {
             "PDepend\\": "src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "PDepend\\": "tests/php/PDepend/"
         }
     },
     "bin": [

--- a/src/DbusUI/ResultPrinter.php
+++ b/src/DbusUI/ResultPrinter.php
@@ -54,7 +54,6 @@ use PDepend\ProcessListener;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\AbstractASTVisitListener;
 use PDepend\Source\Builder\Builder;
-use PDepend\Source\Tokenizer\Tokenizer;
 
 /**
  * Fun result printer that uses dbus to show a notification window.
@@ -92,14 +91,14 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts parsing of a new file.
      */
-    public function startFileParsing(Tokenizer $tokenizer): void
+    public function startFileParsing(): void
     {
     }
 
     /**
      * Is called when PDepend has finished a file.
      */
-    public function endFileParsing(Tokenizer $tokenizer): void
+    public function endFileParsing(): void
     {
         ++$this->parsedFiles;
     }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -45,6 +45,7 @@ namespace PDepend;
 
 use AppendIterator;
 use ArrayIterator;
+use Fidry\CpuCoreCounter\CpuCoreCounter;
 use GlobIterator;
 use InvalidArgumentException;
 use OutOfBoundsException;
@@ -68,9 +69,10 @@ use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Source\Parser\ParserException;
-use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheFactory;
 use PDepend\Util\Configuration;
+use React\EventLoop\Factory as LoopFactory;
+use React\Stream\WritableStreamInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
@@ -133,6 +135,8 @@ class Engine
     /** A filter for namespace. */
     private ArtifactFilter $codeFilter;
 
+    private bool $isWorker = false;
+
     /** Should the parse ignore doc comment annotations? */
     private bool $withoutAnnotations = false;
 
@@ -154,7 +158,7 @@ class Engine
      * List of all {@link ParserException} that were caught during
      * the parsing process.
      *
-     * @var ParserException[]
+     * @var list<ParserException>
      */
     private array $parseExceptions = [];
 
@@ -255,6 +259,11 @@ class Engine
         $this->options = $options;
     }
 
+    public function setWorker(): void
+    {
+        $this->isWorker = true;
+    }
+
     /**
      * Should the parse ignore doc comment annotations?
      */
@@ -286,7 +295,9 @@ class Engine
     {
         $this->builder = new PHPBuilder();
 
+        $this->fireStartParseProcess($this->builder);
         $this->performParseProcess();
+        $this->fireEndParseProcess($this->builder);
 
         // Get global filter collection
         $collection = CollectionArtifactFilter::getInstance();
@@ -437,20 +448,20 @@ class Engine
     /**
      * Sends the start file parsing event.
      */
-    protected function fireStartFileParsing(Tokenizer $tokenizer): void
+    protected function fireStartFileParsing(): void
     {
         foreach ($this->listeners as $listener) {
-            $listener->startFileParsing($tokenizer);
+            $listener->startFileParsing();
         }
     }
 
     /**
      * Sends the end file parsing event.
      */
-    protected function fireEndFileParsing(Tokenizer $tokenizer): void
+    protected function fireEndFileParsing(): void
     {
         foreach ($this->listeners as $listener) {
-            $listener->endFileParsing($tokenizer);
+            $listener->endFileParsing();
         }
     }
 
@@ -504,39 +515,142 @@ class Engine
         // Reset list of thrown exceptions
         $this->parseExceptions = [];
 
-        $tokenizer = new PHPTokenizerInternal();
+        if ($this->isWorker) {
+            $this->runWorker();
 
-        $this->fireStartParseProcess($this->builder);
-
-        foreach ($this->createFileIterator() as $file) {
-            $tokenizer->setSourceFile($file);
-
-            $parser = new PHPParserGeneric(
-                $tokenizer,
-                $this->builder,
-                $this->cacheFactory->create(),
-            );
-            assert($this->configuration->parser instanceof stdClass);
-            assert(is_int($this->configuration->parser->nesting));
-            $parser->setMaxNestingLevel($this->configuration->parser->nesting);
-
-            // Disable annotation parsing?
-            if ($this->withoutAnnotations) {
-                $parser->setIgnoreAnnotations();
-            }
-
-            $this->fireStartFileParsing($tokenizer);
-
-            try {
-                $parser->parse();
-            } catch (ParserException $e) {
-                $this->parseExceptions[] = $e;
-            }
-
-            $this->fireEndFileParsing($tokenizer);
+            return;
         }
 
-        $this->fireEndParseProcess($this->builder);
+        $files = $this->createFileIterator();
+        $fileCount = count($files);
+
+        if ($fileCount > 1) {
+            $coreCount = (new CpuCoreCounter())->getCount();
+            if ($coreCount > 1) {
+                $this->runMultiProcessParse($files, $fileCount, $coreCount);
+
+                return;
+            }
+        }
+
+        $tokenizer = new PHPTokenizerInternal();
+
+        foreach ($files as $file) {
+            $this->fireStartFileParsing();
+            $this->parseFile($tokenizer, $file);
+            $this->fireEndFileParsing();
+        }
+    }
+
+    private function runWorker(): void
+    {
+        $stdin = fopen('php://stdin', 'rb');
+        if ($stdin === false) {
+            throw new RuntimeException('Unable to acquire input stream');
+        }
+
+        $tokenizer = new PHPTokenizerInternal();
+
+        while (($file = fgets($stdin)) !== false) {
+            $file = trim($file);
+            if ($file === '') {
+                continue;
+            }
+
+            $this->parseFile($tokenizer, $file);
+
+            if ($this->parseExceptions) {
+                echo base64_encode(serialize(array_pop($this->parseExceptions))) . "\n";
+                $this->parseExceptions = [];
+
+                continue;
+            }
+
+            $namespaces = $this->builder->getNamespaces();
+            echo base64_encode(serialize($namespaces)) . "\n";
+            $this->builder = new PHPBuilder();
+        }
+    }
+
+    /**
+     * @param ArrayIterator<int, string> $files
+     */
+    private function runMultiProcessParse(ArrayIterator $files, int $fileCount, int $coreCount): void
+    {
+        $processFactory = new ProcessFactory($this->withoutAnnotations);
+        $loop = LoopFactory::create();
+        $proccessCount = min($fileCount, $coreCount);
+        $buffers = [];
+        for ($proccessNo = 0; $proccessNo < $proccessCount; $proccessNo++) {
+            $process = $processFactory->create();
+            $buffers[$proccessNo] = '';
+            $process->start($loop);
+
+            assert(is_callable($process->stdout));
+            $process->stdout->on('data', function (string $chunk) use (&$buffers, $proccessNo, $files, $process): void {
+                $buffers[$proccessNo] .= $chunk;
+
+                while (($pos = strpos($buffers[$proccessNo], "\n")) !== false) {
+                    $this->fireStartFileParsing();
+                    $line = substr($buffers[$proccessNo], 0, $pos);
+                    $buffers[$proccessNo] = substr($buffers[$proccessNo], $pos + 1);
+
+                    $serializedData = base64_decode($line, true);
+                    if ($serializedData === false) {
+                        throw new RuntimeException('Unable to decode message: ' . $line);
+                    }
+
+                    $data = unserialize($serializedData);
+
+                    if ($data instanceof ParserException) {
+                        $this->parseExceptions[] = $data;
+                    }
+
+                    if ($process->stdin instanceof WritableStreamInterface) {
+                        if ($files->valid()) {
+                            $process->stdin->write($files->current() . "\n");
+                            $files->next();
+                        } else {
+                            $process->stdin->end();
+                        }
+                    }
+                    $this->fireEndFileParsing();
+                }
+            });
+
+            if ($process->stdin instanceof WritableStreamInterface) {
+                $process->stdin->write($files->current() . "\n");
+                $files->next();
+            }
+        }
+        $loop->run();
+        $cache = $this->cacheFactory->create();
+        $this->builder->setCache($cache);
+    }
+
+    private function parseFile(PHPTokenizerInternal $tokenizer, string $file): void
+    {
+        $tokenizer->setSourceFile($file);
+
+        $parser = new PHPParserGeneric(
+            $tokenizer,
+            $this->builder,
+            $this->cacheFactory->create(),
+        );
+        assert($this->configuration->parser instanceof stdClass);
+        assert(is_int($this->configuration->parser->nesting));
+        $parser->setMaxNestingLevel($this->configuration->parser->nesting);
+
+        // Disable annotation parsing?
+        if ($this->withoutAnnotations) {
+            $parser->setIgnoreAnnotations();
+        }
+
+        try {
+            $parser->parse();
+        } catch (ParserException $e) {
+            $this->parseExceptions[] = $e;
+        }
     }
 
     /**

--- a/src/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -208,7 +208,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         // Add 2 for the branching per the NPath spec
         $npath += 2;
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -236,7 +236,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = $this->complexityCollector + $expr + 1;
 
         $this->popComplexityCollector();
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -279,7 +279,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             ++$npath;
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -311,7 +311,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             }
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -342,7 +342,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             }
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -386,7 +386,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             ++$npath;
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -404,7 +404,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
      */
     public function visitReturnStatement(ASTReturnStatement $node): void
     {
-        $this->complexityCollector *= $this->sumComplexity($node) ?: 1;
+        $this->complexityCollector = (int) ($this->complexityCollector * ($this->sumComplexity($node) ?: 1));
     }
 
     /**
@@ -436,7 +436,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             }
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -478,7 +478,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
             }
         }
 
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     /**
@@ -505,7 +505,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         $npath = $this->complexityCollector + $expr + 1;
 
         $this->popComplexityCollector();
-        $this->complexityCollector *= $npath;
+        $this->complexityCollector = (int) ($this->complexityCollector * $npath);
     }
 
     public function dispatch(ASTNode $node): void

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -43,63 +43,72 @@
 
 namespace PDepend;
 
-// @codeCoverageIgnoreStart
-use PDepend\Metrics\AnalyzerListener;
-use PDepend\Source\AST\ASTNamespace;
-use PDepend\Source\ASTVisitor\ASTVisitListener;
-use PDepend\Source\Builder\Builder;
+use React\ChildProcess\Process;
+use RuntimeException;
 
-/**
- * This listener can be used to get informations about the current pdepend process.
- *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- */
-interface ProcessListener extends AnalyzerListener, ASTVisitListener
+final class ProcessFactory
 {
+    public function __construct(
+        private readonly bool $withoutAnnotations,
+    ) {
+    }
+
     /**
-     * Is called when PDepend starts the file parsing process.
+     *  @throws RuntimeException
+     */
+    public function create(): Process
+    {
+        $commandArgs = $this->getCommandArgs();
+
+        return new Process(
+            implode(' ', $commandArgs),
+            null,
+            null,
+            [
+                ['socket'],
+                ['socket'],
+                ['socket'],
+            ]
+        );
+    }
+
+    /**
+     * @return list<string>
      *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
+     * @throws RuntimeException
      */
-    public function startParseProcess(Builder $builder): void;
+    public function getCommandArgs(): array
+    {
+        $phpBinary = PHP_BINARY;
 
-    /**
-     * Is called when PDepend has finished the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
-     */
-    public function endParseProcess(Builder $builder): void;
+        /** @var list<string> */
+        $argv = $_SERVER['argv'];
 
-    /**
-     * Is called when PDepend starts parsing of a new file.
-     */
-    public function startFileParsing(): void;
+        $mainScript = realpath(__DIR__ . '/../bin/pdepend');
+        if (false === $mainScript && isset($argv[0]) && str_contains($argv[0], 'pdepend')) {
+            $mainScript = $argv[0];
+        }
+        if (false === $mainScript) {
+            throw new RuntimeException('Unable to determin main script');
+        }
 
-    /**
-     * Is called when PDepend has finished a file.
-     */
-    public function endFileParsing(): void;
+        $commandArgs = [
+            $phpBinary,
+            escapeshellarg($mainScript),
+            '--worker',
+        ];
+        if ($this->withoutAnnotations) {
+            $commandArgs[] = '--without-annotations';
+        }
 
-    /**
-     * Is called when PDepend starts the analyzing process.
-     */
-    public function startAnalyzeProcess(): void;
+        /** @var list<string> */
+        $argv = $_SERVER['argv'];
+        foreach ($argv as $value) {
+            if (str_starts_with($value, '--configuration=')) {
+                $commandArgs[] = trim($value);
+            }
+        }
 
-    /**
-     * Is called when PDepend has finished the analyzing process.
-     */
-    public function endAnalyzeProcess(): void;
-
-    /**
-     * Is called when PDepend starts the logging process.
-     */
-    public function startLogProcess(): void;
-
-    /**
-     * Is called when PDepend has finished the logging process.
-     */
-    public function endLogProcess(): void;
+        return $commandArgs;
+    }
 }
-
-// @codeCoverageIgnoreEnd

--- a/src/Source/AST/ASTAnonymousClass.php
+++ b/src/Source/AST/ASTAnonymousClass.php
@@ -83,8 +83,6 @@ class ASTAnonymousClass extends ASTClass
      */
     public function __wakeup(): void
     {
-        $this->methods = null;
-
         foreach ($this->nodes as $node) {
             $node->setParent($this);
         }

--- a/src/Source/AST/ASTClass.php
+++ b/src/Source/AST/ASTClass.php
@@ -61,6 +61,11 @@ class ASTClass extends AbstractASTClassOrInterface
      */
     private array $properties;
 
+    public function __sleep(): array
+    {
+        return ['properties', ...parent::__sleep()];
+    }
+
     /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation

--- a/src/Source/AST/AbstractASTCallable.php
+++ b/src/Source/AST/AbstractASTCallable.php
@@ -115,6 +115,10 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
             'returnsReference',
             'returnClassReference',
             'exceptionClassReferences',
+            'startColumn',
+            'endColumn',
+            'parent',
+            'compilationUnit',
         ];
     }
 

--- a/src/Source/AST/AbstractASTType.php
+++ b/src/Source/AST/AbstractASTType.php
@@ -88,12 +88,10 @@ abstract class AbstractASTType extends AbstractASTArtifact
     protected int $modifiers = 0;
 
     /**
-     * Temporary property that only holds methods during the parsing process.
-     *
-     * @var ASTMethod[]|null
+     * @var ASTMethod[]
      * @since 1.0.2
      */
-    protected ?array $methods = [];
+    protected array $methods = [];
 
     /** The parent namespace for this class. */
     private ?ASTNamespace $namespace = null;
@@ -108,14 +106,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function __sleep(): array
     {
-        if (is_array($this->methods)) {
-            $this->cache
-                ->type('methods')
-                ->store($this->getId(), $this->methods);
-
-            $this->methods = null;
-        }
-
         return [
             'cache',
             'context',
@@ -128,6 +118,11 @@ abstract class AbstractASTType extends AbstractASTArtifact
             'startLine',
             'userDefined',
             'id',
+            'methods',
+            'startColumn',
+            'endColumn',
+            'parent',
+            'compilationUnit',
         ];
     }
 
@@ -140,8 +135,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function __wakeup(): void
     {
-        $this->methods = null;
-
         foreach ($this->nodes as $node) {
             $node->setParent($this);
         }
@@ -216,23 +209,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
      */
     public function getMethods(): ASTArtifactList
     {
-        if (is_array($this->methods)) {
-            return new ASTArtifactList($this->methods);
-        }
-
-        /** @var ASTMethod[] */
-        $methods = (array) $this->cache
-            ->type('methods')
-            ->restore($this->getId());
-
-        if ($this instanceof AbstractASTClassOrInterface) {
-            foreach ($methods as $method) {
-                $method->compilationUnit = $this->compilationUnit;
-                $method->setParent($this);
-            }
-        }
-
-        return new ASTArtifactList($methods);
+        return new ASTArtifactList($this->methods);
     }
 
     /**

--- a/src/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/Source/Language/PHP/PHPTokenizerInternal.php
@@ -937,7 +937,11 @@ class PHPTokenizerInternal implements FullTokenizer
             }
 
             if (in_array($temp, [T_PRIVATE, T_PROTECTED, T_PUBLIC], true)
-                && $tokens[$index + 1][0] === '(' && $tokens[$index + 2][1] === 'set' && $tokens[$index + 3][0] === ')'
+                && isset($tokens[$index + 3])
+                && is_string($tokens[$index + 1])
+                && is_array($tokens[$index + 2])
+                && is_string($tokens[$index + 3])
+                && $tokens[$index + 1] === '(' && $tokens[$index + 2][1] === 'set' && $tokens[$index + 3] === ')'
             ) {
                 $skipTo = $index + 4;
                 $result[] = match ($temp) {

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -214,7 +214,11 @@ class Command
             unset($options['--without-annotations']);
         }
 
-        if (isset($options['--quiet'])) {
+        if (isset($options['--worker'])) {
+            $runSilent = true;
+            $this->runner->setWorker();
+            unset($options['--worker']);
+        } elseif (isset($options['--quiet'])) {
             $runSilent = true;
             unset($options['--quiet']);
         } else {

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -49,7 +49,6 @@ use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\AbstractASTVisitListener;
 use PDepend\Source\Builder\Builder;
-use PDepend\Source\Tokenizer\Tokenizer;
 
 /**
  * Prints current the PDepend status information.
@@ -90,7 +89,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend starts parsing of a new file.
      */
-    public function startFileParsing(Tokenizer $tokenizer): void
+    public function startFileParsing(): void
     {
         $this->step();
     }
@@ -98,7 +97,7 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
     /**
      * Is called when PDepend has finished a file.
      */
-    public function endFileParsing(Tokenizer $tokenizer): void
+    public function endFileParsing(): void
     {
     }
 

--- a/src/TextUI/Runner.php
+++ b/src/TextUI/Runner.php
@@ -82,6 +82,8 @@ class Runner
      */
     private array $excludeDirectories = ['.git', '.svn', 'CVS'];
 
+    private bool $isWorker = false;
+
     /**
      * List of exclude namespaces.
      *
@@ -156,6 +158,11 @@ class Runner
     public function setExcludeDirectories(array $excludeDirectories): void
     {
         $this->excludeDirectories = $excludeDirectories;
+    }
+
+    public function setWorker(): void
+    {
+        $this->isWorker = true;
     }
 
     /**
@@ -236,6 +243,10 @@ class Runner
             $engine->addFileFilter($filter);
         }
 
+        if ($this->isWorker) {
+            $engine->setWorker();
+        }
+
         if (count($this->excludeNamespaces) > 0) {
             $exclude = $this->excludeNamespaces;
             $filter = new PackageArtifactFilter($exclude);
@@ -259,7 +270,7 @@ class Runner
             throw new RuntimeException($e->getMessage(), self::EXCEPTION_EXIT, $e);
         }
 
-        if (count($this->loggerMap) === 0) {
+        if (!$this->isWorker && count($this->loggerMap) === 0) {
             throw new RuntimeException('No output specified.', self::EXCEPTION_EXIT);
         }
 

--- a/src/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/Util/Cache/Driver/MemoryCacheDriver.php
@@ -113,7 +113,7 @@ class MemoryCacheDriver implements CacheDriver
      */
     public function __wakeup(): void
     {
-        $this->cache = self::$staticCache[$this->staticId];
+        $this->cache = self::$staticCache[$this->staticId] ?? [];
     }
 
     /**

--- a/tests/php/PDepend/AbstractTestCase.php
+++ b/tests/php/PDepend/AbstractTestCase.php
@@ -44,7 +44,6 @@
 namespace PDepend;
 
 use ArrayIterator;
-use DirectoryIterator;
 use ErrorException;
 use Exception;
 use Imagick;
@@ -101,13 +100,6 @@ abstract class AbstractTestCase extends TestCase
     {
         parent::setUp();
 
-        $run = __DIR__ . '/_run';
-        if (file_exists($run) === false) {
-            mkdir($run, 0o755);
-        }
-
-        $this->clearRunResources($run);
-
         if (defined('STDERR') === false) {
             define('STDERR', fopen('php://stderr', '1'));
         }
@@ -120,7 +112,6 @@ abstract class AbstractTestCase extends TestCase
     {
         CollectionArtifactFilter::getInstance()->setFilter();
 
-        $this->clearRunResources();
         $this->resetWorkingDirectory();
 
         if (function_exists('gc_collect_cycles')) {
@@ -458,30 +449,6 @@ abstract class AbstractTestCase extends TestCase
             ->getMock();
 
         return $mock;
-    }
-
-    /**
-     * Clears all temporary resources.
-     */
-    private function clearRunResources(?string $dir = null): void
-    {
-        if ($dir === null) {
-            $dir = __DIR__ . '/_run';
-        }
-
-        foreach (new DirectoryIterator($dir) as $file) {
-            if ($file->isDot() || $file->getFilename() === '.svn') {
-                continue;
-            }
-            $pathName = realpath($file->getPathname());
-            static::assertNotFalse($pathName);
-            if ($file->isDir()) {
-                $this->clearRunResources($pathName);
-                rmdir($pathName);
-            } else {
-                unlink($pathName);
-            }
-        }
     }
 
     /**

--- a/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -94,6 +94,7 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
         static::assertEquals(
             [
                 'metadata',
+                'properties',
                 'constants',
                 'interfaceReferences',
                 'parentClassReference',
@@ -108,6 +109,11 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
                 'startLine',
                 'userDefined',
                 'id',
+                'methods',
+                'startColumn',
+                'endColumn',
+                'parent',
+                'compilationUnit',
             ],
             $class->__sleep()
         );

--- a/tests/php/PDepend/Source/AST/ASTClassTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassTest.php
@@ -1446,6 +1446,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
         static::assertEquals(
             [
+                'properties',
                 'constants',
                 'interfaceReferences',
                 'parentClassReference',
@@ -1460,6 +1461,11 @@ class ASTClassTest extends AbstractASTArtifactTestCase
                 'startLine',
                 'userDefined',
                 'id',
+                'methods',
+                'startColumn',
+                'endColumn',
+                'parent',
+                'compilationUnit',
             ],
             $class->__sleep()
         );

--- a/tests/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -263,6 +263,10 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
                 'returnsReference',
                 'returnClassReference',
                 'exceptionClassReferences',
+                'startColumn',
+                'endColumn',
+                'parent',
+                'compilationUnit',
             ],
             $function->__sleep()
         );

--- a/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -794,6 +794,11 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
                 'startLine',
                 'userDefined',
                 'id',
+                'methods',
+                'startColumn',
+                'endColumn',
+                'parent',
+                'compilationUnit',
             ],
             $interface->__sleep()
         );

--- a/tests/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/tests/php/PDepend/Source/AST/ASTMethodTest.php
@@ -104,6 +104,10 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
                 'returnsReference',
                 'returnClassReference',
                 'exceptionClassReferences',
+                'startColumn',
+                'endColumn',
+                'parent',
+                'compilationUnit',
             ],
             $method->__sleep()
         );

--- a/tests/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/tests/php/PDepend/TextUI/ResultPrinterTest.php
@@ -48,7 +48,6 @@ use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\Language\PHP\PHPBuilder;
-use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -69,13 +68,11 @@ class ResultPrinterTest extends AbstractTestCase
     {
         // Create dummy objects
         $builder = new PHPBuilder();
-        $tokenizer = new PHPTokenizerInternal();
-        $tokenizer->setSourceFile(__FILE__);
 
         $printer = new ResultPrinter();
 
         ob_start();
-        $printer->startFileParsing($tokenizer);
+        $printer->startFileParsing();
         $printer->endParseProcess($builder);
         $actual = ob_get_contents();
         ob_end_clean();
@@ -92,14 +89,12 @@ class ResultPrinterTest extends AbstractTestCase
     {
         // Create dummy objects
         $builder = new PHPBuilder();
-        $tokenizer = new PHPTokenizerInternal();
-        $tokenizer->setSourceFile(__FILE__);
 
         $printer = new ResultPrinter();
 
         ob_start();
         for ($i = 0; $i < 73; ++$i) {
-            $printer->startFileParsing($tokenizer);
+            $printer->startFileParsing();
         }
         $printer->endParseProcess($builder);
         $actual = ob_get_contents();
@@ -204,7 +199,7 @@ class ResultPrinterTest extends AbstractTestCase
             function (): void {
                 $printer = new ResultPrinter();
 
-                $printer->endFileParsing(new PHPTokenizerInternal());
+                $printer->endFileParsing();
                 $printer->startAnalyzeProcess();
                 $printer->endAnalyzeProcess();
                 $printer->endLogProcess();

--- a/tests/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
+++ b/tests/resources/files/TextUI/Command/testCommandHandlesBadDocumentedSourceCode/package2.php
@@ -3,6 +3,10 @@ interface pkg2FooI extends pkg1FooI {
 
 }
 
+class Bar {
+
+}
+
 abstract class pkg2Bar extends pkg1Bar {
     public static function doIt(?Bar $foo = null)
     {

--- a/tests/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
+++ b/tests/resources/files/TextUI/Runner/testSupportBadDocumentation/package2.php
@@ -3,6 +3,10 @@ interface pkg2FooI extends pkg1FooI {
 
 }
 
+class Bar {
+
+}
+
 abstract class pkg2Bar extends pkg1Bar {
     public static function doIt(?Bar $foo = null)
     {
@@ -13,7 +17,7 @@ abstract class pkg2Bar extends pkg1Bar {
 class pkg2Foobar extends pkg1Bar {
     public $bar = null;
     protected static $manager = null;
-    
+
     /**
      * Command manager singleton method which returns a configured instance
      * or <b>null</b>.

--- a/tests/resources/files/config/pdepend.yml.dist
+++ b/tests/resources/files/config/pdepend.yml.dist
@@ -5,5 +5,4 @@ pdepend:
 
   cache:
     driver: file
-    location: ../../../php/PDepend/_run/cache
     ttl: 2592000


### PR DESCRIPTION
Fixes: #341  
Type: feature  
Breaking change: yes  

## Breaking change

This PR introduces a breaking change: `fireStartFileParsing()` and `fireEndFileParsing()` no longer forward the `Tokenizer`.

Previously, this allowed listeners to inspect the file being parsed (along with other internal details that were likely not appropriate to expose). With parallel processing enabled, the tokenizer now lives in a separate process, so it is no longer possible to provide listeners with direct access to it.

This functionality was never used by PDepend itself or by known downstream projects, so no alternative solution has been implemented.

## Description

During file parsing, files are dynamically dispatched to workers, and the results are serialized and sent back to the main process. At the start of parsing, `min(number-of-files, number-of-threads)` workers are spawned. If only a single source file is provided, multiprocessing is not used.

Performance improvements observed on my system (32 threads):

- Scanning PDepend (244 files): ~45% time reduction
- Scanning a medium project (~700 files): ~70% time reduction
- Scanning a large project (~1665 files): ~80% time reduction
- Scanning PDepend + vendor folder (~6,800 files): ~90% time reduction

<img width="344" height="177" alt="image" src="https://github.com/user-attachments/assets/24add362-e4f6-4f5e-b808-5e9f3bb70e4d" />

*(First half: file parsing, second half: report generation)*

On my laptop (4 threads):
- Scanning PDepend (244 files): ~15% time reduction  
- Scanning a medium project (~700 files): ~45% time reduction  
- Scanning a large project (~1665 files): ~45% time reduction
- Scanning PDepend + vendor folder (~6,800 files): ~56% time reduction  

<img width="1410" height="369" alt="image" src="https://github.com/user-attachments/assets/24b9a2f3-1466-4312-8a6f-c553b50bab36" />

