### PR TITLE
add support for large exclusion patterns and associated tests

### DIFF
--- a/src/Input/ExcludePathFilter.php
+++ b/src/Input/ExcludePathFilter.php
@@ -95,13 +95,14 @@ class ExcludePathFilter implements Filter
             return;
         }
 
-        if (strlen($patternString) > self::PATTERN_SPLIT_LIMIT) {
-            $this->isBulk = true;
-            foreach ($quoted as $pattern) {
-                $this->iterativePatterns[] = '(^(' . $pattern . '))i';
-            }
-        } else {
+        if (strlen($patternString) <= self::PATTERN_SPLIT_LIMIT) {
             $this->pattern = '(^(' . $patternString . '))i';
+            return;
+        }
+
+        $this->isBulk = true;
+        foreach ($quoted as $pattern) {
+            $this->iterativePatterns[] = '(^(' . $pattern . '))i';
         }
     }
 

--- a/src/Input/ExcludePathFilter.php
+++ b/src/Input/ExcludePathFilter.php
@@ -65,13 +65,13 @@ class ExcludePathFilter implements Filter
      */
     protected string $pattern = '';
 
-    /**
-     * Indicates if we are in bulk mode.
-     */
+    /** Indicates if we are in bulk mode. */
     protected bool $isBulk = false;
 
     /**
      * List of patterns used for bulk matching.
+     *
+     * @var array<string>
      */
     protected array $iterativePatterns = [];
 
