### PR TITLE
Run tests on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
         setup: [ 'lowest', 'stable' ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,12 +45,12 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.4'
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
       # For now we need to overwrite the PHP version check on the 8.4 beta as paratest has not been releasd for it yet
       - name: Install dependencies (PHP 8.4 beta)
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
+        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
       - name: Check Symfony version


### PR DESCRIPTION
Type: documentation update
Breaking change: no

Start running tests on PHP 8.5 since it's about to be released.