### PR TITLE
Check the difference between an empty string and false to parse the source of an empty file.

### DIFF
--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -289,7 +289,7 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
             (str_starts_with($this->fileName, 'php://') || file_exists($this->fileName))
         ) {
             $source = file_get_contents($this->fileName);
-            if (!$source) {
+            if ($source === false) {
                 throw new RuntimeException('File not found ' . $this->fileName);
             }
 

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -913,7 +913,7 @@ class PHPTokenizerInternal implements FullTokenizer
 
         // No longer replacing short open tags since some want to track them.
         $source = $this->sourceFile->getSource();
-        if (!$source) {
+        if ($source === null) {
             throw new RuntimeException('No source was given');
         }
 


### PR DESCRIPTION
Check the difference between an empty string and false to parse the source of an empty file.

Type: bugfix
Issue: #876 
Breaking change: no