@@ -181,7 +181,7 @@ class ExcludePathFilter implements Filter
     }
 
     /**
-     * Checks if the path matches any pattern in bulk mode.
+     * Checks if the path matches any pattern in bulk mode
      */
     protected function matchesIterativePatterns(string $path): bool
     {

--- a/src/Input/ExcludePathFilter.php
+++ b/src/Input/ExcludePathFilter.php
@@ -97,6 +97,7 @@ class ExcludePathFilter implements Filter
 
         if (strlen($patternString) <= self::PATTERN_SPLIT_LIMIT) {
             $this->pattern = '(^(' . $patternString . '))i';
+
             return;
         }
 

--- a/tests/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/tests/php/PDepend/Input/ExcludePathFilterTest.php
@@ -46,6 +46,8 @@ namespace PDepend\Input;
 use PDepend\AbstractTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use ReflectionException;
+use ReflectionProperty;
 use SplFileInfo;
 
 /**
@@ -66,79 +68,71 @@ class ExcludePathFilterTest extends AbstractTestCase
      * circumstances where too many files are excluded instead of using the baseline.
      *
      * Generates 2,000 patterns of 20, 10 and 5 random alpha characters, with some slashes (about 70k characters))
-     *
-     * @return void
      */
-    public function testPatternsWithSixtyThousandCharactersAcceptsRelativeOrAbsolutePatternNotInList()
+    public function testPatternsWithSixtyThousandCharactersAcceptsRelativeOrAbsolutePatternNotInList(): void
     {
         $patterns = $this->prepareTestPatterns();
 
         $filter = new ExcludePathFilter($patterns);
-        $this->assertTrue($filter->accept('foo0/baz0/bar0', 'C:\\blahblah\\bar'));
+        static::assertTrue($filter->accept('foo0/baz0/bar0', 'C:\\blahblah\\bar'));
     }
 
     /**
      * testPatternsWithSixtyThousandCharactersRejectsRelativePatternFoundInList
-     *
-     * @return void
      */
-    public function testPatternsWithSixtyThousandCharactersRejectsRelativePatternFoundInList()
+    public function testPatternsWithSixtyThousandCharactersRejectsRelativePatternFoundInList(): void
     {
         $patterns = $this->prepareTestPatterns();
 
         $filter = new ExcludePathFilter($patterns);
         $firstPattern = str_replace('/', '\\', $patterns[0]);
-        $relativePath = 'foo\\'.$firstPattern;
+        $relativePath = 'foo\\' . $firstPattern;
 
-        $this->assertFalse($filter->accept($relativePath, 'C:\\blahblah\\bar'));
+        static::assertFalse($filter->accept($relativePath, 'C:\\blahblah\\bar'));
     }
 
     /**
      * testPatternsWithSixtyThousandCharactersRejectsAbsolutePatternFoundInList
-     *
-     * @return void
      */
-    public function testPatternsWithSixtyThousandCharactersRejectsAbsolutePatternFoundInList()
+    public function testPatternsWithSixtyThousandCharactersRejectsAbsolutePatternFoundInList(): void
     {
         $patterns = $this->prepareTestPatterns();
 
         $filter = new ExcludePathFilter($patterns);
         $firstPattern = str_replace('/', '\\', $patterns[0]);
-        $absolutePath = $firstPattern.'\\bar';
+        $absolutePath = $firstPattern . '\\bar';
 
-        $this->assertFalse($filter->accept('/foobar/barf00', $absolutePath));
+        static::assertFalse($filter->accept('/foobar/barf00', $absolutePath));
     }
 
     /**
      * testPatternsWithSixtyThousandCharactersSetProtectedIsBulkToTrue
      *
-     * @return void
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
-    public function testPatternsWithSixtyThousandCharactersSetProtectedIsBulkToTrue()
+    public function testPatternsWithSixtyThousandCharactersSetProtectedIsBulkToTrue(): void
     {
         $patterns = $this->prepareTestPatterns();
 
         $filter = new ExcludePathFilter($patterns);
 
-        $isBulk = new \ReflectionProperty($filter, 'isBulk');
+        $isBulk = new ReflectionProperty($filter, 'isBulk');
 
-        $this->assertTrue($isBulk->getValue($filter));
+        static::assertTrue($isBulk->getValue($filter));
     }
 
     /**
      * testPatternsWithLessThanThirtyThousandCharactersSetProtectedIsBulkToFalse
      *
-     * @return void
-     * @throws \ReflectionException
+     * @throws ReflectionException
      */
-    public function testPatternsWithLessThanThirtyThousandCharactersSetProtectedIsBulkToFalse()
+    public function testPatternsWithLessThanThirtyThousandCharactersSetProtectedIsBulkToFalse(): void
     {
-        $filter = new ExcludePathFilter(array('Just16Characters'));
+        $filter = new ExcludePathFilter(['Just16Characters']);
 
-        $isBulk = new \ReflectionProperty($filter, 'isBulk');
+        $isBulk = new ReflectionProperty($filter, 'isBulk');
 
-        $this->assertFalse($isBulk->getValue($filter));
+        static::assertFalse($isBulk->getValue($filter));
     }
 
     /**
@@ -159,6 +153,9 @@ class ExcludePathFilterTest extends AbstractTestCase
         static::assertTrue($filter->accept('/foo/baz/bar', '/foo/baz/bar'));
     }
 
+    /**
+     * testRelativePathMatchOrNot
+     */
     public function testRelativePathMatchOrNot(): void
     {
         $filter = new ExcludePathFilter(['link-to/bar']);
@@ -305,9 +302,10 @@ class ExcludePathFilterTest extends AbstractTestCase
     /**
      * Returns a random string with a given length.
      *
-     * @param integer $length The length of the random string.
+     * @param int $length The length of the random string.
      *
      * @return string
+     * @throws \Random\RandomException
      */
     protected function randAlpha($length = 3)
     {
@@ -315,8 +313,9 @@ class ExcludePathFilterTest extends AbstractTestCase
         $charsLength = strlen($chars);
         $randomString = '';
         for ($i = 0; $i < $length; $i++) {
-            $randomString .= $chars[mt_rand(0, $charsLength - 1)];
+            $randomString .= $chars[random_int(0, $charsLength - 1)];
         }
+
         return $randomString;
     }
 
@@ -327,9 +326,9 @@ class ExcludePathFilterTest extends AbstractTestCase
      */
     protected function prepareTestPatterns()
     {
-        $patterns = array();
+        $patterns = [];
         for ($i = 0; $i < 2000; $i++) {
-            $patterns[] = $this->randAlpha(20) . '/' . $this->randAlpha(10).'/'.$this->randAlpha(5);
+            $patterns[] = $this->randAlpha(20) . '/' . $this->randAlpha(10) . '/' . $this->randAlpha(5);
         }
 
         return $patterns;

--- a/tests/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/tests/php/PDepend/Input/ExcludePathFilterTest.php
@@ -136,6 +136,27 @@ class ExcludePathFilterTest extends AbstractTestCase
     }
 
     /**
+     * testEmptyPatternListSetsEmptyPattern
+     */
+    public function testEmptyPatternListSetsEmptyPatternAndIsAccepted(): void
+    {
+        $filter = new ExcludePathFilter([]);
+
+        static::assertTrue($filter->accept('any/path', 'C:\\any\\path'));
+    }
+
+    /**
+     * testEmptyPatternStringSetsEmptyPattern
+     *
+     */
+    public function testEmptyPatternStringSetsEmptyPatternAndIsAccepted(): void
+    {
+        $filter = new ExcludePathFilter(['']);
+
+        static::assertTrue($filter->accept('any/path', 'C:\\any\\path'));
+    }
+
+    /**
      * testAbsoluteUnixPathAsFilterPatternMatches
      */
     public function testAbsoluteUnixPathAsFilterPatternMatches(): void

--- a/tests/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/tests/php/PDepend/Input/ExcludePathFilterTest.php
@@ -43,6 +43,7 @@
 
 namespace PDepend\Input;
 
+use Exception;
 use PDepend\AbstractTestCase;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -147,7 +148,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testEmptyPatternStringSetsEmptyPattern
-     *
      */
     public function testEmptyPatternStringSetsEmptyPatternAndIsAccepted(): void
     {
@@ -323,12 +323,9 @@ class ExcludePathFilterTest extends AbstractTestCase
     /**
      * Returns a random string with a given length.
      *
-     * @param int $length The length of the random string.
-     *
-     * @return string
-     * @throws \Random\RandomException
+     * @throws Exception
      */
-    protected function randAlpha($length = 3)
+    private function randAlpha(int $length = 3): string
     {
         $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
         $charsLength = strlen($chars);
@@ -345,7 +342,7 @@ class ExcludePathFilterTest extends AbstractTestCase
      *
      * @return array<string>
      */
-    protected function prepareTestPatterns()
+    private function prepareTestPatterns(): array
     {
         $patterns = [];
         for ($i = 0; $i < 2000; $i++) {


### PR DESCRIPTION
Type: bugfix
Issue: #880
Breaking change: no

As per [the issue](https://github.com/pdepend/pdepend/issues/880), `preg_match()` fails when the pattern exceeds about 32k characters.

This PR addresses the issue by:
a) maintaining existing flows as much as possible, for backwards compatibility
b) adding an alternative flow for any pattern exceeding about 32k characters, in which case it instead operates iteratively on each pattern

Often these tools are used in conjunction with legacy codebases; legacy codebases often come with many files, and many of these require exclusion. While using the baseline is definitely an option, it is not the same as excluding files. Other tools such as phpcs or phpstan seem to not have an issue with supporting large exclusion lists, but phpmd does (for which the problem traces back to pdepend).

Some areas I have **not** looked into:
 - Whether phpcs also relies on pdepend but has it's own solution to avert the "too large pattern" error; or how phpcs implements their solution
 - How phpstan handles "too large" patterns
 
 Some considerations for the reviewers:
  - I have used AI assistance tools (some Github Copilot and some ChatGPT 4) but have steered and reviewed the code output myself (see below point for the reason why I predominantly used these tools). The tests are written by myself.
  - I've tried to conform to the existing somewhat loosely typed nature of the particular file I was working on, which was challenging (thus the above tool usage). My IDE helped enforce some of the PHP minimum version requirements (e.g. `array()` instead of `[]`)
  - I wanted to create a `Bulk*.php` variant of the class but chose not to. If preferred I am happy to do that.
  - The design intentionally doesn't (or tries to avoid) a refactor of the existing class. Again, I am happy to refactor the existing class, particularly to make the above Bulk* class more achievable.