### PR TITLE
Update tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
-        "phpstan/phpstan": "~1.11.0",
-        "phpunit/phpunit": "^10.5.20",
+        "phpstan/phpstan": "~1.12.0",
+        "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },
     "replace": {

--- a/scripts/php-keywords.php
+++ b/scripts/php-keywords.php
@@ -172,11 +172,11 @@ preg_match(
 );
 
 $parserCode = str_replace(
-    $match[0],
+    $match[0] ?? '',
     str_replace(
-        $match[1],
+        $match[1] ?? '',
         trim($methodCode),
-        $match[0]
+        $match[0] ?? ''
     ),
     $parserCode
 );

--- a/src/main/php/PDepend/Application.php
+++ b/src/main/php/PDepend/Application.php
@@ -211,8 +211,7 @@ class Application
 
         foreach ($loggerServices as $loggerServiceTags) {
             foreach ($loggerServiceTags as $loggerServiceTag) {
-                if (
-                    isset($loggerServiceTag['option'], $loggerServiceTag['message'])
+                if (isset($loggerServiceTag['option'], $loggerServiceTag['message'])
                     && is_string($loggerServiceTag['option'])
                     && is_string($loggerServiceTag['message'])
                 ) {

--- a/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/CouplingAnalyzer.php
@@ -350,8 +350,7 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         if (null === $coupledType) {
             return;
         }
-        if (
-            $coupledType->isSubtypeOf($declaringType)
+        if ($coupledType->isSubtypeOf($declaringType)
             || $declaringType->isSubtypeOf($coupledType)
         ) {
             return;

--- a/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -541,8 +541,7 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         if ($node instanceof ASTConditionalExpression) {
             $this->dispatch($node);
             $sum += $this->complexityCollector;
-        } elseif (
-            $node instanceof ASTBooleanAndExpression
+        } elseif ($node instanceof ASTBooleanAndExpression
             || $node instanceof ASTBooleanOrExpression
             || $node instanceof ASTLogicalAndExpression
             || $node instanceof ASTLogicalOrExpression

--- a/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/main/php/PDepend/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -431,8 +431,7 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         for (; $i < $count; ++$i) {
             $token = $tokens[$i];
 
-            if (
-                $token->type === Tokens::T_COMMENT
+            if ($token->type === Tokens::T_COMMENT
                 || $token->type === Tokens::T_DOC_COMMENT
             ) {
                 $lines = &$clines;

--- a/src/main/php/PDepend/Report/Jdepend/Chart.php
+++ b/src/main/php/PDepend/Report/Jdepend/Chart.php
@@ -189,7 +189,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
             $layer->appendChild($ellipse);
 
             $result = preg_match('#\\\\([^\\\\]+)$#', $item['name'], $found);
-            if ($result && count($found)) {
+            if ($result) {
                 $angle = random_int(0, 314) / 100 - 1.57;
                 $legend = $legendTemplate->cloneNode(true);
                 $legend->setAttribute('x', (string) ($e + $item['ratio'] * (1 + cos($angle))));

--- a/src/main/php/PDepend/Report/Jdepend/Xml.php
+++ b/src/main/php/PDepend/Report/Jdepend/Xml.php
@@ -346,8 +346,7 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $this->dispatch($type);
         }
 
-        if (
-            $this->concreteClasses->firstChild === null
+        if ($this->concreteClasses->firstChild === null
             && $this->abstractClasses->firstChild === null
         ) {
             return;

--- a/src/main/php/PDepend/Report/Overview/Pyramid.php
+++ b/src/main/php/PDepend/Report/Overview/Pyramid.php
@@ -195,6 +195,9 @@ class Pyramid implements FileAwareGenerator
                 continue;
             }
             preg_match('/fill:(#[^;"]+)/', $color->getAttribute('style'), $match);
+            if (!isset($match[1])) {
+                continue;
+            }
 
             $style = $rect->getAttribute('style');
             $style = preg_replace('/fill:#[^;"]+/', "fill:{$match[1]}", $style) ?? $style;

--- a/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
+++ b/src/main/php/PDepend/Source/AST/ASTArtifactList/CollectionArtifactFilter.php
@@ -77,7 +77,6 @@ final class CollectionArtifactFilter implements ArtifactFilter
     /**
      * Sets the used filter instance.
      *
-     * @param ?ArtifactFilter $filter
      * @since  0.9.12
      */
     public function setFilter(?ArtifactFilter $filter = null): void

--- a/src/main/php/PDepend/Source/AST/ASTCallable.php
+++ b/src/main/php/PDepend/Source/AST/ASTCallable.php
@@ -51,8 +51,5 @@ namespace PDepend\Source\AST;
  */
 interface ASTCallable extends ASTNode
 {
-    /**
-     * @return ?ASTType
-     */
     public function getReturnType(): ?ASTType;
 }

--- a/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
+++ b/src/main/php/PDepend/Source/AST/ASTCompilationUnit.php
@@ -283,8 +283,7 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      */
     protected function readSource(): void
     {
-        if (
-            $this->source === null &&
+        if ($this->source === null &&
             $this->fileName &&
             (str_starts_with($this->fileName, 'php://') || file_exists($this->fileName))
         ) {

--- a/src/main/php/PDepend/Source/AST/ASTFunction.php
+++ b/src/main/php/PDepend/Source/AST/ASTFunction.php
@@ -115,8 +115,6 @@ class ASTFunction extends AbstractASTCallable
 
     /**
      * Returns the parent namespace for this function.
-     *
-     * @return ?ASTNamespace
      */
     public function getNamespace(): ?ASTNamespace
     {
@@ -147,7 +145,6 @@ class ASTFunction extends AbstractASTCallable
      * Returns the name of the parent namespace/package or <b>NULL</b> when this
      * function does not belong to a namespace.
      *
-     * @return ?string
      * @since  0.10.0
      */
     public function getNamespaceName(): ?string

--- a/src/main/php/PDepend/Source/AST/ASTMethod.php
+++ b/src/main/php/PDepend/Source/AST/ASTMethod.php
@@ -182,7 +182,6 @@ class ASTMethod extends AbstractASTCallable
     /**
      * Returns the source file where this method was declared.
      *
-     * @return ?ASTCompilationUnit
      * @throws ASTCompilationUnitNotFoundException When no parent was set.
      * @since  0.10.0
      */

--- a/src/main/php/PDepend/Source/AST/ASTNode.php
+++ b/src/main/php/PDepend/Source/AST/ASTNode.php
@@ -142,8 +142,6 @@ interface ASTNode
     /**
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
-     *
-     * @return ?string
      */
     public function getComment(): ?string;
 

--- a/src/main/php/PDepend/Source/AST/ASTParameter.php
+++ b/src/main/php/PDepend/Source/AST/ASTParameter.php
@@ -175,7 +175,6 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
     /**
      * Returns the parent function or method instance or <b>null</b>
      *
-     * @return ?AbstractASTCallable
      * @since  0.9.5
      */
     public function getDeclaringFunction(): ?AbstractASTCallable
@@ -284,8 +283,7 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
             return true;
         }
 
-        if (
-            !($node instanceof ASTTypeArray)
+        if (!($node instanceof ASTTypeArray)
             && !($node instanceof ASTScalarType)
             && $this->getClass() === null
         ) {

--- a/src/main/php/PDepend/Source/AST/ASTProperty.php
+++ b/src/main/php/PDepend/Source/AST/ASTProperty.php
@@ -211,8 +211,6 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
 
     /**
      * Returns the doc comment for this item or <b>null</b>.
-     *
-     * @return ?string
      */
     public function getComment(): ?string
     {

--- a/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/main/php/PDepend/Source/AST/ASTTraitAdaptationAlias.php
@@ -53,11 +53,7 @@ namespace PDepend\Source\AST;
  */
 class ASTTraitAdaptationAlias extends ASTStatement
 {
-    /**
-     * The new aliased method name.
-     *
-     * @var ?string
-     */
+    /** The new aliased method name. */
     protected ?string $newName = null;
 
     /** The new method modifier for the imported method. */
@@ -105,8 +101,6 @@ class ASTTraitAdaptationAlias extends ASTStatement
     /**
      * Returns the new aliased method name or <b>NULL</b> when this alias does
      * not specify a new method name.
-     *
-     * @return ?string
      */
     public function getNewName(): ?string
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTArtifact.php
@@ -236,8 +236,6 @@ abstract class AbstractASTArtifact implements ASTArtifact
 
     /**
      * Sets the raw doc comment for this node.
-     *
-     * @param ?string $comment
      */
     public function setComment(?string $comment): void
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTNode.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTNode.php
@@ -125,8 +125,6 @@ abstract class AbstractASTNode implements ASTNode
 
     /**
      * Sets the image for this ast node.
-     *
-     * @param ?string $image
      */
     public function setImage(?string $image): void
     {
@@ -416,8 +414,6 @@ abstract class AbstractASTNode implements ASTNode
     /**
      * Returns a doc comment for this node or <b>null</b> when no comment was
      * found.
-     *
-     * @return ?string
      */
     public function getComment(): ?string
     {

--- a/src/main/php/PDepend/Source/AST/AbstractASTType.php
+++ b/src/main/php/PDepend/Source/AST/AbstractASTType.php
@@ -299,8 +299,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
     /**
      * Returns the name of the parent namespace.
-     *
-     * @return ?string
      */
     public function getNamespaceName(): ?string
     {
@@ -309,8 +307,6 @@ abstract class AbstractASTType extends AbstractASTArtifact
 
     /**
      * Returns the parent namespace for this class.
-     *
-     * @return ?ASTNamespace
      */
     public function getNamespace(): ?ASTNamespace
     {

--- a/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/main/php/PDepend/Source/Language/PHP/AbstractPHPParser.php
@@ -430,8 +430,7 @@ abstract class AbstractPHPParser
         $allowed = State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE;
         $modifiers &= $allowed;
 
-        if (
-            $this->classOrInterface instanceof ASTInterface
+        if ($this->classOrInterface instanceof ASTInterface
             && ($modifiers & (State::IS_PROTECTED | State::IS_PRIVATE)) !== 0
         ) {
             throw new InvalidStateException(
@@ -3603,7 +3602,6 @@ abstract class AbstractPHPParser
      * in the base version. In this method you can implement version specific
      * expressions.
      *
-     * @return ?ASTNode
      * @throws TokenStreamEndException
      * @throws UnexpectedTokenException
      * @since 2.2
@@ -5571,8 +5569,7 @@ abstract class AbstractPHPParser
                 $this->consumeToken(Tokens::T_COMMA);
                 $this->consumeComments();
 
-                if (
-                    $inCall &&
+                if ($inCall &&
                     $this->tokenizer->peek() === Tokens::T_PARENTHESIS_CLOSE
                 ) {
                     break;
@@ -6882,8 +6879,7 @@ abstract class AbstractPHPParser
         $token = $this->tokenizer->currentToken();
         $types = [$firstType];
 
-        while (
-            $this->tokenizer->peekNext() !== Tokens::T_VARIABLE
+        while ($this->tokenizer->peekNext() !== Tokens::T_VARIABLE
             && $this->addTokenToStackIfType(Tokens::T_BITWISE_AND)
         ) {
             $types[] = $this->parseSingleTypeHint();
@@ -7317,8 +7313,7 @@ abstract class AbstractPHPParser
             // Remove alias and add real namespace
             array_shift($fragments);
             array_unshift($fragments, $mapsTo);
-        } elseif (
-            isset($this->namespaceName)
+        } elseif (isset($this->namespaceName)
             && !$this->namespacePrefixReplaced
         ) {
             // Prepend current namespace
@@ -7712,7 +7707,6 @@ abstract class AbstractPHPParser
      * Parses the value of a php constant. By default this can be only static
      * values that were allowed in the oldest supported PHP version.
      *
-     * @return ?ASTValue
      * @since 2.2.x
      */
     protected function parseConstantDeclaratorValue(): ?ASTValue
@@ -7780,8 +7774,7 @@ abstract class AbstractPHPParser
         // Fetch next token type
         $tokenType = $this->tokenizer->peek();
 
-        if (
-            $tokenType === Tokens::T_PARENTHESIS_OPEN
+        if ($tokenType === Tokens::T_PARENTHESIS_OPEN
             || $tokenType === Tokens::T_DOUBLE_COLON
         ) {
             return $this->setNodePositionsAndReturn(
@@ -7904,7 +7897,6 @@ abstract class AbstractPHPParser
      * This method will parse a default value after a parameter/static variable/constant
      * declaration.
      *
-     * @return ?ASTValue
      * @since 2.11.0
      */
     private function parseVariableDefaultValue(): ?ASTValue
@@ -7923,7 +7915,6 @@ abstract class AbstractPHPParser
      * This method will parse a static value or a static array as it is
      * used as default value for a parameter or property declaration.
      *
-     * @return ?ASTValue
      * @since 0.9.6
      */
     private function parseStaticValueOrStaticArray(): ?ASTValue
@@ -7947,7 +7938,6 @@ abstract class AbstractPHPParser
      * This method will parse a static default value as it is used for a
      * parameter, property or constant declaration.
      *
-     * @return ?ASTValue
      * @throws MissingValueException
      * @since 0.9.5
      */
@@ -8396,7 +8386,6 @@ abstract class AbstractPHPParser
      * Returns the name of a declared names. When the parsed code is not namespaced
      * this method will return the name from the @package annotation.
      *
-     * @return ?string
      * @since 0.9.8
      */
     private function getNamespaceOrPackageName(): ?string
@@ -8442,8 +8431,7 @@ abstract class AbstractPHPParser
         }
 
         // Check for doc level comment
-        if (
-            $this->globalPackageName === Builder::DEFAULT_NAMESPACE
+        if ($this->globalPackageName === Builder::DEFAULT_NAMESPACE
             && $this->isFileComment()
         ) {
             $this->globalPackageName = $package;
@@ -8837,8 +8825,7 @@ abstract class AbstractPHPParser
             $this->consumeToken(Tokens::T_COLON);
             $type = $this->parseTypeHint();
 
-            if (
-                !($type instanceof ASTScalarType) ||
+            if (!($type instanceof ASTScalarType) ||
                 !in_array($type->getImage(), ['int', 'string'], true)
             ) {
                 throw new TokenException(

--- a/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPBuilder.php
@@ -1872,8 +1872,7 @@ class PHPBuilder implements Builder
         $namespaces = $this->namespaces;
 
         // Remove default package if empty
-        if (
-            count($this->defaultPackage->getTypes()) === 0
+        if (count($this->defaultPackage->getTypes()) === 0
             && count($this->defaultPackage->getFunctions()) === 0
         ) {
             unset($namespaces[self::DEFAULT_NAMESPACE]);
@@ -2280,8 +2279,6 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a trait instance for later reuse.
      *
-     * @param ?string $traitName
-     * @param ?string $namespaceName
      * @since 1.0.0
      */
     protected function storeTrait(?string $traitName, ?string $namespaceName, ASTTrait $trait): void
@@ -2299,8 +2296,6 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a class instance for later reuse.
      *
-     * @param ?string $className
-     * @param ?string $namespaceName
      * @since 0.9.5
      */
     protected function storeClass(?string $className, ?string $namespaceName, ASTClass $class): void
@@ -2318,8 +2313,6 @@ class PHPBuilder implements Builder
     /**
      * This method will persist a class instance for later reuse.
      *
-     * @param ?string $enumName
-     * @param ?string $namespaceName
      * @since 2.11.0
      */
     protected function storeEnum(?string $enumName, ?string $namespaceName, ASTEnum $enum): void
@@ -2337,8 +2330,6 @@ class PHPBuilder implements Builder
     /**
      * This method will persist an interface instance for later reuse.
      *
-     * @param ?string $interfaceName
-     * @param ?string $namespaceName
      * @since 0.9.5
      */
     protected function storeInterface(?string $interfaceName, ?string $namespaceName, ASTInterface $interface): void
@@ -2440,7 +2431,6 @@ class PHPBuilder implements Builder
      * @template T of ASTNode
      *
      * @param class-string<T> $className
-     * @param ?string $image
      * @return T
      * @since 0.9.12
      */

--- a/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/main/php/PDepend/Source/Language/PHP/PHPTokenizerInternal.php
@@ -866,11 +866,9 @@ class PHPTokenizerInternal implements FullTokenizer
                 foreach ($this->splitQualifiedNameToken($token) as $subToken) {
                     $result[] = $subToken;
                 }
-            } elseif (
-                is_array($token)
+            } elseif (is_array($token)
                 && $temp === T_NAME_RELATIVE
                 && preg_match('/^namespace\\\\(.*)$/', $token[1], $match)
-                && $match
             ) {
                 foreach ($this->splitRelativeNameToken($token, $match[1]) as $subToken) {
                     $result[] = $subToken;
@@ -1063,8 +1061,7 @@ class PHPTokenizerInternal implements FullTokenizer
         $token = (array) current($tokens);
 
         // Skipp all non open tags
-        while (
-            $token[0] !== T_OPEN_TAG_WITH_ECHO &&
+        while ($token[0] !== T_OPEN_TAG_WITH_ECHO &&
                $token[0] !== T_OPEN_TAG &&
                $token[0] !== false
         ) {

--- a/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
+++ b/src/main/php/PDepend/Source/Tokenizer/Tokenizer.php
@@ -103,7 +103,6 @@ interface Tokenizer
      * Returns the type of next token, after the current token. This method
      * ignores all comments between the current and the next token.
      *
-     * @return ?int
      * @since  0.9.12
      */
     public function peekNext(): ?int;

--- a/src/main/php/PDepend/TextUI/Command.php
+++ b/src/main/php/PDepend/TextUI/Command.php
@@ -185,8 +185,7 @@ class Command
                     return self::INPUT_ERROR;
                 }
                 assert(is_string($value));
-                if (
-                    $analyzerOptions[$option]['value'] === 'file'
+                if ($analyzerOptions[$option]['value'] === 'file'
                     && !file_exists($value)
                 ) {
                     echo 'Specified file ' . $option . '=' . $value

--- a/src/main/php/PDepend/Util/Cache/CacheFactory.php
+++ b/src/main/php/PDepend/Util/Cache/CacheFactory.php
@@ -44,11 +44,11 @@
 
 namespace PDepend\Util\Cache;
 
+use Exception;
 use InvalidArgumentException;
 use PDepend\Util\Cache\Driver\FileCacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
 use PDepend\Util\Configuration;
-use Random\RandomException;
 use RuntimeException;
 use stdClass;
 
@@ -85,9 +85,7 @@ class CacheFactory
      * identifier.
      *
      * @param string $cacheKey The name/identifier for the cache instance.
-     * @throws InvalidArgumentException
-     * @throws RandomException
-     * @throws RuntimeException
+     * @throws Exception
      */
     public function create(?string $cacheKey = null): CacheDriver
     {
@@ -103,8 +101,7 @@ class CacheFactory
      *
      * @param string|null $cacheKey The name/identifier for the cache instance.
      * @throws InvalidArgumentException If the configured cache driver is unknown.
-     * @throws RandomException
-     * @throws RuntimeException
+     * @throws Exception
      */
     protected function createCache(?string $cacheKey = null): CacheDriver
     {
@@ -142,7 +139,7 @@ class CacheFactory
     /**
      * Creates an in memory cache instance.
      *
-     * @throws RandomException
+     * @throws Exception
      */
     protected function createMemoryCache(): MemoryCacheDriver
     {

--- a/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/main/php/PDepend/Util/Cache/Driver/MemoryCacheDriver.php
@@ -44,8 +44,8 @@
 
 namespace PDepend\Util\Cache\Driver;
 
+use Exception;
 use PDepend\Util\Cache\CacheDriver;
-use Random\RandomException;
 
 /**
  * A memory based cache implementation.
@@ -86,7 +86,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * Instantiates a new in memory cache instance.
      *
-     * @throws RandomException
+     * @throws Exception
      */
     public function __construct()
     {

--- a/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/src/test/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -43,6 +43,7 @@
 
 namespace PDepend\Bugs;
 
+use Exception;
 use PDepend\AbstractTestCase;
 use PDepend\Report\Summary\Xml;
 use PDepend\Source\AST\ASTArtifactList;
@@ -104,6 +105,10 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
         [$class, $method] = explode('::', $testCase);
 
         preg_match('(Bug(\d+)Test$)', $class, $match);
+
+        if (!isset($match[1])) {
+            throw new Exception('Unable to find tests case ID');
+        }
 
         return self::createCodeResourceURI(
             sprintf('bugs/%s/%s.php', $match[1], $method)

--- a/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/src/test/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -103,8 +103,6 @@ class ParserBug21500611Test extends AbstractRegressionTestCase
 
     /**
      * Returns the first heredoc found in a class.
-     *
-     * @return ?ASTHeredoc
      */
     protected function getFirstHeredocInClass(): ?ASTHeredoc
     {

--- a/src/test/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/src/test/php/PDepend/Input/ExcludePathFilterTest.php
@@ -207,8 +207,7 @@ class ExcludePathFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if (
-                $file instanceof SplFileInfo
+            if ($file instanceof SplFileInfo
                 && $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')

--- a/src/test/php/PDepend/Input/ExtensionFilterTest.php
+++ b/src/test/php/PDepend/Input/ExtensionFilterTest.php
@@ -107,8 +107,7 @@ class ExtensionFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if (
-                $file instanceof SplFileInfo
+            if ($file instanceof SplFileInfo
                 && $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')

--- a/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
+++ b/src/test/php/PDepend/Issues/AbstractFeatureTestCase.php
@@ -92,7 +92,7 @@ abstract class AbstractFeatureTestCase extends AbstractTestCase
     public function parseTestCaseSource(string $testCase, bool $ignoreAnnotations = false): ASTArtifactList
     {
         [$class, $method] = explode('::', $testCase);
-        if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0) {
+        if (preg_match('([^\d](\d+)Test$)', $class, $match) === 0 || !isset($match[1])) {
             throw new ErrorException('Unexpected class name format');
         }
 

--- a/src/test/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/src/test/php/PDepend/Report/Jdepend/ChartTest.php
@@ -269,8 +269,8 @@ class ChartTest extends AbstractTestCase
         static::assertInstanceOf(DOMElement::class, $ellipseA);
         $matrixA = $ellipseA->getAttribute('transform');
         preg_match('/matrix\(([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)\)/', $matrixA, $matches);
-        static::assertEquals(1, $matches[1]);
-        static::assertEquals(1, $matches[4]);
+        static::assertEquals(1, $matches[1] ?? null);
+        static::assertEquals(1, $matches[4] ?? null);
 
         $xmlElement = $xpath->query("//s:ellipse[@title='package1']");
         static::assertNotFalse($xmlElement);
@@ -278,8 +278,8 @@ class ChartTest extends AbstractTestCase
         static::assertInstanceOf(DOMElement::class, $ellipseB);
         $matrixB = $ellipseB->getAttribute('transform');
         preg_match('/matrix\(([^,]+),([^,]+),([^,]+),([^,]+),([^,]+),([^,]+)\)/', $matrixB, $matches);
-        static::assertEqualsWithDelta(0.3333333, $matches[1], 0.000001);
-        static::assertEqualsWithDelta(0.3333333, $matches[4], 0.000001);
+        static::assertEqualsWithDelta(0.3333333, $matches[1] ?? null, 0.000001);
+        static::assertEqualsWithDelta(0.3333333, $matches[4] ?? null, 0.000001);
     }
 
     /**

--- a/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/src/test/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -75,11 +75,10 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
             ];
         }, $children);
 
-        foreach (
-            [
-                ['null', '$nullish'],
-                ['false', '$falsy'],
-            ] as $index => $expected
+        foreach ([
+            ['null', '$nullish'],
+            ['false', '$falsy'],
+        ] as $index => $expected
         ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = ASTScalarType::class;

--- a/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/src/test/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -1171,31 +1171,30 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach (
-            [
-                ['int', '$id'],
-                ['float', '$money'],
-                ['bool', '$active'],
-                ['string', '$name'],
-                ['array', '$list', ASTTypeArray::class],
-                ['self', '$parent', ASTSelfReference::class],
-                ['callable', '$event', ASTTypeCallable::class],
-                ['\Closure', '$fqn', ASTClassOrInterfaceReference::class],
-                ['iterable', '$actions', ASTTypeIterable::class],
-                ['object', '$bag', ASTClassOrInterfaceReference::class],
-                ['Role', '$role', ASTClassOrInterfaceReference::class],
-                ['?int', '$idN'],
-                ['?float', '$moneyN'],
-                ['?bool', '$activeN'],
-                ['?string', '$nameN'],
-                ['?array', '$listN', ASTTypeArray::class],
-                ['?self', '$parentN', ASTSelfReference::class],
-                ['?callable', '$eventN', ASTTypeCallable::class],
-                ['?\Closure', '$fqnN', ASTClassOrInterfaceReference::class],
-                ['?iterable', '$actionsN', ASTTypeIterable::class],
-                ['?object', '$bagN', ASTClassOrInterfaceReference::class],
-                ['?Role', '$roleN', ASTClassOrInterfaceReference::class],
-            ] as $index => $expected
+        foreach ([
+            ['int', '$id'],
+            ['float', '$money'],
+            ['bool', '$active'],
+            ['string', '$name'],
+            ['array', '$list', ASTTypeArray::class],
+            ['self', '$parent', ASTSelfReference::class],
+            ['callable', '$event', ASTTypeCallable::class],
+            ['\Closure', '$fqn', ASTClassOrInterfaceReference::class],
+            ['iterable', '$actions', ASTTypeIterable::class],
+            ['object', '$bag', ASTClassOrInterfaceReference::class],
+            ['Role', '$role', ASTClassOrInterfaceReference::class],
+            ['?int', '$idN'],
+            ['?float', '$moneyN'],
+            ['?bool', '$activeN'],
+            ['?string', '$nameN'],
+            ['?array', '$listN', ASTTypeArray::class],
+            ['?self', '$parentN', ASTSelfReference::class],
+            ['?callable', '$eventN', ASTTypeCallable::class],
+            ['?\Closure', '$fqnN', ASTClassOrInterfaceReference::class],
+            ['?iterable', '$actionsN', ASTTypeIterable::class],
+            ['?object', '$bagN', ASTClassOrInterfaceReference::class],
+            ['?Role', '$roleN', ASTClassOrInterfaceReference::class],
+        ] as $index => $expected
         ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
@@ -1495,10 +1494,9 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach (
-            [
-                ['null|int|float', '$number', ASTUnionType::class],
-            ] as $index => $expected
+        foreach ([
+            ['null|int|float', '$number', ASTUnionType::class],
+        ] as $index => $expected
         ) {
             [$expectedType, $expectedVariable, $expectedTypeClass] = $expected;
             [$type, $variable] = $declarations[$index];


### PR DESCRIPTION
Type: bugfix / refactoring
Breaking change: no

- [RandomException](https://www.php.net/manual/en/class.random-randomexception.php) is only thrown in 8.2+
- phpcs/php-cs-fixer: Now detects a few more redundant return types, if clause must start on first line.
- phpunit: Locked to 10.5.31 since 10.5.32 has a breaking change that conflicts with Paratest, see https://github.com/paratestphp/paratest/pull/883#issuecomment-2330971002 for alternatives.
- phpstan: stricter checks for preg-functions
