### PR TITLE
Upgrade to PHPStan 2.1

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -64,7 +64,7 @@ jobs:
             sh -c "echo $PASSPHRASE | gpg --command-fd 0 --pinentry-mode loopback -u pgp@pdepend.org --batch --detach-sign --output pdepend.phar.asc pdepend.phar";
 
       - name: Upload pdepend.phar and pdepend.phar.asc
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: |
             pdepend.phar

--- a/bin/pdepend.php
+++ b/bin/pdepend.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 /**
  * This file is part of PDepend.
  *

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
-        "phpstan/phpstan": "~1.12.0",
+        "phpstan/phpstan": "~2.1.0",
         "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },

--- a/scripts/build.php
+++ b/scripts/build.php
@@ -3,6 +3,8 @@
 $root = realpath(__DIR__ . '/../') . '/';
 
 $archiveName = 'pdepend.phar';
+
+/** @var string */
 $version = parse_ini_file($root . 'build.properties')['project.version'] ?? '@package_version@';
 
 echo 'PDepend ', $version, PHP_EOL, PHP_EOL;

--- a/scripts/update-version.php
+++ b/scripts/update-version.php
@@ -1,5 +1,6 @@
 #!/usr/bin/env php
 <?php
+
 /**
  * This file is part of PDepend.
  *
@@ -184,4 +185,4 @@ class CacheVersionUpdater
     }
 }
 
-CacheVersionUpdater::main($_SERVER['argv']);
+CacheVersionUpdater::main($argv);

--- a/site/config.php
+++ b/site/config.php
@@ -17,7 +17,9 @@ class ParagraphClassNode extends ParagraphNode
 
     public function render(): string
     {
-        $text = trim($this->value);
+        /** @var string */
+        $text = $this->value;
+        $text = trim($text);
         $class = $this->class;
 
         if ($text === '') {
@@ -86,7 +88,10 @@ class PHPDependEnvironment extends Environment
     {
         $root = substr($url, 0, 1) === '/';
 
-        return ($root ? $this->getBaseHref() . '/' : '') . parent::relativeUrl($url);
+        /** @var string */
+        $url = parent::relativeUrl($url);
+
+        return ($root ? $this->getBaseHref() . '/' : '') . $url;
     }
 }
 
