### PR TITLE
Remove replace section from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,6 @@
         "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },
-    "replace": {
-        "symfony/polyfill-php80": "*"
-    },
     "autoload": {
         "psr-4": {
             "PDepend\\": "src"


### PR DESCRIPTION
Type: documentation update  
Breaking change: no

This does optimize the number of packages installed (our dependency on PHP 8.1 makes the 8.0 poly-fill redundant), but this can create conflicts in someone down stream also has a similar replace for the same package as composer sees this a potential issue.
