### PR TITLE
PHP 8.4 Asymmetric Property Visibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
-        "phpstan/phpstan": "~2.1.30",
+        "phpstan/phpstan": "2.1.31",
         "phpunit/phpunit": "^10.5.20,<10.5.32",
         "squizlabs/php_codesniffer": "^3.8.0"
     },

--- a/src/Source/AST/ASTFieldDeclaration.php
+++ b/src/Source/AST/ASTFieldDeclaration.php
@@ -118,7 +118,9 @@ class ASTFieldDeclaration extends AbstractASTNode
                   & ~State::IS_PROTECTED
                   & ~State::IS_PRIVATE
                   & ~State::IS_STATIC
-                  & ~State::IS_READONLY;
+                  & ~State::IS_READONLY
+                  & ~State::IS_PRIVATE_SET
+                  & ~State::IS_PROTECTED_SET;
 
         if (($expected & $modifiers) !== 0) {
             throw new InvalidArgumentException(

--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -1464,7 +1464,7 @@ abstract class AbstractPHPParser
      *
      * @throws UnexpectedTokenException
      */
-    private function parseUnknownDeclaration(int $tokenType, int $modifiers): AbstractASTNode
+    protected function parseUnknownDeclaration(int $tokenType, int $modifiers): AbstractASTNode
     {
         /**
          * Typed properties

--- a/src/Source/Language/PHP/PHPParserVersion84.php
+++ b/src/Source/Language/PHP/PHPParserVersion84.php
@@ -45,7 +45,9 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\State;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Tokens;
 
@@ -95,5 +97,37 @@ abstract class PHPParserVersion84 extends PHPParserVersion83
         }
 
         return null;
+    }
+
+    protected function parseUnknownDeclaration(int $tokenType, int $modifiers): AbstractASTNode
+    {
+        // Handle Asymmetric Property Visibility
+        if (in_array($tokenType, [Tokens::T_PRIVATE_SET, Tokens::T_PROTECTED_SET, Tokens::T_PUBLIC_SET], true)) {
+            switch ($tokenType) {
+                case Tokens::T_PRIVATE_SET:
+                    $modifiers |= State::IS_PRIVATE_SET;
+                    $modifiers &= ~State::IS_PUBLIC;
+
+                    break;
+
+                case Tokens::T_PROTECTED_SET:
+                    $modifiers |= State::IS_PROTECTED_SET;
+                    $modifiers &= ~State::IS_PUBLIC;
+
+                    break;
+
+                case Tokens::T_PUBLIC_SET:
+                    $modifiers |= State::IS_PUBLIC;
+
+                    break;
+            }
+
+            $this->consumeToken($tokenType);
+            $this->consumeComments();
+
+            $tokenType = $this->tokenizer->peek();
+        }
+
+        return parent::parseUnknownDeclaration($tokenType, $modifiers);
     }
 }

--- a/src/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/Source/Language/PHP/PHPTokenizerInternal.php
@@ -223,6 +223,21 @@ if (!defined('T_ENUM')) {
     define('T_ENUM', 42372);
 }
 
+/**
+ * Define PHP 8.4 tokens
+ */
+if (!defined('T_PRIVATE_SET')) {
+    define('T_PRIVATE_SET', 42450);
+}
+
+if (!defined('T_PROTECTED_SET')) {
+    define('T_PROTECTED_SET', 42451);
+}
+
+if (!defined('T_PUBLIC_SET')) {
+    define('T_PUBLIC_SET', 42452);
+}
+
 /** @codeCoverageIgnoreEnd */
 
 /**
@@ -382,6 +397,9 @@ class PHPTokenizerInternal implements FullTokenizer
         T_MATCH => Tokens::T_STRING,
         T_NULLSAFE_OBJECT_OPERATOR => Tokens::T_NULLSAFE_OBJECT_OPERATOR,
         T_READONLY => Tokens::T_READONLY,
+        T_PRIVATE_SET => Tokens::T_PRIVATE_SET,
+        T_PROTECTED_SET => Tokens::T_PROTECTED_SET,
+        T_PUBLIC_SET => Tokens::T_PUBLIC_SET,
     ];
 
     /**
@@ -836,11 +854,19 @@ class PHPTokenizerInternal implements FullTokenizer
         $attributeComment = null;
         $attributeCommentLine = null;
         $brackets = 0;
+        $asymmetricToken = false;
 
         foreach ($tokens as $index => $token) {
             $temp = (array) $token;
             $temp = $temp[0];
 
+            if ($asymmetricToken) {
+                if ($temp === ')') {
+                    $asymmetricToken = false;
+                }
+
+                continue;
+            }
             if ($attributeComment) {
                 if ($temp === '[') {
                     $brackets++;
@@ -884,6 +910,15 @@ class PHPTokenizerInternal implements FullTokenizer
                     '?->',
                     1,
                 ];
+
+                continue;
+            } elseif (in_array($temp, [T_PRIVATE, T_PROTECTED, T_PUBLIC], true) && $tokens[$index + 1][0] === '(' && $tokens[$index + 2][1] === 'set' && $tokens[$index + 3][0] === ')') {
+                $asymmetricToken = true;
+                $result[] = match ($temp) {
+                    T_PRIVATE => [T_PRIVATE_SET, 'private(set)', $token[2]],
+                    T_PROTECTED => [T_PROTECTED_SET, 'protected(set)', $token[2]],
+                    T_PUBLIC => [T_PUBLIC_SET, 'public(set)', $token[2]],
+                };
 
                 continue;
             } else {

--- a/src/Source/Tokenizer/Tokens.php
+++ b/src/Source/Tokenizer/Tokens.php
@@ -562,6 +562,15 @@ interface Tokens
     /** Marks an enum token. */
     public const T_ENUM = 372;
 
+    /** Marks a setter restricted to private. */
+    public const T_PRIVATE_SET = 327;
+
+    /** Marks a setter restricted to protected. */
+    public const T_PROTECTED_SET = 328;
+
+    /** Marks a setter restricted to public. */
+    public const T_PUBLIC_SET = 329;
+
     /** Marks any content not between php tags. */
     public const T_NO_PHP = 255;
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
@@ -3,8 +3,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -41,50 +39,29 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Source\AST;
-
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionProperty;
+namespace PDepend\Source\Language\PHP\Features\PHP84;
 
 /**
- * Holds constants with internal state constants
- *
+ * @covers \PDepend\Source\AST\ASTConstantDeclarator
+ * @covers \PDepend\Source\Language\PHP\PHPParserVersion84
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ *
+ * @group unittest
+ * @group php8.4
  */
-interface State
+class AsymmetricPropertyVisibilityTest extends PHPParserVersion84TestCase
 {
-    /** Marks a class or interface as implicit abstract. */
-    public const IS_IMPLICIT_ABSTRACT = ReflectionClass::IS_IMPLICIT_ABSTRACT;
+    /**
+     * testParserHandlesAsymmetricVisibility
+     */
+    public function testParserHandlesAsymmetricVisibility(): void
+    {
+        $class = $this->parseCodeResourceForTest()
+            ->current()
+            ->getClasses()
+            ->current();
 
-    /** Marks a class or interface as explicit abstract. */
-    public const IS_EXPLICIT_ABSTRACT = ReflectionClass::IS_EXPLICIT_ABSTRACT;
-
-    /** Marks a node as public. */
-    public const IS_PUBLIC = ReflectionMethod::IS_PUBLIC;
-
-    /** Marks a node as protected. */
-    public const IS_PROTECTED = ReflectionMethod::IS_PROTECTED;
-
-    /** Marks a node as private. */
-    public const IS_PRIVATE = ReflectionMethod::IS_PRIVATE;
-
-    /** Marks a node as abstract. */
-    public const IS_ABSTRACT = ReflectionMethod::IS_ABSTRACT;
-
-    /** Marks a node as final. */
-    public const IS_FINAL = ReflectionMethod::IS_FINAL;
-
-    /** Marks a node as static. */
-    public const IS_STATIC = ReflectionMethod::IS_STATIC;
-
-    /** Marks a node as readonly. */
-    public const IS_READONLY = ReflectionProperty::IS_READONLY;
-
-    /** Marks a property setter as private (asymmetric visibility). */
-    public const IS_PRIVATE_SET = 4096; // ReflectionProperty::IS_PRIVATE_SET
-
-    /** Marks a property setter as protected (asymmetric visibility). */
-    public const IS_PROTECTED_SET = 2048; // ReflectionProperty::IS_PROTECTED_SET
+        static::assertCount(1, $class->getProperties());
+    }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP84/PHPParserVersion84TestCase.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP84/PHPParserVersion84TestCase.php
@@ -3,8 +3,6 @@
 /**
  * This file is part of PDepend.
  *
- * PHP Version 5
- *
  * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
  * All rights reserved.
  *
@@ -41,50 +39,27 @@
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
 
-namespace PDepend\Source\AST;
+namespace PDepend\Source\Language\PHP\Features\PHP84;
 
-use ReflectionClass;
-use ReflectionMethod;
-use ReflectionProperty;
+use PDepend\AbstractTestCase;
+use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Tokenizer\Tokenizer;
+use PDepend\Util\Cache\CacheDriver;
 
 /**
- * Holds constants with internal state constants
- *
+ * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * @group unittest
  */
-interface State
+abstract class PHPParserVersion84TestCase extends AbstractTestCase
 {
-    /** Marks a class or interface as implicit abstract. */
-    public const IS_IMPLICIT_ABSTRACT = ReflectionClass::IS_IMPLICIT_ABSTRACT;
-
-    /** Marks a class or interface as explicit abstract. */
-    public const IS_EXPLICIT_ABSTRACT = ReflectionClass::IS_EXPLICIT_ABSTRACT;
-
-    /** Marks a node as public. */
-    public const IS_PUBLIC = ReflectionMethod::IS_PUBLIC;
-
-    /** Marks a node as protected. */
-    public const IS_PROTECTED = ReflectionMethod::IS_PROTECTED;
-
-    /** Marks a node as private. */
-    public const IS_PRIVATE = ReflectionMethod::IS_PRIVATE;
-
-    /** Marks a node as abstract. */
-    public const IS_ABSTRACT = ReflectionMethod::IS_ABSTRACT;
-
-    /** Marks a node as final. */
-    public const IS_FINAL = ReflectionMethod::IS_FINAL;
-
-    /** Marks a node as static. */
-    public const IS_STATIC = ReflectionMethod::IS_STATIC;
-
-    /** Marks a node as readonly. */
-    public const IS_READONLY = ReflectionProperty::IS_READONLY;
-
-    /** Marks a property setter as private (asymmetric visibility). */
-    public const IS_PRIVATE_SET = 4096; // ReflectionProperty::IS_PRIVATE_SET
-
-    /** Marks a property setter as protected (asymmetric visibility). */
-    public const IS_PROTECTED_SET = 2048; // ReflectionProperty::IS_PROTECTED_SET
+    protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
+    {
+        return $this->getMockForAbstractClass(
+            'PDepend\\Source\\Language\\PHP\\PHPParserVersion84',
+            [$tokenizer, $builder, $cache]
+        );
+    }
 }

--- a/tests/resources/files/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibility/testParserHandlesAsymmetricVisibility.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibility/testParserHandlesAsymmetricVisibility.php
@@ -1,0 +1,6 @@
+<?php
+
+class testParserHandlesClassWithPropertyHooks
+{
+    public private(set) string $data;
+}


### PR DESCRIPTION
Type: feature
Issue: #892
Breaking change: no

This adds parser support for [Asymmetric Property Visibility](https://www.php.net/manual/en/language.oop5.visibility.php#language.oop5.visibility-members-aviz), a new feature of PHP 8.4