@@ -104,7 +109,7 @@ return [
     'layout' => __DIR__ . '/resources/layout.php',
     'publishPhar' => 'pdepend/pdepend',
     'extensions' => [
-        'rst' => function ($file) use ($parser) {
+        'rst' => function (string $file) use ($parser) {
             $parser->getEnvironment()->setCurrentDirectory(dirname($file));
             $content = $parser->parseFile($file);
             // Rewrite links anchors

--- a/site/resources/layout.php
+++ b/site/resources/layout.php
@@ -1,6 +1,8 @@
 <?php
-/** @var ?string $baseHref */
-/** @var ?string $content */
+/**
+ * @var ?string $baseHref
+ * @var ?string $content
+ */
 ?><!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/site/resources/layout.php
+++ b/site/resources/layout.php
@@ -1,4 +1,7 @@
-<!DOCTYPE html>
+<?php
+/** @var ?string $baseHref */
+/** @var ?string $content */
+?><!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>

--- a/src/Application.php
+++ b/src/Application.php
@@ -205,20 +205,17 @@ class Application
     {
         $container = $this->getContainer();
 
+        /** @var array<array<array<string, string>>> */
         $loggerServices = $container->findTaggedServiceIds($serviceTag);
 
         $options = [];
 
         foreach ($loggerServices as $loggerServiceTags) {
             foreach ($loggerServiceTags as $loggerServiceTag) {
-                if (isset($loggerServiceTag['option'], $loggerServiceTag['message'])
-                    && is_string($loggerServiceTag['option'])
-                    && is_string($loggerServiceTag['message'])
-                ) {
-                    $hasValue = isset($loggerServiceTag['value']) && is_string($loggerServiceTag['value']);
+                if (isset($loggerServiceTag['option'], $loggerServiceTag['message'])) {
                     $options[$loggerServiceTag['option']] = [
                         'message' => $loggerServiceTag['message'],
-                        'value' => $hasValue ? $loggerServiceTag['value'] : 'file',
+                        'value' => $loggerServiceTag['value'] ?? 'file',
                     ];
                 }
             }

--- a/src/DependencyInjection/PdependExtension.php
+++ b/src/DependencyInjection/PdependExtension.php
@@ -89,12 +89,15 @@ class PdependExtension extends SymfonyExtension
         }
 
         $configuration = new Configuration($extensionManager->getActivatedExtensions());
+
+        /** @var array<string, array<string, mixed>> */
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../../resources'));
         $loader->load('services.xml');
 
         foreach ($extensionManager->getActivatedExtensions() as $extension) {
+            /** @var array<mixed> */
             $extensionConfig = $config['extensions'][$extension->getName()];
 
             $tempContainer = new ContainerBuilder(new ParameterBag([]));
@@ -114,7 +117,7 @@ class PdependExtension extends SymfonyExtension
     }
 
     /**
-     * @param array<string, array<string, string>> $config
+     * @param array<string, array<string, mixed>> $config
      */
     private function createSettings(array $config): stdClass
     {

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -74,6 +74,7 @@ use PDepend\Util\Configuration;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+use SplFileInfo;
 use SplFileObject;
 use stdClass;
 
@@ -516,6 +517,7 @@ class Engine
                 $this->cacheFactory->create(),
             );
             assert($this->configuration->parser instanceof stdClass);
+            assert(is_int($this->configuration->parser->nesting));
             $parser->setMaxNestingLevel($this->configuration->parser->nesting);
 
             // Disable annotation parsing?
@@ -553,6 +555,7 @@ class Engine
         $this->fireStartAnalyzeProcess();
 
         assert($this->configuration->parser instanceof stdClass);
+        assert(is_int($this->configuration->parser->nesting));
         ini_set('xdebug.max_nesting_level', $this->configuration->parser->nesting);
 
         foreach ($analyzerLoader as $analyzer) {
@@ -589,6 +592,7 @@ class Engine
             throw new RuntimeException('No source directory and file set.');
         }
 
+        /** @var AppendIterator<int, SplFileInfo|string, \Iterator<int, SplFileInfo|string>> */
         $fileIterator = new AppendIterator();
 
         foreach ($this->files as $file) {

--- a/src/Metrics/AbstractCachingAnalyzer.php
+++ b/src/Metrics/AbstractCachingAnalyzer.php
@@ -118,9 +118,12 @@ abstract class AbstractCachingAnalyzer extends AbstractAnalyzer implements Analy
      */
     protected function loadCache(): void
     {
-        $this->metricsCached = (array) $this->cache
+        /** @var array<string, TData> */
+        $nodes = (array) $this->cache
             ->type('metrics')
             ->restore(static::class);
+
+        $this->metricsCached = $nodes;
     }
 
     /**

--- a/src/Metrics/Analyzer/CodeRankAnalyzer.php
+++ b/src/Metrics/Analyzer/CodeRankAnalyzer.php
@@ -144,7 +144,10 @@ class CodeRankAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware
             // Collect all nodes
             foreach ($this->strategies as $strategy) {
                 $collected = $strategy->getCollectedNodes();
-                $this->nodes = array_merge_recursive($collected, $this->nodes);
+
+                /** @var array<string, array<string, array<int, string>>> */
+                $nodes = array_merge_recursive($collected, $this->nodes);
+                $this->nodes = $nodes;
             }
 
             // Init node metrics

--- a/src/Metrics/Analyzer/CouplingAnalyzer.php
+++ b/src/Metrics/Analyzer/CouplingAnalyzer.php
@@ -350,7 +350,8 @@ class CouplingAnalyzer extends AbstractAnalyzer implements AnalyzerNodeAware, An
         if (null === $coupledType) {
             return;
         }
-        if ($coupledType->isSubtypeOf($declaringType)
+        if (
+            $coupledType->isSubtypeOf($declaringType)
             || $declaringType->isSubtypeOf($coupledType)
         ) {
             return;

--- a/src/Metrics/Analyzer/DependencyAnalyzer.php
+++ b/src/Metrics/Analyzer/DependencyAnalyzer.php
@@ -446,7 +446,7 @@ class DependencyAnalyzer extends AbstractAnalyzer
      * Collects a single cycle that is reachable by this namespace. All namespaces
      * that are part of the cylce are stored in the given <b>$list</b> array.
      *
-     * @param ASTNamespace[] $list
+     * @param array<int, ASTNamespace> $list
      * @return bool If this method detects a cycle the return value is <b>true</b>
      *              otherwise this method will return <b>false</b>.
      */

--- a/src/Metrics/Analyzer/NPathComplexityAnalyzer.php
+++ b/src/Metrics/Analyzer/NPathComplexityAnalyzer.php
@@ -541,7 +541,8 @@ class NPathComplexityAnalyzer extends AbstractCachingAnalyzer implements Analyze
         if ($node instanceof ASTConditionalExpression) {
             $this->dispatch($node);
             $sum += $this->complexityCollector;
-        } elseif ($node instanceof ASTBooleanAndExpression
+        } elseif (
+            $node instanceof ASTBooleanAndExpression
             || $node instanceof ASTBooleanOrExpression
             || $node instanceof ASTLogicalAndExpression
             || $node instanceof ASTLogicalOrExpression

--- a/src/Metrics/Analyzer/NodeLocAnalyzer.php
+++ b/src/Metrics/Analyzer/NodeLocAnalyzer.php
@@ -431,7 +431,8 @@ class NodeLocAnalyzer extends AbstractCachingAnalyzer implements
         for (; $i < $count; ++$i) {
             $token = $tokens[$i];
 
-            if ($token->type === Tokens::T_COMMENT
+            if (
+                $token->type === Tokens::T_COMMENT
                 || $token->type === Tokens::T_DOC_COMMENT
             ) {
                 $lines = &$clines;

--- a/src/Report/Jdepend/Xml.php
+++ b/src/Report/Jdepend/Xml.php
@@ -346,7 +346,8 @@ class Xml extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareGen
             $this->dispatch($type);
         }
 
-        if ($this->concreteClasses->firstChild === null
+        if (
+            $this->concreteClasses->firstChild === null
             && $this->abstractClasses->firstChild === null
         ) {
             return;

--- a/src/Report/Overview/Pyramid.php
+++ b/src/Report/Overview/Pyramid.php
@@ -220,9 +220,9 @@ class Pyramid implements FileAwareGenerator
      * <b>null</b>.
      *
      * @param string $name The metric/field identfier.
-     * @param mixed $value The metric/field value.
+     * @param float $value The metric/field value.
      */
-    private function computeThreshold(string $name, mixed $value): ?string
+    private function computeThreshold(string $name, float $value): ?string
     {
         if (!isset($this->thresholds[$name])) {
             return null;

--- a/src/Report/ReportGeneratorFactory.php
+++ b/src/Report/ReportGeneratorFactory.php
@@ -85,6 +85,7 @@ class ReportGeneratorFactory
     public function createGenerator(string $identifier, string $fileName): ReportGenerator
     {
         if (!isset($this->instances[$identifier])) {
+            /** @var array<string, array<array<string, string>>> */
             $loggerServices = $this->container->findTaggedServiceIds('pdepend.logger');
 
             $logger = null;

--- a/src/Source/AST/ASTAnonymousClass.php
+++ b/src/Source/AST/ASTAnonymousClass.php
@@ -67,6 +67,7 @@ class ASTAnonymousClass extends ASTClass
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
+     * @return list<string>
      * @since 0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTClassOrInterfaceReference.php
+++ b/src/Source/AST/ASTClassOrInterfaceReference.php
@@ -77,6 +77,7 @@ class ASTClassOrInterfaceReference extends ASTType
      * Magic method which returns the names of all those properties that should
      * be cached for this node instance.
      *
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTCompilationUnit.php
+++ b/src/Source/AST/ASTCompilationUnit.php
@@ -103,7 +103,7 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      * before it serializes an instance of this class. This method returns an
      * array with those property names that should be serialized.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array
@@ -195,11 +195,11 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
     /**
      * Returns an <b>array</b> with all tokens within this file.
      *
-     * @return array<Token>
+     * @return array<int, Token>
      */
     public function getTokens(): array
     {
-        /** @var Token[] */
+        /** @var array<int, Token> */
         return (array) $this->cache
             ->type('tokens')
             ->restore($this->getId());

--- a/src/Source/AST/ASTCompilationUnit.php
+++ b/src/Source/AST/ASTCompilationUnit.php
@@ -283,7 +283,8 @@ class ASTCompilationUnit extends AbstractASTArtifact implements Stringable
      */
     protected function readSource(): void
     {
-        if ($this->source === null &&
+        if (
+            $this->source === null &&
             $this->fileName &&
             (str_starts_with($this->fileName, 'php://') || file_exists($this->fileName))
         ) {

--- a/src/Source/AST/ASTConstantDeclarator.php
+++ b/src/Source/AST/ASTConstantDeclarator.php
@@ -90,7 +90,7 @@ class ASTConstantDeclarator extends AbstractASTNode
      * Magic sleep method that returns an array with those property names that
      * should be cached for this node instance.
      *
-     * @return array<string>
+     * @return list<string>
      */
     public function __sleep(): array
     {

--- a/src/Source/AST/ASTDeclareStatement.php
+++ b/src/Source/AST/ASTDeclareStatement.php
@@ -83,7 +83,7 @@ class ASTDeclareStatement extends ASTStatement
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTEnum.php
+++ b/src/Source/AST/ASTEnum.php
@@ -88,6 +88,8 @@ class ASTEnum extends AbstractASTClassOrInterface
      * instance of this class gets serialized. It returns an array with the
      * names of all those properties that should be cached for this class or
      * interface instance.
+     *
+     * @return list<string>
      */
     public function __sleep(): array
     {

--- a/src/Source/AST/ASTFormalParameter.php
+++ b/src/Source/AST/ASTFormalParameter.php
@@ -64,6 +64,9 @@ class ASTFormalParameter extends AbstractASTNode
     /** Defined modifiers for this property node. */
     protected int $modifiers = 0;
 
+    /**
+     * @return list<string>
+     */
     public function __sleep(): array
     {
         return ['modifiers', ...parent::__sleep()];

--- a/src/Source/AST/ASTFunction.php
+++ b/src/Source/AST/ASTFunction.php
@@ -78,7 +78,7 @@ class ASTFunction extends AbstractASTCallable
      * gets serialized. It returns an array with those properties that should be
      * cached for all function instances.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTIncludeExpression.php
+++ b/src/Source/AST/ASTIncludeExpression.php
@@ -61,7 +61,7 @@ class ASTIncludeExpression extends ASTExpression
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTMethod.php
+++ b/src/Source/AST/ASTMethod.php
@@ -63,7 +63,7 @@ class ASTMethod extends AbstractASTCallable
      * gets serialized. It returns an array with those properties that should be
      * cached for method instances.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTParameter.php
+++ b/src/Source/AST/ASTParameter.php
@@ -122,15 +122,13 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
             if ($value === null) {
                 $default .= 'NULL';
                 $typeHint .= ($typeHint !== '' ? ' or NULL' : '');
-            } elseif ($value === false) {
-                $default .= 'false';
-            } elseif ($value === true) {
-                $default .= 'true';
+            } elseif (is_bool($value)) {
+                $default .= $value ? 'true' : 'false';
             } elseif (is_array($value)) {
                 $default .= 'Array';
             } elseif (is_string($value)) {
                 $default .= "'" . $value . "'";
-            } else {
+            } elseif ($value instanceof Stringable || is_int($value) || is_float($value)) {
                 $default .= $value;
             }
         }

--- a/src/Source/AST/ASTParameter.php
+++ b/src/Source/AST/ASTParameter.php
@@ -281,7 +281,8 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
             return true;
         }
 
-        if (!($node instanceof ASTTypeArray)
+        if (
+            !($node instanceof ASTTypeArray)
             && !($node instanceof ASTScalarType)
             && $this->getClass() === null
         ) {

--- a/src/Source/AST/ASTParentReference.php
+++ b/src/Source/AST/ASTParentReference.php
@@ -73,7 +73,7 @@ final class ASTParentReference extends ASTClassOrInterfaceReference
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTRequireExpression.php
+++ b/src/Source/AST/ASTRequireExpression.php
@@ -61,7 +61,7 @@ class ASTRequireExpression extends ASTExpression
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTSelfReference.php
+++ b/src/Source/AST/ASTSelfReference.php
@@ -89,6 +89,7 @@ class ASTSelfReference extends ASTClassOrInterfaceReference
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTSwitchLabel.php
+++ b/src/Source/AST/ASTSwitchLabel.php
@@ -61,7 +61,7 @@ class ASTSwitchLabel extends AbstractASTNode
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/ASTTraitAdaptationAlias.php
+++ b/src/Source/AST/ASTTraitAdaptationAlias.php
@@ -63,6 +63,8 @@ class ASTTraitAdaptationAlias extends ASTStatement
      * The magic sleep method will be called by PHP's runtime environment right
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
+     *
+     * @return list<string>
      */
     public function __sleep(): array
     {

--- a/src/Source/AST/ASTVariableDeclarator.php
+++ b/src/Source/AST/ASTVariableDeclarator.php
@@ -63,7 +63,7 @@ class ASTVariableDeclarator extends ASTExpression
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
-     * @return array<string>
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/AbstractASTCallable.php
+++ b/src/Source/AST/AbstractASTCallable.php
@@ -99,6 +99,7 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
      * gets serialized. It returns an array with those properties that should be
      * cached for all callable instances.
      *
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array
@@ -171,11 +172,11 @@ abstract class AbstractASTCallable extends AbstractASTArtifact implements ASTCal
     /**
      * Returns the tokens found in the function body.
      *
-     * @return Token[]
+     * @return array<int, Token>
      */
     public function getTokens(): array
     {
-        /** @var Token[] */
+        /** @var array<int, Token> */
         return (array) $this->cache
             ->type('tokens')
             ->restore($this->getId());

--- a/src/Source/AST/AbstractASTClassOrInterface.php
+++ b/src/Source/AST/AbstractASTClassOrInterface.php
@@ -87,6 +87,7 @@ abstract class AbstractASTClassOrInterface extends AbstractASTType
      * names of all those properties that should be cached for this class or
      * interface instance.
      *
+     * @return list<string>
      * @since  0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/AbstractASTNode.php
+++ b/src/Source/AST/AbstractASTNode.php
@@ -97,6 +97,7 @@ abstract class AbstractASTNode implements ASTNode
      * before an instance of this class gets serialized. It should return an
      * array with those property names that should be serialized for this class.
      *
+     * @return list<string>
      * @since 0.10.0
      */
     public function __sleep(): array

--- a/src/Source/AST/AbstractASTType.php
+++ b/src/Source/AST/AbstractASTType.php
@@ -252,11 +252,11 @@ abstract class AbstractASTType extends AbstractASTArtifact
     /**
      * Returns an <b>array</b> with all tokens within this type.
      *
-     * @return Token[]
+     * @return array<int, Token>
      */
     public function getTokens(): array
     {
-        /** @var Token[] */
+        /** @var array<int, Token> */
         return (array) $this->cache
             ->type('tokens')
             ->restore($this->getId());

--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -2584,7 +2584,7 @@ abstract class AbstractPHPParser
      * @template T of ASTNode
      *
      * @param T $node
-     * @param array<int, Token> $tokens
+     * @param array<Token> $tokens
      * @return T
      * @since 0.9.8
      */
@@ -2626,6 +2626,9 @@ abstract class AbstractPHPParser
                 break;
             }
         }
+
+        /** @var T */
+        $tokens = array_values($tokens);
 
         return $tokens;
     }
@@ -3664,7 +3667,10 @@ abstract class AbstractPHPParser
             }
         }
 
-        return array_values($expressions);
+        /** @var T */
+        $values = array_values($expressions);
+
+        return $values;
     }
 
     /**
@@ -6345,6 +6351,7 @@ abstract class AbstractPHPParser
      */
     private function parseConstructFormalParameterModifiers(): int
     {
+        /** @var array<int, int> */
         static $states = [
             Tokens::T_PUBLIC => State::IS_PUBLIC,
             Tokens::T_PROTECTED => State::IS_PROTECTED,

--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -430,7 +430,8 @@ abstract class AbstractPHPParser
         $allowed = State::IS_PUBLIC | State::IS_PROTECTED | State::IS_PRIVATE;
         $modifiers &= $allowed;
 
-        if ($this->classOrInterface instanceof ASTInterface
+        if (
+            $this->classOrInterface instanceof ASTInterface
             && ($modifiers & (State::IS_PROTECTED | State::IS_PRIVATE)) !== 0
         ) {
             throw new InvalidStateException(
@@ -5575,7 +5576,8 @@ abstract class AbstractPHPParser
                 $this->consumeToken(Tokens::T_COMMA);
                 $this->consumeComments();
 
-                if ($inCall &&
+                if (
+                    $inCall &&
                     $this->tokenizer->peek() === Tokens::T_PARENTHESIS_CLOSE
                 ) {
                     break;
@@ -6886,7 +6888,8 @@ abstract class AbstractPHPParser
         $token = $this->tokenizer->currentToken();
         $types = [$firstType];
 
-        while ($this->tokenizer->peekNext() !== Tokens::T_VARIABLE
+        while (
+            $this->tokenizer->peekNext() !== Tokens::T_VARIABLE
             && $this->addTokenToStackIfType(Tokens::T_BITWISE_AND)
         ) {
             $types[] = $this->parseSingleTypeHint();
@@ -7320,7 +7323,8 @@ abstract class AbstractPHPParser
             // Remove alias and add real namespace
             array_shift($fragments);
             array_unshift($fragments, $mapsTo);
-        } elseif (isset($this->namespaceName)
+        } elseif (
+            isset($this->namespaceName)
             && !$this->namespacePrefixReplaced
         ) {
             // Prepend current namespace
@@ -7781,7 +7785,8 @@ abstract class AbstractPHPParser
         // Fetch next token type
         $tokenType = $this->tokenizer->peek();
 
-        if ($tokenType === Tokens::T_PARENTHESIS_OPEN
+        if (
+            $tokenType === Tokens::T_PARENTHESIS_OPEN
             || $tokenType === Tokens::T_DOUBLE_COLON
         ) {
             return $this->setNodePositionsAndReturn(
@@ -8438,7 +8443,8 @@ abstract class AbstractPHPParser
         }
 
         // Check for doc level comment
-        if ($this->globalPackageName === Builder::DEFAULT_NAMESPACE
+        if (
+            $this->globalPackageName === Builder::DEFAULT_NAMESPACE
             && $this->isFileComment()
         ) {
             $this->globalPackageName = $package;
@@ -8832,7 +8838,8 @@ abstract class AbstractPHPParser
             $this->consumeToken(Tokens::T_COLON);
             $type = $this->parseTypeHint();
 
-            if (!($type instanceof ASTScalarType) ||
+            if (
+                !($type instanceof ASTScalarType) ||
                 !in_array($type->getImage(), ['int', 'string'], true)
             ) {
                 throw new TokenException(

--- a/src/Source/Language/PHP/PHPBuilder.php
+++ b/src/Source/Language/PHP/PHPBuilder.php
@@ -1872,7 +1872,8 @@ class PHPBuilder implements Builder
         $namespaces = $this->namespaces;
 
         // Remove default package if empty
-        if (count($this->defaultPackage->getTypes()) === 0
+        if (
+            count($this->defaultPackage->getTypes()) === 0
             && count($this->defaultPackage->getFunctions()) === 0
         ) {
             unset($namespaces[self::DEFAULT_NAMESPACE]);

--- a/src/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/Source/Language/PHP/PHPTokenizerInternal.php
@@ -1000,7 +1000,7 @@ class PHPTokenizerInternal implements FullTokenizer
                 }
             }
 
-            if ($type) {
+            if ($type && is_string($image)) {
                 $rtrim = rtrim($image);
                 $lines = substr_count($rtrim, "\n");
                 if ($lines === 0) {

--- a/src/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/Source/Language/PHP/PHPTokenizerInternal.php
@@ -866,7 +866,8 @@ class PHPTokenizerInternal implements FullTokenizer
                 foreach ($this->splitQualifiedNameToken($token) as $subToken) {
                     $result[] = $subToken;
                 }
-            } elseif (is_array($token)
+            } elseif (
+                is_array($token)
                 && $temp === T_NAME_RELATIVE
                 && preg_match('/^namespace\\\\(.*)$/', $token[1], $match)
             ) {
@@ -1061,7 +1062,8 @@ class PHPTokenizerInternal implements FullTokenizer
         $token = (array) current($tokens);
 
         // Skipp all non open tags
-        while ($token[0] !== T_OPEN_TAG_WITH_ECHO &&
+        while (
+            $token[0] !== T_OPEN_TAG_WITH_ECHO &&
                $token[0] !== T_OPEN_TAG &&
                $token[0] !== false
         ) {

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -293,6 +293,7 @@ class Command
             return false;
         }
 
+        /** @var array<string> */
         $argv = $_SERVER['argv'];
 
         // Remove the pdepend command line file
@@ -309,9 +310,9 @@ class Command
 
         for ($i = 0, $c = count($argv); $i < $c; ++$i) {
             // Is it an ini_set option?
-            $arg = (string) $argv[$i];
+            $arg = $argv[$i];
             if ($arg === '-d' && isset($argv[$i + 1])) {
-                $arg = (string) $argv[++$i];
+                $arg = $argv[++$i];
                 if (!str_contains($arg, '=')) {
                     ini_set($arg, 'on');
                 } else {
@@ -403,7 +404,7 @@ class Command
         $version = '@package_version@';
         if (file_exists($build)) {
             $data = @parse_ini_file($build);
-            if (is_array($data)) {
+            if (is_array($data) && is_string($data['project.version'])) {
                 $version = $data['project.version'];
             }
         }

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -185,7 +185,8 @@ class Command
                     return self::INPUT_ERROR;
                 }
                 assert(is_string($value));
-                if ($analyzerOptions[$option]['value'] === 'file'
+                if (
+                    $analyzerOptions[$option]['value'] === 'file'
                     && !file_exists($value)
                 ) {
                     echo 'Specified file ' . $option . '=' . $value

--- a/src/Util/Cache/CacheFactory.php
+++ b/src/Util/Cache/CacheFactory.php
@@ -106,6 +106,9 @@ class CacheFactory
     protected function createCache(?string $cacheKey = null): CacheDriver
     {
         assert($this->configuration->cache instanceof stdClass);
+        assert(is_string($this->configuration->cache->driver));
+        assert(is_string($this->configuration->cache->location));
+        assert(is_int($this->configuration->cache->ttl));
 
         return match ($this->configuration->cache->driver) {
             'file' => $this->createFileCache(

--- a/src/Util/Cache/Driver/FileCacheDriver.php
+++ b/src/Util/Cache/Driver/FileCacheDriver.php
@@ -180,7 +180,6 @@ class FileCacheDriver implements CacheDriver
     protected function restoreFile(string $file, ?string $hash): mixed
     {
         // unserialize() throws E_NOTICE when data is corrupt
-        /** @var array{hash: ?string, data: mixed} */
         $data = @unserialize($this->read($file));
         if (is_array($data) && ($hash === null || $data['hash'] === $hash)) {
             return $data['data'];

--- a/src/Util/Cache/Driver/MemoryCacheDriver.php
+++ b/src/Util/Cache/Driver/MemoryCacheDriver.php
@@ -96,6 +96,7 @@ class MemoryCacheDriver implements CacheDriver
     /**
      * PHP's magic serialize sleep method.
      *
+     * @return list<string>
      * @since  1.0.2
      */
     public function __sleep(): array

--- a/src/Util/ImageConvert.php
+++ b/src/Util/ImageConvert.php
@@ -121,7 +121,7 @@ class ImageConvert
         ];
 
         $proc = proc_open('convert', $desc, $pipes);
-        if (is_resource($proc)) {
+        if (is_resource($proc) && is_array($pipes) && is_resource($pipes[0])) {
             fwrite($pipes[0], '-version');
             fclose($pipes[0]);
 
@@ -158,7 +158,8 @@ class ImageConvert
             // Check for font family
             if (isset($config->imageConvert->fontFamily)) {
                 // Get font family
-                $fontFamily = (string) $config->imageConvert->fontFamily;
+                /** @var string */
+                $fontFamily = $config->imageConvert->fontFamily;
                 // Replace CSS separators
                 $fontReplace = 'font-family:' . strtr($fontFamily, ';:', '  ');
                 $fontPattern = '/font-family:\s*Arial/';
@@ -169,7 +170,9 @@ class ImageConvert
             // Check for font size
             if (isset($config->imageConvert->fontSize)) {
                 // Get font size
-                $fontSize = abs((float) $config->imageConvert->fontSize);
+                /** @var float */
+                $fontSize = $config->imageConvert->fontSize;
+                $fontSize = abs($fontSize);
 
                 // Fetch all font-size expressions
                 preg_match_all('/font-size:\s*(\d+)/', $svg, $fontSizes);

--- a/tests/php/PDepend/AbstractTestCase.php
+++ b/tests/php/PDepend/AbstractTestCase.php
@@ -560,7 +560,10 @@ abstract class AbstractTestCase extends TestCase
         $name = $name ?: static::class;
 
         $class = new ASTClass($name);
-        $class->setCompilationUnit(new ASTCompilationUnit($GLOBALS['argv'][0]));
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $class->setCompilationUnit(new ASTCompilationUnit($arg[0]));
         $class->setCache(new MemoryCacheDriver());
         $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
@@ -580,7 +583,10 @@ abstract class AbstractTestCase extends TestCase
         $name = $name ?: static::class;
 
         $interface = new ASTInterface($name);
-        $interface->setCompilationUnit(new ASTCompilationUnit($GLOBALS['argv'][0]));
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $interface->setCompilationUnit(new ASTCompilationUnit($arg[0]));
         $interface->setCache(new MemoryCacheDriver());
 
         return $interface;
@@ -613,7 +619,10 @@ abstract class AbstractTestCase extends TestCase
         $name = $name ?: static::class;
 
         $function = new ASTFunction($name);
-        $function->setCompilationUnit(new ASTCompilationUnit($GLOBALS['argv'][0]));
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $function->setCompilationUnit(new ASTCompilationUnit($arg[0]));
         $function->setCache(new MemoryCacheDriver());
         $function->addChild(new ASTFormalParameters());
 

--- a/tests/php/PDepend/Bugs/AbstractRegressionTestCase.php
+++ b/tests/php/PDepend/Bugs/AbstractRegressionTestCase.php
@@ -99,6 +99,7 @@ abstract class AbstractRegressionTestCase extends AbstractTestCase
      * Returns the source file for the given test case.
      *
      * @param string $testCase The qualified test case name.
+     * @throws Exception When test case ID can't be found.
      */
     protected function getSourceFileForTestCase(string $testCase): string
     {

--- a/tests/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
+++ b/tests/php/PDepend/Bugs/Phpmd/FunctionDocBlockBugPhpmd914Test.php
@@ -69,7 +69,6 @@ class FunctionDocBlockBugPhpmd914Test extends AbstractRegressionTestCase
 
     public function testMethodDocBlockCanBeRead(): void
     {
-        /** @var ASTFunction $function */
         $function = $this->getFirstClassMethodForTestCase();
 
         $lines = array_map(

--- a/tests/php/PDepend/EngineTest.php
+++ b/tests/php/PDepend/EngineTest.php
@@ -161,7 +161,6 @@ class EngineTest extends AbstractTestCase
 
         $function = $namespaces->current()->getFunctions()->current();
 
-        static::assertNotNull($function);
         static::assertEquals('foo', $function->getImage());
         static::assertEquals(0, $function->getExceptionClasses()->count());
     }
@@ -301,8 +300,6 @@ class EngineTest extends AbstractTestCase
 
         $namespace1 = $engine->analyze();
         $namespace2 = $engine->getNamespaces();
-
-        static::assertNotNull($namespace1);
 
         static::assertSame($namespace1, $namespace2);
     }

--- a/tests/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/tests/php/PDepend/Input/ExcludePathFilterTest.php
@@ -307,7 +307,8 @@ class ExcludePathFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if ($file instanceof SplFileInfo
+            if (
+                $file instanceof SplFileInfo
                 && $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')

--- a/tests/php/PDepend/Input/ExtensionFilterTest.php
+++ b/tests/php/PDepend/Input/ExtensionFilterTest.php
@@ -107,7 +107,8 @@ class ExtensionFilterTest extends AbstractTestCase
 
         $actual = [];
         foreach ($files as $file) {
-            if ($file instanceof SplFileInfo
+            if (
+                $file instanceof SplFileInfo
                 && $filter->accept($file, $file)
                 && $file->isFile()
                 && false === stripos($file->getPathname(), '.svn')

--- a/tests/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/tests/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -78,6 +78,27 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
     }
 
     /**
+     * Data provider that returns a list of actual input and expected output
+     * primitive types.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserSetsExpectedPrimitivePropertyType(): array
+    {
+        return [
+            ['int', 'integer'],
+            ['INTEger', 'integer'],
+            ['float', 'float'],
+            ['real', 'float'],
+            ['double', 'float'],
+            ['bool', 'boolean'],
+            ['boolean', 'boolean'],
+            ['false', 'boolean'],
+            ['true', 'boolean'],
+        ];
+    }
+
+    /**
      * Tests that the parser sets the expected array type information.
      */
     public function testParserSetsExpectedArrayPropertyType(): void
@@ -99,26 +120,5 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
             ?->getFirstChildOfType(ASTType::class);
 
         static::assertTrue($type?->isArray());
-    }
-
-    /**
-     * Data provider that returns a list of actual input and expected output
-     * primitive types.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserSetsExpectedPrimitivePropertyType(): array
-    {
-        return [
-            ['int', 'integer'],
-            ['INTEger', 'integer'],
-            ['float', 'float'],
-            ['real', 'float'],
-            ['double', 'float'],
-            ['bool', 'boolean'],
-            ['boolean', 'boolean'],
-            ['false', 'boolean'],
-            ['true', 'boolean'],
-        ];
     }
 }

--- a/tests/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/tests/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -312,6 +312,23 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     }
 
     /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserResolvesQualifiedTypeNameInTypeSignature(): array
+    {
+        return [
+            ['issues/002-031-resolve-qualified-type-names.php', 'baz'],
+            ['issues/002-035-resolve-qualified-type-names.php', 'baz'],
+            ['issues/002-039-resolve-qualified-type-names.php', 'baz'],
+            ['issues/002-043-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-046-resolve-qualified-type-names.php', 'foo\foo'],
+        ];
+    }
+
+    /**
      * Tests that the parser expands a local name within the body of a
      * namespaced function correct.
      *
@@ -337,6 +354,24 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     }
 
     /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserResolvesQualifiedTypeNameInFunction(): array
+    {
+        return [
+            ['issues/002-015-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-019-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-023-resolve-qualified-type-names.php', 'foo\baz'],
+            ['issues/002-027-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-047-resolve-qualified-type-names.php', 'foo\foo'],
+            ['issues/002-051-resolve-qualified-type-names.php', 'baz\baz'],
+        ];
+    }
+
+    /**
      * Tests that the parser does not expand a qualified name within the
      * signature of a namespaced class or interface correct.
      *
@@ -357,6 +392,21 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     }
 
     /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserKeepsQualifiedTypeNameInTypeSignature(): array
+    {
+        return [
+            ['issues/002-032-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-036-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-040-resolve-qualified-type-names.php', 'foo\bar'],
+        ];
+    }
+
+    /**
      * Tests that the parser does not expand a qualified name within the body of
      * a namespaced function correct.
      *
@@ -374,6 +424,24 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->current();
 
         static::assertEquals($namespaceName, $dependency->getNamespace()?->getImage());
+    }
+
+    /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserKeepsQualifiedTypeNameInFunction(): array
+    {
+        return [
+            ['issues/002-016-resolve-qualified-type-names.php', ''],
+            ['issues/002-020-resolve-qualified-type-names.php', ''],
+            ['issues/002-024-resolve-qualified-type-names.php', 'baz'],
+            ['issues/002-028-resolve-qualified-type-names.php', 'bar'],
+            ['issues/002-048-resolve-qualified-type-names.php', 'foo'],
+            ['issues/002-052-resolve-qualified-type-names.php', 'bar'],
+        ];
     }
 
     /**
@@ -399,6 +467,22 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     }
 
     /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax(): array
+    {
+        return [
+            ['issues/002-033-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-037-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-041-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-044-resolve-qualified-type-names.php', 'foo\foo'],
+        ];
+    }
+
+    /**
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
@@ -421,6 +505,23 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
     }
 
     /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax(): array
+    {
+        return [
+            ['issues/002-017-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-021-resolve-qualified-type-names.php', 'foo\bar'],
+            ['issues/002-025-resolve-qualified-type-names.php', 'foo\bar\baz'],
+            ['issues/002-029-resolve-qualified-type-names.php', 'foo\bar\baz'],
+            ['issues/002-049-resolve-qualified-type-names.php', 'bar\bar'],
+        ];
+    }
+
+    /**
      * Tests that the parser resolves a type name when the name is prefixed with
      * PHP's namespace keyword.
      *
@@ -440,6 +541,22 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ->current();
 
         static::assertEquals($namespaceName, $dependency->getNamespace()?->getImage());
+    }
+
+    /**
+     * Data provider method that returns test data for class name resolving
+     * tests.
+     *
+     * @return list<list<string>>
+     */
+    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax(): array
+    {
+        return [
+            ['issues/002-034-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-038-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-042-resolve-qualified-type-names.php', 'baz\foo'],
+            ['issues/002-045-resolve-qualified-type-names.php', 'foo\foo'],
+        ];
     }
 
     /**
@@ -470,107 +587,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @return list<list<string>>
      */
-    public static function dataProviderParserResolvesQualifiedTypeNameInFunction(): array
-    {
-        return [
-            ['issues/002-015-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-019-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-023-resolve-qualified-type-names.php', 'foo\baz'],
-            ['issues/002-027-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-047-resolve-qualified-type-names.php', 'foo\foo'],
-            ['issues/002-051-resolve-qualified-type-names.php', 'baz\baz'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserResolvesQualifiedTypeNameInTypeSignature(): array
-    {
-        return [
-            ['issues/002-031-resolve-qualified-type-names.php', 'baz'],
-            ['issues/002-035-resolve-qualified-type-names.php', 'baz'],
-            ['issues/002-039-resolve-qualified-type-names.php', 'baz'],
-            ['issues/002-043-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-046-resolve-qualified-type-names.php', 'foo\foo'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserKeepsQualifiedTypeNameInFunction(): array
-    {
-        return [
-            ['issues/002-016-resolve-qualified-type-names.php', ''],
-            ['issues/002-020-resolve-qualified-type-names.php', ''],
-            ['issues/002-024-resolve-qualified-type-names.php', 'baz'],
-            ['issues/002-028-resolve-qualified-type-names.php', 'bar'],
-            ['issues/002-048-resolve-qualified-type-names.php', 'foo'],
-            ['issues/002-052-resolve-qualified-type-names.php', 'bar'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserKeepsQualifiedTypeNameInTypeSignature(): array
-    {
-        return [
-            ['issues/002-032-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-036-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-040-resolve-qualified-type-names.php', 'foo\bar'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax(): array
-    {
-        return [
-            ['issues/002-017-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-021-resolve-qualified-type-names.php', 'foo\bar'],
-            ['issues/002-025-resolve-qualified-type-names.php', 'foo\bar\baz'],
-            ['issues/002-029-resolve-qualified-type-names.php', 'foo\bar\baz'],
-            ['issues/002-049-resolve-qualified-type-names.php', 'bar\bar'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax(): array
-    {
-        return [
-            ['issues/002-033-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-037-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-041-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-044-resolve-qualified-type-names.php', 'foo\foo'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
     public static function dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax(): array
     {
         return [
@@ -579,22 +595,6 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
             ['issues/002-026-resolve-qualified-type-names.php', 'baz'],
             ['issues/002-030-resolve-qualified-type-names.php', 'baz'],
             ['issues/002-050-resolve-qualified-type-names.php', 'baz\baz'],
-        ];
-    }
-
-    /**
-     * Data provider method that returns test data for class name resolving
-     * tests.
-     *
-     * @return list<list<string>>
-     */
-    public static function dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax(): array
-    {
-        return [
-            ['issues/002-034-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-038-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-042-resolve-qualified-type-names.php', 'baz\foo'],
-            ['issues/002-045-resolve-qualified-type-names.php', 'foo\foo'],
         ];
     }
 }

--- a/tests/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -432,11 +432,7 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      */
     public function testGetNodeMetricsForTrait(): array
     {
-        $metrics = $this->calculateTraitMetrics();
-
-        static::assertIsArray($metrics);
-
-        return $metrics;
+        return $this->calculateTraitMetrics();
     }
 
     /**

--- a/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -429,7 +429,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
         $class = new ASTClass('PDepend');
         $metrics = $this->analyzer->getNodeMetrics($class);
 
-        static::assertIsArray($metrics);
         static::assertCount(0, $metrics);
     }
 

--- a/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -652,24 +652,6 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
     }
 
     /**
-     * Parses the source code for the currently calling test method and returns
-     * the calculated project metrics.
-     *
-     * @param string $testCase Optional name of the calling test case.
-     * @return array<string, mixed>
-     * @since 0.10.2
-     */
-    private function calculateProjectMetrics(?string $testCase = null): array
-    {
-        $testCase = ($testCase ?: $this->getCallingTestMethod());
-
-        $analyzer = new CouplingAnalyzer();
-        $analyzer->analyze($this->parseTestCaseSource($testCase));
-
-        return $analyzer->getProjectMetrics();
-    }
-
-    /**
      * Data provider that returns different test files and the corresponding
      * invocation count value.
      *
@@ -698,5 +680,23 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
             [__METHOD__ . '#18', 1, 0],
             [__METHOD__ . '#19', 1, 1],
         ];
+    }
+
+    /**
+     * Parses the source code for the currently calling test method and returns
+     * the calculated project metrics.
+     *
+     * @param string $testCase Optional name of the calling test case.
+     * @return array<string, mixed>
+     * @since 0.10.2
+     */
+    private function calculateProjectMetrics(?string $testCase = null): array
+    {
+        $testCase = ($testCase ?: $this->getCallingTestMethod());
+
+        $analyzer = new CouplingAnalyzer();
+        $analyzer->analyze($this->parseTestCaseSource($testCase));
+
+        return $analyzer->getProjectMetrics();
     }
 }

--- a/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -508,10 +508,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      */
     public function testGetNodeMetricsForTrait(): array
     {
-        $metrics = $this->calculateTraitMetrics();
-        static::assertIsArray($metrics);
-
-        return $metrics;
+        return $this->calculateTraitMetrics();
     }
 
     /**
@@ -577,10 +574,7 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
         $analyzer = new CouplingAnalyzer();
         $analyzer->analyze($this->parseCodeResourceForTest());
 
-        $metrics = $analyzer->getProjectMetrics();
-        static::assertIsArray($metrics);
-
-        return $metrics;
+        return $analyzer->getProjectMetrics();
     }
 
     /**

--- a/tests/php/PDepend/ParserTest.php
+++ b/tests/php/PDepend/ParserTest.php
@@ -268,7 +268,6 @@ class ParserTest extends AbstractTestCase
         static::assertEquals('default\package', $namespace->getImage());
 
         $class = $namespace->getClasses()->current();
-        static::assertNotNull($class);
 
         $actual = $class->getCompilationUnit()?->getComment();
         static::assertNotNull($actual);
@@ -296,7 +295,6 @@ class ParserTest extends AbstractTestCase
         static::assertEquals('+global', $namespace->getImage());
 
         $class = $namespace->getClasses()->current();
-        static::assertNotNull($class);
 
         $actual = $class->getCompilationUnit()?->getComment();
         static::assertNull($actual);
@@ -314,7 +312,6 @@ class ParserTest extends AbstractTestCase
         static::assertEquals('+global', $namespace->getImage());
 
         $function = $namespace->getFunctions()->current();
-        static::assertNotNull($function);
 
         $actual = $function->getCompilationUnit()?->getComment();
         static::assertNull($actual);
@@ -1176,8 +1173,7 @@ class ParserTest extends AbstractTestCase
      */
     public function testParserHandlesSelfKeywordAsParameterTypeHint(): void
     {
-        $parameters = $this->getFirstClassMethodForTestCase()->getParameters();
-        static::assertNotNull($parameters[0]);
+        $this->getFirstClassMethodForTestCase()->getParameters();
     }
 
     /**

--- a/tests/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -103,11 +103,15 @@ class ASTArtifactListTest extends AbstractTestCase
      */
     public function testNodeIteratorReturnsObjectsUnique(): void
     {
+        $object2 = new ASTClass('o2');
+        $object1 = new ASTClass('o1');
+        $object3 = new ASTClass('o3');
+
         $iterator = new ASTArtifactList(
             [
-                $object2 = new ASTClass('o2'),
-                $object1 = new ASTClass('o1'),
-                $object3 = new ASTClass('o3'),
+                $object2,
+                $object1,
+                $object3,
                 $object1,
                 $object2,
                 $object3,

--- a/tests/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -237,7 +237,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
         static::assertInstanceOf(ASTConstantDefinition::class, $constantDefinition);
 
-        /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
         static::assertInstanceOf(ASTConstantDeclarator::class, $constantDeclarator);
@@ -255,7 +254,6 @@ class ASTClassFqnPostfixTest extends ASTNodeTestCase
 
         static::assertInstanceOf(ASTConstantDefinition::class, $constantDefinition);
 
-        /** @var ASTConstantDeclarator $constantDefinition */
         $constantDeclarator = $constantDefinition->getChild(0);
 
         static::assertInstanceOf(ASTConstantDeclarator::class, $constantDeclarator);

--- a/tests/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -71,6 +71,20 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
     }
 
     /**
+     * Returns valid field declation modifiers.
+     *
+     * @return list<array<int, mixed>>
+     */
+    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
+    {
+        return [
+            [State::IS_PRIVATE],
+            [State::IS_PROTECTED],
+            [State::IS_PUBLIC],
+        ];
+    }
+
+    /**
      * Tests that the <b>setModifiers()</b> method throws an exception when an
      * invalid modifier or modifier combination was set.
      *
@@ -90,6 +104,39 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
         );
 
         $definition->setModifiers($modifiers);
+    }
+
+    /**
+     * Returns invalid field declation modifiers.
+     *
+     * @return array<mixed>
+     */
+    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
+    {
+        return [
+            [State::IS_ABSTRACT],
+            [State::IS_STATIC],
+            [
+                State::IS_PRIVATE |
+                State::IS_ABSTRACT,
+            ],
+            [
+                State::IS_PROTECTED |
+                State::IS_ABSTRACT,
+            ],
+            [
+                State::IS_PUBLIC |
+                State::IS_STATIC,
+            ],
+            [
+                State::IS_PROTECTED |
+                State::IS_STATIC,
+            ],
+            [
+                State::IS_PRIVATE |
+                State::IS_STATIC,
+            ],
+        ];
     }
 
     /**
@@ -328,52 +375,5 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
         return $this->getFirstNodeOfTypeInClass(
             ASTConstantDefinition::class
         );
-    }
-
-    /**
-     * Returns valid field declation modifiers.
-     *
-     * @return list<array<int, mixed>>
-     */
-    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
-    {
-        return [
-            [State::IS_PRIVATE],
-            [State::IS_PROTECTED],
-            [State::IS_PUBLIC],
-        ];
-    }
-
-    /**
-     * Returns invalid field declation modifiers.
-     *
-     * @return array<mixed>
-     */
-    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
-    {
-        return [
-            [State::IS_ABSTRACT],
-            [State::IS_STATIC],
-            [
-                State::IS_PRIVATE |
-                State::IS_ABSTRACT,
-            ],
-            [
-                State::IS_PROTECTED |
-                State::IS_ABSTRACT,
-            ],
-            [
-                State::IS_PUBLIC |
-                State::IS_STATIC,
-            ],
-            [
-                State::IS_PROTECTED |
-                State::IS_STATIC,
-            ],
-            [
-                State::IS_PRIVATE |
-                State::IS_STATIC,
-            ],
-        ];
     }
 }

--- a/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -128,6 +128,32 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
     }
 
     /**
+     * Returns valid field declation modifiers.
+     *
+     * @return array<mixed>
+     */
+    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
+    {
+        return [
+            [State::IS_PRIVATE],
+            [State::IS_PROTECTED],
+            [State::IS_PUBLIC],
+            [
+                State::IS_PRIVATE |
+                State::IS_STATIC,
+            ],
+            [
+                State::IS_PROTECTED |
+                State::IS_STATIC,
+            ],
+            [
+                State::IS_PUBLIC |
+                State::IS_STATIC,
+            ],
+        ];
+    }
+
+    /**
      * Tests that the <b>setModifiers()</b> method throws an exception when an
      * invalid modifier or modifier combination was set.
      *
@@ -147,6 +173,36 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
         );
 
         $declaration->setModifiers($modifiers);
+    }
+
+    /**
+     * Returns invalid field declation modifiers.
+     *
+     * @return array<mixed>
+     */
+    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
+    {
+        return [
+            [State::IS_ABSTRACT],
+            [State::IS_FINAL],
+            [
+                State::IS_PRIVATE |
+                State::IS_ABSTRACT,
+            ],
+            [
+                State::IS_PROTECTED |
+                State::IS_ABSTRACT,
+            ],
+            [
+                State::IS_PUBLIC |
+                State::IS_FINAL,
+            ],
+            [
+                State::IS_PUBLIC |
+                State::IS_STATIC |
+                State::IS_FINAL,
+            ],
+        ];
     }
 
     /**
@@ -297,61 +353,5 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
         return $this->getFirstNodeOfTypeInClass(
             ASTFieldDeclaration::class
         );
-    }
-
-    /**
-     * Returns valid field declation modifiers.
-     *
-     * @return array<mixed>
-     */
-    public static function dataProviderSetModifiersAcceptsExpectedModifierCombinations(): array
-    {
-        return [
-            [State::IS_PRIVATE],
-            [State::IS_PROTECTED],
-            [State::IS_PUBLIC],
-            [
-                State::IS_PRIVATE |
-                State::IS_STATIC,
-            ],
-            [
-                State::IS_PROTECTED |
-                State::IS_STATIC,
-            ],
-            [
-                State::IS_PUBLIC |
-                State::IS_STATIC,
-            ],
-        ];
-    }
-
-    /**
-     * Returns invalid field declation modifiers.
-     *
-     * @return array<mixed>
-     */
-    public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
-    {
-        return [
-            [State::IS_ABSTRACT],
-            [State::IS_FINAL],
-            [
-                State::IS_PRIVATE |
-                State::IS_ABSTRACT,
-            ],
-            [
-                State::IS_PROTECTED |
-                State::IS_ABSTRACT,
-            ],
-            [
-                State::IS_PUBLIC |
-                State::IS_FINAL,
-            ],
-            [
-                State::IS_PUBLIC |
-                State::IS_STATIC |
-                State::IS_FINAL,
-            ],
-        ];
     }
 }

--- a/tests/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/tests/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -685,7 +685,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     {
         /** @var class-string<AbstractASTNode|ASTAnonymousClass> */
         $class = substr(static::class, 0, -4);
-        static::assertTrue(class_exists($class), "Class {$class} does not exist.");
+        static::assertNotSame('', class_exists($class), "Class {$class} does not exist.");
 
         $reflection = new ReflectionClass($class);
         if ($reflection->isAbstract()) {

--- a/tests/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitTest.php
@@ -324,8 +324,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      */
     public function testTraitCanUseParentKeywordInMethodBody(): void
     {
-        $trait = $this->getFirstTraitForTest();
-        static::assertNotNull($trait);
+        $this->getFirstTraitForTest();
     }
 
     /**
@@ -333,8 +332,7 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      */
     public function testTraitCanUseParentKeywordAsMethodTypeHint(): void
     {
-        $trait = $this->getFirstTraitForTest();
-        static::assertNotNull($trait);
+        $this->getFirstTraitForTest();
     }
 
     public function testGetNamespacedName(): void

--- a/tests/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -127,7 +127,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      */
     public function testTraitUseInsteadOfSelf(): void
     {
-        /** @var AbstractASTClassOrInterface $class */
         $class = $this->getFirstClassForTestCase();
         $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
         $getTraitMethods->setAccessible(true);
@@ -146,7 +145,6 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
      */
     public function testTraitMethodAlias(): void
     {
-        /** @var AbstractASTClassOrInterface $class */
         $class = $this->getFirstClassForTestCase();
         $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
         $getTraitMethods->setAccessible(true);

--- a/tests/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/tests/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -118,11 +118,15 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor->dispatch($class);
 
         $actual = $listener->nodes;
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $path = realpath($arg[0]);
         $expected = [
             __FUNCTION__ . '#start' => true,
             __FUNCTION__ . '#end' => true,
-            realpath($GLOBALS['argv'][0]) . '#start' => true,
-            realpath($GLOBALS['argv'][0]) . '#end' => true,
+            $path . '#start' => true,
+            $path . '#end' => true,
         ];
 
         static::assertEquals($expected, $actual);
@@ -144,11 +148,15 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor->dispatch($interface);
 
         $actual = $listener->nodes;
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $path = realpath($arg[0]);
         $expected = [
             __FUNCTION__ . '#start' => true,
             __FUNCTION__ . '#end' => true,
-            realpath($GLOBALS['argv'][0]) . '#start' => true,
-            realpath($GLOBALS['argv'][0]) . '#end' => true,
+            $path . '#start' => true,
+            $path . '#end' => true,
         ];
 
         static::assertEquals($expected, $actual);
@@ -170,11 +178,15 @@ class DefaultListenerTest extends AbstractTestCase
         $visitor->dispatch($function);
 
         $actual = $listener->nodes;
+
+        /** @var array<string> */
+        $arg = $GLOBALS['argv'];
+        $path = realpath($arg[0]);
         $expected = [
             __FUNCTION__ . '#start' => true,
             __FUNCTION__ . '#end' => true,
-            realpath($GLOBALS['argv'][0]) . '#start' => true,
-            realpath($GLOBALS['argv'][0]) . '#end' => true,
+            $path . '#start' => true,
+            $path . '#end' => true,
         ];
 
         static::assertEquals($expected, $actual);

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -142,7 +142,6 @@ class InInitializersTest extends PHPParserVersion81TestCase
         static::assertTrue($str->isPromoted());
         static::assertTrue($str->isProtected());
 
-        /** @var ASTScalarType $variable */
         $type = $str->getChild(0);
         static::assertInstanceOf(ASTScalarType::class, $type);
         static::assertSame('string', $type->getImage());

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -43,7 +43,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFieldDeclaration;
-use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
@@ -103,7 +102,6 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
     {
         $class = $this->getFirstClassForTestCase();
 
-        /** @var ASTMethod[] $methods */
         $methods = $class->getMethods();
         $nullish = $methods[0]->getReturnType();
         $falsy = $methods[1]->getReturnType();

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -74,10 +74,11 @@ class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
             ];
         }, $children);
 
-        foreach ([
-            ['null', '$nullish'],
-            ['false', '$falsy'],
-        ] as $index => $expected
+        foreach (
+            [
+                ['null', '$nullish'],
+                ['false', '$falsy'],
+            ] as $index => $expected
         ) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = ASTScalarType::class;

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -43,7 +43,6 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFieldDeclaration;
-use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
@@ -98,10 +97,8 @@ class TrueTypeTest extends PHPParserVersion82TestCase
     {
         $class = $this->getFirstClassForTestCase();
 
-        /** @var ASTMethod[] $methods */
         $methods = $class->getMethods();
 
-        /** @var ASTScalarType $truthy */
         $truthy = $methods[0]->getReturnType();
 
         static::assertInstanceOf(ASTScalarType::class, $truthy);

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -690,8 +690,7 @@ class PHPParserGenericTest extends AbstractTestCase
      */
     public function testParserAllowsKeywordCallableAsPropertyName(): void
     {
-        $method = $this->getFirstClassMethodForTestCase();
-        static::assertNotNull($method);
+        $this->getFirstClassMethodForTestCase();
     }
 
     public function testParserHandlesExtraParenthesisForIsset(): void
@@ -1229,8 +1228,7 @@ class PHPParserGenericTest extends AbstractTestCase
 
     public function testListKeywordAsMethodName(): void
     {
-        $method = $this->getFirstMethodForTestCase();
-        static::assertNotNull($method);
+        $this->getFirstMethodForTestCase();
     }
 
     public function testListKeywordAsFunctionNameThrowsException(): void
@@ -1243,7 +1241,7 @@ class PHPParserGenericTest extends AbstractTestCase
     public function testGroupUseStatement(): ASTNamespace
     {
         $namespaces = $this->parseCodeResourceForTest();
-        static::assertNotNull($namespaces);
+        static::assertNotSame(0, $namespaces->count());
 
         return $namespaces[0];
     }

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -108,8 +108,7 @@ class PHPParserVersion81Test extends AbstractTestCase
      */
     public function testParserAllowsKeywordCallableAsPropertyName(): void
     {
-        $method = $this->getFirstClassMethodForTestCase();
-        static::assertNotNull($method);
+        $this->getFirstClassMethodForTestCase();
     }
 
     /**
@@ -729,8 +728,7 @@ class PHPParserVersion81Test extends AbstractTestCase
 
     public function testListKeywordAsMethodName(): void
     {
-        $method = $this->getFirstMethodForTestCase();
-        static::assertNotNull($method);
+        $this->getFirstMethodForTestCase();
     }
 
     public function testListKeywordAsFunctionNameThrowsException(): void
@@ -743,7 +741,7 @@ class PHPParserVersion81Test extends AbstractTestCase
     public function testGroupUseStatement(): ASTNamespace
     {
         $namespaces = $this->parseCodeResourceForTest();
-        static::assertNotNull($namespaces);
+        static::assertNotSame(0, $namespaces->count());
 
         return $namespaces[0];
     }
@@ -1241,34 +1239,28 @@ class PHPParserVersion81Test extends AbstractTestCase
 
     public function testArrowFunctions(): void
     {
-        /** @var ASTClosure $closure */
         $closure = $this->getFirstNodeOfTypeInFunction(
             ASTFunctionPostfix::class
         )->getChild(1)->getChild(0);
 
         static::assertInstanceOf(ASTClosure::class, $closure);
 
-        /** @var ASTFormalParameters $parameters */
         $parameters = $closure->getChild(0);
         static::assertInstanceOf(ASTFormalParameters::class, $parameters);
         static::assertCount(1, $parameters->getChildren());
 
-        /** @var ASTFormalParameter $parameter */
         $parameter = $parameters->getChild(0);
         static::assertInstanceOf(ASTFormalParameter::class, $parameter);
 
-        /** @var ASTVariableDeclarator $parameter */
         $variableDeclarator = $parameter->getChild(0);
         static::assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         static::assertSame('$number', $variableDeclarator->getImage());
 
-        /** @var ASTReturnStatement $parameters */
         $return = $closure->getChild(1);
         static::assertInstanceOf(ASTReturnStatement::class, $return);
         static::assertSame('=>', $return->getImage());
         static::assertCount(1, $return->getChildren());
 
-        /** @var ASTExpression $expression */
         $expression = $return->getChild(0);
         static::assertInstanceOf(ASTExpression::class, $expression);
         static::assertSame([
@@ -1285,31 +1277,25 @@ class PHPParserVersion81Test extends AbstractTestCase
 
     public function testArrowFunctionsWithReturnType(): void
     {
-        /** @var ASTClosure $closure */
         $closure = $this->getFirstNodeOfTypeInFunction(ASTFunctionPostfix::class)->getChild(1)->getChild(0);
 
         static::assertInstanceOf(ASTClosure::class, $closure);
 
-        /** @var ASTFormalParameters $parameters */
         $parameters = $closure->getChild(0);
         static::assertInstanceOf(ASTFormalParameters::class, $parameters);
         static::assertCount(1, $parameters->getChildren());
 
-        /** @var ASTFormalParameter $parameter */
         $parameter = $parameters->getChild(0);
         static::assertInstanceOf(ASTFormalParameter::class, $parameter);
 
-        /** @var ASTVariableDeclarator $parameter */
         $variableDeclarator = $parameter->getChild(0);
         static::assertInstanceOf(ASTVariableDeclarator::class, $variableDeclarator);
         static::assertSame('$number', $variableDeclarator->getImage());
 
-        /** @var ASTScalarType $parameters */
         $type = $closure->getChild(1);
         static::assertInstanceOf(ASTScalarType::class, $type);
         static::assertSame('int', $type->getImage());
 
-        /** @var ASTReturnStatement $parameters */
         $return = $closure->getChild(2);
         static::assertInstanceOf(ASTReturnStatement::class, $return);
         static::assertSame('=>', $return->getImage());

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -1169,7 +1169,7 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach ([
+        $items = [
             ['int', '$id'],
             ['float', '$money'],
             ['bool', '$active'],
@@ -1192,8 +1192,8 @@ class PHPParserVersion81Test extends AbstractTestCase
             ['?iterable', '$actionsN', ASTTypeIterable::class],
             ['?object', '$bagN', ASTClassOrInterfaceReference::class],
             ['?Role', '$roleN', ASTClassOrInterfaceReference::class],
-        ] as $index => $expected
-        ) {
+        ];
+        foreach ($items as $index => $expected) {
             [$expectedType, $expectedVariable] = $expected;
             $expectedTypeClass = $expected[2] ?? ASTScalarType::class;
             [$type, $variable] = $declarations[$index];
@@ -1480,10 +1480,10 @@ class PHPParserVersion81Test extends AbstractTestCase
             ];
         }, $children);
 
-        foreach ([
+        $items = [
             ['null|int|float', '$number', ASTUnionType::class],
-        ] as $index => $expected
-        ) {
+        ];
+        foreach ($items as $index => $expected) {
             [$expectedType, $expectedVariable, $expectedTypeClass] = $expected;
             [$type, $variable] = $declarations[$index];
 

--- a/tests/php/PDepend/TextUI/CommandTest.php
+++ b/tests/php/PDepend/TextUI/CommandTest.php
@@ -75,7 +75,10 @@ class CommandTest extends AbstractTestCase
 
         $data = @parse_ini_file(__DIR__ . '/../../../../build.properties');
 
-        $this->versionOutput = sprintf('PDepend %s%s%s', $data['project.version'] ?? '', PHP_EOL, PHP_EOL);
+        /** @var string */
+        $version = $data['project.version'] ?? '';
+
+        $this->versionOutput = sprintf('PDepend %s%s%s', $version, PHP_EOL, PHP_EOL);
         $this->usageOutput = 'Usage: pdepend [options] [logger] <dir[,dir[,...]]>' . PHP_EOL . PHP_EOL;
     }
 
@@ -524,7 +527,7 @@ class CommandTest extends AbstractTestCase
 
         static::assertEquals(Runner::SUCCESS_EXIT, $exitCode);
         static::assertIsString($actual);
-        static::assertEmpty('', $actual);
+        static::assertEmpty($actual);
     }
 
     public function testErrorDisplay(): void


### PR DESCRIPTION
Type: documentation update
Breaking change: no

This upgrades PHPStan to 2.1 and deals with most of the new issues detected. The new version of PHPStan adds a new level (10) which is also addressed in this PR.

Most issues detected by the new version are outdated PHPDoc, impossible cases and some implicit mixed types. This fixes a few test assertion that would not have detected issues when if there where issues in the tested code. Very little actual code has been changed except for some places that unpack strings from arrays.