### PR TITLE
Issue 892: Add test for PHP8.4 property hook support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,18 @@
     "require": {
         "php": ">=8.1",
         "php-64bit": "*",
-        "phpunit/phpunit": "^11.0",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
-        "brianium/paratest": "^7.6",
+        "brianium/paratest": "^7.3",
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
         "phpstan/phpstan": "~2.1.0",
+        "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,18 +12,18 @@
     "require": {
         "php": ">=8.1",
         "php-64bit": "*",
+        "phpunit/phpunit": "^11.0",
         "symfony/config": "^5.4 || ^6.0 || ^7.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
         "symfony/polyfill-mbstring": "^1.19"
     },
     "require-dev": {
-        "brianium/paratest": "^7.3",
+        "brianium/paratest": "^7.6",
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
         "phpstan/phpstan": "~2.1.0",
-        "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },
     "autoload": {

--- a/tests/php/PDepend/ParserTest.php
+++ b/tests/php/PDepend/ParserTest.php
@@ -415,6 +415,19 @@ class ParserTest extends AbstractTestCase
     }
 
     /**
+     * testParserHandlesClassWithPropertyHooks
+     */
+    public function testParserHandlesClassWithPropertyHooks(): void
+    {
+        $class = $this->parseCodeResourceForTest()
+            ->current()
+            ->getClasses()
+            ->current();
+
+        static::assertCount(2, $class->getProperties());
+    }
+
+    /**
      * testParserHandlesInterfaceWithMultipleParentInterfaces
      */
     public function testParserHandlesInterfaceWithMultipleParentInterfaces(): void

--- a/tests/resources/files/Parser/testParserHandlesClassWithPropertyHooks.php
+++ b/tests/resources/files/Parser/testParserHandlesClassWithPropertyHooks.php
@@ -1,0 +1,14 @@
+<?php
+
+class testParserHandlesClassWithPropertyHooks
+{
+    public private(set) string $data;
+    public string $foo {
+        get {
+            return 'foo:' . $this->data;
+        }
+        set {
+            $this->data = $value;
+        }
+    }
+}

--- a/tests/resources/files/Parser/testParserHandlesClassWithPropertyHooks.php
+++ b/tests/resources/files/Parser/testParserHandlesClassWithPropertyHooks.php
@@ -2,7 +2,6 @@
 
 class testParserHandlesClassWithPropertyHooks
 {
-    public private(set) string $data;
     public string $foo {
         get {
             return 'foo:' . $this->data;


### PR DESCRIPTION
Type: testcase contribution
Issue: #898
Breaking change: no

Adds a testcase to demonstrate parser issues with PHP8.4 property hooks and asymmetric visibility.