### PR TITLE
Cast cacheKey to string in create method

### DIFF
--- a/src/Util/Cache/CacheFactory.php
+++ b/src/Util/Cache/CacheFactory.php
@@ -87,7 +87,7 @@ class CacheFactory
      * @param string $cacheKey The name/identifier for the cache instance.
      * @throws Exception
      */
-    public function create(?string $cacheKey = null): CacheDriver
+    public function create(string $cacheKey = ''): CacheDriver
     {
         if (false === isset($this->caches[$cacheKey])) {
             $this->caches[$cacheKey] = $this->createCache($cacheKey);


### PR DESCRIPTION
fixes deprecation warnings in PHP 8.5: 
Deprecated:  Using null as an array offset is deprecated, use an empty string instead in vendor/pdepend/pdepend/src/Util/Cache/CacheFactory.php on line 92 
Deprecated:  Using null as an array offset is deprecated, use an empty string instead in vendor/pdepend/pdepend/src/Util/Cache/CacheFactory.php on line 93 
Deprecated:  Using null as an array offset is deprecated, use an empty string instead in vendor/pdepend/pdepend/src/Util/Cache/CacheFactory.php on line 96

Type: bugfix
Breaking change: no


<!--
Explain what the PR does and also why. If you have parts you are not sure about, please explain. 

Please check this points before submitting your PR.
 - Add test to cover the changes you made on the code.
 - If you have a change on the documentation, please link to the page that you change.
 - If you add a new feature please update the documentation in the same PR.
 - If you really need to add a breaking change, explain why it is needed. Understand that this result in a lower change to get the PR accepted.
 - Any PR need 2 approvals before it get merged, sometimes this can take some time. Please be patient.
-->