### PR TITLE
Update CI tools to run on PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '8.1', '8.2', '8.3', '8.4', '8.5' ]
         setup: [ 'lowest', 'stable' ]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.setup }}
@@ -45,12 +45,12 @@ jobs:
           key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php != '8.4'
+        if: matrix.php != '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
 
-      # For now we need to overwrite the PHP version check on the 8.4 beta as paratest has not been releasd for it yet
-      - name: Install dependencies (PHP 8.4 beta)
-        if: steps.composer-cache.outputs.cache-hit != 'true' && matrix.php == '8.4'
+      # For now we need to overwrite the PHP version check on the 8.5 beta as paratest has not been releasd for it yet
+      - name: Install dependencies (PHP 8.5 beta)
+        if: matrix.php == '8.5'
         run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }} --ignore-platform-req=php
 
       - name: Check Symfony version
@@ -60,5 +60,4 @@ jobs:
         run: composer test
 
       - name: Run PHPStan
-        if: matrix.php != '8.4'
         run: vendor/bin/phpstan

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
-        "phpstan/phpstan": "2.1.31",
-        "phpunit/phpunit": "^10.5.20,<10.5.32",
+        "phpstan/phpstan": "~2.1.32",
+        "phpunit/phpunit": "^10.5.20,<10.5.32|^11.0.0",
         "squizlabs/php_codesniffer": "^3.8.0"
     },
     "autoload": {

--- a/phpstan-baseline-symfony-pre-7.neon
+++ b/phpstan-baseline-symfony-pre-7.neon
@@ -1,0 +1,151 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^PHPDoc tag @return contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Configuration.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\>\>\>\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\>\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\>\>\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @param for parameter \$builder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/Extension.php
+
+		-
+			message: '#^PHPDoc tag @return contains generic type Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^PHPDoc tag @return contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 2
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^PHPDoc tag @var for property PDepend\\DependencyInjection\\TreeBuilder\:\:\$rootNode contains generic type Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\>\> but class Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^PHPDoc tag @var for property PDepend\\DependencyInjection\\TreeBuilder\:\:\$rootNode contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^PHPDoc tag @var for property PDepend\\DependencyInjection\\TreeBuilder\:\:\$treeBuilder contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^Property PDepend\\DependencyInjection\\TreeBuilder\:\:\$rootNode \(Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<''array''\>\>\) does not accept Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\.$#'
+			identifier: assign.propertyType
+			count: 1
+			path: src/DependencyInjection/TreeBuilder.php
+
+		-
+			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeDefinition\:\:children\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method addDefaultsIfNotSet\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method arrayNode\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 5
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method children\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 4
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method defaultValue\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 6
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method enumNode\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method info\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method integerNode\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 2
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method scalarNode\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 3
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Cannot call method values\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^PHPDoc tag @return contains generic type Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<string\> but class Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder is not generic\.$#'
+			identifier: generics.notGeneric
+			count: 1
+			path: src/DependencyInjection/TreeBuilderFactory.php
+
+		-
+			message: '#^Parameter \#1 \$builder of method PDepend\\DependencyInjection\\Extension\:\:getConfig\(\) expects Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder\<Symfony\\Component\\Config\\Definition\\Builder\\ArrayNodeDefinition\<Symfony\\Component\\Config\\Definition\\Builder\\TreeBuilder\<''array''\>\>\>\>\>\>, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/DependencyInjection/TreeBuilderFactory.php

--- a/phpstan-baseline.neon.php
+++ b/phpstan-baseline.neon.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+$composerLock = __DIR__ . '/composer.lock';
+$symfonyVersion = null;
+
+if (is_file($composerLock)) {
+    $lock = json_decode(file_get_contents($composerLock), true);
+
+    if (isset($lock['packages']) && is_array($lock['packages'])) {
+        foreach ($lock['packages'] as $pkg) {
+            if ($pkg['name'] === 'symfony/config') {
+                $symfonyVersion = ltrim($pkg['version'], 'v');
+                break;
+            }
+        }
+    }
+}
+
+$includes = [];
+// only include baseline if composer.lock exists AND version is older than 7
+if ($symfonyVersion !== null && version_compare($symfonyVersion, '7.0.0', '<')) {
+    $includes[] = __DIR__ . '/phpstan-baseline-symfony-pre-7.neon';
+}
+
+$config = [];
+$config['includes'] = $includes;
+
+return $config;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+	- phpstan-baseline.neon.php
 parameters:
     paths:
         - scripts

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/php/PDepend/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd">
-  <coverage includeUncoveredFiles="true" cacheDirectory=".phpunit.cache">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="tests/php/PDepend/bootstrap.php"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+>
+  <coverage includeUncoveredFiles="true">
     <report>
       <clover outputFile="clover.xml"/>
     </report>

--- a/scripts/update-version.php
+++ b/scripts/update-version.php
@@ -185,4 +185,4 @@ class CacheVersionUpdater
     }
 }
 
-CacheVersionUpdater::main($argv);
+CacheVersionUpdater::main($argv ?? []);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -68,6 +68,7 @@ class Configuration implements ConfigurationInterface
 
     /**
      * {@inheritDoc}
+     * @return TreeBuilder<'array'>
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {

--- a/src/DependencyInjection/Extension.php
+++ b/src/DependencyInjection/Extension.php
@@ -46,6 +46,8 @@ namespace PDepend\DependencyInjection;
 use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -101,6 +103,8 @@ abstract class Extension
 
     /**
      * Setups configuration for current extension.
+     *
+     * @param ArrayNodeDefinition<NodeBuilder<ArrayNodeDefinition<NodeBuilder<ArrayNodeDefinition<TreeBuilder<'array'>>>>>> $builder
      */
     public function getConfig(ArrayNodeDefinition $builder): void
     {

--- a/src/DependencyInjection/TreeBuilder.php
+++ b/src/DependencyInjection/TreeBuilder.php
@@ -51,8 +51,10 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder as BaseTreeBuilder;
  */
 class TreeBuilder
 {
+    /** @var ArrayNodeDefinition<BaseTreeBuilder<'array'>> */
     protected ArrayNodeDefinition $rootNode;
 
+    /** @var BaseTreeBuilder<'array'> */
     protected BaseTreeBuilder $treeBuilder;
 
     /**
@@ -62,12 +64,13 @@ class TreeBuilder
     {
         $this->treeBuilder = new BaseTreeBuilder($name, 'array');
         $rootNode = $this->treeBuilder->getRootNode();
-        assert($rootNode instanceof ArrayNodeDefinition);
         $this->rootNode = $rootNode;
     }
 
     /**
      * Get the root node of the built tree.
+     *
+     * @return ArrayNodeDefinition<BaseTreeBuilder<'array'>>
      */
     public function getRootNode(): ArrayNodeDefinition
     {
@@ -76,6 +79,8 @@ class TreeBuilder
 
     /**
      * Get the base Symfony tree builder.
+     *
+     * @return BaseTreeBuilder<'array'>
      */
     public function getTreeBuilder(): BaseTreeBuilder
     {

--- a/src/DependencyInjection/TreeBuilderFactory.php
+++ b/src/DependencyInjection/TreeBuilderFactory.php
@@ -44,7 +44,6 @@
 namespace PDepend\DependencyInjection;
 
 use PDepend\Util\FileUtil;
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 /**
@@ -67,6 +66,8 @@ class TreeBuilderFactory
 
     /**
      * Generates the configuration tree builder.
+     *
+     * @return TreeBuilder<'array'>
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
@@ -74,7 +75,6 @@ class TreeBuilderFactory
 
         $treeBuilder = new TreeBuilder('pdepend', 'array');
         $rootNode = $treeBuilder->getRootNode();
-        assert($rootNode instanceof ArrayNodeDefinition);
         $nodes = $rootNode->children();
 
         $cacheNode = $nodes->arrayNode('cache')->addDefaultsIfNotSet()->children();

--- a/src/Report/Jdepend/Chart.php
+++ b/src/Report/Jdepend/Chart.php
@@ -260,7 +260,7 @@ class Chart extends AbstractASTVisitor implements CodeAwareGenerator, FileAwareG
 
             foreach ($items as &$item) {
                 if ($diff !== 0) {
-                    $item['ratio'] = 5 + (($item['size'] - $min) / $diff);
+                    $item['ratio'] = (int) (5 + (($item['size'] - $min) / $diff));
                 }
             }
         }

--- a/src/Source/Language/PHP/PHPBuilder.php
+++ b/src/Source/Language/PHP/PHPBuilder.php
@@ -2191,7 +2191,7 @@ class PHPBuilder implements Builder
     {
         $this->storeTrait(
             $trait->getImage(),
-            $trait->getNamespaceName(),
+            $trait->getNamespaceName() ?? self::DEFAULT_NAMESPACE,
             $trait,
         );
     }
@@ -2205,7 +2205,7 @@ class PHPBuilder implements Builder
     {
         $this->storeClass(
             $class->getImage(),
-            $class->getNamespaceName(),
+            $class->getNamespaceName() ?? self::DEFAULT_NAMESPACE,
             $class,
         );
     }
@@ -2219,7 +2219,7 @@ class PHPBuilder implements Builder
     {
         $this->storeEnum(
             $enum->getImage(),
-            $enum->getNamespaceName(),
+            $enum->getNamespaceName() ?? self::DEFAULT_NAMESPACE,
             $enum,
         );
     }
@@ -2233,7 +2233,7 @@ class PHPBuilder implements Builder
     {
         $this->storeInterface(
             $interface->getImage(),
-            $interface->getNamespaceName(),
+            $interface->getNamespaceName() ?? self::DEFAULT_NAMESPACE,
             $interface,
         );
     }
@@ -2282,7 +2282,7 @@ class PHPBuilder implements Builder
      *
      * @since 1.0.0
      */
-    protected function storeTrait(?string $traitName, ?string $namespaceName, ASTTrait $trait): void
+    protected function storeTrait(?string $traitName, string $namespaceName, ASTTrait $trait): void
     {
         $traitName = strtolower($traitName ?? '');
         if (!isset($this->traits[$traitName][$namespaceName])) {
@@ -2290,7 +2290,7 @@ class PHPBuilder implements Builder
         }
         $this->traits[$traitName][$namespaceName][$trait->getId()] = $trait;
 
-        $namespace = $this->buildNamespace($namespaceName ?? self::DEFAULT_NAMESPACE);
+        $namespace = $this->buildNamespace($namespaceName);
         $namespace->addType($trait);
     }
 
@@ -2299,7 +2299,7 @@ class PHPBuilder implements Builder
      *
      * @since 0.9.5
      */
-    protected function storeClass(?string $className, ?string $namespaceName, ASTClass $class): void
+    protected function storeClass(?string $className, string $namespaceName, ASTClass $class): void
     {
         $className = strtolower($className ?? '');
         if (!isset($this->classes[$className][$namespaceName])) {
@@ -2307,7 +2307,7 @@ class PHPBuilder implements Builder
         }
         $this->classes[$className][$namespaceName][$class->getId()] = $class;
 
-        $namespace = $this->buildNamespace($namespaceName ?? self::DEFAULT_NAMESPACE);
+        $namespace = $this->buildNamespace($namespaceName);
         $namespace->addType($class);
     }
 
@@ -2316,7 +2316,7 @@ class PHPBuilder implements Builder
      *
      * @since 2.11.0
      */
-    protected function storeEnum(?string $enumName, ?string $namespaceName, ASTEnum $enum): void
+    protected function storeEnum(?string $enumName, string $namespaceName, ASTEnum $enum): void
     {
         $enumName = strtolower($enumName ?? '');
         if (!isset($this->classes[$enumName][$namespaceName])) {
@@ -2324,7 +2324,7 @@ class PHPBuilder implements Builder
         }
         $this->classes[$enumName][$namespaceName][$enum->getId()] = $enum;
 
-        $namespace = $this->buildNamespace($namespaceName ?? self::DEFAULT_NAMESPACE);
+        $namespace = $this->buildNamespace($namespaceName);
         $namespace->addType($enum);
     }
 
@@ -2333,16 +2333,16 @@ class PHPBuilder implements Builder
      *
      * @since 0.9.5
      */
-    protected function storeInterface(?string $interfaceName, ?string $namespaceName, ASTInterface $interface): void
+    protected function storeInterface(string $interfaceName, string $namespaceName, ASTInterface $interface): void
     {
-        $interfaceName = strtolower($interfaceName ?? '');
+        $interfaceName = strtolower($interfaceName);
         if (!isset($this->interfaces[$interfaceName][$namespaceName])) {
             $this->interfaces[$interfaceName][$namespaceName] = [];
         }
         $this->interfaces[$interfaceName][$namespaceName][$interface->getId()]
             = $interface;
 
-        $namespace = $this->buildNamespace($namespaceName ?? self::DEFAULT_NAMESPACE);
+        $namespace = $this->buildNamespace($namespaceName);
         $namespace->addType($interface);
     }
 

--- a/src/Source/Language/PHP/PHPTokenizerInternal.php
+++ b/src/Source/Language/PHP/PHPTokenizerInternal.php
@@ -1008,23 +1008,23 @@ class PHPTokenizerInternal implements FullTokenizer
                     $image = $token[1];
 
                     // Check for a context sensitive alternative
-                    if (isset(self::$alternativeMap[$type][$previousType])) {
-                        $type = self::$alternativeMap[$type][$previousType];
+                    if (isset(self::$alternativeMap[$type][$previousType ?? 0])) {
+                        $type = self::$alternativeMap[$type][$previousType ?? 0];
                     }
 
-                    if (isset(self::$reductionMap[$type][$previousType])) {
-                        $image = self::$reductionMap[$type][$previousType]['image'];
-                        $type = (int) self::$reductionMap[$type][$previousType]['type'];
+                    if (isset(self::$reductionMap[$type][$previousType ?? 0])) {
+                        $image = self::$reductionMap[$type][$previousType ?? 0]['image'];
+                        $type = (int) self::$reductionMap[$type][$previousType ?? 0]['type'];
 
                         $startColumn = $previousStartColumn;
 
                         array_pop($this->tokens);
                     }
-                } elseif (isset($tokenMap[$token[0]])) {
-                    $type = (int) $tokenMap[$token[0]];
+                } elseif (isset($tokenMap[$token[0] ?? ''])) {
+                    $type = (int) $tokenMap[$token[0] ?? ''];
                     // Check for a context sensitive alternative
-                    if (isset(self::$alternativeMap[$type][$previousType])) {
-                        $type = self::$alternativeMap[$type][$previousType];
+                    if (isset(self::$alternativeMap[$type][$previousType ?? 0])) {
+                        $type = self::$alternativeMap[$type][$previousType ?? 0];
                     }
 
                     $image = $token[1];

--- a/tests/php/PDepend/ApplicationTest.php
+++ b/tests/php/PDepend/ApplicationTest.php
@@ -49,16 +49,17 @@ use PDepend\Metrics\AnalyzerFactory;
 use PDepend\Report\ReportGeneratorFactory;
 use PDepend\TextUI\Runner;
 use PDepend\Util\Configuration;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
- * @covers \PDepend\Application
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group integration
  */
+#[CoversClass(Application::class)]
+#[Group('integration')]
 class ApplicationTest extends AbstractTestCase
 {
     public function testGetRunner(): void

--- a/tests/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
+++ b/tests/php/PDepend/Bugs/AlternativeSyntaxClosingTagBug163Test.php
@@ -44,15 +44,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #163.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link      http://tracker.pdepend.org/pdepend/issue_tracker/issue/163
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class AlternativeSyntaxClosingTagBug163Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
+++ b/tests/php/PDepend/Bugs/ClassAndInterfaceNamesBug169Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #169.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
+++ b/tests/php/PDepend/Bugs/ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 91, magic constant __CLASS__ as array default value results
  * in an exception.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClassConstantAsArrayDefaultValueResultsInExceptionBug091Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
+++ b/tests/php/PDepend/Bugs/ClassConstantAsArrayExpressionBug299Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 91, magic constant __CLASS__ as array default value results
  * in an exception.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClassConstantAsArrayExpressionBug299Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
+++ b/tests/php/PDepend/Bugs/ClassDeclarationWithoutBodyBug065Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case related to bug 65.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClassDeclarationWithoutBodyBug065Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
+++ b/tests/php/PDepend/Bugs/ClassInterfaceSizeShouldNotSumComplexityBug176Test.php
@@ -47,6 +47,7 @@ namespace PDepend\Bugs;
 use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for ticket #176.
@@ -54,9 +55,8 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/176
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClassInterfaceSizeShouldNotSumComplexityBug176Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
+++ b/tests/php/PDepend/Bugs/ClassLevelAnalyzerBug09936901Test.php
@@ -47,6 +47,8 @@ namespace PDepend\Bugs;
 use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case related to bug #9936901.
@@ -54,11 +56,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link https://www.pivotaltracker.com/story/show/9936901
- *
- * @ticket 9936901
- *
- * @group regressiontest
  */
+#[Ticket('9936901')]
+#[Group('regressiontest')]
 class ClassLevelAnalyzerBug09936901Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
+++ b/tests/php/PDepend/Bugs/CloneIsValidNameInOlderPhpVersionsBug182Test.php
@@ -43,15 +43,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #182.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/182
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class CloneIsValidNameInOlderPhpVersionsBug182Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
+++ b/tests/php/PDepend/Bugs/ClosureAsArrayElement126Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #131.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClosureAsArrayElement126Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
+++ b/tests/php/PDepend/Bugs/ClosureResultsInExceptionBug070Test.php
@@ -44,15 +44,15 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case related to bug 70.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClosureResultsInExceptionBug070Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
+++ b/tests/php/PDepend/Bugs/ClosureReturnsByReferenceBug094Test.php
@@ -43,15 +43,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Tests that the parser handles a closure that returns a reference correct.
  * This test is related to bug #94.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ClosureReturnsByReferenceBug094Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
+++ b/tests/php/PDepend/Bugs/ComplexStringParsingBug114Test.php
@@ -45,15 +45,15 @@ namespace PDepend\Bugs;
 
 use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTString;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for ticket #114.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ComplexStringParsingBug114Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
+++ b/tests/php/PDepend/Bugs/CouplingAnalyzerBug014Test.php
@@ -44,15 +44,15 @@
 namespace PDepend\Bugs;
 
 use PDepend\Metrics\Analyzer\CouplingAnalyzer;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case related to bug 14.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class CouplingAnalyzerBug014Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
+++ b/tests/php/PDepend/Bugs/DefaultNamespaceBug106Test.php
@@ -43,15 +43,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #106, where internal classes appear in the metrics log
  * file.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class DefaultNamespaceBug106Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
+++ b/tests/php/PDepend/Bugs/DefaultPackageContainsBrokenAritfactsBug098Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #98. The default package contains software artifacts like
  * functions or classes that are broken. This can result in a fatal error during
@@ -50,9 +52,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class DefaultPackageContainsBrokenAritfactsBug098Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
+++ b/tests/php/PDepend/Bugs/EndLessLoopBetweenForParentClassBug152Test.php
@@ -44,15 +44,15 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug #152.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class EndLessLoopBetweenForParentClassBug152Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
+++ b/tests/php/PDepend/Bugs/EndlessInheritanceBug18459091Test.php
@@ -51,6 +51,8 @@ use PDepend\Metrics\Analyzer\InheritanceAnalyzer;
 use PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException;
 use PDepend\TextUI\Command;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #18459091.
@@ -59,11 +61,9 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link https://www.pivotaltracker.com/story/show/18459091
  * @since 1.0.0
- *
- * @ticket 18459091
- *
- * @group regressiontest
  */
+#[Ticket('18459091')]
+#[Group('regressiontest')]
 class EndlessInheritanceBug18459091Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
+++ b/tests/php/PDepend/Bugs/ExcludePathFilterShouldFilterByAbsolutePathBug191Test.php
@@ -44,6 +44,7 @@
 namespace PDepend\Bugs;
 
 use PDepend\Input\ExcludePathFilter;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug #191.
@@ -51,9 +52,8 @@ use PDepend\Input\ExcludePathFilter;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/191
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ExcludePathFilterShouldFilterByAbsolutePathBug191Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
+++ b/tests/php/PDepend/Bugs/InconsistentObjectGraphBug073Test.php
@@ -43,15 +43,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 73 that results in an inconsistent object graph and fatal
  * errors.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InconsistentObjectGraphBug073Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
+++ b/tests/php/PDepend/Bugs/IncorrectPropertyEndlineBug068Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 68 where the property end line of a property was not set
  * correct.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class IncorrectPropertyEndlineBug068Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
+++ b/tests/php/PDepend/Bugs/InputIteratorShouldOnlyFilterOnLocalPathBug164Test.php
@@ -46,6 +46,7 @@ namespace PDepend\Bugs;
 use ArrayIterator;
 use PDepend\Input\Filter;
 use PDepend\Input\Iterator;
+use PHPUnit\Framework\Attributes\Group;
 use SplFileInfo;
 
 /**
@@ -54,9 +55,8 @@ use SplFileInfo;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link http://tracker.pdepend.org/pdepend/issue_tracker/issue/164
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InputIteratorShouldOnlyFilterOnLocalPathBug164Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
+++ b/tests/php/PDepend/Bugs/InstanceOfExpressionReferenceHandlingBug062Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 62 where reference in an instanceof operator weren't handled
  * correct.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InstanceOfExpressionReferenceHandlingBug062Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
+++ b/tests/php/PDepend/Bugs/InvalidNowdocSubstitutionBug150Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #150.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InvalidNowdocSubstitutionBug150Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
+++ b/tests/php/PDepend/Bugs/InvalidResultWhenFunctionReturnsByReferenceBug004Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #4
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InvalidResultWhenFunctionReturnsByReferenceBug004Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
+++ b/tests/php/PDepend/Bugs/InvalidTokenObjectOperatorInForeachLoopBug161Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #161.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class InvalidTokenObjectOperatorInForeachLoopBug161Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
+++ b/tests/php/PDepend/Bugs/KeywordFunctionNameResultsInExceptionBug116Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #116
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class KeywordFunctionNameResultsInExceptionBug116Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
+++ b/tests/php/PDepend/Bugs/MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test.php
@@ -44,15 +44,15 @@
 namespace PDepend\Bugs;
 
 use PDepend\Metrics\Analyzer\InheritanceAnalyzer;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug #118
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class MethodsDeclaredAbstractAreCountedAsOverwrittenBug118Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
+++ b/tests/php/PDepend/Bugs/NPathComplexityIsBrokenInVersion096Bug095Test.php
@@ -45,6 +45,7 @@ namespace PDepend\Bugs;
 
 use PDepend\Metrics\Analyzer\NPathComplexityAnalyzer;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug 95.
@@ -53,9 +54,8 @@ use PDepend\Util\Cache\Driver\MemoryCacheDriver;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class NPathComplexityIsBrokenInVersion096Bug095Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
+++ b/tests/php/PDepend/Bugs/NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test.php
@@ -44,6 +44,7 @@
 namespace PDepend\Bugs;
 
 use PDepend\Metrics\Analyzer\CouplingAnalyzer;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug 090 where the coupling analyzer calculates wrong results
@@ -54,9 +55,8 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class NamespaceChainsNotHandledCorrectByCouplingAnalyzerBug090Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
+++ b/tests/php/PDepend/Bugs/NamespaceKeywordInParameterTypeHintBug102Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 102. The current parser implementation does not handle
  * the <b>namespace</b> keyword in parameter type hints.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class NamespaceKeywordInParameterTypeHintBug102Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
+++ b/tests/php/PDepend/Bugs/NamespacedConstsAndFunctionsBug00000247Test.php
@@ -50,6 +50,8 @@ use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
@@ -58,11 +60,9 @@ use PHPUnit\Framework\MockObject\MockObject;
  * @copyright 2008-2016 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link    https://github.com/pdepend/pdepend/issues/247
- *
- * @ticket 247
- *
- * @group regressiontest
  */
+#[Ticket('247')]
+#[Group('regressiontest')]
 class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTestCase
 {
     /**
@@ -115,9 +115,9 @@ class NamespacedConstsAndFunctionsBug00000247Test extends AbstractRegressionTest
      */
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            AbstractPHPParser::class,
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(AbstractPHPParser::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Bugs/PHPDependBug13405179Test.php
+++ b/tests/php/PDepend/Bugs/PHPDependBug13405179Test.php
@@ -49,6 +49,9 @@ use PDepend\Report\Jdepend\Chart;
 use PDepend\Report\Jdepend\Xml as JdependXml;
 use PDepend\Report\Overview\Pyramid;
 use PDepend\Report\Summary\Xml as SummaryXml;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #13405179.
@@ -56,11 +59,9 @@ use PDepend\Report\Summary\Xml as SummaryXml;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link https://www.pivotaltracker.com/story/show/13405179
- *
- * @ticket 13405179
- *
- * @group regressiontest
  */
+#[Ticket('13405179')]
+#[Group('regressiontest')]
 class PHPDependBug13405179Test extends AbstractRegressionTestCase
 {
     /**
@@ -68,8 +69,8 @@ class PHPDependBug13405179Test extends AbstractRegressionTestCase
      *
      * @param class-string<FileAwareGenerator> $className Class name of a logger implementation.
      * @param string $extension Log file extension.
-     * @dataProvider getLoggerClassNames
      */
+    #[DataProvider('getLoggerClassNames')]
     public function testLogFileIsCreatedForUnstructuredCode(string $className, string $extension): void
     {
         $file = $this->createRunResourceURI() . '.' . $extension;

--- a/tests/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
+++ b/tests/php/PDepend/Bugs/ParameterStringDefaultValueBug103Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 103. The current parser implementation does not handle
  * string parameter default values as expected. For example the following source
@@ -52,9 +54,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ParameterStringDefaultValueBug103Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
+++ b/tests/php/PDepend/Bugs/ParentKeywordAsParameterTypeHintBug087Test.php
@@ -44,6 +44,7 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the parent keyword type hint bug no #87.
@@ -52,9 +53,8 @@ use PDepend\Source\Parser\InvalidStateException;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ParentKeywordAsParameterTypeHintBug087Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug001Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug001Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #1.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 1
- *
- * @group regressiontest
  */
+#[Ticket('1')]
+#[Group('regressiontest')]
 class ParserBug001Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug006Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug006Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #006.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 006
- *
- * @group regressiontest
  */
+#[Ticket('006')]
+#[Group('regressiontest')]
 class ParserBug006Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug007Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug007Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #7.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 7
- *
- * @group regressiontest
  */
+#[Ticket('7')]
+#[Group('regressiontest')]
 class ParserBug007Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug008Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug008Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #8.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 8
- *
- * @group regressiontest
  */
+#[Ticket('8')]
+#[Group('regressiontest')]
 class ParserBug008Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug015Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug015Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #15.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 15
- *
- * @group regressiontest
  */
+#[Ticket('15')]
+#[Group('regressiontest')]
 class ParserBug015Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug016Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug016Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #16.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 16
- *
- * @group regressiontest
  */
+#[Ticket('16')]
+#[Group('regressiontest')]
 class ParserBug016Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug017Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug017Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #17.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 17
- *
- * @group regressiontest
  */
+#[Ticket('17')]
+#[Group('regressiontest')]
 class ParserBug017Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug030Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug030Test.php
@@ -44,17 +44,17 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #30.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 30
- *
- * @group regressiontest
  */
+#[Ticket('30')]
+#[Group('regressiontest')]
 class ParserBug030Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug033Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug033Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #33.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 33
- *
- * @group regressiontest
  */
+#[Ticket('33')]
+#[Group('regressiontest')]
 class ParserBug033Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug059Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug059Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #59.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 59
- *
- * @group regressiontest
  */
+#[Ticket('59')]
+#[Group('regressiontest')]
 class ParserBug059Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug069Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug069Test.php
@@ -43,16 +43,17 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #69.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 69
- *
- * @group regressiontest
  */
+#[Ticket('69')]
+#[Group('regressiontest')]
 class ParserBug069Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug124Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug124Test.php
@@ -45,16 +45,16 @@ namespace PDepend\Bugs;
 
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #124.
  *
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @ticket 124
- *
- * @group regressiontest
  */
+#[Ticket('124')]
+#[Group('regressiontest')]
 class ParserBug124Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -44,17 +44,18 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #17264279.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       https://www.pivotaltracker.com/story/show/17264279
- *
- * @ticket 17264279
- *
- * @group regressiontest
  */
+#[Ticket('17264279')]
+#[Group('regressiontest')]
 class ParserBug17264279Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug21500611Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug21500611Test.php
@@ -46,6 +46,8 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\AST\ASTHeredoc;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #21500611.
@@ -54,11 +56,9 @@ use PDepend\Source\AST\ASTHeredoc;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link https://www.pivotaltracker.com/story/show/21500611
  * @since 1.0.0
- *
- * @ticket 21500611
- *
- * @group regressiontest
  */
+#[Ticket('21500611')]
+#[Group('regressiontest')]
 class ParserBug21500611Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug23905939Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug23905939Test.php
@@ -45,6 +45,9 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #23905939.
  *
@@ -52,11 +55,9 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       https://www.pivotaltracker.com/story/show/23905939
  * @since 0.10.8
- *
- * @ticket 23905939
- *
- * @group regressiontest
  */
+#[Ticket('23905939')]
+#[Group('regressiontest')]
 class ParserBug23905939Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug23951621Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug23951621Test.php
@@ -47,6 +47,8 @@ namespace PDepend\Bugs;
 
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTInterface;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #23951621.
@@ -55,11 +57,9 @@ use PDepend\Source\AST\ASTInterface;
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @link https://www.pivotaltracker.com/story/show/23951621
  * @since 0.10.9
- *
- * @ticket 23951621
- *
- * @group regressiontest
  */
+#[Ticket('23951621')]
+#[Group('regressiontest')]
 class ParserBug23951621Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserBug713Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug713Test.php
@@ -6,21 +6,23 @@ use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #713.
- *
- * @ticket 713
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseIssetExpression
  * @covers \PDepend\Source\Language\PHP\AbstractPHPParser::parseVariableList
- * @group regressiontest
  */
+#[Ticket('713')]
+#[Group('regressiontest')]
 class ParserBug713Test extends AbstractRegressionTestCase
 {
     /**
      * Expect no uncaught exceptions.
-     * @doesNotPerformAssertions
      */
+    #[DoesNotPerformAssertions]
     public function testConstantArrayIndexIsset(): void
     {
         $cache = new MemoryCacheDriver();

--- a/tests/php/PDepend/Bugs/ParserBug8927377Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug8927377Test.php
@@ -45,6 +45,8 @@
 namespace PDepend\Bugs;
 
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
 
 /**
  * Test case for bug #8927377.
@@ -52,11 +54,9 @@ use PDepend\Source\AST\ASTPropertyPostfix;
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       https://www.pivotaltracker.com/story/show/8927377
- *
- * @ticket 8927377
- *
- * @group regressiontest
  */
+#[Ticket('8927377')]
+#[Group('regressiontest')]
 class ParserBug8927377Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
+++ b/tests/php/PDepend/Bugs/ParserKeywordAsConstantNameBug76Test.php
@@ -43,6 +43,9 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the keyword substitution bug no 76.
  *
@@ -50,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
 {
     /**
@@ -61,8 +63,8 @@ class ParserKeywordAsConstantNameBug76Test extends AbstractRegressionTestCase
      *
      * @param string $sourceFile Name of the test file.
      * @param string $constantName Name of the expected constant
-     * @dataProvider dataProviderReservedKeywordAsTypeConstantName
      */
+    #[DataProvider('dataProviderReservedKeywordAsTypeConstantName')]
     public function testReservedKeywordAsTypeConstantName(string $sourceFile, string $constantName): void
     {
         $namespaces = $this->parseSource($sourceFile);

--- a/tests/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
+++ b/tests/php/PDepend/Bugs/ParserSetsIncorrectStartLineBug101Test.php
@@ -43,15 +43,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Tests that the parser handles a closure that returns a reference correct.
  * This test is related to bug #94.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ParserSetsIncorrectStartLineBug101Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
+++ b/tests/php/PDepend/Bugs/ReconfigureXdebugMaxNestingLevelBug133Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #133
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ReconfigureXdebugMaxNestingLevelBug133Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
+++ b/tests/php/PDepend/Bugs/ShortArraySyntaxInitializerBug00000104Test.php
@@ -46,6 +46,9 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
 /**
  * Test case for bug #104 and #95.
  *
@@ -54,12 +57,10 @@ namespace PDepend\Bugs;
  * @link       https://github.com/pdepend/pdepend/issues/95
  * @link       https://github.com/pdepend/pdepend/issues/104
  * @since 1.1.1
- *
- * @ticket 104
- * @ticket 95
- *
- * @group regressiontest
  */
+#[Ticket('104')]
+#[Ticket('95')]
+#[Group('regressiontest')]
 class ShortArraySyntaxInitializerBug00000104Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
+++ b/tests/php/PDepend/Bugs/SignedDefaultValueResultsInExceptionBug071Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the signed default value bug no. 71.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class SignedDefaultValueResultsInExceptionBug071Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
+++ b/tests/php/PDepend/Bugs/StringWithDollarStringLiteralBug162Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for ticket #162.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class StringWithDollarStringLiteralBug162Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
+++ b/tests/php/PDepend/Bugs/SummaryReportContainsClassesWithoutSourceFileBug115Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #115
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class SummaryReportContainsClassesWithoutSourceFileBug115Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
+++ b/tests/php/PDepend/Bugs/SupportCommaSeparatedConstantDefinitionsBug082Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug #82 where PDepend does not handle comma separated
  * constant definitions.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class SupportCommaSeparatedConstantDefinitionsBug082Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
+++ b/tests/php/PDepend/Bugs/SupportCommaSeparatedPropertyDeclarationsBug081Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 081 where PDepend does not handle comma separated property
  * declarations.
@@ -51,9 +53,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class SupportCommaSeparatedPropertyDeclarationsBug081Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
+++ b/tests/php/PDepend/Bugs/TokenizerKeywordSubstitutionBug76Test.php
@@ -45,6 +45,8 @@ namespace PDepend\Bugs;
 
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the keyword substitution bug no 76.
@@ -53,9 +55,8 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
 {
     /**
@@ -64,8 +65,8 @@ class TokenizerKeywordSubstitutionBug76Test extends AbstractRegressionTestCase
      *
      * @param string $sourceFile Name of the text file.
      * @param array<int> $tokenTypes List of all expected token types.
-     * @dataProvider dataProviderTokenizerKeywordSubstitutionInOperatorChain
      */
+    #[DataProvider('dataProviderTokenizerKeywordSubstitutionInOperatorChain')]
     public function testTokenizerKeywordSubstitutionInOperatorChain(string $sourceFile, array $tokenTypes): void
     {
         $tokenizer = new PHPTokenizerInternal();

--- a/tests/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
+++ b/tests/php/PDepend/Bugs/TraitsNotHandledCorrrectBug00000100Test.php
@@ -44,15 +44,16 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case issue 00000100.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       https://github.com/pdepend/pdepend/issues/100
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class TraitsNotHandledCorrrectBug00000100Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
+++ b/tests/php/PDepend/Bugs/TrueFalseKeywordInNamespaceBug1412288686Test.php
@@ -43,14 +43,15 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case issue 1412288686.
  *
  * @copyright 2008-2014 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class TrueFalseKeywordInNamespaceBug1412288686Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
+++ b/tests/php/PDepend/Bugs/UnexpectedTokenAsciiChar39Bug181Test.php
@@ -45,6 +45,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for bug 181, where an unexpected token in a chinese translation
  * file forces PDepend to quit.
@@ -55,9 +57,8 @@ namespace PDepend\Bugs;
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @link       http://tracker.pdepend.org/pdepend/issue_tracker/issue/181
  * @since 0.10.0
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class UnexpectedTokenAsciiChar39Bug181Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
+++ b/tests/php/PDepend/Bugs/VariableVariablesInForeachStatementBug128Test.php
@@ -43,6 +43,8 @@
 
 namespace PDepend\Bugs;
 
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the keyword substitution bug no 128.
  *
@@ -50,9 +52,8 @@ namespace PDepend\Bugs;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class VariableVariablesInForeachStatementBug128Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
+++ b/tests/php/PDepend/Bugs/WrongCouplingAnalyzerForCommentsBug089Test.php
@@ -44,6 +44,7 @@
 namespace PDepend\Bugs;
 
 use PDepend\Metrics\Analyzer\CouplingAnalyzer;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for bug 089 where the coupling analyzer calculates wrong results
@@ -53,9 +54,8 @@ use PDepend\Metrics\Analyzer\CouplingAnalyzer;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class WrongCouplingAnalyzerForCommentsBug089Test extends AbstractRegressionTestCase
 {
     /**

--- a/tests/php/PDepend/DependencyInjection/ConfigurationTest.php
+++ b/tests/php/PDepend/DependencyInjection/ConfigurationTest.php
@@ -45,20 +45,21 @@ namespace PDepend\DependencyInjection;
 
 use PDepend\AbstractTestCase;
 use PDepend\TestExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
 use ReflectionNamedType;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder as SymfonyTreeBuilder;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
- * @covers \PDepend\DependencyInjection\TreeBuilder
- * @covers \PDepend\DependencyInjection\TreeBuilderFactory
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(TreeBuilder::class)]
+#[CoversClass(TreeBuilderFactory::class)]
+#[Group('unittest')]
 class ConfigurationTest extends AbstractTestCase
 {
     public function testSymfony(): void
@@ -66,7 +67,7 @@ class ConfigurationTest extends AbstractTestCase
         $config = new Configuration([TestExtension::create()]);
 
         static::assertInstanceOf(
-            TreeBuilder::class,
+            SymfonyTreeBuilder::class,
             $config->getConfigTreeBuilder()
         );
 
@@ -78,6 +79,6 @@ class ConfigurationTest extends AbstractTestCase
         $type = $method->getReturnType();
         static::assertInstanceOf(ReflectionNamedType::class, $type);
 
-        static::assertSame(TreeBuilder::class, $type->getName());
+        static::assertSame(SymfonyTreeBuilder::class, $type->getName());
     }
 }

--- a/tests/php/PDepend/DependencyInjection/ExtensionManagerTest.php
+++ b/tests/php/PDepend/DependencyInjection/ExtensionManagerTest.php
@@ -45,19 +45,20 @@ namespace PDepend\DependencyInjection;
 
 use PDepend\AbstractTestCase;
 use PDepend\TestExtension;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
- * @covers \PDepend\DependencyInjection\Extension
- * @covers \PDepend\DependencyInjection\ExtensionManager
- * @covers \PDepend\DependencyInjection\TreeBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Extension::class)]
+#[CoversClass(ExtensionManager::class)]
+#[CoversClass(TreeBuilder::class)]
+#[Group('unittest')]
 class ExtensionManagerTest extends AbstractTestCase
 {
     public function testExtensionManager(): void

--- a/tests/php/PDepend/DependencyInjection/TreeBuilderTest.php
+++ b/tests/php/PDepend/DependencyInjection/TreeBuilderTest.php
@@ -44,18 +44,19 @@
 namespace PDepend\DependencyInjection;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder as SymfonyTreeBuilder;
 
 /**
  * Test cases for the {@link \PDepend\Application} class.
  *
- * @covers \PDepend\DependencyInjection\TreeBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(TreeBuilder::class)]
+#[Group('unittest')]
 class TreeBuilderTest extends AbstractTestCase
 {
     public function testTreeBuilder(): void

--- a/tests/php/PDepend/EngineTest.php
+++ b/tests/php/PDepend/EngineTest.php
@@ -45,16 +45,18 @@ namespace PDepend;
 
 use InvalidArgumentException;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for \PDepend\Engine facade.
  *
- * @covers \PDepend\Engine
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Engine::class)]
+#[Group('unittest')]
 class EngineTest extends AbstractTestCase
 {
     /**
@@ -337,17 +339,13 @@ class EngineTest extends AbstractTestCase
         return $namespaces[0];
     }
 
-    /**
-     * @depends testSupportForSingleFileIssue90
-     */
+    #[Depends('testSupportForSingleFileIssue90')]
     public function testSupportForSingleFileIssue90ExpectedNumberOfClasses(ASTNamespace $namespace): void
     {
         static::assertCount(1, $namespace->getClasses());
     }
 
-    /**
-     * @depends testSupportForSingleFileIssue90
-     */
+    #[Depends('testSupportForSingleFileIssue90')]
     public function testSupportForSingleFileIssue90ExpectedNumberOfInterfaces(ASTNamespace $namespace): void
     {
         static::assertCount(1, $namespace->getInterfaces());

--- a/tests/php/PDepend/Input/CompositeFilterTest.php
+++ b/tests/php/PDepend/Input/CompositeFilterTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Input;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the composite filter.
  *
- * @covers \PDepend\Input\CompositeFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(CompositeFilter::class)]
+#[Group('unittest')]
 class CompositeFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Input/ExcludePathFilterTest.php
+++ b/tests/php/PDepend/Input/ExcludePathFilterTest.php
@@ -45,21 +45,21 @@ namespace PDepend\Input;
 
 use Exception;
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
-use ReflectionException;
 use ReflectionProperty;
 use SplFileInfo;
 
 /**
  * Test case for the exclude path filter.
  *
- * @covers \PDepend\Input\ExcludePathFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ExcludePathFilter::class)]
+#[Group('unittest')]
 class ExcludePathFilterTest extends AbstractTestCase
 {
     /**
@@ -108,8 +108,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testPatternsWithSixtyThousandCharactersSetProtectedIsBulkToTrue
-     *
-     * @throws ReflectionException
      */
     public function testPatternsWithSixtyThousandCharactersSetProtectedIsBulkToTrue(): void
     {
@@ -124,8 +122,6 @@ class ExcludePathFilterTest extends AbstractTestCase
 
     /**
      * testPatternsWithLessThanThirtyThousandCharactersSetProtectedIsBulkToFalse
-     *
-     * @throws ReflectionException
      */
     public function testPatternsWithLessThanThirtyThousandCharactersSetProtectedIsBulkToFalse(): void
     {

--- a/tests/php/PDepend/Input/ExtensionFilterTest.php
+++ b/tests/php/PDepend/Input/ExtensionFilterTest.php
@@ -44,6 +44,8 @@
 namespace PDepend\Input;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -51,12 +53,11 @@ use SplFileInfo;
 /**
  * Test case for the file extension filter.
  *
- * @covers \PDepend\Input\ExtensionFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ExtensionFilter::class)]
+#[Group('unittest')]
 class ExtensionFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Input/IteratorTest.php
+++ b/tests/php/PDepend/Input/IteratorTest.php
@@ -46,6 +46,8 @@ namespace PDepend\Input;
 use ArrayIterator;
 use DirectoryIterator;
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use SplFileInfo;
@@ -53,12 +55,11 @@ use SplFileInfo;
 /**
  * Test case for the php file filter iterator.
  *
- * @covers \PDepend\Input\Iterator
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Iterator::class)]
+#[Group('unittest')]
 class IteratorTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Integration/BuilderParserCacheTest.php
+++ b/tests/php/PDepend/Integration/BuilderParserCacheTest.php
@@ -49,15 +49,15 @@ use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Util\Cache\Driver\FileCacheDriver;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the integration of parser and builder together with the cache component.
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group integrationtest
  */
+#[Group('regressiontest')]
 class BuilderParserCacheTest extends AbstractTestCase
 {
     /** The temporary cache directory. */

--- a/tests/php/PDepend/Integration/DependExcludePathFilterTest.php
+++ b/tests/php/PDepend/Integration/DependExcludePathFilterTest.php
@@ -45,6 +45,7 @@ namespace PDepend\Integration;
 
 use PDepend\AbstractTestCase;
 use PDepend\Input\ExcludePathFilter;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the integration of the {@link \PDepend\Engine} class and the
@@ -52,9 +53,8 @@ use PDepend\Input\ExcludePathFilter;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group integrationtest
  */
+#[Group('regressiontest')]
 class DependExcludePathFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
+++ b/tests/php/PDepend/Issues/DoubleClassModifierIssue638Test.php
@@ -44,19 +44,21 @@
 namespace PDepend\Issues;
 
 use PDepend\Source\AST\State;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for issue #638, php 8.2 readonly allows double class modifiers.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class DoubleClassModifierIssue638Test extends AbstractFeatureTestCase
 {
     /**

--- a/tests/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
+++ b/tests/php/PDepend/Issues/HandlingOfIdeStyleDependenciesInCommentsIssue087Test.php
@@ -43,15 +43,18 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for issue #87. Handling of dependencies declared in inline comments.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class HandlingOfIdeStyleDependenciesInCommentsIssue087Test extends AbstractFeatureTestCase
 {
     /**

--- a/tests/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
+++ b/tests/php/PDepend/Issues/KeepTypeInformationForPrimitivesIssue084Test.php
@@ -45,17 +45,20 @@ namespace PDepend\Issues;
 
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTType;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for issue #84, where the object model should keep information about
  * primitive property and parameter types.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCase
 {
     /**
@@ -63,8 +66,8 @@ class KeepTypeInformationForPrimitivesIssue084Test extends AbstractFeatureTestCa
      *
      * @param string $actual The actual used type identifier.
      * @param string $expected The expected primitive type image.
-     * @dataProvider dataProviderParserSetsExpectedPrimitivePropertyType
      */
+    #[DataProvider('dataProviderParserSetsExpectedPrimitivePropertyType')]
     public function testParserSetsExpectedPrimitivePropertyType(string $actual, string $expected): void
     {
         $type = $this->parseTestCase(__METHOD__ . '_' . $actual)

--- a/tests/php/PDepend/Issues/NamespaceSupportIssue002Test.php
+++ b/tests/php/PDepend/Issues/NamespaceSupportIssue002Test.php
@@ -43,17 +43,20 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
 {
     /**
@@ -297,8 +300,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesQualifiedTypeNameInTypeSignature
      */
+    #[DataProvider('dataProviderParserResolvesQualifiedTypeNameInTypeSignature')]
     public function testParserResolvesQualifiedTypeNameInTypeSignature(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
@@ -334,8 +337,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesQualifiedTypeNameInFunction
      */
+    #[DataProvider('dataProviderParserResolvesQualifiedTypeNameInFunction')]
     public function testParserResolvesQualifiedTypeNameInFunction(string $fileName, string $namespaceName): void
     {
         $namespaces = $this->parseSource($fileName);
@@ -377,8 +380,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserKeepsQualifiedTypeNameInTypeSignature
      */
+    #[DataProvider('dataProviderParserKeepsQualifiedTypeNameInTypeSignature')]
     public function testParserKeepsQualifiedTypeNameInTypeSignature(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
@@ -412,8 +415,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserKeepsQualifiedTypeNameInFunction
      */
+    #[DataProvider('dataProviderParserKeepsQualifiedTypeNameInFunction')]
     public function testParserKeepsQualifiedTypeNameInFunction(string $fileName, string $namespaceName): void
     {
         $dependency = $this->parseSource($fileName)
@@ -450,8 +453,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax
      */
+    #[DataProvider('dataProviderParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax')]
     public function testParserResolvesNamespaceKeywordInTypeSignatureSemicolonSyntax(
         string $fileName,
         string $namespaceName
@@ -488,8 +491,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax
      */
+    #[DataProvider('dataProviderParserResolvesNamespaceKeywordInFunctionSemicolonSyntax')]
     public function testParserResolvesNamespaceKeywordInFunctionSemicolonSyntax(
         string $fileName,
         string $namespaceName
@@ -527,8 +530,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax
      */
+    #[DataProvider('dataProviderParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax')]
     public function testParserResolvesNamespaceKeywordInTypeSignatureCurlyBraceSyntax(
         string $fileName,
         string $namespaceName
@@ -565,8 +568,8 @@ class NamespaceSupportIssue002Test extends AbstractFeatureTestCase
      *
      * @param string $fileName Name of the test file.
      * @param string $namespaceName Name of the expected namespace.
-     * @dataProvider dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax
      */
+    #[DataProvider('dataProviderParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax')]
     public function testParserResolvesNamespaceKeywordInFunctionCurlyBraceSyntax(
         string $fileName,
         string $namespaceName

--- a/tests/php/PDepend/Issues/NewClassInstanceTest.php
+++ b/tests/php/PDepend/Issues/NewClassInstanceTest.php
@@ -50,16 +50,18 @@ use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTStatement;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for ticket 002, PHP 5.3 namespace support.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class NewClassInstanceTest extends AbstractFeatureTestCase
 {
     /**

--- a/tests/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
+++ b/tests/php/PDepend/Issues/PHPDependCatchesParsingErrorsIssue061Test.php
@@ -43,19 +43,24 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Engine;
 use PDepend\Input\ExtensionFilter;
 use PDepend\Report\Dummy\Logger;
 use PDepend\TextUI\Command;
+use PDepend\TextUI\Runner;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the catch error ticket #61.
  *
- * @covers \PDepend\Engine
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Engine::class)]
+#[CoversClass(Runner::class)]
+#[CoversClass(Command::class)]
+#[Group('unittest')]
 class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
 {
     /**
@@ -80,8 +85,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * Tests that the {@link \PDepend\TextUI\Runner::hasErrors()} method will
      * return <b>false</b> when not parsing error occurred.
-     *
-     * @covers \PDepend\TextUI\Runner
      */
     public function testRunnerReturnsFalseWhenNoErrorOccurredDuringTheParsingProcess(): void
     {
@@ -96,8 +99,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * Tests that the {@link \PDepend\TextUI\Runner::hasErrors()} method will
      * return <b>true</b> when a parsing error occurred.
-     *
-     * @covers \PDepend\TextUI\Runner
      */
     public function testRunnerReturnsTrueWhenAnErrorOccurredDuringTheParsingProcess(): void
     {
@@ -113,8 +114,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
     /**
      * Tests that the output does not contain the error hint when the parsing
      * process was successful.
-     *
-     * @covers \PDepend\TextUI\Command
      */
     public function testCommandDoesNotPrintErrorOutputOnSuccessfulParsingProcess(): void
     {
@@ -133,8 +132,6 @@ class PHPDependCatchesParsingErrorsIssue061Test extends AbstractFeatureTestCase
 
     /**
      * testCommandPrintsExceptionMessageWhenAnErrorOccurredDuringTheParsingProcess
-     *
-     * @covers \PDepend\TextUI\Command
      */
     public function testCommandPrintsExceptionMessageWhenAnErrorOccurredDuringTheParsingProcess(): void
     {

--- a/tests/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
+++ b/tests/php/PDepend/Issues/ParserSetsCorrectParametersIssue032Test.php
@@ -44,16 +44,18 @@
 namespace PDepend\Issues;
 
 use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for parameter related ticker #32.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ParserSetsCorrectParametersIssue032Test extends AbstractFeatureTestCase
 {
     /**

--- a/tests/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
+++ b/tests/php/PDepend/Issues/ReflectionCompatibilityIssue067Test.php
@@ -48,19 +48,24 @@ use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\MissingValueException;
 use PDepend\Source\Parser\TokenStreamEndException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the Reflection API compatibility ticket #67.
  *
- * @covers \PDepend\Source\AST\ASTParameter
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTParameter::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(MissingValueException::class)]
+#[CoversClass(TokenStreamEndException::class)]
+#[Group('unittest')]
 class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
 {
     /**
@@ -579,8 +584,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser throws the expected exception when no default value
      * was defined.
-     *
-     * @covers \PDepend\Source\Parser\MissingValueException
      */
     public function testParserThrowsExpectedExceptionForMissingDefaultValue(): void
     {
@@ -592,8 +595,6 @@ class ReflectionCompatibilityIssue067Test extends AbstractFeatureTestCase
     /**
      * Tests that the parser throws the expected exception when it reaches the
      * end of file while it parses a parameter default value.
-     *
-     * @covers \PDepend\Source\Parser\TokenStreamEndException
      */
     public function testParserThrowsExpectedExceptionWhenReachesEofWhileParsingDefaultValue(): void
     {

--- a/tests/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
+++ b/tests/php/PDepend/Issues/StoreTokensForAllNodeTypesIssue079Test.php
@@ -43,8 +43,16 @@
 
 namespace PDepend\Issues;
 
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTFunction;
+use PDepend\Source\AST\ASTInterface;
+use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for issue #79 where we should store the tokens for each created
@@ -52,18 +60,20 @@ use PDepend\Source\Tokenizer\Tokens;
  *
  * http://tracker.pdepend.org/pdepend/issue_tracker/issue/79
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(ASTClass::class)]
+#[CoversClass(ASTFunction::class)]
+#[CoversClass(ASTInterface::class)]
+#[CoversClass(ASTMethod::class)]
+#[CoversClass(ASTParameter::class)]
+#[Group('unittest')]
 class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 {
     /**
      * Tests that the parameter contains the start line of the first token.
-     *
-     * @covers \PDepend\Source\AST\ASTParameter
      */
     public function testParameterContainsStartLineOfFirstToken(): void
     {
@@ -78,8 +88,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parameter contains the end line of the last token.
-     *
-     * @covers \PDepend\Source\AST\ASTParameter
      */
     public function testParameterContainsEndLineOfLastToken(): void
     {
@@ -94,8 +102,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected function tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testParserStoresExpectedFunctionTokens(): void
     {
@@ -121,8 +127,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected function tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testParserStoresExpectedFunctionTokensWithParameters(): void
     {
@@ -157,8 +161,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the function uses the start line of the first token.
-     *
-     * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testFunctionContainsStartLineOfFirstToken(): void
     {
@@ -176,8 +178,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the function uses the end line of the last token.
-     *
-     * @covers \PDepend\Source\AST\ASTFunction
      */
     public function testFunctionContainsEndLineOfLastToken(): void
     {
@@ -195,8 +195,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected method tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokens(): void
     {
@@ -225,8 +223,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected method tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokensWithStaticModifier(): void
     {
@@ -256,8 +252,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected method tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testParserStoresExpectedMethodTokensWithStaticAndFinalModifiers(): void
     {
@@ -288,8 +282,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the method uses the start line of the first token.
-     *
-     * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testMethodContainsStartLineOfFirstToken(): void
     {
@@ -309,8 +301,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the method uses the end line of the last token.
-     *
-     * @covers \PDepend\Source\AST\ASTMethod
      */
     public function testMethodContainsEndLineOfLastToken(): void
     {
@@ -330,8 +320,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected class tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokens(): void
     {
@@ -359,8 +347,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected class tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokensWithFinalModifier(): void
     {
@@ -389,8 +375,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected class tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTClass
      */
     public function testParserStoresExpectedClassTokensWithAbstractModifier(): void
     {
@@ -419,8 +403,6 @@ class StoreTokensForAllNodeTypesIssue079Test extends AbstractFeatureTestCase
 
     /**
      * Tests that the parser stores the expected interface tokens.
-     *
-     * @covers \PDepend\Source\AST\ASTInterface
      */
     public function testParserStoresExpectedInterfaceTokens(): void
     {

--- a/tests/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/ClassDependencyAnalyzerTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\Builder\Builder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the for the package metrics visitor.
  *
- * @covers \PDepend\Metrics\Analyzer\ClassDependencyAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(ClassDependencyAnalyzer::class)]
+#[Group('unittest')]
 class ClassDependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @var Builder<mixed> The used node builder. */

--- a/tests/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/ClassLevelAnalyzerTest.php
@@ -48,17 +48,19 @@ use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
  * Test case for the class level analyzer.
  *
- * @covers \PDepend\Metrics\Analyzer\ClassLevelAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ClassLevelAnalyzer::class)]
+#[Group('unittest')]
 class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
@@ -440,9 +442,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, mixed> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testGetNodeMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
     {
         static::assertEquals(
@@ -456,9 +457,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateIMPLMetricForTrait(array $metrics): void
     {
         static::assertEquals(0, $metrics['impl']);
@@ -469,9 +469,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateCISMetricForTrait(array $metrics): void
     {
         static::assertEquals(2, $metrics['cis']);
@@ -482,9 +481,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateCSZMetricForTrait(array $metrics): void
     {
         static::assertEquals(3, $metrics['csz']);
@@ -495,9 +493,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateNpmMetricForTrait(array $metrics): void
     {
         static::assertEquals(2, $metrics['npm']);
@@ -508,9 +505,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateVARSMetricForTrait(array $metrics): void
     {
         static::assertEquals(0, $metrics['vars']);
@@ -521,9 +517,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateVARSiMetricForTrait(array $metrics): void
     {
         static::assertEquals(0, $metrics['varsi']);
@@ -534,9 +529,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateVARSnpMetricForTrait(array $metrics): void
     {
         static::assertEquals(0, $metrics['varsnp']);
@@ -547,9 +541,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateWMCMetricForTrait(array $metrics): void
     {
         static::assertEquals(10, $metrics['wmc']);
@@ -560,9 +553,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateWMCiMetricForTrait(array $metrics): void
     {
         static::assertEquals(10, $metrics['wmci']);
@@ -573,9 +565,8 @@ class ClassLevelAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated class metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateWMCnpMetricForTrait(array $metrics): void
     {
         static::assertEquals(8, $metrics['wmcnp']);

--- a/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/MethodStrategyTest.php
@@ -46,16 +46,17 @@ namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the method strategy.
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(MethodStrategy::class)]
+#[Group('unittest')]
 class MethodStrategyTest extends AbstractTestCase
 {
     /**
@@ -84,7 +85,7 @@ class MethodStrategyTest extends AbstractTestCase
         }
 
         $expected = [
-            $idMap['PDepend_CodeRank_ClassA'] => [
+            $idMap['PDepend_CodeRank_ClassA'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassB'],
                     $idMap['PDepend_CodeRank_ClassC'],
@@ -95,7 +96,7 @@ class MethodStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassA',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend_CodeRank_ClassB'] => [
+            $idMap['PDepend_CodeRank_ClassB'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassC'],
                     $idMap['PDepend_CodeRank_ClassC'],
@@ -106,7 +107,7 @@ class MethodStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassB',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend_CodeRank_ClassC'] => [
+            $idMap['PDepend_CodeRank_ClassC'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassA'],
                 ],
@@ -118,7 +119,7 @@ class MethodStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassC',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend::CodeRankA'] => [
+            $idMap['PDepend::CodeRankA'] ?? '' => [
                 'in' => [
                     $idMap['PDepend::CodeRankB'],
                     $idMap['PDepend::CodeRankB'],
@@ -130,7 +131,7 @@ class MethodStrategyTest extends AbstractTestCase
                 'name' => 'PDepend::CodeRankA',
                 'type' => ASTNamespace::class,
             ],
-            $idMap['PDepend::CodeRankB'] => [
+            $idMap['PDepend::CodeRankB'] ?? '' => [
                 'in' => [
                     $idMap['PDepend::CodeRankA'],
                 ],

--- a/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/PropertyStrategyTest.php
@@ -46,16 +46,17 @@ namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code rank property strategy.
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PropertyStrategy::class)]
+#[Group('unittest')]
 class PropertyStrategyTest extends AbstractTestCase
 {
     /**
@@ -84,7 +85,7 @@ class PropertyStrategyTest extends AbstractTestCase
         }
 
         $expected = [
-            $idMap['PDepend_CodeRank_ClassA'] => [
+            $idMap['PDepend_CodeRank_ClassA'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassB'],
                     $idMap['PDepend_CodeRank_ClassC'],
@@ -95,7 +96,7 @@ class PropertyStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassA',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend_CodeRank_ClassB'] => [
+            $idMap['PDepend_CodeRank_ClassB'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassC'],
                     $idMap['PDepend_CodeRank_ClassC'],
@@ -106,7 +107,7 @@ class PropertyStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassB',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend_CodeRank_ClassC'] => [
+            $idMap['PDepend_CodeRank_ClassC'] ?? '' => [
                 'in' => [
                     $idMap['PDepend_CodeRank_ClassA'],
                 ],
@@ -118,7 +119,7 @@ class PropertyStrategyTest extends AbstractTestCase
                 'name' => 'PDepend_CodeRank_ClassC',
                 'type' => ASTClass::class,
             ],
-            $idMap['PDepend::CodeRankA'] => [
+            $idMap['PDepend::CodeRankA'] ?? '' => [
                 'in' => [
                     $idMap['PDepend::CodeRankB'],
                     $idMap['PDepend::CodeRankB'],
@@ -130,7 +131,7 @@ class PropertyStrategyTest extends AbstractTestCase
                 'name' => 'PDepend::CodeRankA',
                 'type' => ASTNamespace::class,
             ],
-            $idMap['PDepend::CodeRankB'] => [
+            $idMap['PDepend::CodeRankB'] ?? '' => [
                 'in' => [
                     $idMap['PDepend::CodeRankA'],
                 ],

--- a/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzer/StrategyFactoryTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Metrics\Analyzer\CodeRankAnalyzer;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code rank property strategy.
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\StrategyFactory
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(StrategyFactory::class)]
+#[Group('unittest')]
 class StrategyFactoryTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CodeRankAnalyzerTest.php
@@ -44,17 +44,24 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy;
+use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
+use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
 use PDepend\Source\AST\ASTClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code metric analyzer class.
  *
- * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(CodeRankAnalyzer::class)]
+#[CoversClass(InheritanceStrategy::class)]
+#[CoversClass(MethodStrategy::class)]
+#[CoversClass(PropertyStrategy::class)]
+#[Group('unittest')]
 class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
@@ -85,8 +92,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfSimpleInheritanceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testCodeRankOfSimpleInheritanceExample(): void
     {
@@ -102,8 +107,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfSimpleInheritanceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testReverseCodeRankOfSimpleInheritanceExample(): void
     {
@@ -119,8 +122,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfNamespacedSameNameInheritanceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testCodeRankOfNamespacedSameNameInheritanceExample(): void
     {
@@ -130,8 +131,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfNamespacedSameNamePropertyExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testCodeRankOfNamespacedSameNamePropertyExample(): void
     {
@@ -143,8 +142,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfNamespacedSameNamePropertyExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNamePropertyExample(): void
     {
@@ -156,8 +153,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfNamespacedSameNameMethodParamExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodParamExample(): void
     {
@@ -169,8 +164,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodParamExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodParamExample(): void
     {
@@ -182,8 +175,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfNamespacedSameNameMethodReturnExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodReturnExample(): void
     {
@@ -195,8 +186,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodReturnExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodReturnExample(): void
     {
@@ -208,8 +197,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfNamespacedSameNameMethodExceptionExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfNamespacedSameNameMethodExceptionExample(): void
     {
@@ -221,8 +208,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfNamespacedSameNameMethodExceptionExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameMethodExceptionExample(): void
     {
@@ -234,8 +219,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfNamespacedSameNameInheritanceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
      */
     public function testReverseCodeRankOfNamespacedSameNameInheritanceExample(): void
     {
@@ -245,9 +228,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfOrderExampleWithInheritanceAndMethodStrategy
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testCodeRankOfOrderExampleWithInheritanceAndMethodStrategy(): void
     {
@@ -267,9 +247,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfOrderExampleWithInheritanceAndMethodStrategy
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
      */
     public function testReverseCodeRankOfOrderExampleWithInheritanceAndMethodStrategy(): void
     {
@@ -289,9 +266,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy(): void
     {
@@ -311,9 +285,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testReverseCodeRankOfOrderExampleWithInheritanceAndPropertyStrategy(): void
     {
@@ -333,10 +304,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testCodeRankOfInternalInterfaceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testCodeRankOfInternalInterfaceExample(): void
     {
@@ -355,10 +322,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
 
     /**
      * testReverseCodeRankOfInternalInterfaceExample
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testReverseCodeRankOfInternalInterfaceExample(): void
     {
@@ -377,10 +340,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests the result of the class rank calculation against previous computed
      * values.
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testGetNodeMetrics(): void
     {
@@ -414,10 +373,6 @@ class CodeRankAnalyzerTest extends AbstractMetricsTestCase
     /**
      * Tests that {@link \PDepend\Metrics\Analyzer\CodeRankAnalyzer::getNodeMetrics()}
      * returns an empty <b>array</b> for an unknown identifier.
-     *
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\InheritanceStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy
-     * @covers \PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy
      */
     public function testGetNodeMetricsInvalidIdentifier(): void
     {

--- a/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CouplingAnalyzerTest.php
@@ -45,16 +45,19 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifact;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the coupling analyzer.
  *
- * @covers \PDepend\Metrics\Analyzer\CouplingAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(CouplingAnalyzer::class)]
+#[Group('unittest')]
 class CouplingAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
@@ -516,9 +519,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, mixed> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testGetNodeMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
     {
         static::assertEquals(['ca', 'cbo', 'ce'], array_keys($metrics));
@@ -529,9 +531,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateCEMetricForTrait(array $metrics): void
     {
         static::assertEquals(4, $metrics['ce']);
@@ -542,9 +543,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateCBOMetricForTrait(array $metrics): void
     {
         static::assertEquals(4, $metrics['cbo']);
@@ -555,9 +555,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetNodeMetricsForTrait
      */
+    #[Depends('testGetNodeMetricsForTrait')]
     public function testCalculateCAMetricForTrait(array $metrics): void
     {
         static::assertEquals(0, $metrics['ca']);
@@ -582,9 +581,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, mixed> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetProjectMetricsForTrait
      */
+    #[Depends('testGetProjectMetricsForTrait')]
     public function testGetProjectMetricsForTraitReturnsExpectedMetricSet(array $metrics): void
     {
         static::assertEquals(['calls', 'fanout'], array_keys($metrics));
@@ -595,9 +593,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     *
-     * @depends testGetProjectMetricsForTrait
      */
+    #[Depends('testGetProjectMetricsForTrait')]
     public function testCalculateCallsMetricForTrait(array $metrics): void
     {
         static::assertEquals(7, $metrics['calls']);
@@ -608,8 +605,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      *
      * @param array<string, int> $metrics Calculated coupling metrics.
      * @since 1.0.6
-     * @depends testGetProjectMetricsForTrait
      */
+    #[Depends('testGetProjectMetricsForTrait')]
     public function testCalculateFanoutMetricForTrait(array $metrics): void
     {
         static::assertEquals(4, $metrics['fanout']);
@@ -638,8 +635,8 @@ class CouplingAnalyzerTest extends AbstractMetricsTestCase
      * @param string $testCase File with test source.
      * @param int $calls Number of expected calls.
      * @param int $fanout Expected fanout value.
-     * @dataProvider dataProviderAnalyzerCalculatesExpectedCallCount
      */
+    #[DataProvider('dataProviderAnalyzerCalculatesExpectedCallCount')]
     public function testAnalyzerCalculatesExpectedCallCount(
         string $testCase,
         int $calls,

--- a/tests/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CrapIndexAnalyzerTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test cases for the {@link \PDepend\Metrics\Analyzer\CrapIndexAnalyzer} class.
  *
- * @covers \PDepend\Metrics\Analyzer\CrapIndexAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(CrapIndexAnalyzer::class)]
+#[Group('unittest')]
 class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /**
@@ -219,7 +220,7 @@ class CrapIndexAnalyzerTest extends AbstractMetricsTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getCCN2')
-            ->will(static::returnValue($ccn));
+            ->willReturn($ccn);
 
         return $mock;
     }

--- a/tests/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/CyclomaticComplexityAnalyzerTest.php
@@ -43,21 +43,23 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the cyclomatic analyzer.
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\CyclomaticComplexityAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractCachingAnalyzer::class)]
+#[CoversClass(CyclomaticComplexityAnalyzer::class)]
+#[Group('unittest')]
 class CyclomaticComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @since 1.0.0 */

--- a/tests/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/DependencyAnalyzerTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\Builder\Builder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Tests the for the package metrics visitor.
  *
- * @covers \PDepend\Metrics\Analyzer\DependencyAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(DependencyAnalyzer::class)]
+#[Group('unittest')]
 class DependencyAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @var Builder<mixed> The used node builder. */

--- a/tests/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/HalsteadAnalyzerTest.php
@@ -43,21 +43,23 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the cyclomatic analyzer.
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\HalsteadAnalyzer
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractCachingAnalyzer::class)]
+#[CoversClass(HalsteadAnalyzer::class)]
+#[Group('unittest')]
 class HalsteadAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @since 1.0.0 */

--- a/tests/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/HierarchyAnalyzerTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Metrics\Analyzer;
 
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the hierarchy analyzer.
  *
- * @covers \PDepend\Metrics\Analyzer\HierarchyAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(HierarchyAnalyzer::class)]
+#[Group('unittest')]
 class HierarchyAnalyzerTest extends AbstractMetricsTestCase
 {
     /**

--- a/tests/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/InheritanceAnalyzerTest.php
@@ -47,16 +47,17 @@ use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use PDepend\Source\AST\ASTClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the inheritance analyzer.
  *
- * @covers \PDepend\Metrics\Analyzer\InheritanceAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(InheritanceAnalyzer::class)]
+#[Group('unittest')]
 class InheritanceAnalyzerTest extends AbstractMetricsTestCase
 {
     /**

--- a/tests/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/MaintainabilityIndexAnalyzerTest.php
@@ -43,21 +43,23 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifact;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the cyclomatic analyzer.
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\MaintainabilityIndexAnalyzer
  * @copyright 2015 Matthias Mullie. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractCachingAnalyzer::class)]
+#[CoversClass(MaintainabilityIndexAnalyzer::class)]
+#[Group('unittest')]
 class MaintainabilityIndexAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @since 1.0.0 */

--- a/tests/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/NPathComplexityAnalyzerTest.php
@@ -43,23 +43,25 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\AbstractASTCallable;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the NPath complexity analyzer.
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\NPathComplexityAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractCachingAnalyzer::class)]
+#[CoversClass(NPathComplexityAnalyzer::class)]
+#[Group('unittest')]
 class NPathComplexityAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @since 1.0.0 */

--- a/tests/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/NodeCountAnalyzerTest.php
@@ -46,16 +46,17 @@ namespace PDepend\Metrics\Analyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the node count analyzer.
  *
- * @covers \PDepend\Metrics\Analyzer\NodeCountAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(NodeCountAnalyzer::class)]
+#[Group('unittest')]
 class NodeCountAnalyzerTest extends AbstractMetricsTestCase
 {
     /**

--- a/tests/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
+++ b/tests/php/PDepend/Metrics/Analyzer/NodeLocAnalyzerTest.php
@@ -43,21 +43,23 @@
 
 namespace PDepend\Metrics\Analyzer;
 
+use PDepend\Metrics\AbstractCachingAnalyzer;
 use PDepend\Metrics\AbstractMetricsTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the node lines of code analyzer.
  *
- * @covers \PDepend\Metrics\AbstractCachingAnalyzer
- * @covers \PDepend\Metrics\Analyzer\NodeLocAnalyzer
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractCachingAnalyzer::class)]
+#[CoversClass(NodeLocAnalyzer::class)]
+#[Group('unittest')]
 class NodeLocAnalyzerTest extends AbstractMetricsTestCase
 {
     /** @since 1.0.0 */

--- a/tests/php/PDepend/ParserRegressionTest.php
+++ b/tests/php/PDepend/ParserRegressionTest.php
@@ -44,6 +44,8 @@
 namespace PDepend;
 
 use DirectoryIterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case that parses several files where we have found errors in PDepend's
@@ -51,17 +53,16 @@ use DirectoryIterator;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group regressiontest
  */
+#[Group('regressiontest')]
 class ParserRegressionTest extends AbstractTestCase
 {
     /**
      * Tests that the parser handles the given source file.
      *
      * @param string $pathName Name of the file to parse.
-     * @dataProvider dataProviderSourceFiles
      */
+    #[DataProvider('dataProviderSourceFiles')]
     public function testParserHandlesSourceFileWithoutException(string $pathName): void
     {
         $this->parseSource($pathName);

--- a/tests/php/PDepend/ParserTest.php
+++ b/tests/php/PDepend/ParserTest.php
@@ -57,6 +57,7 @@ use PDepend\Source\AST\ASTString;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\State;
 use PDepend\Source\Builder\Builder;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPParserGeneric;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
@@ -66,17 +67,19 @@ use PDepend\Source\Parser\UnexpectedTokenException;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Source\Tokenizer\Tokens;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
  * Test case implementation for the PDepend code parser.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ParserTest extends AbstractTestCase
 {
     /**
@@ -512,9 +515,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTFunction> $functions
-     *
-     * @depends testParserSetsCorrectFunctionReturnType
      */
+    #[Depends('testParserSetsCorrectFunctionReturnType')]
     public function testParserSetsFunctionReturnTypeToNull(ASTArtifactList $functions): void
     {
         static::assertSame(
@@ -531,9 +533,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTFunction> $functions
-     *
-     * @depends testParserSetsCorrectFunctionReturnType
      */
+    #[Depends('testParserSetsCorrectFunctionReturnType')]
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionTwo(ASTArtifactList $functions): void
     {
         static::assertSame(
@@ -550,9 +551,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTFunction> $functions
-     *
-     * @depends testParserSetsCorrectFunctionReturnType
      */
+    #[Depends('testParserSetsCorrectFunctionReturnType')]
     public function testParserSetsExpectedFunctionReturnTypeOfFunctionThree(ASTArtifactList $functions): void
     {
         static::assertSame(
@@ -939,9 +939,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
-     * @depends testParserSetsFileLevelFunctionPackage
      */
+    #[Depends('testParserSetsFileLevelFunctionPackage')]
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInFirstNamespace(
         ASTArtifactList $namespaces
     ): void {
@@ -951,9 +950,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
-     * @depends testParserSetsFileLevelFunctionPackage
      */
+    #[Depends('testParserSetsFileLevelFunctionPackage')]
     public function testParserSetsFileLevelFunctionPackageNumberOfFunctionsInSecondNamespace(
         ASTArtifactList $namespaces
     ): void {
@@ -963,9 +961,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
-     * @depends testParserSetsFileLevelFunctionPackage
      */
+    #[Depends('testParserSetsFileLevelFunctionPackage')]
     public function testParserSetsFileExpectedPackageForFirstFunctionInFirstNamespace(ASTArtifactList $namespaces): void
     {
         $functions = $namespaces[0]->getFunctions();
@@ -975,9 +972,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
-     * @depends testParserSetsFileLevelFunctionPackage
      */
+    #[Depends('testParserSetsFileLevelFunctionPackage')]
     public function testParserSetsFileExpectedPackageForSecondFunctionInFirstNamespace(
         ASTArtifactList $namespaces
     ): void {
@@ -988,9 +984,8 @@ class ParserTest extends AbstractTestCase
 
     /**
      * @param ASTArtifactList<ASTNamespace> $namespaces
-     *
-     * @depends testParserSetsFileLevelFunctionPackage
      */
+    #[Depends('testParserSetsFileLevelFunctionPackage')]
     public function testParserSetsFileExpectedPackageForFirstFunctionInSecondNamespace(
         ASTArtifactList $namespaces
     ): void {
@@ -1348,7 +1343,7 @@ class ParserTest extends AbstractTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('restore')
-            ->will(static::returnValue(true));
+            ->willReturn(true);
         $cache->expects(static::never())
             ->method('store');
 

--- a/tests/php/PDepend/Report/Dependencies/XmlTest.php
+++ b/tests/php/PDepend/Report/Dependencies/XmlTest.php
@@ -50,16 +50,17 @@ use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\AbstractASTClassOrInterface;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the xml summary log.
  *
- * @covers \PDepend\Report\Dependencies\Xml
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Xml::class)]
+#[Group('unittest')]
 class XmlTest extends AbstractTestCase
 {
     /**
@@ -186,22 +187,22 @@ class XmlTest extends AbstractTestCase
         $type
             ->expects(static::any())
             ->method('getImage')
-            ->will(static::returnValue('class'));
+            ->willReturn('class');
         $type
             ->expects(static::any())
             ->method('getNamespaceName')
-            ->will(static::returnValue('namespace'));
+            ->willReturn('namespace');
 
         $analyzer = $this->getMockBuilder(ClassDependencyAnalyzer::class)
             ->getMock();
         $analyzer
             ->expects(static::any())
             ->method('getEfferents')
-            ->will(static::returnValue([$type]));
+            ->willReturn([$type]);
         $analyzer
             ->expects(static::any())
             ->method('getAfferents')
-            ->will(static::returnValue([$type, $type]));
+            ->willReturn([$type, $type]);
 
         $log = new Xml();
         $log->log($analyzer);

--- a/tests/php/PDepend/Report/Jdepend/ChartTest.php
+++ b/tests/php/PDepend/Report/Jdepend/ChartTest.php
@@ -54,16 +54,17 @@ use PDepend\Source\AST\AbstractASTArtifact;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the jdepend chart logger.
  *
- * @covers \PDepend\Report\Jdepend\Chart
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Chart::class)]
+#[Group('unittest')]
 class ChartTest extends AbstractTestCase
 {
     /** Temporary output file. */
@@ -219,33 +220,31 @@ class ChartTest extends AbstractTestCase
             ->getMock();
         $analyzer->expects(static::atLeastOnce())
             ->method('getStats')
-            ->will(
-                static::returnCallback(
-                    function (AbstractASTArtifact $node) use ($nodes) {
-                        $data = [
-                            $nodes[0]->getId() => [
-                                'a' => 0,
-                                'i' => 0,
-                                'd' => 0,
-                                'cc' => 250,
-                                'ac' => 250,
-                            ],
-                            $nodes[1]->getId() => [
-                                'a' => 0,
-                                'i' => 0,
-                                'd' => 0,
-                                'cc' => 50,
-                                'ac' => 50,
-                            ],
-                        ];
+            ->willReturnCallback(
+                function (AbstractASTArtifact $node) use ($nodes) {
+                    $data = [
+                        $nodes[0]->getId() => [
+                            'a' => 0,
+                            'i' => 0,
+                            'd' => 0,
+                            'cc' => 250,
+                            'ac' => 250,
+                        ],
+                        $nodes[1]->getId() => [
+                            'a' => 0,
+                            'i' => 0,
+                            'd' => 0,
+                            'cc' => 50,
+                            'ac' => 50,
+                        ],
+                    ];
 
-                        if (isset($data[$node->getId()])) {
-                            return $data[$node->getId()];
-                        }
-
-                        return [];
+                    if (isset($data[$node->getId()])) {
+                        return $data[$node->getId()];
                     }
-                )
+
+                    return [];
+                }
             );
 
         $nodes = new ASTArtifactList($nodes);
@@ -342,7 +341,7 @@ class ChartTest extends AbstractTestCase
             ->getMock();
         $type->expects(static::atLeastOnce())
             ->method('isUserDefined')
-            ->will(static::returnValue($userDefined));
+            ->willReturn($userDefined);
         $packageA->addType($type);
 
         return $packageA;

--- a/tests/php/PDepend/Report/Jdepend/XmlTest.php
+++ b/tests/php/PDepend/Report/Jdepend/XmlTest.php
@@ -47,16 +47,17 @@ use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Report\DummyAnalyzer;
 use PDepend\Report\NoLogOutputException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the jdepend xml logger.
  *
- * @covers \PDepend\Report\Jdepend\Xml
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Xml::class)]
+#[Group('unittest')]
 class XmlTest extends AbstractTestCase
 {
     /** Test dependency analyzer. */

--- a/tests/php/PDepend/Report/Overview/PyramidTest.php
+++ b/tests/php/PDepend/Report/Overview/PyramidTest.php
@@ -53,16 +53,18 @@ use PDepend\Metrics\Analyzer\NodeCountAnalyzer;
 use PDepend\Metrics\Analyzer\NodeLocAnalyzer;
 use PDepend\Report\DummyAnalyzer;
 use PDepend\Report\NoLogOutputException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the overview pyramid logger.
  *
- * @covers \PDepend\Report\Overview\Pyramid
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Pyramid::class)]
+#[CoversClass(NoLogOutputException::class)]
+#[Group('unittest')]
 class PyramidTest extends AbstractTestCase
 {
     /**
@@ -86,8 +88,6 @@ class PyramidTest extends AbstractTestCase
     /**
      * Tests that the logger throws an exception if the log target wasn't
      * configured.
-     *
-     * @covers \PDepend\Report\NoLogOutputException
      */
     public function testThrowsExceptionForInvalidLogTarget(): void
     {
@@ -274,12 +274,12 @@ class PyramidTest extends AbstractTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getProjectMetrics')
-            ->will(static::returnValue(
+            ->willReturn(
                 [
                     'fanout' => 8590,
                     'calls' => 15128,
                 ]
-            ));
+            );
 
         return $mock;
     }
@@ -290,11 +290,11 @@ class PyramidTest extends AbstractTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getProjectMetrics')
-            ->will(static::returnValue(
+            ->willReturn(
                 [
                     'ccn2' => 5579,
                 ]
-            ));
+            );
 
         return $mock;
     }
@@ -305,12 +305,12 @@ class PyramidTest extends AbstractTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getProjectMetrics')
-            ->will(static::returnValue(
+            ->willReturn(
                 [
                     'andc' => 0.31,
                     'ahh' => 0.12,
                 ]
-            ));
+            );
 
         return $mock;
     }
@@ -321,14 +321,14 @@ class PyramidTest extends AbstractTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getProjectMetrics')
-            ->will(static::returnValue(
+            ->willReturn(
                 [
                     'nop' => 19,
                     'noc' => 384,
                     'nom' => 2018,
                     'nof' => 1600,
                 ]
-            ));
+            );
 
         return $mock;
     }
@@ -339,11 +339,11 @@ class PyramidTest extends AbstractTestCase
             ->getMock();
         $mock->expects(static::any())
             ->method('getProjectMetrics')
-            ->will(static::returnValue(
+            ->willReturn(
                 [
                     'eloc' => 35175,
                 ]
-            ));
+            );
 
         return $mock;
     }

--- a/tests/php/PDepend/Report/Summary/XmlTest.php
+++ b/tests/php/PDepend/Report/Summary/XmlTest.php
@@ -49,16 +49,18 @@ use PDepend\Metrics\AnalyzerProjectAware;
 use PDepend\Report\NoLogOutputException;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the xml summary log.
  *
- * @covers \PDepend\Report\Summary\Xml
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Xml::class)]
+#[Group('unittest')]
 class XmlTest extends AbstractTestCase
 {
     /**
@@ -236,9 +238,7 @@ class XmlTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @dataProvider dataProviderNodeAware
-     */
+    #[DataProvider('dataProviderNodeAware')]
     public function testNodeAwareAnalyzer(string $fixture, string $expectation): void
     {
         $this->namespaces = $this->parseSource($fixture);

--- a/tests/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTAllocationExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTAllocationExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTAllocationExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTAllocationExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTAllocationExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCatchStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTAnonymousClass
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTAnonymousClass::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTAnonymousClassTest extends ASTNodeTestCase
 {
     public function testAnonymousClassHasExpectedStartLine(): void

--- a/tests/php/PDepend/Source/AST/ASTArgumentsTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArgumentsTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArguments} class.
  *
- * @covers \PDepend\Source\AST\ASTArguments
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTArguments::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTArgumentsTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTArrayElementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArrayElementTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArrayElement} class.
  *
- * @covers \PDepend\Source\AST\ASTArrayElement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTArrayElement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTArrayElementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArrayIndexExpressionTest.php
@@ -43,17 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArrayIndexExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTArrayIndexExpression
- * @covers \PDepend\Source\AST\ASTIndexExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTArrayIndexExpression::class)]
+#[CoversClass(ASTIndexExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTArrayIndexExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTArrayTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArrayTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArray} class.
  *
- * @covers \PDepend\Source\AST\ASTArray
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTArray::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTArrayTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTArtifactListTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArtifactListTest.php
@@ -46,16 +46,17 @@ namespace PDepend\Source\AST;
 use BadMethodCallException;
 use OutOfBoundsException;
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case the node iterator.
  *
- * @covers \PDepend\Source\AST\ASTArtifactList
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTArtifactList::class)]
+#[Group('unittest')]
 class ASTArtifactListTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTArtifactTest.php
+++ b/tests/php/PDepend/Source/AST/ASTArtifactTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\AbstractASTArtifact} class.
  *
- * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTArtifact::class)]
+#[Group('unittest')]
 class ASTArtifactTest extends AbstractTestCase
 {
     /**
@@ -145,9 +146,9 @@ class ASTArtifactTest extends AbstractTestCase
      */
     protected function getItemMock(): AbstractASTArtifact
     {
-        return $this->getMockForAbstractClass(
-            AbstractASTArtifact::class,
-            [__CLASS__]
-        );
+        return $this->getMockBuilder(AbstractASTArtifact::class)
+            ->setConstructorArgs([__CLASS__])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTAssignmentExpressionTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTAssignmentExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTAssignmentExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTAssignmentExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTAssignmentExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -284,9 +288,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line of an assignment-expression.
-     *
-     * @depends testVariableAssignmentExpression
      */
+    #[Depends('testVariableAssignmentExpression')]
     public function testVariableAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -294,9 +297,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column of an assignment-expression.
-     *
-     * @depends testVariableAssignmentExpression
      */
+    #[Depends('testVariableAssignmentExpression')]
     public function testVariableAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -304,9 +306,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line of an assignment-expression.
-     *
-     * @depends testVariableAssignmentExpression
      */
+    #[Depends('testVariableAssignmentExpression')]
     public function testVariableAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
@@ -314,9 +315,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column of an assignment-expression.
-     *
-     * @depends testVariableAssignmentExpression
      */
+    #[Depends('testVariableAssignmentExpression')]
     public function testVariableAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());
@@ -337,9 +337,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line of an assignment-expression.
-     *
-     * @depends testStaticPropertyAssignmentExpression
      */
+    #[Depends('testStaticPropertyAssignmentExpression')]
     public function testStaticPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -347,9 +346,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column of an assignment-expression.
-     *
-     * @depends testStaticPropertyAssignmentExpression
      */
+    #[Depends('testStaticPropertyAssignmentExpression')]
     public function testStaticPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -357,9 +355,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line of an assignment-expression.
-     *
-     * @depends testStaticPropertyAssignmentExpression
      */
+    #[Depends('testStaticPropertyAssignmentExpression')]
     public function testStaticPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -367,9 +364,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column of an assignment-expression.
-     *
-     * @depends testStaticPropertyAssignmentExpression
      */
+    #[Depends('testStaticPropertyAssignmentExpression')]
     public function testStaticPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(60, $expr->getEndColumn());
@@ -390,9 +386,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line of an assignment-expression.
-     *
-     * @depends testObjectPropertyAssignmentExpression
      */
+    #[Depends('testObjectPropertyAssignmentExpression')]
     public function testObjectPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -400,9 +395,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column of an assignment-expression.
-     *
-     * @depends testObjectPropertyAssignmentExpression
      */
+    #[Depends('testObjectPropertyAssignmentExpression')]
     public function testObjectPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -410,9 +404,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line of an assignment-expression.
-     *
-     * @depends testObjectPropertyAssignmentExpression
      */
+    #[Depends('testObjectPropertyAssignmentExpression')]
     public function testObjectPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndLine());
@@ -420,9 +413,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column of an assignment-expression.
-     *
-     * @depends testObjectPropertyAssignmentExpression
      */
+    #[Depends('testObjectPropertyAssignmentExpression')]
     public function testObjectPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(15, $expr->getEndColumn());
@@ -443,9 +435,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line of an assignment-expression.
-     *
-     * @depends testChainedPropertyAssignmentExpression
      */
+    #[Depends('testChainedPropertyAssignmentExpression')]
     public function testChainedPropertyAssignmentExpressionHasExpectedStartLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -453,9 +444,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column of an assignment-expression.
-     *
-     * @depends testChainedPropertyAssignmentExpression
      */
+    #[Depends('testChainedPropertyAssignmentExpression')]
     public function testChainedPropertyAssignmentExpressionHasExpectedStartColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -463,9 +453,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column of an assignment-expression.
-     *
-     * @depends testChainedPropertyAssignmentExpression
      */
+    #[Depends('testChainedPropertyAssignmentExpression')]
     public function testChainedPropertyAssignmentExpressionHasExpectedEndColumn(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(23, $expr->getEndColumn());
@@ -473,9 +462,8 @@ class ASTAssignmentExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line of an assignment-expression.
-     *
-     * @depends testChainedPropertyAssignmentExpression
      */
+    #[Depends('testChainedPropertyAssignmentExpression')]
     public function testChainedPropertyAssignmentExpressionHasExpectedEndLine(ASTAssignmentExpression $expr): void
     {
         static::assertEquals(8, $expr->getEndLine());

--- a/tests/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTBooleanAndExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBooleanAndExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTBooleanAndExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTBooleanAndExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTBooleanAndExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTBooleanOrExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBooleanOrExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTBooleanOrExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTBooleanOrExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTBooleanOrExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTBreakStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTBreakStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTBreakStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTBreakStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTBreakStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTBreakStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTCallableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCallableTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Tokenizer\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\AbstractASTCallable} class.
  *
- * @covers \PDepend\Source\AST\AbstractASTCallable
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTCallable::class)]
+#[Group('unittest')]
 class ASTCallableTest extends AbstractTestCase
 {
     /**
@@ -151,7 +152,7 @@ class ASTCallableTest extends AbstractTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore');
 
@@ -171,7 +172,7 @@ class ASTCallableTest extends AbstractTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('store');
 
@@ -202,7 +203,7 @@ class ASTCallableTest extends AbstractTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $callable = $this->getCallableMock();
         $callable->setCache($cache)
@@ -233,7 +234,7 @@ class ASTCallableTest extends AbstractTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $callable = $this->getCallableMock();
         $callable->setCache($cache)
@@ -267,9 +268,9 @@ class ASTCallableTest extends AbstractTestCase
      */
     protected function getCallableMock(): AbstractASTCallable
     {
-        return $this->getMockForAbstractClass(
-            AbstractASTCallable::class,
-            [__CLASS__]
-        );
+        return $this->getMockBuilder(AbstractASTCallable::class)
+            ->setConstructorArgs([__CLASS__])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/AST/ASTCastExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCastExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCastExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTCastExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCastExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCastExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTCatchStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCatchStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCatchStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTCatchStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCatchStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCatchStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassFqnPostfixTest.php
@@ -43,18 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPropertyPostfix} class.
  *
- * @covers \PDepend\Source\AST\ASTClassFqnPostfix
- *
- * @group unittest
- *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
+#[CoversClass(ASTClassFqnPostfix::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(PHPBuilder::class)]
+#[Group('unittest')]
 class ASTClassFqnPostfixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIteratorTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceIteratorTest.php
@@ -45,18 +45,19 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator}
  * class.
  *
- * @covers \PDepend\Source\AST\ASTClassOrInterfaceReferenceIterator
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTClassOrInterfaceReferenceIterator::class)]
+#[Group('unittest')]
 class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
 {
     /**
@@ -75,14 +76,14 @@ class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
             ->getMock();
         $reference1->expects(static::once())
             ->method('getType')
-            ->will(static::returnValue($class1));
+            ->willReturn($class1);
 
         $reference2 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference2->expects(static::once())
             ->method('getType')
-            ->will(static::returnValue($class2));
+            ->willReturn($class2);
 
         $references = [$reference1, $reference2];
 
@@ -111,14 +112,14 @@ class ASTClassOrInterfaceReferenceIteratorTest extends AbstractTestCase
             ->getMock();
         $reference1->expects(static::once())
             ->method('getType')
-            ->will(static::returnValue($class1));
+            ->willReturn($class1);
 
         $reference2 = $this->getMockBuilder(ASTSelfReference::class)
             ->disableOriginalConstructor()
             ->getMock();
         $reference2->expects(static::once())
             ->method('getType')
-            ->will(static::returnValue($class2));
+            ->willReturn($class2);
 
         $references = [$reference1, $reference2];
 

--- a/tests/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassOrInterfaceReferenceTest.php
@@ -44,18 +44,18 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
- * description
- *
- * @covers \PDepend\Source\AST\ASTClassOrInterfaceReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTClassOrInterfaceReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
 {
     /**
@@ -91,7 +91,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
         $context->expects(static::once())
             ->method('getClassOrInterface')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($class));
+            ->willReturn($class);
 
         $reference = new ASTClassOrInterfaceReference(
             $context,
@@ -113,7 +113,7 @@ class ASTClassOrInterfaceReferenceTest extends ASTNodeTestCase
         $context->expects(static::exactly(1))
             ->method('getClassOrInterface')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($class));
+            ->willReturn($class);
 
         $reference = new ASTClassOrInterfaceReference(
             $context,

--- a/tests/php/PDepend/Source/AST/ASTClassReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassReferenceTest.php
@@ -44,18 +44,20 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClassReference} class.
  *
- * @covers \PDepend\Source\AST\ASTClassReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTClassReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTClassReferenceTest extends ASTNodeTestCase
 {
     /**
@@ -70,7 +72,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
         $context->expects(static::once())
             ->method('getClass')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($class));
+            ->willReturn($class);
 
         $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();
@@ -88,7 +90,7 @@ class ASTClassReferenceTest extends ASTNodeTestCase
         $context->expects(static::exactly(1))
             ->method('getClass')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($class));
+            ->willReturn($class);
 
         $reference = new ASTClassReference($context, __CLASS__);
         $reference->getType();

--- a/tests/php/PDepend/Source/AST/ASTClassTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClassTest.php
@@ -49,20 +49,24 @@ use PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTClass class.
  *
- * @covers \PDepend\Source\AST\AbstractASTClassOrInterface
- * @covers \PDepend\Source\AST\AbstractASTType
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTClassOrInterface::class)]
+#[CoversClass(AbstractASTType::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(ASTTraitMethodCollisionException::class)]
+#[CoversClass(ASTClassOrInterfaceRecursiveInheritanceException::class)]
+#[Group('unittest')]
 class ASTClassTest extends AbstractASTArtifactTestCase
 {
     /**
@@ -338,11 +342,9 @@ class ASTClassTest extends AbstractASTArtifactTestCase
     /**
      * testGetAllMethodsWithMethodCollisionThrowsExpectedException
      *
-     * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
      * @since 1.0.0
-     *
-     * @group issue-154
      */
+    #[Group('issue-154')]
     public function testGetAllMethodsWithMethodCollisionThrowsExpectedException(): void
     {
         $this->expectException(ASTTraitMethodCollisionException::class);
@@ -550,7 +552,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -559,7 +561,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::never())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $class = new ASTClass('Clazz');
         $class->addChild($node1);
@@ -589,7 +591,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -598,7 +600,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node3->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue($node1));
+            ->willReturn($node1);
 
         $class = new ASTClass('Clazz');
         $class->addChild($node2);
@@ -620,7 +622,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -629,7 +631,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $class = new ASTClass('Clazz');
         $class->setCache(new MemoryCacheDriver());
@@ -1155,7 +1157,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore');
 
@@ -1175,7 +1177,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('store')
             ->with(static::isType('string'), static::equalTo($tokens));
@@ -1202,7 +1204,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $class = new ASTClass(__CLASS__);
         $class->setCache($cache)
@@ -1233,7 +1235,7 @@ class ASTClassTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $class = new ASTClass(__CLASS__);
         $class->setCache($cache)
@@ -1272,8 +1274,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassThrowsExpectedExceptionWhenBothAreTheSame
-     *
-     * @covers \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function testGetParentClassThrowsExpectedExceptionWhenBothAreTheSame(): void
     {
@@ -1337,8 +1337,6 @@ class ASTClassTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetParentClassesThrowsExpectedExceptionForRecursiveInheritanceHierarchy
-     *
-     * @covers \PDepend\Source\AST\ASTClassOrInterfaceRecursiveInheritanceException
      */
     public function testGetParentClassesThrowsExpectedExceptionForRecursiveInheritanceHierarchy(): void
     {

--- a/tests/php/PDepend/Source/AST/ASTCloneExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCloneExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCloneExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTCloneExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCloneExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCloneExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTClosureTest.php
+++ b/tests/php/PDepend/Source/AST/ASTClosureTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTClosure} class.
  *
- * @covers \PDepend\Source\AST\ASTClosure
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTClosure::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTClosureTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTCommentTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCommentTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTComment} class.
  *
- * @covers \PDepend\Source\AST\ASTComment
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTComment::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCommentTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\Tokenizer\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code file class.
  *
- * @covers \PDepend\Source\AST\ASTCompilationUnit
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCompilationUnit::class)]
+#[Group('unittest')]
 class ASTCompilationUnitTest extends AbstractTestCase
 {
     /**
@@ -106,7 +107,7 @@ class ASTCompilationUnitTest extends AbstractTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore')
             ->with(static::equalTo(__FUNCTION__));
@@ -127,7 +128,7 @@ class ASTCompilationUnitTest extends AbstractTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $payload = [$this->getMockBuilder(Token::class)->disableOriginalConstructor()->getMock()];
         $cache->expects(static::once())
             ->method('store')

--- a/tests/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCompoundExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCompoundExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTCompoundExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCompoundExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCompoundExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTCompoundVariableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCompoundVariableTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenStreamEndException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTCompoundVariable} class.
  *
- * @covers \PDepend\Source\AST\ASTCompoundVariable
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTCompoundVariable::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTCompoundVariableTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConditionalExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConditionalExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTConditionalExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTConditionalExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTConditionalExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConstantDeclaratorTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantDeclarator} class.
  *
- * @covers \PDepend\Source\AST\ASTConstantDeclarator
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTConstantDeclarator::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTConstantDeclaratorTest extends ASTNodeTestCase
 {
     /**
@@ -116,9 +120,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testConstantDeclaratorHasExpectedStartLine
-     *
-     * @depends testConstantDeclarator
      */
+    #[Depends('testConstantDeclarator')]
     public function testConstantDeclaratorHasExpectedStartLine(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(5, $declarator->getStartLine());
@@ -126,9 +129,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testConstantDeclaratorHasExpectedStartColumn
-     *
-     * @depends testConstantDeclarator
      */
+    #[Depends('testConstantDeclarator')]
     public function testConstantDeclaratorHasExpectedStartColumn(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(7, $declarator->getStartColumn());
@@ -136,9 +138,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testConstantDeclaratorHasExpectedEndLine
-     *
-     * @depends testConstantDeclarator
      */
+    #[Depends('testConstantDeclarator')]
     public function testConstantDeclaratorHasExpectedEndLine(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(7, $declarator->getEndLine());
@@ -146,9 +147,8 @@ class ASTConstantDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testConstantDeclaratorHasExpectedEndColumn
-     *
-     * @depends testConstantDeclarator
      */
+    #[Depends('testConstantDeclarator')]
     public function testConstantDeclaratorHasExpectedEndColumn(ASTConstantDeclarator $declarator): void
     {
         static::assertEquals(14, $declarator->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConstantDefinitionTest.php
@@ -43,16 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantDefinition} class.
  *
- * @covers \PDepend\Source\AST\ASTConstantDefinition
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTConstantDefinition::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTConstantDefinitionTest extends ASTNodeTestCase
 {
     /**
@@ -60,8 +65,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * valid combinations of modifiers.
      *
      * @param int $modifiers Combinations of valid modifiers.
-     * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
+    #[DataProvider('dataProviderSetModifiersAcceptsExpectedModifierCombinations')]
     public function testSetModifiersAcceptsExpectedModifierCombinations(int $modifiers): void
     {
         $definition = new ASTConstantDefinition();
@@ -89,8 +94,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * invalid modifier or modifier combination was set.
      *
      * @param int $modifiers Combinations of invalid modifiers.
-     * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
+    #[DataProvider('dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers')]
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers(int $modifiers): void
     {
         $definition = new ASTConstantDefinition();
@@ -248,9 +253,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testConstantDefinitionHasExpectedStartLine
-     *
-     * @depends testConstantDefinition
      */
+    #[Depends('testConstantDefinition')]
     public function testConstantDefinitionHasExpectedStartLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(4, $constant->getStartLine());
@@ -258,9 +262,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testConstantDefinitionHasExpectedStartColumn
-     *
-     * @depends testConstantDefinition
      */
+    #[Depends('testConstantDefinition')]
     public function testConstantDefinitionHasExpectedStartColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(5, $constant->getStartColumn());
@@ -268,9 +271,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testConstantDefinitionHasExpectedEndLine
-     *
-     * @depends testConstantDefinition
      */
+    #[Depends('testConstantDefinition')]
     public function testConstantDefinitionHasExpectedEndLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(7, $constant->getEndLine());
@@ -278,9 +280,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
 
     /**
      * testConstantDefinitionHasExpectedEndColumn
-     *
-     * @depends testConstantDefinition
      */
+    #[Depends('testConstantDefinition')]
     public function testConstantDefinitionHasExpectedEndColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(12, $constant->getEndColumn());
@@ -303,9 +304,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedStartLine
      *
      * @since 1.0.2
-     *
-     * @depends testConstantDefinitionWithDeclarators
      */
+    #[Depends('testConstantDefinitionWithDeclarators')]
     public function testConstantDefinitionWithDeclaratorsHasExpectedStartLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(4, $constant->getStartLine());
@@ -315,9 +315,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedStartColumn
      *
      * @since 1.0.2
-     *
-     * @depends testConstantDefinitionWithDeclarators
      */
+    #[Depends('testConstantDefinitionWithDeclarators')]
     public function testConstantDefinitionWithDeclaratorsHasExpectedStartColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(5, $constant->getStartColumn());
@@ -327,9 +326,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedEndLine
      *
      * @since 1.0.2
-     *
-     * @depends testConstantDefinitionWithDeclarators
      */
+    #[Depends('testConstantDefinitionWithDeclarators')]
     public function testConstantDefinitionWithDeclaratorsHasExpectedEndLine(ASTConstantDefinition $constant): void
     {
         static::assertEquals(6, $constant->getEndLine());
@@ -339,9 +337,8 @@ class ASTConstantDefinitionTest extends ASTNodeTestCase
      * testConstantDefinitionWithDeclaratorsHasExpectedEndColumn
      *
      * @since 1.0.2
-     *
-     * @depends testConstantDefinitionWithDeclarators
      */
+    #[Depends('testConstantDefinitionWithDeclarators')]
     public function testConstantDefinitionWithDeclaratorsHasExpectedEndColumn(ASTConstantDefinition $constant): void
     {
         static::assertEquals(18, $constant->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTConstantPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConstantPostfixTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstantPostfix} class.
  *
- * @covers \PDepend\Source\AST\ASTConstantPostfix
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTConstantPostfix::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTConstantPostfixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTConstantTest.php
+++ b/tests/php/PDepend/Source/AST/ASTConstantTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTConstant} class.
  *
- * @covers \PDepend\Source\AST\ASTConstant
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTConstant::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTConstantTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTContinueStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTContinueStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTContinueStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTContinueStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTContinueStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTContinueStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTDeclareStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTDeclareStatementTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTDeclareStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTDeclareStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.0
- *
- * @group unittest
  */
+#[CoversClass(ASTDeclareStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTDeclareStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTDoWhileStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTDoWhileStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTDoWhileStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTDoWhileStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTDoWhileStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTEchoStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTEchoStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTEchoStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTEchoStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTEchoStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTEchoStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTElseIfStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTElseIfStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTElseIfStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTElseIfStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTElseIfStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTElseIfStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTEnumTest.php
+++ b/tests/php/PDepend/Source/AST/ASTEnumTest.php
@@ -46,19 +46,21 @@ namespace PDepend\Source\AST;
 use InvalidArgumentException;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\MethodStrategy;
 use PDepend\Metrics\Analyzer\CodeRankAnalyzer\PropertyStrategy;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForInit} class.
  *
- * @covers \PDepend\Source\AST\ASTForInit
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForInit::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTEnumTest extends AbstractASTArtifactTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTEvalExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTEvalExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTEvalExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTEvalExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTEvalExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTEvalExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTExitExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTExitExpressionTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTExitExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTExitExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTExitExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTExitExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -72,9 +76,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedStartLine
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithExitCode
      */
+    #[Depends('testExitExpressionWithExitCode')]
     public function testExitExpressionWithExitCodeHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -84,9 +87,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedEndLine
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithExitCode
      */
+    #[Depends('testExitExpressionWithExitCode')]
     public function testExitExpressionWithExitCodeHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
@@ -96,9 +98,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedStartColumn
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithExitCode
      */
+    #[Depends('testExitExpressionWithExitCode')]
     public function testExitExpressionWithExitCodeHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -108,9 +109,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithExitCodeHasExpectedEndColumn
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithExitCode
      */
+    #[Depends('testExitExpressionWithExitCode')]
     public function testExitExpressionWithExitCodeHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());
@@ -133,9 +133,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedStartLine
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithEmptyArgs
      */
+    #[Depends('testExitExpressionWithEmptyArgs')]
     public function testExitExpressionWithEmptyArgsHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -145,9 +144,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedEndLine
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithEmptyArgs
      */
+    #[Depends('testExitExpressionWithEmptyArgs')]
     public function testExitExpressionWithEmptyArgsHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -157,9 +155,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedStartColumn
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithEmptyArgs
      */
+    #[Depends('testExitExpressionWithEmptyArgs')]
     public function testExitExpressionWithEmptyArgsHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -169,9 +166,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
      * testExitExpressionWithEmptyArgsHasExpectedEndColumn
      *
      * @since 1.0.1
-     *
-     * @depends testExitExpressionWithEmptyArgs
      */
+    #[Depends('testExitExpressionWithEmptyArgs')]
     public function testExitExpressionWithEmptyArgsHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(10, $expr->getEndColumn());
@@ -192,9 +188,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
 
     /**
      * testExitExpressionWithoutArgsHasExpectedStartLine
-     *
-     * @depends testExitExpressionWithoutArgs
      */
+    #[Depends('testExitExpressionWithoutArgs')]
     public function testExitExpressionWithoutArgsHasExpectedStartLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -202,9 +197,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
 
     /**
      * testExitExpressionWithoutArgsHasExpectedStartColumn
-     *
-     * @depends testExitExpressionWithoutArgs
      */
+    #[Depends('testExitExpressionWithoutArgs')]
     public function testExitExpressionWithoutArgsHasExpectedStartColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -212,9 +206,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
 
     /**
      * testExitExpressionHasExpectedEndLineWithoutArgs
-     *
-     * @depends testExitExpressionWithoutArgs
      */
+    #[Depends('testExitExpressionWithoutArgs')]
     public function testExitExpressionWithoutArgsHasExpectedEndLine(ASTExitExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -222,9 +215,8 @@ class ASTExitExpressionTest extends ASTNodeTestCase
 
     /**
      * testExitExpressionHasExpectedEndColumnWithoutArgs
-     *
-     * @depends testExitExpressionWithoutArgs
      */
+    #[Depends('testExitExpressionWithoutArgs')]
     public function testExitExpressionWithoutArgsHasExpectedEndColumn(ASTExitExpression $expr): void
     {
         static::assertEquals(8, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -43,16 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFieldDeclaration} class.
  *
- * @covers \PDepend\Source\AST\ASTFieldDeclaration
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTFieldDeclaration::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFieldDeclarationTest extends ASTNodeTestCase
 {
     /**
@@ -105,9 +110,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
         return $type;
     }
 
-    /**
-     * @depends testClassReferenceForJavaStyleArrayNotation
-     */
+    #[Depends('testClassReferenceForJavaStyleArrayNotation')]
     public function testNamespaceForJavaStyleArrayNotation(AbstractASTClassOrInterface $type): void
     {
         static::assertEquals('Java\\Style', $type->getNamespaceName());
@@ -118,8 +121,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * valid combinations of modifiers.
      *
      * @param int $modifiers Combinations of valid modifiers.
-     * @dataProvider dataProviderSetModifiersAcceptsExpectedModifierCombinations
      */
+    #[DataProvider('dataProviderSetModifiersAcceptsExpectedModifierCombinations')]
     public function testSetModifiersAcceptsExpectedModifierCombinations(int $modifiers): void
     {
         $declaration = new ASTFieldDeclaration();
@@ -158,8 +161,8 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
      * invalid modifier or modifier combination was set.
      *
      * @param int $modifiers Combinations of invalid modifiers.
-     * @dataProvider dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers
      */
+    #[DataProvider('dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers')]
     public function testSetModifiersThrowsExpectedExceptionForInvalidModifiers(int $modifiers): void
     {
         $declaration = new ASTFieldDeclaration();

--- a/tests/php/PDepend/Source/AST/ASTFinallyStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFinallyStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFinallyStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTFinallyStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTFinallyStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFinallyStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTForInitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForInitTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForInit} class.
  *
- * @covers \PDepend\Source\AST\ASTForInit
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForInit::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTForInitTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTForStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTForStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTForStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTForUpdateTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForUpdateTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForUpdate} class.
  *
- * @covers \PDepend\Source\AST\ASTForUpdate
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForUpdate::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTForUpdateTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTForeachStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTForeachStatementTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTForeachStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTForeachStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForeachStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTForeachStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTFormalParameterTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFormalParameterTest.php
@@ -44,17 +44,19 @@
 namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFormalParameter} class.
  *
- * @covers \PDepend\Source\AST\ASTFormalParameter
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTFormalParameter::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFormalParameterTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTFormalParametersTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFormalParametersTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFormalParameterss} class.
  *
- * @covers \PDepend\Source\AST\ASTFormalParameters
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.0
- *
- * @group unittest
  */
+#[CoversClass(ASTFormalParameters::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFormalParametersTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFunctionPostfixTest.php
@@ -43,17 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTFunctionPostfix} class.
  *
- * @covers \PDepend\Source\AST\ASTFunctionPostfix
- * @covers \PDepend\Source\AST\ASTInvocation
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTFunctionPostfix::class)]
+#[CoversClass(ASTInvocation::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFunctionPostfixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTFunctionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFunctionTest.php
@@ -45,19 +45,22 @@ namespace PDepend\Source\AST;
 
 use PDepend\Source\ASTVisitor\StubASTVisitor;
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTFunction class.
  *
- * @covers \PDepend\Source\AST\AbstractASTCallable
- * @covers \PDepend\Source\AST\ASTFunction
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTCallable::class)]
+#[CoversClass(ASTFunction::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFunctionTest extends AbstractASTArtifactTestCase
 {
     /**
@@ -167,9 +170,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         return $type;
     }
 
-    /**
-     * @depends testClassReferenceForJavaStyleArrayNotation
-     */
+    #[Depends('testClassReferenceForJavaStyleArrayNotation')]
     public function testNamespaceForJavaStyleArrayNotation(AbstractASTClassOrInterface $type): void
     {
         static::assertEquals('Java\\Style', $type->getNamespaceName());
@@ -277,7 +278,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('store')
             ->with(static::isType('string'), static::equalTo($tokens));
@@ -295,11 +296,11 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore')
             ->with(static::isType('string'))
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         $function = $this->createItem();
         $function->setCache($cache)
@@ -314,11 +315,11 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore')
             ->with(static::isType('string'))
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $function = $this->createItem();
         $function->setCache($cache);
@@ -338,7 +339,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -347,7 +348,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::never())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $function = $this->createItem();
         $function->addChild($node1);
@@ -377,7 +378,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -386,7 +387,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node3->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue($node1));
+            ->willReturn($node1);
 
         $function = $this->createItem();
         $function->addChild($node2);
@@ -408,7 +409,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -417,7 +418,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $function = $this->createItem();
         $function->addChild($node1);
@@ -441,7 +442,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('findChildrenOfType')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -450,7 +451,7 @@ class ASTFunctionTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('findChildrenOfType')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         $function = $this->createItem();
         $function->addChild($node1);

--- a/tests/php/PDepend/Source/AST/ASTGlobalStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTGlobalStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTGlobalStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTGlobalStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTGlobalStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTGlobalStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTGotoStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTGotoStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTGotoStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTGotoStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTGotoStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTGotoStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTHeredocTest.php
+++ b/tests/php/PDepend/Source/AST/ASTHeredocTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTHeredoc} class.
  *
- * @covers \PDepend\Source\AST\ASTHeredoc
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTHeredoc::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTHeredocTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTIdentifierTest.php
+++ b/tests/php/PDepend/Source/AST/ASTIdentifierTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIdentifier} class.
  *
- * @covers \PDepend\Source\AST\ASTIdentifier
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTIdentifier::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTIdentifierTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTIfStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTIfStatementTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIfStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTIfStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTIfStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTIfStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTIncludeExpressionTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIncludeExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTIncludeExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.12
- *
- * @group unittest
  */
+#[CoversClass(ASTIncludeExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTIncludeExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTInstanceOfExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTInstanceOfExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTInstanceOfExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTInstanceOfExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTInstanceOfExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -45,21 +45,23 @@ namespace PDepend\Source\AST;
 
 use BadMethodCallException;
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Token;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code interface class.
  *
- * @covers \PDepend\Source\AST\AbstractASTClassOrInterface
- * @covers \PDepend\Source\AST\AbstractASTType
- * @covers \PDepend\Source\AST\ASTInterface
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTClassOrInterface::class)]
+#[CoversClass(AbstractASTType::class)]
+#[CoversClass(ASTInterface::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTInterfaceTest extends AbstractASTArtifactTestCase
 {
     /**
@@ -74,7 +76,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Mock_' . __FUNCTION__ . '_' . md5(microtime());
@@ -83,7 +85,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::never())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $interface = $this->createItem();
         $interface->addChild($node1);
@@ -113,7 +115,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Mock_' . __FUNCTION__ . '_' . md5(microtime());
@@ -122,7 +124,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node3->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue($node1));
+            ->willReturn($node1);
 
         $interface = $this->createItem();
         $interface->addChild($node2);
@@ -144,7 +146,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Mock_' . __FUNCTION__ . '_' . md5(microtime());
@@ -153,7 +155,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $interface = $this->createItem();
         $interface->addChild($node1);
@@ -487,7 +489,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('restore');
 
@@ -507,7 +509,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $cache->expects(static::once())
             ->method('type')
             ->with(static::equalTo('tokens'))
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
         $cache->expects(static::once())
             ->method('store')
             ->with(static::isType('string'), static::equalTo($tokens));
@@ -534,7 +536,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $interface = $this->createItem();
         $interface->setCache($cache)
@@ -669,7 +671,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $cache = $this->createCacheFixture();
         $cache->expects(static::once())
             ->method('type')
-            ->will(static::returnValue($cache));
+            ->willReturn($cache);
 
         $interface = $this->createItem();
         $interface->setCache($cache)

--- a/tests/php/PDepend/Source/AST/ASTIssetExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTIssetExpressionTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTIssetExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTIssetExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.12
- *
- * @group unittest
  */
+#[CoversClass(ASTIssetExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTIssetExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTLabelStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTLabelStatementTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLabelStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTLabelStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTLabelStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTLabelStatementTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTListExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTListExpressionTest.php
@@ -43,18 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTListExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTListExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTListExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTListExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -72,9 +75,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @depends testListExpression
      */
+    #[Depends('testListExpression')]
     public function testListExpressionHasExpectedStartLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -82,9 +84,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @depends testListExpression
      */
+    #[Depends('testListExpression')]
     public function testListExpressionHasExpectedStartColumn(ASTListExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -92,9 +93,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @depends testListExpression
      */
+    #[Depends('testListExpression')]
     public function testListExpressionHasExpectedEndLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -102,9 +102,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @depends testListExpression
      */
+    #[Depends('testListExpression')]
     public function testListExpressionHasExpectedEndColumn(ASTListExpression $expr): void
     {
         static::assertEquals(16, $expr->getEndColumn());
@@ -127,9 +126,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedStartLine
      *
      * @since 1.0.2
-     *
-     * @depends testListExpressionWithNestedList
      */
+    #[Depends('testListExpressionWithNestedList')]
     public function testListExpressionWithNestedListHasExpectedStartLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -139,9 +137,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedStartColumn
      *
      * @since 1.0.2
-     *
-     * @depends testListExpressionWithNestedList
      */
+    #[Depends('testListExpressionWithNestedList')]
     public function testListExpressionWithNestedListHasExpectedStartColumn(ASTListExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -151,9 +148,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedEndLine
      *
      * @since 1.0.2
-     *
-     * @depends testListExpressionWithNestedList
      */
+    #[Depends('testListExpressionWithNestedList')]
     public function testListExpressionWithNestedListHasExpectedEndLine(ASTListExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -163,9 +159,8 @@ class ASTListExpressionTest extends ASTNodeTestCase
      * testListExpressionWithNestedListHasExpectedEndColumn
      *
      * @since 1.0.2
-     *
-     * @depends testListExpressionWithNestedList
      */
+    #[Depends('testListExpressionWithNestedList')]
     public function testListExpressionWithNestedListHasExpectedEndColumn(ASTListExpression $expr): void
     {
         static::assertEquals(42, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTLiteralTest.php
+++ b/tests/php/PDepend/Source/AST/ASTLiteralTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenStreamEndException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLiteral} class.
  *
- * @covers \PDepend\Source\AST\ASTLiteral
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTLiteral::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTLiteralTest extends ASTNodeTestCase
 {
     /**
@@ -156,7 +158,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroBinaryIntegerValue
      *
-     * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
      * @since 1.0.0
      */
     public function testLiteralWithZeroBinaryIntegerValue(): void
@@ -190,7 +191,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithNonZeroBinaryIntegerValue
      *
-     * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
      * @since 1.0.0
      */
     public function testLiteralWithNonZeroBinaryIntegerValue(): void
@@ -202,7 +202,6 @@ class ASTLiteralTest extends ASTNodeTestCase
     /**
      * testLiteralWithZeroFloatValue
      *
-     * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
      * @since 2.16.0
      */
     public function testLiteralWithZeroFloatValue(): void

--- a/tests/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTLogicalAndExpressionTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalAndExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTLogicalAndExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.8
- *
- * @group unittest
  */
+#[CoversClass(ASTLogicalAndExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTLogicalAndExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTLogicalOrExpressionTest.php
@@ -44,17 +44,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalOrExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTLogicalOrExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.8
- *
- * @group unittest
  */
+#[CoversClass(ASTLogicalOrExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTLogicalOrExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTLogicalXorExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTLogicalXorExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTLogicalXorExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTLogicalXorExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTLogicalXorExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTMemberPrimaryPrefixTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTMemberPrimaryPrefix} class.
  *
- * @covers \PDepend\Source\AST\ASTMemberPrimaryPrefix
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTMemberPrimaryPrefix::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTMemberPrimaryPrefixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTMethodPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTMethodPostfixTest.php
@@ -43,17 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTMethodPostfix} class.
  *
- * @covers \PDepend\Source\AST\ASTInvocation
- * @covers \PDepend\Source\AST\ASTMethodPostfix
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTInvocation::class)]
+#[CoversClass(ASTMethodPostfix::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTMethodPostfixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/tests/php/PDepend/Source/AST/ASTMethodTest.php
@@ -45,18 +45,21 @@ namespace PDepend\Source\AST;
 
 use InvalidArgumentException;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTMethod class.
  *
- * @covers \PDepend\Source\AST\AbstractASTCallable
- * @covers \PDepend\Source\AST\ASTMethod
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTCallable::class)]
+#[CoversClass(ASTMethod::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(ASTCompilationUnitNotFoundException::class)]
+#[Group('unittest')]
 class ASTMethodTest extends AbstractASTArtifactTestCase
 {
     /**
@@ -263,8 +266,6 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetSourceFileThrowsExpectedExceptionWhenNoParentWasDefined
-     *
-     * @covers \PDepend\Source\AST\ASTCompilationUnitNotFoundException
      */
     public function testGetSourceFileThrowsExpectedExceptionWhenNoParentWasDefined(): void
     {
@@ -510,7 +511,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -519,7 +520,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::never())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $method = new ASTMethod('Method');
         $method->addChild($node1);
@@ -549,7 +550,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -558,7 +559,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node3->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue($node1));
+            ->willReturn($node1);
 
         $method = new ASTMethod('Method');
         $method->addChild($node2);
@@ -580,7 +581,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -589,7 +590,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $method = new ASTMethod('Method');
         $method->addChild($node1);
@@ -613,7 +614,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node1->expects(static::once())
             ->method('findChildrenOfType')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         /** @var class-string */
         $class = 'Class_' . __FUNCTION__ . '_' . md5(microtime());
@@ -622,7 +623,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('findChildrenOfType')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         $method = new ASTMethod('Method');
         $method->addChild($node1);

--- a/tests/php/PDepend/Source/AST/ASTNamespaceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTNamespaceTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\ASTVisitor\StubASTVisitor;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case implementation for the \PDepend\Source\AST\ASTNamespace class.
  *
- * @covers \PDepend\Source\AST\ASTNamespace
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTNamespace::class)]
+#[Group('unittest')]
 class ASTNamespaceTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTNodeTestCase.php
+++ b/tests/php/PDepend/Source/AST/ASTNodeTestCase.php
@@ -45,17 +45,18 @@ namespace PDepend\Source\AST;
 
 use OutOfBoundsException;
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
 
 /**
  * Abstract test case for classes derived {@link \PDepend\Source\AST\ASTNode}ö
  *
- * @covers \PDepend\Source\AST\AbstractASTNode
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTNode::class)]
+#[Group('unittest')]
 abstract class ASTNodeTestCase extends AbstractTestCase
 {
     /**
@@ -178,10 +179,10 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetParentsOfTypeReturnsExpectedParentNodes(): void
     {
-        $parent0 = $this->getMockForAbstractClass(ASTScope::class);
-        $parent1 = $this->getMockForAbstractClass(AbstractASTNode::class);
-        $parent2 = $this->getMockForAbstractClass(ASTScope::class);
-        $parent3 = $this->getMockForAbstractClass(AbstractASTNode::class);
+        $parent0 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
+        $parent1 = $this->getMockBuilder(AbstractASTNode::class)->onlyMethods([])->getMock();
+        $parent2 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
+        $parent3 = $this->getMockBuilder(AbstractASTNode::class)->onlyMethods([])->getMock();
 
         $node = $this->createNodeInstance();
 
@@ -273,9 +274,9 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetFirstChildOfTypeReturnsFirstMatchingChild(): void
     {
-        $child0 = $this->getMockForAbstractClass(
-            ASTIndexExpression::class
-        );
+        $child0 = $this->getMockBuilder(ASTIndexExpression::class)
+            ->onlyMethods([])
+            ->getMock();
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -293,12 +294,12 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testGetFirstChildOfTypeReturnsFirstMatchingChildRecursive(): void
     {
-        $child0 = $this->getMockForAbstractClass(
-            ASTIndexExpression::class
-        );
-        $child1 = $this->getMockForAbstractClass(
-            ASTArguments::class
-        );
+        $child0 = $this->getMockBuilder(ASTIndexExpression::class)
+            ->onlyMethods([])
+            ->getMock();
+        $child1 = $this->getMockBuilder(ASTArguments::class)
+            ->onlyMethods([])
+            ->getMock();
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -332,7 +333,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testFindChildrenOfTypeReturnsDirectChild(): void
     {
         $child0 = $this->getNodeMock();
-        $child1 = $this->getMockForAbstractClass(ASTScope::class);
+        $child1 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -352,7 +353,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
     public function testFindChildrenOfTypeReturnsIndirectChild(): void
     {
         $child0 = $this->getNodeMock();
-        $child1 = $this->getMockForAbstractClass(ASTScope::class);
+        $child1 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -371,9 +372,9 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     public function testFindChildrenOfTypeReturnsDirectAndIndirectChild(): void
     {
-        $child0 = $this->getMockForAbstractClass(ASTScope::class);
-        $child1 = $this->getMockForAbstractClass(ASTScope::class);
-        $child2 = $this->getMockForAbstractClass(ASTScope::class);
+        $child0 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
+        $child1 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
+        $child2 = $this->getMockBuilder(ASTScope::class)->onlyMethods([])->getMock();
 
         $node = $this->getNodeMock();
         $node->addChild($child0);
@@ -551,7 +552,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
      */
     private function getNodeMock(): AbstractASTNode
     {
-        return $this->getMockForAbstractClass(AbstractASTNode::class);
+        return $this->getMockBuilder(AbstractASTNode::class)->onlyMethods([])->getMock();
     }
 
     /**
@@ -583,7 +584,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
             ->getMock();
         $node2->expects(static::never())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $node = $this->createNodeInstance();
         $node->addChild($node2);
@@ -612,7 +613,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
             ->getMock();
         $node3->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue($node1));
+            ->willReturn($node1);
 
         $node = $this->createNodeInstance();
         $node->addChild($node3);
@@ -634,7 +635,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('getFirstChildOfType')
-            ->will(static::returnValue(null));
+            ->willReturn(null);
 
         $node = $this->createNodeInstance();
         $node->addChild($node2);
@@ -657,7 +658,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
             ->getMock();
         $node2->expects(static::once())
             ->method('findChildrenOfType')
-            ->will(static::returnValue([]));
+            ->willReturn([]);
 
         $node = $this->createNodeInstance();
         $node->addChild($node2);
@@ -689,7 +690,7 @@ abstract class ASTNodeTestCase extends AbstractTestCase
 
         $reflection = new ReflectionClass($class);
         if ($reflection->isAbstract()) {
-            return $this->getMockForAbstractClass($class, [__METHOD__]);
+            return $this->getMockBuilder($class)->setConstructorArgs([__METHOD__])->getMock();
         }
 
         return $reflection->newInstanceArgs([__METHOD__]);

--- a/tests/php/PDepend/Source/AST/ASTParameterTest.php
+++ b/tests/php/PDepend/Source/AST/ASTParameterTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code parameter class.
  *
- * @covers \PDepend\Source\AST\ASTParameter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTParameter::class)]
+#[Group('unittest')]
 class ASTParameterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTParentReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTParentReferenceTest.php
@@ -43,19 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTParentReference} class.
  *
- * @covers \PDepend\Source\AST\ASTParentReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTParentReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTParentReferenceTest extends ASTNodeTestCase
 {
     /** The mocked reference instance. */

--- a/tests/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPostfixExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link ASTPostfixExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTPostfixExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTPostfixExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTPostfixExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPreDecrementExpressionTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPreDecrementExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTPreDecrementExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTPreDecrementExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTPreDecrementExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPreIncrementExpressionTest.php
@@ -43,17 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPreIncrementExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTPreIncrementExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTPreIncrementExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(PHPBuilder::class)]
+#[Group('unittest')]
 class ASTPreIncrementExpressionTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTPrintExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPrintExpressionTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPrintExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTPrintExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTPrintExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTPrintExpressionTest extends ASTNodeTestCase
 {
     public function testSimplePrintExpression(): ASTPrintExpression
@@ -63,33 +67,25 @@ class ASTPrintExpressionTest extends ASTNodeTestCase
         return $print;
     }
 
-    /**
-     * @depends testSimplePrintExpression
-     */
+    #[Depends('testSimplePrintExpression')]
     public function testSimplePrintExpressionHasExpectedStartLine(ASTPrintExpression $expr): void
     {
         static::assertSame(4, $expr->getStartLine());
     }
 
-    /**
-     * @depends testSimplePrintExpression
-     */
+    #[Depends('testSimplePrintExpression')]
     public function testSimplePrintExpressionHasExpectedEndLine(ASTPrintExpression $expr): void
     {
         static::assertSame(4, $expr->getEndLine());
     }
 
-    /**
-     * @depends testSimplePrintExpression
-     */
+    #[Depends('testSimplePrintExpression')]
     public function testSimplePrintExpressionHasExpectedStartColumn(ASTPrintExpression $expr): void
     {
         static::assertSame(5, $expr->getStartColumn());
     }
 
-    /**
-     * @depends testSimplePrintExpression
-     */
+    #[Depends('testSimplePrintExpression')]
     public function testSimplePrintExpressionHasExpectedEndColumn(ASTPrintExpression $expr): void
     {
         static::assertSame(9, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPropertyPostfixTest.php
@@ -43,20 +43,22 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTPropertyPostfix} class.
  *
- * @covers \PDepend\Source\AST\ASTPropertyPostfix
- *
- * @group unittest
- *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  */
+#[CoversClass(ASTPropertyPostfix::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(PHPBuilder::class)]
+#[Group('unittest')]
 class ASTPropertyPostfixTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTPropertyTest.php
+++ b/tests/php/PDepend/Source/AST/ASTPropertyTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the code property class.
  *
- * @covers \PDepend\Source\AST\ASTProperty
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTProperty::class)]
+#[Group('unittest')]
 class ASTPropertyTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTRequireExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTRequireExpressionTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTRequireExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTRequireExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.12
- *
- * @group unittest
  */
+#[CoversClass(ASTRequireExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTRequireExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -107,9 +111,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionHasExpectedStartLine
-     *
-     * @depends testRequireExpression
      */
+    #[Depends('testRequireExpression')]
     public function testRequireExpressionHasExpectedStartLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -117,9 +120,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionHasExpectedStartColumn
-     *
-     * @depends testRequireExpression
      */
+    #[Depends('testRequireExpression')]
     public function testRequireExpressionHasExpectedStartColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -127,9 +129,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionHasExpectedEndLine
-     *
-     * @depends testRequireExpression
      */
+    #[Depends('testRequireExpression')]
     public function testRequireExpressionHasExpectedEndLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -137,9 +138,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionHasExpectedEndColumn
-     *
-     * @depends testRequireExpression
      */
+    #[Depends('testRequireExpression')]
     public function testRequireExpressionHasExpectedEndColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(35, $expr->getEndColumn());
@@ -160,9 +160,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartLine
-     *
-     * @depends testRequireExpressionWithParenthesis
      */
+    #[Depends('testRequireExpressionWithParenthesis')]
     public function testRequireExpressionWithParenthesisHasExpectedStartLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -170,9 +169,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionWithParenthesisHasExpectedStartColumn
-     *
-     * @depends testRequireExpressionWithParenthesis
      */
+    #[Depends('testRequireExpressionWithParenthesis')]
     public function testRequireExpressionWithParenthesisHasExpectedStartColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getStartColumn());
@@ -180,9 +178,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndLine
-     *
-     * @depends testRequireExpressionWithParenthesis
      */
+    #[Depends('testRequireExpressionWithParenthesis')]
     public function testRequireExpressionWithParenthesisHasExpectedEndLine(ASTRequireExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
@@ -190,9 +187,8 @@ class ASTRequireExpressionTest extends ASTNodeTestCase
 
     /**
      * testRequireExpressionWithParenthesisHasExpectedEndColumn
-     *
-     * @depends testRequireExpressionWithParenthesis
      */
+    #[Depends('testRequireExpressionWithParenthesis')]
     public function testRequireExpressionWithParenthesisHasExpectedEndColumn(ASTRequireExpression $expr): void
     {
         static::assertEquals(5, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTReturnStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTReturnStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTReturnStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTReturnStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTReturnStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTReturnStatementTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testReturnStatementHasExpectedStartLine
-     *
-     * @depends testReturnStatement
      */
+    #[Depends('testReturnStatement')]
     public function testReturnStatementHasExpectedStartLine(ASTReturnStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -80,9 +83,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testReturnStatementHasExpectedStartColumn
-     *
-     * @depends testReturnStatement
      */
+    #[Depends('testReturnStatement')]
     public function testReturnStatementHasExpectedStartColumn(ASTReturnStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -90,9 +92,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testReturnStatementHasExpectedEndLine
-     *
-     * @depends testReturnStatement
      */
+    #[Depends('testReturnStatement')]
     public function testReturnStatementHasExpectedEndLine(ASTReturnStatement $stmt): void
     {
         static::assertEquals(7, $stmt->getEndLine());
@@ -100,9 +101,8 @@ class ASTReturnStatementTest extends ASTNodeTestCase
 
     /**
      * testReturnStatementHasExpectedEndColumn
-     *
-     * @depends testReturnStatement
      */
+    #[Depends('testReturnStatement')]
     public function testReturnStatementHasExpectedEndColumn(ASTReturnStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTScalarTypeTest.php
+++ b/tests/php/PDepend/Source/AST/ASTScalarTypeTest.php
@@ -43,16 +43,19 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScalarType} class.
  *
- * @covers \PDepend\Source\AST\ASTScalarType
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTScalarType::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTScalarTypeTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTScopeStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTScopeStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScopeStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTScopeStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTScopeStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTScopeStatementTest extends ASTNodeTestCase
 {
     /**
@@ -72,9 +76,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedStartLine
      *
      * @since 1.0.0
-     *
-     * @depends testParserHandlesInlineScopeStatement
      */
+    #[Depends('testParserHandlesInlineScopeStatement')]
     public function testInlineScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -86,9 +89,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedStartColumn
      *
      * @since 1.0.0
-     *
-     * @depends testInlineScopeStatementHasExpectedStartLine
      */
+    #[Depends('testInlineScopeStatementHasExpectedStartLine')]
     public function testInlineScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -100,9 +102,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedEndLine
      *
      * @since 1.0.0
-     *
-     * @depends testInlineScopeStatementHasExpectedStartColumn
      */
+    #[Depends('testInlineScopeStatementHasExpectedStartColumn')]
     public function testInlineScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt): ASTScopeStatement
     {
         static::assertEquals(5, $stmt->getEndLine());
@@ -114,9 +115,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
      * testInlineScopeStatementHasExpectedEndColumn
      *
      * @since 1.0.0
-     *
-     * @depends testInlineScopeStatementHasExpectedEndLine
      */
+    #[Depends('testInlineScopeStatementHasExpectedEndLine')]
     public function testInlineScopeStatementHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(20, $stmt->getEndColumn());
@@ -137,9 +137,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected start line value.
-     *
-     * @depends testScopeStatement
      */
+    #[Depends('testScopeStatement')]
     public function testScopeStatementHasExpectedStartLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -147,9 +146,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected start column value.
-     *
-     * @depends testScopeStatement
      */
+    #[Depends('testScopeStatement')]
     public function testScopeStatementHasExpectedStartColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(34, $stmt->getStartColumn());
@@ -157,9 +155,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected end line value.
-     *
-     * @depends testScopeStatement
      */
+    #[Depends('testScopeStatement')]
     public function testScopeStatementHasExpectedEndLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
@@ -167,9 +164,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected end column value.
-     *
-     * @depends testScopeStatement
      */
+    #[Depends('testScopeStatement')]
     public function testScopeStatementHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
@@ -190,9 +186,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * testScopeStatementWithAlternativeHasExpectedStartLine
-     *
-     * @depends testScopeStatementWithAlternative
      */
+    #[Depends('testScopeStatementWithAlternative')]
     public function testScopeStatementWithAlternativeHasExpectedStartLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getStartLine());
@@ -200,9 +195,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * testScopeStatementWithAlternativeHasExpectedStartColumn
-     *
-     * @depends testScopeStatementWithAlternative
      */
+    #[Depends('testScopeStatementWithAlternative')]
     public function testScopeStatementWithAlternativeHasExpectedStartColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getStartColumn());
@@ -210,9 +204,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * testScopeStatementWithAlternativeHasExpectedEndLine
-     *
-     * @depends testScopeStatementWithAlternative
      */
+    #[Depends('testScopeStatementWithAlternative')]
     public function testScopeStatementWithAlternativeHasExpectedEndLine(ASTScopeStatement $stmt): void
     {
         static::assertEquals(17, $stmt->getEndLine());
@@ -220,9 +213,8 @@ class ASTScopeStatementTest extends ASTNodeTestCase
 
     /**
      * testScopeStatementWithAlternativeHasExpectedEndColumn
-     *
-     * @depends testScopeStatementWithAlternative
      */
+    #[Depends('testScopeStatementWithAlternative')]
     public function testScopeStatementWithAlternativeHasExpectedEndColumn(ASTScopeStatement $stmt): void
     {
         static::assertEquals(15, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTScopeTest.php
+++ b/tests/php/PDepend/Source/AST/ASTScopeTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTScope} class.
  *
- * @covers \PDepend\Source\AST\ASTScope
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTScope::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTScopeTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTScopeTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected start line value.
-     *
-     * @depends testScope
      */
+    #[Depends('testScope')]
     public function testScopeHasExpectedStartLine(ASTScope $scope): void
     {
         static::assertEquals(3, $scope->getStartLine());
@@ -80,9 +83,8 @@ class ASTScopeTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected start column value.
-     *
-     * @depends testScope
      */
+    #[Depends('testScope')]
     public function testScopeHasExpectedStartColumn(ASTScope $scope): void
     {
         static::assertEquals(1, $scope->getStartColumn());
@@ -90,9 +92,8 @@ class ASTScopeTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected end line value.
-     *
-     * @depends testScope
      */
+    #[Depends('testScope')]
     public function testScopeHasExpectedEndLine(ASTScope $scope): void
     {
         static::assertEquals(8, $scope->getEndLine());
@@ -100,9 +101,8 @@ class ASTScopeTest extends ASTNodeTestCase
 
     /**
      * Tests that the scope-statement has the expected end column value.
-     *
-     * @depends testScope
      */
+    #[Depends('testScope')]
     public function testScopeHasExpectedEndColumn(ASTScope $scope): void
     {
         static::assertEquals(1, $scope->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTSelfReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTSelfReferenceTest.php
@@ -46,18 +46,21 @@ namespace PDepend\Source\AST;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSelfReference} class.
  *
- * @covers \PDepend\Source\AST\ASTSelfReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTSelfReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTSelfReferenceTest extends ASTNodeTestCase
 {
     /**
@@ -65,10 +68,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
-        $target = $this->getMockForAbstractClass(
-            AbstractASTClassOrInterface::class,
-            [__CLASS__]
-        );
+        $target = $this->getMockBuilder(AbstractASTClassOrInterface::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
@@ -81,10 +83,9 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
-        $target = $this->getMockForAbstractClass(
-            AbstractASTClassOrInterface::class,
-            [__CLASS__]
-        );
+        $target = $this->getMockBuilder(AbstractASTClassOrInterface::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
 
         $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
@@ -163,9 +164,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testSelfReferenceHasExpectedStartLine
-     *
-     * @depends testSelfReference
      */
+    #[Depends('testSelfReference')]
     public function testSelfReferenceHasExpectedStartLine(ASTSelfReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
@@ -173,9 +173,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testSelfReferenceHasExpectedStartColumn
-     *
-     * @depends testSelfReference
      */
+    #[Depends('testSelfReference')]
     public function testSelfReferenceHasExpectedStartColumn(ASTSelfReference $reference): void
     {
         static::assertEquals(13, $reference->getStartColumn());
@@ -183,9 +182,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testSelfReferenceHasExpectedEndLine
-     *
-     * @depends testSelfReference
      */
+    #[Depends('testSelfReference')]
     public function testSelfReferenceHasExpectedEndLine(ASTSelfReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
@@ -193,9 +191,8 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
     /**
      * testSelfReferenceHasExpectedEndColumn
-     *
-     * @depends testSelfReference
      */
+    #[Depends('testSelfReference')]
     public function testSelfReferenceHasExpectedEndColumn(ASTSelfReference $reference): void
     {
         static::assertEquals(16, $reference->getEndColumn());
@@ -211,7 +208,7 @@ class ASTSelfReferenceTest extends ASTNodeTestCase
 
         return new ASTSelfReference(
             $context,
-            $this->getMockForAbstractClass(AbstractASTClassOrInterface::class, [__CLASS__])
+            $this->getMockBuilder(AbstractASTClassOrInterface::class)->setConstructorArgs([__CLASS__])->getMock()
         );
     }
 

--- a/tests/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTShiftLeftExpressionTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTShiftLeftExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTShiftLeftExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.1
- *
- * @group unittest
  */
+#[CoversClass(ASTShiftLeftExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -79,9 +83,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftLeftExpressionHasExpectedStartLine
-     *
-     * @depends testShiftLeftExpression
      */
+    #[Depends('testShiftLeftExpression')]
     public function testShiftLeftExpressionHasExpectedStartLine(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(6, $expr->getStartLine());
@@ -89,9 +92,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftLeftExpressionHasExpectedStartColumn
-     *
-     * @depends testShiftLeftExpression
      */
+    #[Depends('testShiftLeftExpression')]
     public function testShiftLeftExpressionHasExpectedStartColumn(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(13, $expr->getStartColumn());
@@ -99,9 +101,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftLeftExpressionHasExpectedEndLine
-     *
-     * @depends testShiftLeftExpression
      */
+    #[Depends('testShiftLeftExpression')]
     public function testShiftLeftExpressionHasExpectedEndLine(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
@@ -109,9 +110,8 @@ class ASTShiftLeftExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftLeftExpressionHasExpectedEndColumn
-     *
-     * @depends testShiftLeftExpression
      */
+    #[Depends('testShiftLeftExpression')]
     public function testShiftLeftExpressionHasExpectedEndColumn(ASTShiftLeftExpression $expr): void
     {
         static::assertEquals(14, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTShiftRightExpressionTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTShiftRightExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTShiftRightExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.1
- *
- * @group unittest
  */
+#[CoversClass(ASTShiftRightExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTShiftRightExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -79,9 +83,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftRightExpressionHasExpectedStartLine
-     *
-     * @depends testShiftRightExpression
      */
+    #[Depends('testShiftRightExpression')]
     public function testShiftRightExpressionHasExpectedStartLine(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(6, $expr->getStartLine());
@@ -89,9 +92,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftRightExpressionHasExpectedStartColumn
-     *
-     * @depends testShiftRightExpression
      */
+    #[Depends('testShiftRightExpression')]
     public function testShiftRightExpressionHasExpectedStartColumn(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(13, $expr->getStartColumn());
@@ -99,9 +101,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftRightExpressionHasExpectedEndLine
-     *
-     * @depends testShiftRightExpression
      */
+    #[Depends('testShiftRightExpression')]
     public function testShiftRightExpressionHasExpectedEndLine(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(6, $expr->getEndLine());
@@ -109,9 +110,8 @@ class ASTShiftRightExpressionTest extends ASTNodeTestCase
 
     /**
      * testShiftRightExpressionHasExpectedEndColumn
-     *
-     * @depends testShiftRightExpression
      */
+    #[Depends('testShiftRightExpression')]
     public function testShiftRightExpressionHasExpectedEndColumn(ASTShiftRightExpression $expr): void
     {
         static::assertEquals(14, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTStatementTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTStatementTest extends ASTNodeTestCase
 
     /**
      * testStatementHasExpectedStartLine
-     *
-     * @depends testStatement
      */
+    #[Depends('testStatement')]
     public function testStatementHasExpectedStartLine(ASTStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -80,9 +83,8 @@ class ASTStatementTest extends ASTNodeTestCase
 
     /**
      * testStatementHasExpectedStartColumn
-     *
-     * @depends testStatement
      */
+    #[Depends('testStatement')]
     public function testStatementHasExpectedStartColumn(ASTStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -90,9 +92,8 @@ class ASTStatementTest extends ASTNodeTestCase
 
     /**
      * testStatementHasExpectedEndLine
-     *
-     * @depends testStatement
      */
+    #[Depends('testStatement')]
     public function testStatementHasExpectedEndLine(ASTStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
@@ -100,9 +101,8 @@ class ASTStatementTest extends ASTNodeTestCase
 
     /**
      * testStatementHasExpectedEndColumn
-     *
-     * @depends testStatement
      */
+    #[Depends('testStatement')]
     public function testStatementHasExpectedEndColumn(ASTStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -46,18 +46,21 @@ namespace PDepend\Source\AST;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStaticReference} class.
  *
- * @covers \PDepend\Source\AST\ASTStaticReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTStaticReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTStaticReferenceTest extends ASTNodeTestCase
 {
     /**
@@ -65,10 +68,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeReturnsInjectedConstructorTargetArgument(): void
     {
-        $target = $this->getMockForAbstractClass(
-            AbstractASTClassOrInterface::class,
-            [__CLASS__]
-        );
+        $target = $this->getMockBuilder(AbstractASTClassOrInterface::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
         $context = $this->getMockBuilder(BuilderContext::class)
             ->getMock();
 
@@ -81,10 +83,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
      */
     public function testGetTypeInvokesBuilderContextWhenTypeInstanceIsNull(): void
     {
-        $target = $this->getMockForAbstractClass(
-            AbstractASTClassOrInterface::class,
-            [__CLASS__]
-        );
+        $target = $this->getMockBuilder(AbstractASTClassOrInterface::class)
+            ->setConstructorArgs([__CLASS__])
+            ->getMock();
 
         $builder = $this->getMockBuilder(Builder::class)
             ->getMock();
@@ -173,9 +174,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * testStaticReferenceHasExpectedStartLine
-     *
-     * @depends testStaticReference
      */
+    #[Depends('testStaticReference')]
     public function testStaticReferenceHasExpectedStartLine(ASTStaticReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
@@ -183,9 +183,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * testStaticReferenceHasExpectedStartColumn
-     *
-     * @depends testStaticReference
      */
+    #[Depends('testStaticReference')]
     public function testStaticReferenceHasExpectedStartColumn(ASTStaticReference $reference): void
     {
         static::assertEquals(13, $reference->getStartColumn());
@@ -193,9 +192,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * testStaticReferenceHasExpectedEndLine
-     *
-     * @depends testStaticReference
      */
+    #[Depends('testStaticReference')]
     public function testStaticReferenceHasExpectedEndLine(ASTStaticReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
@@ -203,9 +201,8 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
     /**
      * testStaticReferenceHasExpectedEndColumn
-     *
-     * @depends testStaticReference
      */
+    #[Depends('testStaticReference')]
     public function testStaticReferenceHasExpectedEndColumn(ASTStaticReference $reference): void
     {
         static::assertEquals(18, $reference->getEndColumn());
@@ -221,10 +218,9 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
 
         return new ASTStaticReference(
             $context,
-            $this->getMockForAbstractClass(
-                AbstractASTClassOrInterface::class,
-                [__CLASS__]
-            )
+            $this->getMockBuilder(AbstractASTClassOrInterface::class)
+                ->setConstructorArgs([__CLASS__])
+                ->getMock()
         );
     }
 

--- a/tests/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStaticVariableDeclarationTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStaticVariableDeclaration} class.
  *
- * @covers \PDepend\Source\AST\ASTStaticVariableDeclaration
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTStaticVariableDeclaration::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 
     /**
      * Tests that the declaration has the expected start line value.
-     *
-     * @depends testStaticVariableDeclaration
      */
+    #[Depends('testStaticVariableDeclaration')]
     public function testStaticVariableDeclarationHasExpectedStartLine(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(4, $declaration->getStartLine());
@@ -80,9 +83,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 
     /**
      * Tests that the declaration has the expected start column value.
-     *
-     * @depends testStaticVariableDeclaration
      */
+    #[Depends('testStaticVariableDeclaration')]
     public function testStaticVariableDeclarationHasExpectedStartColumn(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(5, $declaration->getStartColumn());
@@ -90,9 +92,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 
     /**
      * Tests that the declaration has the expected end line value.
-     *
-     * @depends testStaticVariableDeclaration
      */
+    #[Depends('testStaticVariableDeclaration')]
     public function testStaticVariableDeclarationHasExpectedEndLine(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(5, $declaration->getEndLine());
@@ -100,9 +101,8 @@ class ASTStaticVariableDeclarationTest extends ASTNodeTestCase
 
     /**
      * Tests that the declaration has the expected end column value.
-     *
-     * @depends testStaticVariableDeclaration
      */
+    #[Depends('testStaticVariableDeclaration')]
     public function testStaticVariableDeclarationHasExpectedEndColumn(ASTStaticVariableDeclaration $declaration): void
     {
         static::assertSame(23, $declaration->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStringIndexExpressionTest.php
@@ -44,18 +44,22 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTStringIndexExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTIndexExpression
- * @covers \PDepend\Source\AST\ASTStringIndexExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.12
- *
- * @group unittest
  */
+#[CoversClass(ASTIndexExpression::class)]
+#[CoversClass(ASTStringIndexExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTStringIndexExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -73,9 +77,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testStringIndexExpressionHasExpectedStartLine
-     *
-     * @depends testStringIndexExpression
      */
+    #[Depends('testStringIndexExpression')]
     public function testStringIndexExpressionHasExpectedStartLine(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(4, $expr->getStartLine());
@@ -83,9 +86,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testStringIndexExpressionHasExpectedStartColumn
-     *
-     * @depends testStringIndexExpression
      */
+    #[Depends('testStringIndexExpression')]
     public function testStringIndexExpressionHasExpectedStartColumn(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(23, $expr->getStartColumn());
@@ -93,9 +95,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testStringIndexExpressionHasExpectedEndLine
-     *
-     * @depends testStringIndexExpression
      */
+    #[Depends('testStringIndexExpression')]
     public function testStringIndexExpressionHasExpectedEndLine(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(4, $expr->getEndLine());
@@ -103,9 +104,8 @@ class ASTStringIndexExpressionTest extends ASTNodeTestCase
 
     /**
      * testStringIndexExpressionHasExpectedEndColumn
-     *
-     * @depends testStringIndexExpression
      */
+    #[Depends('testStringIndexExpression')]
     public function testStringIndexExpressionHasExpectedEndColumn(ASTStringIndexExpression $expr): void
     {
         static::assertEquals(28, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTStringTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStringTest.php
@@ -43,18 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTString} class.
  *
- * @covers \PDepend\Source\AST\ASTString
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTString::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTStringTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTSwitchLabelTest.php
+++ b/tests/php/PDepend/Source/AST/ASTSwitchLabelTest.php
@@ -43,18 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenStreamEndException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchLabel} class.
  *
- * @covers \PDepend\Source\AST\ASTSwitchLabel
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTSwitchLabel::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTSwitchLabelTest extends ASTNodeTestCase
 {
     /**
@@ -109,9 +112,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @depends testSwitchLabel
      */
+    #[Depends('testSwitchLabel')]
     public function testSwitchLabelHasExpectedStartLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(6, $label->getStartLine());
@@ -119,9 +121,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @depends testSwitchLabel
      */
+    #[Depends('testSwitchLabel')]
     public function testSwitchLabelHasExpectedStartColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(9, $label->getStartColumn());
@@ -129,9 +130,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @depends testSwitchLabel
      */
+    #[Depends('testSwitchLabel')]
     public function testSwitchLabelHasExpectedEndLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(7, $label->getEndLine());
@@ -139,9 +139,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @depends testSwitchLabel
      */
+    #[Depends('testSwitchLabel')]
     public function testSwitchLabelHasExpectedEndColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(18, $label->getEndColumn());
@@ -193,9 +192,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeStartLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelWithNestedNonePhpCode')]
     public function testSwitchLabelWithNestedNonePhpCodeStartLine(ASTSwitchLabel $label): void
     {
         static::assertSame(6, $label->getStartLine());
@@ -205,9 +203,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeEndLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelWithNestedNonePhpCode')]
     public function testSwitchLabelWithNestedNonePhpCodeEndLine(ASTSwitchLabel $label): void
     {
         static::assertSame(9, $label->getEndLine());
@@ -217,9 +214,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeStartColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelWithNestedNonePhpCode')]
     public function testSwitchLabelWithNestedNonePhpCodeStartColumn(ASTSwitchLabel $label): void
     {
         static::assertSame(7, $label->getStartColumn());
@@ -229,9 +225,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeEndColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelWithNestedNonePhpCode')]
     public function testSwitchLabelWithNestedNonePhpCodeEndColumn(ASTSwitchLabel $label): void
     {
         static::assertSame(5, $label->getEndColumn());
@@ -252,9 +247,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @depends testSwitchLabelDefault
      */
+    #[Depends('testSwitchLabelDefault')]
     public function testSwitchLabelDefaultHasExpectedStartLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(6, $label->getStartLine());
@@ -262,9 +256,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @depends testSwitchLabelDefault
      */
+    #[Depends('testSwitchLabelDefault')]
     public function testSwitchLabelDefaultHasExpectedStartColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(9, $label->getStartColumn());
@@ -272,9 +265,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @depends testSwitchLabelDefault
      */
+    #[Depends('testSwitchLabelDefault')]
     public function testSwitchLabelDefaultHasExpectedEndLine(ASTSwitchLabel $label): void
     {
         static::assertEquals(7, $label->getEndLine());
@@ -282,9 +274,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @depends testSwitchLabelDefault
      */
+    #[Depends('testSwitchLabelDefault')]
     public function testSwitchLabelDefaultHasExpectedEndColumn(ASTSwitchLabel $label): void
     {
         static::assertEquals(18, $label->getEndColumn());
@@ -335,9 +326,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeStartLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelWithNestedNonePhpCode')]
     public function testSwitchLabelDefaultDefaultWithNestedNonePhpCodeStartLine(ASTSwitchLabel $label): void
     {
         static::assertSame(6, $label->getStartLine());
@@ -347,9 +337,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeEndLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelDefaultWithNestedNonePhpCode')]
     public function testSwitchLabelDefaultWithNestedNonePhpCodeEndLine(ASTSwitchLabel $label): void
     {
         static::assertSame(9, $label->getEndLine());
@@ -359,9 +348,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeStartColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelDefaultWithNestedNonePhpCode')]
     public function testSwitchLabelDefaultWithNestedNonePhpCodeStartColumn(ASTSwitchLabel $label): void
     {
         static::assertSame(7, $label->getStartColumn());
@@ -371,9 +359,8 @@ class ASTSwitchLabelTest extends ASTNodeTestCase
      * testSwitchLabelWithNestedNonePhpCodeEndColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchLabelDefaultWithNestedNonePhpCode
      */
+    #[Depends('testSwitchLabelDefaultWithNestedNonePhpCode')]
     public function testSwitchLabelDefaultWithNestedNonePhpCodeEndColumn(ASTSwitchLabel $label): void
     {
         static::assertSame(5, $label->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTSwitchStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTSwitchStatementTest.php
@@ -43,19 +43,22 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTSwitchStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTSwitchStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTSwitchStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTSwitchStatementTest extends ASTNodeTestCase
 {
     /**
@@ -96,9 +99,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start line value.
-     *
-     * @depends testSwitchStatement
      */
+    #[Depends('testSwitchStatement')]
     public function testSwitchStatementHasExpectedStartLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -106,9 +108,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the start column value.
-     *
-     * @depends testSwitchStatement
      */
+    #[Depends('testSwitchStatement')]
     public function testSwitchStatementHasExpectedStartColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -116,9 +117,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end line value.
-     *
-     * @depends testSwitchStatement
      */
+    #[Depends('testSwitchStatement')]
     public function testSwitchStatementHasExpectedEndLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
@@ -126,9 +126,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * Tests the end column value.
-     *
-     * @depends testSwitchStatement
      */
+    #[Depends('testSwitchStatement')]
     public function testSwitchStatementHasExpectedEndColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
@@ -185,9 +184,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @depends testSwitchStatementWithAlternativeScope
      */
+    #[Depends('testSwitchStatementWithAlternativeScope')]
     public function testSwitchStatementAlternativeScopeHasExpectedStartLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -195,9 +193,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @depends testSwitchStatementWithAlternativeScope
      */
+    #[Depends('testSwitchStatementWithAlternativeScope')]
     public function testSwitchStatementAlternativeScopeHasExpectedStartColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -205,9 +202,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @depends testSwitchStatementWithAlternativeScope
      */
+    #[Depends('testSwitchStatementWithAlternativeScope')]
     public function testSwitchStatementAlternativeScopeHasExpectedEndLine(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(25, $stmt->getEndLine());
@@ -215,9 +211,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
 
     /**
      * testSwitchStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @depends testSwitchStatementWithAlternativeScope
      */
+    #[Depends('testSwitchStatementWithAlternativeScope')]
     public function testSwitchStatementAlternativeScopeHasExpectedEndColumn(ASTSwitchStatement $stmt): void
     {
         static::assertEquals(14, $stmt->getEndColumn());
@@ -249,9 +244,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithNestedNonePhpCodeStartLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchStatementWithNestedNonePhpCode
      */
+    #[Depends('testSwitchStatementWithNestedNonePhpCode')]
     public function testSwitchStatementWithNestedNonePhpCodeStartLine(ASTSwitchStatement $switch): void
     {
         static::assertSame(5, $switch->getStartLine());
@@ -261,9 +255,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithNestedNonePhpCodeEndLine
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchStatementWithNestedNonePhpCode
      */
+    #[Depends('testSwitchStatementWithNestedNonePhpCode')]
     public function testSwitchStatementWithNestedNonePhpCodeEndLine(ASTSwitchStatement $switch): void
     {
         static::assertSame(16, $switch->getEndLine());
@@ -273,9 +266,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithNestedNonePhpCodeStartColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchStatementWithNestedNonePhpCode
      */
+    #[Depends('testSwitchStatementWithNestedNonePhpCode')]
     public function testSwitchStatementWithNestedNonePhpCodeStartColumn(ASTSwitchStatement $switch): void
     {
         static::assertSame(7, $switch->getStartColumn());
@@ -285,9 +277,8 @@ class ASTSwitchStatementTest extends ASTNodeTestCase
      * testSwitchStatementWithNestedNonePhpCodeEndColumn
      *
      * @since 2.1.0
-     *
-     * @depends testSwitchStatementWithNestedNonePhpCode
      */
+    #[Depends('testSwitchStatementWithNestedNonePhpCode')]
     public function testSwitchStatementWithNestedNonePhpCodeEndColumn(ASTSwitchStatement $switch): void
     {
         static::assertSame(16, $switch->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTThrowStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTThrowStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTThrowStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTThrowStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTThrowStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTThrowStatementTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
 
     /**
      * testThrowStatementHasExpectedStartLine
-     *
-     * @depends testThrowStatement
      */
+    #[Depends('testThrowStatement')]
     public function testThrowStatementHasExpectedStartLine(ASTThrowStatement $stmt): void
     {
         static::assertSame(4, $stmt->getStartLine());
@@ -80,9 +83,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
 
     /**
      * testThrowStatementHasExpectedStartColumn
-     *
-     * @depends testThrowStatement
      */
+    #[Depends('testThrowStatement')]
     public function testThrowStatementHasExpectedStartColumn(ASTThrowStatement $stmt): void
     {
         static::assertSame(5, $stmt->getStartColumn());
@@ -90,9 +92,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
 
     /**
      * testThrowStatementHasExpectedEndLine
-     *
-     * @depends testThrowStatement
      */
+    #[Depends('testThrowStatement')]
     public function testThrowStatementHasExpectedEndLine(ASTThrowStatement $stmt): void
     {
         static::assertSame(5, $stmt->getEndLine());
@@ -100,9 +101,8 @@ class ASTThrowStatementTest extends ASTNodeTestCase
 
     /**
      * testThrowStatementHasExpectedEndColumn
-     *
-     * @depends testThrowStatement
      */
+    #[Depends('testThrowStatement')]
     public function testThrowStatementHasExpectedEndColumn(ASTThrowStatement $stmt): void
     {
         static::assertSame(38, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitAdaptationAliasTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptationAlias} class.
  *
- * @covers \PDepend\Source\AST\ASTTraitAdaptationAlias
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTraitAdaptationAlias::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 {
     /**
@@ -150,9 +154,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationAliasHasExpectedStartLine
-     *
-     * @depends testTraitAdaptationAlias
      */
+    #[Depends('testTraitAdaptationAlias')]
     public function testTraitAdaptationAliasHasExpectedStartLine(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(6, $alias->getStartLine());
@@ -160,9 +163,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationAliasHasExpectedStartColumn
-     *
-     * @depends testTraitAdaptationAlias
      */
+    #[Depends('testTraitAdaptationAlias')]
     public function testTraitAdaptationAliasHasExpectedStartColumn(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(9, $alias->getStartColumn());
@@ -170,9 +172,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationAliasHasExpectedEndLine
-     *
-     * @depends testTraitAdaptationAlias
      */
+    #[Depends('testTraitAdaptationAlias')]
     public function testTraitAdaptationAliasHasExpectedEndLine(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(6, $alias->getEndLine());
@@ -180,9 +181,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationAliasHasExpectedEndColumn
-     *
-     * @depends testTraitAdaptationAlias
      */
+    #[Depends('testTraitAdaptationAlias')]
     public function testTraitAdaptationAliasHasExpectedEndColumn(ASTTraitAdaptationAlias $alias): void
     {
         static::assertEquals(46, $alias->getEndColumn());
@@ -213,9 +213,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(7, $reference->getStartLine());
@@ -223,9 +222,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
@@ -233,9 +231,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(7, $reference->getEndLine());
@@ -243,9 +240,8 @@ class ASTTraitAdaptationAliasTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(36, $reference->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitAdaptationPrecedenceTest.php
@@ -44,19 +44,22 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\InvalidStateException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptationPrecedence} class.
  *
- * @covers \PDepend\Source\AST\ASTTraitAdaptationPrecedence
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTraitAdaptationPrecedence::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 {
     /**
@@ -98,9 +101,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartLine
-     *
-     * @depends testTraitAdaptationPrecedence
      */
+    #[Depends('testTraitAdaptationPrecedence')]
     public function testTraitAdaptationPrecedenceHasExpectedStartLine(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(6, $precedence->getStartLine());
@@ -108,9 +110,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationPrecedenceHasExpectedStartColumn
-     *
-     * @depends testTraitAdaptationPrecedence
      */
+    #[Depends('testTraitAdaptationPrecedence')]
     public function testTraitAdaptationPrecedenceHasExpectedStartColumn(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(9, $precedence->getStartColumn());
@@ -118,9 +119,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndLine
-     *
-     * @depends testTraitAdaptationPrecedence
      */
+    #[Depends('testTraitAdaptationPrecedence')]
     public function testTraitAdaptationPrecedenceHasExpectedEndLine(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(8, $precedence->getEndLine());
@@ -128,9 +128,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationPrecedenceHasExpectedEndColumn
-     *
-     * @depends testTraitAdaptationPrecedence
      */
+    #[Depends('testTraitAdaptationPrecedence')]
     public function testTraitAdaptationPrecedenceHasExpectedEndColumn(ASTTraitAdaptationPrecedence $precedence): void
     {
         static::assertEquals(56, $precedence->getEndColumn());
@@ -161,9 +160,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(6, $reference->getStartLine());
@@ -171,9 +169,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
@@ -181,9 +178,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(6, $reference->getEndLine());
@@ -191,9 +187,8 @@ class ASTTraitAdaptationPrecedenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(36, $reference->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitAdaptationTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitAdaptation} class.
  *
- * @covers \PDepend\Source\AST\ASTTraitAdaptation
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTraitAdaptation::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTraitAdaptationTest extends ASTNodeTestCase
 {
     /**
@@ -72,9 +76,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationHasExpectedStartLine
-     *
-     * @depends testTraitAdaptation
      */
+    #[Depends('testTraitAdaptation')]
     public function testTraitAdaptationHasExpectedStartLine(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(5, $scope->getStartLine());
@@ -82,9 +85,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationHasExpectedStartColumn
-     *
-     * @depends testTraitAdaptation
      */
+    #[Depends('testTraitAdaptation')]
     public function testTraitAdaptationHasExpectedStartColumn(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(32, $scope->getStartColumn());
@@ -92,9 +94,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationHasExpectedEndLine
-     *
-     * @depends testTraitAdaptation
      */
+    #[Depends('testTraitAdaptation')]
     public function testTraitAdaptationHasExpectedEndLine(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(9, $scope->getEndLine());
@@ -102,9 +103,8 @@ class ASTTraitAdaptationTest extends ASTNodeTestCase
 
     /**
      * testTraitAdaptationHasExpectedEndColumn
-     *
-     * @depends testTraitAdaptation
      */
+    #[Depends('testTraitAdaptation')]
     public function testTraitAdaptationHasExpectedEndColumn(ASTTraitAdaptation $scope): void
     {
         static::assertEquals(5, $scope->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTraitReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitReferenceTest.php
@@ -45,18 +45,21 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitReference} class.
  *
- * @covers \PDepend\Source\AST\ASTTraitReference
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTraitReference::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTraitReferenceTest extends ASTNodeTestCase
 {
     /**
@@ -89,9 +92,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartLine(ASTTraitReference $reference): void
     {
         static::assertEquals(5, $reference->getStartLine());
@@ -99,9 +101,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedStartColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedStartColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(9, $reference->getStartColumn());
@@ -109,9 +110,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndLine
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndLine(ASTTraitReference $reference): void
     {
         static::assertEquals(5, $reference->getEndLine());
@@ -119,9 +119,8 @@ class ASTTraitReferenceTest extends ASTNodeTestCase
 
     /**
      * testTraitReferenceHasExpectedEndColumn
-     *
-     * @depends testTraitReference
      */
+    #[Depends('testTraitReference')]
     public function testTraitReferenceHasExpectedEndColumn(ASTTraitReference $reference): void
     {
         static::assertEquals(27, $reference->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitTest.php
@@ -45,19 +45,22 @@
 namespace PDepend\Source\AST;
 
 use PDepend\Source\Builder\BuilderContext;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTrait} class.
  *
- * @covers \PDepend\Source\AST\AbstractASTType
- * @covers \PDepend\Source\AST\ASTTrait
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTType::class)]
+#[CoversClass(ASTTrait::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[CoversClass(ASTTraitMethodCollisionException::class)]
+#[Group('unittest')]
 class ASTTraitTest extends AbstractASTArtifactTestCase
 {
     /**
@@ -214,11 +217,8 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
 
     /**
      * testGetAllMethodsWithMethodCollisionThrowsExpectedException
-     *
-     * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
-     *
-     * @group issue-154
      */
+    #[Group('issue-154')]
     public function testGetAllMethodsWithMethodCollisionThrowsExpectedException(): void
     {
         $this->expectException(ASTTraitMethodCollisionException::class);
@@ -232,11 +232,8 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
      * case with abstract methods.
      * No ASTTraitMethodCollisionException is thrown if only one method is not abstract.
      * Fix issue 154.
-     *
-     * @covers \PDepend\Source\AST\ASTTraitMethodCollisionException
-     *
-     * @group issue-154
      */
+    #[Group('issue-154')]
     public function testGetAllMethodsWithAbstractMethods(): void
     {
         $trait = $this->getFirstTraitForTest();

--- a/tests/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitUseStatementTest.php
@@ -44,20 +44,22 @@
 
 namespace PDepend\Source\AST;
 
-use ReflectionException;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTraitUseStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTTraitUseStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTraitUseStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTraitUseStatementTest extends ASTNodeTestCase
 {
     /**
@@ -120,16 +122,12 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseInsteadOfSelf
-     *
-     * @throws ReflectionException
-     *
-     * @group issue-154
      */
+    #[Group('issue-154')]
     public function testTraitUseInsteadOfSelf(): void
     {
         $class = $this->getFirstClassForTestCase();
         $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
-        $getTraitMethods->setAccessible(true);
         $methods = $getTraitMethods->invoke($class);
 
         static::assertIsArray($methods);
@@ -138,16 +136,12 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitMethodAlias
-     *
-     * @throws ReflectionException
-     *
-     * @group issue-154
      */
+    #[Group('issue-154')]
     public function testTraitMethodAlias(): void
     {
         $class = $this->getFirstClassForTestCase();
         $getTraitMethods = new ReflectionMethod($class, 'getTraitMethods');
-        $getTraitMethods->setAccessible(true);
         $methods = $getTraitMethods->invoke($class);
 
         static::assertIsArray($methods);
@@ -395,9 +389,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementHasExpectedStartLine
-     *
-     * @depends testTraitUseStatement
      */
+    #[Depends('testTraitUseStatement')]
     public function testTraitUseStatementHasExpectedStartLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -405,9 +398,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementHasExpectedStartColumn
-     *
-     * @depends testTraitUseStatement
      */
+    #[Depends('testTraitUseStatement')]
     public function testTraitUseStatementHasExpectedStartColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -415,9 +407,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementHasExpectedEndLine
-     *
-     * @depends testTraitUseStatement
      */
+    #[Depends('testTraitUseStatement')]
     public function testTraitUseStatementHasExpectedEndLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(9, $stmt->getEndLine());
@@ -425,9 +416,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementHasExpectedEndColumn
-     *
-     * @depends testTraitUseStatement
      */
+    #[Depends('testTraitUseStatement')]
     public function testTraitUseStatementHasExpectedEndColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getEndColumn());
@@ -448,9 +438,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementInTraitHasExpectedStartLine
-     *
-     * @depends testTraitUseStatementInTrait
      */
+    #[Depends('testTraitUseStatementInTrait')]
     public function testTraitUseStatementInTraitHasExpectedStartLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -458,9 +447,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementInTraitHasExpectedStartColumn
-     *
-     * @depends testTraitUseStatementInTrait
      */
+    #[Depends('testTraitUseStatementInTrait')]
     public function testTraitUseStatementInTraitHasExpectedStartColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -468,9 +456,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementInTraitHasExpectedEndLine
-     *
-     * @depends testTraitUseStatementInTrait
      */
+    #[Depends('testTraitUseStatementInTrait')]
     public function testTraitUseStatementInTraitHasExpectedEndLine(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getEndLine());
@@ -478,9 +465,8 @@ class ASTTraitUseStatementTest extends ASTNodeTestCase
 
     /**
      * testTraitUseStatementInTraitHasExpectedEndColumn
-     *
-     * @depends testTraitUseStatementInTrait
      */
+    #[Depends('testTraitUseStatementInTrait')]
     public function testTraitUseStatementInTraitHasExpectedEndColumn(ASTTraitUseStatement $stmt): void
     {
         static::assertEquals(19, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTryStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTryStatementTest.php
@@ -43,18 +43,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTryStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTTryStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTTryStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTryStatementTest extends ASTNodeTestCase
 {
     /**
@@ -72,9 +75,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the try-statement has the expected start line value.
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testTryStatementHasExpectedStartLine(ASTTryStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -82,9 +84,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the try-statement has the expected start column value.
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testTryStatementHasExpectedStartColumn(ASTTryStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -92,9 +93,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the try-statement has the expected end line value.
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testTryStatementHasExpectedEndLine(ASTTryStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
@@ -102,9 +102,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * Tests that the try-statement has the expected end column value.
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testTryStatementHasExpectedEndColumn(ASTTryStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
@@ -112,9 +111,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * testFirstChildOfTryStatementIsInstanceOfScopeStatement
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testFirstChildOfTryStatementIsInstanceOfScopeStatement(ASTTryStatement $stmt): void
     {
         static::assertInstanceOf(ASTScopeStatement::class, $stmt->getChild(0));
@@ -122,9 +120,8 @@ class ASTTryStatementTest extends ASTNodeTestCase
 
     /**
      * testSecondChildOfTryStatementIsInstanceOfCatchStatement
-     *
-     * @depends testTryStatement
      */
+    #[Depends('testTryStatement')]
     public function testSecondChildOfTryStatementIsInstanceOfCatchStatement(ASTTryStatement $stmt): void
     {
         static::assertInstanceOf(ASTCatchStatement::class, $stmt->getChild(1));

--- a/tests/php/PDepend/Source/AST/ASTTypeArrayTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTypeArrayTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeArray} class.
  *
- * @covers \PDepend\Source\AST\ASTTypeArray
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTTypeArray::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTypeArrayTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * testArrayTypeHasExpectedStartLine
-     *
-     * @depends testArrayType
      */
+    #[Depends('testArrayType')]
     public function testArrayTypeHasExpectedStartLine(ASTTypeArray $type): void
     {
         static::assertEquals(2, $type->getStartLine());
@@ -80,9 +83,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * testArrayTypeHasExpectedStartColumn
-     *
-     * @depends testArrayType
      */
+    #[Depends('testArrayType')]
     public function testArrayTypeHasExpectedStartColumn(ASTTypeArray $type): void
     {
         static::assertEquals(14, $type->getStartColumn());
@@ -90,9 +92,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * testArrayTypeHasExpectedEndLine
-     *
-     * @depends testArrayType
      */
+    #[Depends('testArrayType')]
     public function testArrayTypeHasExpectedEndLine(ASTTypeArray $type): void
     {
         static::assertEquals(2, $type->getEndLine());
@@ -100,9 +101,8 @@ class ASTTypeArrayTest extends ASTNodeTestCase
 
     /**
      * testArrayTypeHasExpectedEndColumn
-     *
-     * @depends testArrayType
      */
+    #[Depends('testArrayType')]
     public function testArrayTypeHasExpectedEndColumn(ASTTypeArray $type): void
     {
         static::assertEquals(18, $type->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTypeCallableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTypeCallableTest.php
@@ -44,17 +44,21 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeCallable} class.
  *
- * @covers \PDepend\Source\AST\ASTTypeCallable
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(ASTTypeCallable::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTypeCallableTest extends ASTNodeTestCase
 {
     /**
@@ -80,9 +84,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
 
     /**
      * testCallableTypeHasExpectedStartLine
-     *
-     * @depends testCallableType
      */
+    #[Depends('testCallableType')]
     public function testCallableTypeHasExpectedStartLine(ASTTypeCallable $type): void
     {
         static::assertEquals(2, $type->getStartLine());
@@ -90,9 +93,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
 
     /**
      * testCallableTypeHasExpectedEndLine
-     *
-     * @depends testCallableType
      */
+    #[Depends('testCallableType')]
     public function testCallableTypeHasExpectedEndLine(ASTTypeCallable $type): void
     {
         static::assertEquals(2, $type->getEndLine());
@@ -100,9 +102,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
 
     /**
      * testCallableTypeHasExpectedStartColumn
-     *
-     * @depends testCallableType
      */
+    #[Depends('testCallableType')]
     public function testCallableTypeHasExpectedStartColumn(ASTTypeCallable $type): void
     {
         static::assertEquals(27, $type->getStartColumn());
@@ -110,9 +111,8 @@ class ASTTypeCallableTest extends ASTNodeTestCase
 
     /**
      * testCallableTypeHasExpectedEndColumn
-     *
-     * @depends testCallableType
      */
+    #[Depends('testCallableType')]
     public function testCallableTypeHasExpectedEndColumn(ASTTypeCallable $type): void
     {
         static::assertEquals(34, $type->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTypeIterableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTypeIterableTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTTypeIterable} class.
  *
- * @covers \PDepend\Source\AST\ASTTypeIterable
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTTypeIterable::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTTypeIterableTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * testIterableTypeHasExpectedStartLine
-     *
-     * @depends testIterableType
      */
+    #[Depends('testIterableType')]
     public function testIterableTypeHasExpectedStartLine(ASTTypeIterable $type): void
     {
         static::assertEquals(2, $type->getStartLine());
@@ -80,9 +83,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * testIterableTypeHasExpectedStartColumn
-     *
-     * @depends testIterableType
      */
+    #[Depends('testIterableType')]
     public function testIterableTypeHasExpectedStartColumn(ASTTypeIterable $type): void
     {
         static::assertEquals(24, $type->getStartColumn());
@@ -90,9 +92,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * testIterableTypeHasExpectedEndLine
-     *
-     * @depends testIterableType
      */
+    #[Depends('testIterableType')]
     public function testIterableTypeHasExpectedEndLine(ASTTypeIterable $type): void
     {
         static::assertEquals(2, $type->getEndLine());
@@ -100,9 +101,8 @@ class ASTTypeIterableTest extends ASTNodeTestCase
 
     /**
      * testIterableTypeHasExpectedEndColumn
-     *
-     * @depends testIterableType
      */
+    #[Depends('testIterableType')]
     public function testIterableTypeHasExpectedEndColumn(ASTTypeIterable $type): void
     {
         static::assertEquals(31, $type->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTTypeTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTypeTest.php
@@ -43,15 +43,17 @@
 
 namespace PDepend\Source\AST;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTType} class.
  *
- * @covers \PDepend\Source\AST\ASTType
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTType::class)]
+#[Group('unittest')]
 class ASTTypeTest extends ASTNodeTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
+++ b/tests/php/PDepend/Source/AST/ASTUnaryExpressionTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTUnaryExpression} class.
  *
- * @covers \PDepend\Source\AST\ASTUnaryExpression
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTUnaryExpression::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTUnaryExpressionTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
 
     /**
      * testUnaryExpressionHasExpectedStartLine
-     *
-     * @depends testUnaryExpression
      */
+    #[Depends('testUnaryExpression')]
     public function testUnaryExpressionHasExpectedStartLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(4, $expr->getStartLine());
@@ -80,9 +83,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
 
     /**
      * testUnaryExpressionHasExpectedEndLine
-     *
-     * @depends testUnaryExpression
      */
+    #[Depends('testUnaryExpression')]
     public function testUnaryExpressionHasExpectedEndLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(5, $expr->getEndLine());
@@ -90,9 +92,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
 
     /**
      * testUnaryExpressionHasExpectedStartColumn
-     *
-     * @depends testUnaryExpression
      */
+    #[Depends('testUnaryExpression')]
     public function testUnaryExpressionHasExpectedStartColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(22, $expr->getStartColumn());
@@ -100,9 +101,8 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
 
     /**
      * testUnaryExpressionHasExpectedEndColumn
-     *
-     * @depends testUnaryExpression
      */
+    #[Depends('testUnaryExpression')]
     public function testUnaryExpressionHasExpectedEndColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(14, $expr->getEndColumn());
@@ -116,33 +116,25 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
         return $expr;
     }
 
-    /**
-     * @depends testUnaryExpressionNot
-     */
+    #[Depends('testUnaryExpressionNot')]
     public function testUnaryExpressionNotHasExpectedStartLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(4, $expr->getStartLine());
     }
 
-    /**
-     * @depends testUnaryExpressionNot
-     */
+    #[Depends('testUnaryExpressionNot')]
     public function testUnaryExpressionNotHasExpectedEndLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(6, $expr->getEndLine());
     }
 
-    /**
-     * @depends testUnaryExpressionNot
-     */
+    #[Depends('testUnaryExpressionNot')]
     public function testUnaryExpressionNotHasExpectedStartColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(12, $expr->getStartColumn());
     }
 
-    /**
-     * @depends testUnaryExpressionNot
-     */
+    #[Depends('testUnaryExpressionNot')]
     public function testUnaryExpressionNotHasExpectedEndColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(5, $expr->getEndColumn());
@@ -156,33 +148,25 @@ class ASTUnaryExpressionTest extends ASTNodeTestCase
         return $expr;
     }
 
-    /**
-     * @depends testUnaryExpressionSuppressWarning
-     */
+    #[Depends('testUnaryExpressionSuppressWarning')]
     public function testUnaryExpressionSuppressWarningHasExpectedStartLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(4, $expr->getStartLine());
     }
 
-    /**
-     * @depends testUnaryExpressionSuppressWarning
-     */
+    #[Depends('testUnaryExpressionSuppressWarning')]
     public function testUnaryExpressionSuppressWarningHasExpectedEndLine(ASTUnaryExpression $expr): void
     {
         static::assertSame(4, $expr->getEndLine());
     }
 
-    /**
-     * @depends testUnaryExpressionSuppressWarning
-     */
+    #[Depends('testUnaryExpressionSuppressWarning')]
     public function testUnaryExpressionSuppressWarningHasExpectedStartColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(12, $expr->getStartColumn());
     }
 
-    /**
-     * @depends testUnaryExpressionSuppressWarning
-     */
+    #[Depends('testUnaryExpressionSuppressWarning')]
     public function testUnaryExpressionSuppressWarningHasExpectedEndColumn(ASTUnaryExpression $expr): void
     {
         static::assertSame(47, $expr->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTUnsetStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTUnsetStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTUnsetStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTUnsetStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTUnsetStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTUnsetStatementTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
 
     /**
      * testUnsetStatementHasExpectedStartLine
-     *
-     * @depends testUnsetStatement
      */
+    #[Depends('testUnsetStatement')]
     public function testUnsetStatementHasExpectedStartLine(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -80,9 +83,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
 
     /**
      * testUnsetStatementHasExpectedStartColumn
-     *
-     * @depends testUnsetStatement
      */
+    #[Depends('testUnsetStatement')]
     public function testUnsetStatementHasExpectedStartColumn(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -90,9 +92,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
 
     /**
      * testUnsetStatementHasExpectedEndLine
-     *
-     * @depends testUnsetStatement
      */
+    #[Depends('testUnsetStatement')]
     public function testUnsetStatementHasExpectedEndLine(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
@@ -100,9 +101,8 @@ class ASTUnsetStatementTest extends ASTNodeTestCase
 
     /**
      * testUnsetStatementHasExpectedEndColumn
-     *
-     * @depends testUnsetStatement
      */
+    #[Depends('testUnsetStatement')]
     public function testUnsetStatementHasExpectedEndColumn(ASTUnsetStatement $stmt): void
     {
         static::assertEquals(22, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTValueTest.php
+++ b/tests/php/PDepend/Source/AST/ASTValueTest.php
@@ -45,17 +45,18 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTValue} class.
  *
- * @covers \PDepend\Source\AST\ASTValue
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.2
- *
- * @group unittest
  */
+#[CoversClass(ASTValue::class)]
+#[Group('unittest')]
 class ASTValueTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
+++ b/tests/php/PDepend/Source/AST/ASTVariableDeclaratorTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariableDeclarator} class.
  *
- * @covers \PDepend\Source\AST\ASTVariableDeclarator
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTVariableDeclarator::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTVariableDeclaratorTest extends ASTNodeTestCase
 {
     /**
@@ -107,9 +111,8 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testVariableDeclaratorHasExpectedStartLine
-     *
-     * @depends testVariableDeclarator
      */
+    #[Depends('testVariableDeclarator')]
     public function testVariableDeclaratorHasExpectedStartLine(ASTVariableDeclarator $declarator): void
     {
         static::assertEquals(4, $declarator->getStartLine());
@@ -117,9 +120,8 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testVariableDeclaratorHasExpectedStartColumn
-     *
-     * @depends testVariableDeclarator
      */
+    #[Depends('testVariableDeclarator')]
     public function testVariableDeclaratorHasExpectedStartColumn(ASTVariableDeclarator $declarator): void
     {
         static::assertEquals(12, $declarator->getStartColumn());
@@ -127,9 +129,8 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testVariableDeclaratorHasExpectedEndLine
-     *
-     * @depends testVariableDeclarator
      */
+    #[Depends('testVariableDeclarator')]
     public function testVariableDeclaratorHasExpectedEndLine(ASTVariableDeclarator $declarator): void
     {
         static::assertEquals(4, $declarator->getEndLine());
@@ -137,9 +138,8 @@ class ASTVariableDeclaratorTest extends ASTNodeTestCase
 
     /**
      * testVariableDeclaratorHasExpectedEndColumn
-     *
-     * @depends testVariableDeclarator
      */
+    #[Depends('testVariableDeclarator')]
     public function testVariableDeclaratorHasExpectedEndColumn(ASTVariableDeclarator $declarator): void
     {
         static::assertEquals(17, $declarator->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTVariableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTVariableTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariable} class.
  *
- * @covers \PDepend\Source\AST\ASTVariable
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTVariable::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTVariableTest extends ASTNodeTestCase
 {
     /**
@@ -97,9 +101,8 @@ class ASTVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableHasExpectedStartLine
-     *
-     * @depends testVariable
      */
+    #[Depends('testVariable')]
     public function testVariableHasExpectedStartLine(ASTVariable $variable): void
     {
         static::assertEquals(6, $variable->getStartLine());
@@ -107,9 +110,8 @@ class ASTVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableHasExpectedStartColumn
-     *
-     * @depends testVariable
      */
+    #[Depends('testVariable')]
     public function testVariableHasExpectedStartColumn(ASTVariable $variable): void
     {
         static::assertEquals(9, $variable->getStartColumn());
@@ -117,9 +119,8 @@ class ASTVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableHasExpectedEndLine
-     *
-     * @depends testVariable
      */
+    #[Depends('testVariable')]
     public function testVariableHasExpectedEndLine(ASTVariable $variable): void
     {
         static::assertEquals(6, $variable->getEndLine());
@@ -127,9 +128,8 @@ class ASTVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableHasExpectedEndColumn
-     *
-     * @depends testVariable
      */
+    #[Depends('testVariable')]
     public function testVariableHasExpectedEndColumn(ASTVariable $variable): void
     {
         static::assertEquals(10, $variable->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTVariableVariableTest.php
+++ b/tests/php/PDepend/Source/AST/ASTVariableVariableTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTVariableVariable} class.
  *
- * @covers \PDepend\Source\AST\ASTVariableVariable
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTVariableVariable::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTVariableVariableTest extends ASTNodeTestCase
 {
     /**
@@ -70,9 +74,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableVariableHasExpectedStartLine
-     *
-     * @depends testVariableVariable
      */
+    #[Depends('testVariableVariable')]
     public function testVariableVariableHasExpectedStartLine(ASTVariableVariable $variable): void
     {
         static::assertEquals(6, $variable->getStartLine());
@@ -80,9 +83,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableVariableHasExpectedStartColumn
-     *
-     * @depends testVariableVariable
      */
+    #[Depends('testVariableVariable')]
     public function testVariableVariableHasExpectedStartColumn(ASTVariableVariable $variable): void
     {
         static::assertEquals(9, $variable->getStartColumn());
@@ -90,9 +92,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableVariableHasExpectedEndLine
-     *
-     * @depends testVariableVariable
      */
+    #[Depends('testVariableVariable')]
     public function testVariableVariableHasExpectedEndLine(ASTVariableVariable $variable): void
     {
         static::assertEquals(8, $variable->getEndLine());
@@ -100,9 +101,8 @@ class ASTVariableVariableTest extends ASTNodeTestCase
 
     /**
      * testVariableVariableHasExpectedEndColumn
-     *
-     * @depends testVariableVariable
      */
+    #[Depends('testVariableVariable')]
     public function testVariableVariableHasExpectedEndColumn(ASTVariableVariable $variable): void
     {
         static::assertEquals(12, $variable->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTWhileStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTWhileStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTWhileStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTWhileStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTWhileStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTWhileStatementTest extends ASTNodeTestCase
 {
     /**
@@ -97,9 +101,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementHasExpectedStartLine
-     *
-     * @depends testWhileStatement
      */
+    #[Depends('testWhileStatement')]
     public function testWhileStatementHasExpectedStartLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -107,9 +110,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementHasExpectedStartColumn
-     *
-     * @depends testWhileStatement
      */
+    #[Depends('testWhileStatement')]
     public function testWhileStatementHasExpectedStartColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -117,9 +119,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementHasExpectedEndLine
-     *
-     * @depends testWhileStatement
      */
+    #[Depends('testWhileStatement')]
     public function testWhileStatementHasExpectedEndLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(6, $stmt->getEndLine());
@@ -127,9 +128,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementHasExpectedEndColumn
-     *
-     * @depends testWhileStatement
      */
+    #[Depends('testWhileStatement')]
     public function testWhileStatementHasExpectedEndColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getEndColumn());
@@ -150,9 +150,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartLine
-     *
-     * @depends testWhileStatementWithAlternativeScope
      */
+    #[Depends('testWhileStatementWithAlternativeScope')]
     public function testWhileStatementAlternativeScopeHasExpectedStartLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(4, $stmt->getStartLine());
@@ -160,9 +159,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementAlternativeScopeHasExpectedStartColumn
-     *
-     * @depends testWhileStatementWithAlternativeScope
      */
+    #[Depends('testWhileStatementWithAlternativeScope')]
     public function testWhileStatementAlternativeScopeHasExpectedStartColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(5, $stmt->getStartColumn());
@@ -170,9 +168,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndLine
-     *
-     * @depends testWhileStatementWithAlternativeScope
      */
+    #[Depends('testWhileStatementWithAlternativeScope')]
     public function testWhileStatementAlternativeScopeHasExpectedEndLine(ASTWhileStatement $stmt): void
     {
         static::assertEquals(8, $stmt->getEndLine());
@@ -180,9 +177,8 @@ class ASTWhileStatementTest extends ASTNodeTestCase
 
     /**
      * testWhileStatementAlternativeScopeHasExpectedEndColumn
-     *
-     * @depends testWhileStatementWithAlternativeScope
      */
+    #[Depends('testWhileStatementWithAlternativeScope')]
     public function testWhileStatementAlternativeScopeHasExpectedEndColumn(ASTWhileStatement $stmt): void
     {
         static::assertEquals(13, $stmt->getEndColumn());

--- a/tests/php/PDepend/Source/AST/ASTYieldStatementTest.php
+++ b/tests/php/PDepend/Source/AST/ASTYieldStatementTest.php
@@ -43,16 +43,20 @@
 
 namespace PDepend\Source\AST;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTYieldStatement} class.
  *
- * @covers \PDepend\Source\AST\ASTForeachStatement
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ASTForeachStatement::class)]
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTYieldStatementTest extends ASTNodeTestCase
 {
     /**
@@ -150,9 +154,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
      * testYieldKeyValueChildNodes
      *
      * @param ASTExpression[] $nodes
-     *
-     * @depends testYieldKeyValue
      */
+    #[Depends('testYieldKeyValue')]
     public function testYieldKeyValueChildNodes(array $nodes): void
     {
         static::assertEquals('$id', $nodes[0]->getImage());
@@ -174,9 +177,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldValueAssignmentSimpleParent
-     *
-     * @depends testYieldValueAssignmentSimple
      */
+    #[Depends('testYieldValueAssignmentSimple')]
     public function testYieldValueAssignmentSimpleParent(ASTStatement $yield): void
     {
         static::assertInstanceOf(
@@ -200,9 +202,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldValueAssignmentKeyValueParent
-     *
-     * @depends testYieldValueAssignmentKeyValue
      */
+    #[Depends('testYieldValueAssignmentKeyValue')]
     public function testYieldValueAssignmentKeyValueParent(ASTYieldStatement $yield): void
     {
         static::assertInstanceOf(
@@ -213,9 +214,8 @@ class ASTYieldStatementTest extends ASTNodeTestCase
 
     /**
      * testYieldValueAssignmentKeyValueChildren
-     *
-     * @depends testYieldValueAssignmentKeyValue
      */
+    #[Depends('testYieldValueAssignmentKeyValue')]
     public function testYieldValueAssignmentKeyValueChildren(ASTYieldStatement $yield): void
     {
         $nodes = $yield->getChildren();

--- a/tests/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
+++ b/tests/php/PDepend/Source/AST/AbstractASTArtifactTestCase.php
@@ -44,16 +44,17 @@
 namespace PDepend\Source\AST;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Base test case for abstract item implementations.
  *
- * @covers \PDepend\Source\AST\AbstractASTArtifact
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTArtifact::class)]
+#[Group('unittest')]
 abstract class AbstractASTArtifactTestCase extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
+++ b/tests/php/PDepend/Source/AST/ArtifactFilter/CollectionArtifactFilterTest.php
@@ -46,18 +46,19 @@ namespace PDepend\Source\AST\ASTArtifactList;
 
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter}
  * class.
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\CollectionArtifactFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(CollectionArtifactFilter::class)]
+#[Group('unittest')]
 class CollectionArtifactFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
+++ b/tests/php/PDepend/Source/AST/ArtifactFilter/NullArtifactFilterTest.php
@@ -52,17 +52,18 @@ use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter} class.
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\NullArtifactFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(NullArtifactFilter::class)]
+#[Group('unittest')]
 class NullArtifactFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
+++ b/tests/php/PDepend/Source/AST/ArtifactFilter/PackageArtifactFilterTest.php
@@ -48,17 +48,18 @@ use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter}
  * class.
  *
- * @covers \PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PackageArtifactFilter::class)]
+#[Group('unittest')]
 class PackageArtifactFilterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
+++ b/tests/php/PDepend/Source/ASTVisitor/DefaultListenerTest.php
@@ -47,16 +47,17 @@ use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the default visit listener implementation.
  *
- * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTVisitor::class)]
+#[Group('unittest')]
 class DefaultListenerTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
+++ b/tests/php/PDepend/Source/ASTVisitor/DefaultVisitorTest.php
@@ -48,16 +48,17 @@ use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\AST\ASTTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the default visitor implementation.
  *
- * @covers \PDepend\Source\ASTVisitor\AbstractASTVisitor
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(AbstractASTVisitor::class)]
+#[Group('unittest')]
 class DefaultVisitorTest extends AbstractTestCase
 {
     /**
@@ -346,7 +347,9 @@ class DefaultVisitorTest extends AbstractTestCase
      */
     public function testGetVisitListenersReturnsIterator(): void
     {
-        $visitor = $this->getMockForAbstractClass(AbstractASTVisitor::class);
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
+            ->onlyMethods([])
+            ->getMock();
         static::assertInstanceOf('Iterator', $visitor->getVisitListeners());
     }
 
@@ -355,7 +358,9 @@ class DefaultVisitorTest extends AbstractTestCase
      */
     public function testGetVisitListenersContainsAddedListener(): void
     {
-        $visitor = $this->getMockForAbstractClass(AbstractASTVisitor::class);
+        $visitor = $this->getMockBuilder(AbstractASTVisitor::class)
+            ->onlyMethods([])
+            ->getMock();
 
         $listener = $this->getMockBuilder(ASTVisitListener::class)
             ->getMock();

--- a/tests/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
+++ b/tests/php/PDepend/Source/Builder/BuilderContext/GlobalBuilderContextTest.php
@@ -49,17 +49,18 @@ use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\Builder\Builder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext}
  * class.
  *
- * @covers \PDepend\Source\Builder\BuilderContext\GlobalBuilderContext
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(GlobalBuilderContext::class)]
+#[Group('unittest')]
 class GlobalBuilderContextTest extends AbstractTestCase
 {
     /**
@@ -154,7 +155,7 @@ class GlobalBuilderContextTest extends AbstractTestCase
         $builder->expects(static::once())
             ->method('getClass')
             ->with(static::equalTo(__CLASS__))
-            ->will(static::returnValue($class));
+            ->willReturn($class);
 
         $context = new GlobalBuilderContext($builder);
         $context->getClass(__CLASS__);

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ArrayUnpackingWithStringKeysTest.php
@@ -45,19 +45,20 @@ use PDepend\Source\AST\ASTArray;
 use PDepend\Source\AST\ASTArrayElement;
 use PDepend\Source\AST\ASTReturnStatement;
 use PDepend\Source\AST\ASTTypeArray;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class ArrayUnpackingWithStringKeysTest extends PHPParserVersion81TestCase
 {
-    /**
-     * @group y
-     */
+    #[Group('y')]
     public function testArrayUnpackingWithStringKeys(): void
     {
         $method = $this->getFirstMethodForTestCase();

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
@@ -43,14 +43,17 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTMethod;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class AttributeTest extends PHPParserVersion81TestCase
 {
     public function testAttribute(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ConstructorPropertyPromotionTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ConstructorPropertyPromotionTest.php
@@ -43,15 +43,18 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\TokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class ConstructorPropertyPromotionTest extends PHPParserVersion81TestCase
 {
     public function testConstructorPropertyPromotion(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -49,14 +49,17 @@ use PDepend\Source\AST\ASTEnumCase;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTParameter;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class EnumTest extends PHPParserVersion81TestCase
 {
     public function testEnum(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ExplicitOctalNotationTest.php
@@ -43,15 +43,17 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTLiteral;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class ExplicitOctalNotationTest extends PHPParserVersion81TestCase
 {
     public function testExplicitOctalNotation(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FinalClassConstantTest.php
@@ -43,14 +43,17 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTConstantDefinition;
 use PDepend\Source\AST\State;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class FinalClassConstantTest extends PHPParserVersion81TestCase
 {
     public function testFinalClassConstant(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableSyntaxTest.php
@@ -48,14 +48,17 @@ use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTReturnStatement;
 use PDepend\Source\AST\ASTTypeCallable;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class FirstClassCallableSyntaxTest extends PHPParserVersion81TestCase
 {
     public function testFirstClassCallable(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/FirstClassCallableTest.php
@@ -42,14 +42,17 @@
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTArguments;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class FirstClassCallableTest extends PHPParserVersion81TestCase
 {
     public function testFirstClassCallable(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/InInitializersTest.php
@@ -48,13 +48,16 @@ use PDepend\Source\AST\ASTFormalParameters;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTValue;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class InInitializersTest extends PHPParserVersion81TestCase
 {
     public function testInInitializers(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/IntersectionTypesTest.php
@@ -46,15 +46,18 @@ use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\ParserException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class IntersectionTypesTest extends PHPParserVersion81TestCase
 {
     public function testIntersectionTypes(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/MatchExpressionTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/MatchExpressionTest.php
@@ -52,15 +52,18 @@ use PDepend\Source\AST\ASTReturnStatement;
 use PDepend\Source\AST\ASTSwitchLabel;
 use PDepend\Source\AST\ASTThrowStatement;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class MatchExpressionTest extends PHPParserVersion81TestCase
 {
     public function testMatchExpression(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NamedArgumentsTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NamedArgumentsTest.php
@@ -48,14 +48,17 @@ use PDepend\Source\AST\ASTLiteral;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class NamedArgumentsTest extends PHPParserVersion81TestCase
 {
     public function testNamedArguments(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NeverReturnTypeTest.php
@@ -41,13 +41,17 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class NeverReturnTypeTest extends PHPParserVersion81TestCase
 {
     public function testFunctionReturnType(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NullsafeOperatorTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/NullsafeOperatorTest.php
@@ -47,14 +47,17 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.3')]
 class NullsafeOperatorTest extends PHPParserVersion81TestCase
 {
     public function testNullsafeOperator(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/PHPParserVersion81TestCase.php
@@ -46,20 +46,22 @@ use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 abstract class PHPParserVersion81TestCase extends AbstractTestCase
 {
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            'PDepend\\Source\\Language\\PHP\\AbstractPHPParser',
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(AbstractPHPParser::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyClassTest.php
@@ -41,15 +41,18 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP81;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class ReadonlyClassTest extends PHPParserVersion81TestCase
 {
     public function testReadonlyClass(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ReadonlyPropertiesTest.php
@@ -46,14 +46,17 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTMethodPostfix;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\State;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.1
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8.1')]
 class ReadonlyPropertiesTest extends PHPParserVersion81TestCase
 {
     public function testReadonlyProperty(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ThrowExpressionTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/ThrowExpressionTest.php
@@ -50,14 +50,17 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTReturnStatement;
 use PDepend\Source\AST\ASTThrowStatement;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class ThrowExpressionTest extends PHPParserVersion81TestCase
 {
     public function testNullcoalescingThrow(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/UnionTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/UnionTypesTest.php
@@ -46,15 +46,18 @@ use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\AST\ASTType;
 use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PDepend\Source\Parser\ParserException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+#[Group('php8')]
 class UnionTypesTest extends PHPParserVersion81TestCase
 {
     public function testUnionTypes(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/AllowNullAndFalseAsStandAloneTypesTest.php
@@ -47,15 +47,17 @@ use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\PHPParserVersion82;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class AllowNullAndFalseAsStandAloneTypesTest extends PHPParserVersion82TestCase
 {
     public function testTypedProperties(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -45,15 +45,17 @@ use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTUnionType;
+use PDepend\Source\Language\PHP\PHPParserVersion82;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
 {
     public function testReturnParenthesesFirst(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/FetchPropertiesOfEnumsInConstExpressionsTest.php
@@ -49,15 +49,17 @@ use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTProperty;
 use PDepend\Source\AST\ASTPropertyPostfix;
+use PDepend\Source\Language\PHP\PHPParserVersion82;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class FetchPropertiesOfEnumsInConstExpressionsTest extends PHPParserVersion82TestCase
 {
     public function testEnumConst(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/PHPParserVersion82TestCase.php
@@ -44,23 +44,25 @@ namespace PDepend\Source\Language\PHP\Features\PHP82;
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPParserVersion82;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
 abstract class PHPParserVersion82TestCase extends AbstractTestCase
 {
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion82',
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(PHPParserVersion82::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/ReadonlyClassTest.php
@@ -41,14 +41,17 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\Language\PHP\PHPParserVersion82;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion82
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class ReadonlyClassTest extends PHPParserVersion82TestCase
 {
     public function testReadonlyClass(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TrueTypeTest.php
@@ -47,14 +47,17 @@ use PDepend\Source\AST\ASTNode;
 use PDepend\Source\AST\ASTParameter;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTVariableDeclarator;
+use PDepend\Source\Language\PHP\PHPParserVersion82;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class TrueTypeTest extends PHPParserVersion82TestCase
 {
     public function testTypedProperties(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/TypedClassConstantsTest.php
@@ -41,16 +41,18 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\Language\PHP\PHPParserVersion82;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.2
  */
+#[CoversClass(PHPParserVersion82::class)]
+#[Group('unittest')]
+#[Group('php8.2')]
 class TypedClassConstantsTest extends PHPParserVersion82TestCase
 {
     public function testInterface(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP83/DynamicClassConstantFetchTest.php
@@ -47,16 +47,19 @@ use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTScope;
 use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\PHPBuilder;
+use PDepend\Source\Language\PHP\PHPParserVersion83;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.3
  */
+#[CoversClass(PHPParserVersion83::class)]
+#[CoversClass(PHPBuilder::class)]
+#[Group('unittest')]
+#[Group('php8.3')]
 class DynamicClassConstantFetchTest extends PHPParserVersion83TestCase
 {
     public function testFetch(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP83/PHPParserVersion83TestCase.php
@@ -44,23 +44,25 @@ namespace PDepend\Source\Language\PHP\Features\PHP83;
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPParserVersion83;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PHPParserVersion83::class)]
+#[Group('unittest')]
 abstract class PHPParserVersion83TestCase extends AbstractTestCase
 {
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion83',
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(PHPParserVersion83::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP83/TypedClassConstantsTest.php
@@ -52,17 +52,19 @@ use PDepend\Source\AST\ASTMemberPrimaryPrefix;
 use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTValue;
+use PDepend\Source\Language\PHP\PHPParserVersion83;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\AST\ASTConstantDeclarator
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.3
  */
+#[CoversClass(ASTConstantDeclarator::class)]
+#[CoversClass(PHPParserVersion83::class)]
+#[Group('unittest')]
+#[Group('php8.3')]
 class TypedClassConstantsTest extends PHPParserVersion83TestCase
 {
     public function testInterface(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP83/UnionTypedClassConstantsTest.php
@@ -53,17 +53,19 @@ use PDepend\Source\AST\ASTScalarType;
 use PDepend\Source\AST\ASTTrait;
 use PDepend\Source\AST\ASTUnionType;
 use PDepend\Source\AST\ASTValue;
+use PDepend\Source\Language\PHP\PHPParserVersion83;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\AST\ASTConstantDeclarator
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion83
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.3
  */
+#[CoversClass(ASTConstantDeclarator::class)]
+#[CoversClass(PHPParserVersion83::class)]
+#[Group('unittest')]
+#[Group('php8.3')]
 class UnionTypedClassConstantsTest extends PHPParserVersion83TestCase
 {
     public function testInterface(): void

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
@@ -41,15 +41,19 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP84;
 
+use PDepend\Source\AST\ASTConstantDeclarator;
+use PDepend\Source\Language\PHP\PHPParserVersion84;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
- * @covers \PDepend\Source\AST\ASTConstantDeclarator
- * @covers \PDepend\Source\Language\PHP\PHPParserVersion84
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
- * @group php8.4
  */
+#[CoversClass(ASTConstantDeclarator::class)]
+#[CoversClass(PHPParserVersion84::class)]
+#[Group('unittest')]
+#[Group('php8.4')]
 class AsymmetricPropertyVisibilityTest extends PHPParserVersion84TestCase
 {
     /**

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP84/PHPParserVersion84TestCase.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP84/PHPParserVersion84TestCase.php
@@ -44,22 +44,25 @@ namespace PDepend\Source\Language\PHP\Features\PHP84;
 use PDepend\AbstractTestCase;
 use PDepend\Source\Builder\Builder;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PDepend\Source\Language\PHP\PHPParserVersion84;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
  */
+#[CoversClass(PHPParserVersion84::class)]
+#[Group('unittest')]
 abstract class PHPParserVersion84TestCase extends AbstractTestCase
 {
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            'PDepend\\Source\\Language\\PHP\\PHPParserVersion84',
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(PHPParserVersion84::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPBuilderTest.php
@@ -138,16 +138,17 @@ use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableDeclarator;
 use PDepend\Source\AST\ASTVariableVariable;
 use PDepend\Source\AST\ASTWhileStatement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case implementation for the default node builder implementation.
  *
- * @covers \PDepend\Source\Language\PHP\PHPBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PHPBuilder::class)]
+#[Group('unittest')]
 class PHPBuilderTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -60,17 +60,21 @@ use PDepend\Source\AST\ASTTypeArray;
 use PDepend\Source\AST\ASTTypeCallable;
 use PDepend\Source\Parser\TokenStreamEndException;
 use PDepend\Source\Parser\UnexpectedTokenException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPParserGeneric} class.
  *
- * @covers \PDepend\Source\Language\PHP\PHPParserGeneric
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.9.20
- *
- * @group unittest
  */
+#[CoversClass(PHPParserGeneric::class)]
+#[CoversClass(UnexpectedTokenException::class)]
+#[CoversClass(TokenStreamEndException::class)]
+#[Group('unittest')]
 class PHPParserGenericTest extends AbstractTestCase
 {
     /**
@@ -338,8 +342,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionOnTokenStreamEnd
-     *
-     * @covers \PDepend\Source\Parser\TokenStreamEndException
      */
     public function testParserThrowsExpectedExceptionOnTokenStreamEnd(): void
     {
@@ -350,8 +352,6 @@ class PHPParserGenericTest extends AbstractTestCase
 
     /**
      * testParserThrowsExpectedExceptionForUnexpectedTokenType
-     *
-     * @covers \PDepend\Source\Parser\UnexpectedTokenException
      */
     public function testParserThrowsExpectedExceptionForUnexpectedTokenType(): void
     {
@@ -1182,33 +1182,25 @@ class PHPParserGenericTest extends AbstractTestCase
         return $expr;
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedStartLine(ASTExpression $expr): void
     {
         static::assertSame(6, $expr->getStartLine());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedEndLine(ASTExpression $expr): void
     {
         static::assertSame(6, $expr->getEndLine());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedStartColumn(ASTExpression $expr): void
     {
         static::assertSame(27, $expr->getStartColumn());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedEndColumn(ASTExpression $expr): void
     {
         static::assertSame(29, $expr->getEndColumn());
@@ -1246,9 +1238,7 @@ class PHPParserGenericTest extends AbstractTestCase
         return $namespaces[0];
     }
 
-    /**
-     * @depends testGroupUseStatement
-     */
+    #[Depends('testGroupUseStatement')]
     public function testGroupUseStatementClassNameResolution(ASTNamespace $namespace): void
     {
         $classes = $namespace->getClasses();
@@ -1260,9 +1250,7 @@ class PHPParserGenericTest extends AbstractTestCase
         );
     }
 
-    /**
-     * @depends testGroupUseStatement
-     */
+    #[Depends('testGroupUseStatement')]
     public function testGroupUseStatementAliasResolution(ASTNamespace $namespace): void
     {
         $classes = $namespace->getClasses();

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserVersion81Test.php
@@ -91,16 +91,19 @@ use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Source\Tokenizer\Tokens;
 use PDepend\Util\Cache\CacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionMethod;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class PHPParserVersion81Test extends AbstractTestCase
 {
     /**
@@ -153,7 +156,6 @@ class PHPParserVersion81Test extends AbstractTestCase
             ->willReturn(null);
         $parser = $this->createPHPParser($tokenizer, $builder, $cache);
         $parseArray = new ReflectionMethod($parser, 'parseArray');
-        $parseArray->setAccessible(true);
         $parseArray->invoke($parser, new ASTArray());
     }
 
@@ -408,7 +410,6 @@ class PHPParserVersion81Test extends AbstractTestCase
             ->willReturn(new Token(Tokens::T_FUNCTION, 'function', 1, 1, 1, 9));
         $parser = $this->createPHPParser($tokenizer, $builder, $cache);
         $parseArray = new ReflectionMethod($parser, 'parseStaticValueVersionSpecific');
-        $parseArray->setAccessible(true);
         $parseArray->invoke($parser, new ASTValue());
     }
 
@@ -682,33 +683,25 @@ class PHPParserVersion81Test extends AbstractTestCase
         return $expr;
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedStartLine(ASTExpression $expr): void
     {
         static::assertSame(6, $expr->getStartLine());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedEndLine(ASTExpression $expr): void
     {
         static::assertSame(6, $expr->getEndLine());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedStartColumn(ASTExpression $expr): void
     {
         static::assertSame(27, $expr->getStartColumn());
     }
 
-    /**
-     * @depends testSpaceshipOperatorWithArrays
-     */
+    #[Depends('testSpaceshipOperatorWithArrays')]
     public function testSpaceshipOperatorHasExpectedEndColumn(ASTExpression $expr): void
     {
         static::assertSame(29, $expr->getEndColumn());
@@ -746,9 +739,7 @@ class PHPParserVersion81Test extends AbstractTestCase
         return $namespaces[0];
     }
 
-    /**
-     * @depends testGroupUseStatement
-     */
+    #[Depends('testGroupUseStatement')]
     public function testGroupUseStatementClassNameResolution(ASTNamespace $namespace): void
     {
         $classes = $namespace->getClasses();
@@ -760,9 +751,7 @@ class PHPParserVersion81Test extends AbstractTestCase
         );
     }
 
-    /**
-     * @depends testGroupUseStatement
-     */
+    #[Depends('testGroupUseStatement')]
     public function testGroupUseStatementAliasResolution(ASTNamespace $namespace): void
     {
         $classes = $namespace->getClasses();
@@ -1009,7 +998,6 @@ class PHPParserVersion81Test extends AbstractTestCase
     {
         $namespaces = $this->parseCodeResourceForTest();
         static::assertGreaterThan(0, count($namespaces));
-        static::assertContainsOnlyInstancesOf(ASTNamespace::class, $namespaces);
     }
 
     public function testHereDocAndNowDoc(): void
@@ -1504,9 +1492,9 @@ class PHPParserVersion81Test extends AbstractTestCase
 
     protected function createPHPParser(Tokenizer $tokenizer, Builder $builder, CacheDriver $cache): AbstractPHPParser
     {
-        return $this->getMockForAbstractClass(
-            AbstractPHPParser::class,
-            [$tokenizer, $builder, $cache]
-        );
+        return $this->getMockBuilder(AbstractPHPParser::class)
+            ->setConstructorArgs([$tokenizer, $builder, $cache])
+            ->onlyMethods([])
+            ->getMock();
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPTokenizerInternalTest.php
@@ -47,16 +47,17 @@ use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\Tokenizer\Tokenizer;
 use PDepend\Source\Tokenizer\Tokens;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\PHPTokenizerInternal} class.
  *
- * @covers \PDepend\Source\Language\PHP\PHPTokenizerInternal
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(PHPTokenizerInternal::class)]
+#[Group('unittest')]
 class PHPTokenizerInternalTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
+++ b/tests/php/PDepend/Source/Parser/ASTAllocationExpressionParsingTest.php
@@ -53,17 +53,19 @@ use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTStaticReference;
 use PDepend\Source\AST\ASTVariable;
 use PDepend\Source\AST\ASTVariableVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.2
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTAllocationExpressionParsingTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
+++ b/tests/php/PDepend/Source/Parser/ASTArgumentsParsingTest.php
@@ -56,17 +56,19 @@ use PDepend\Source\AST\ASTParentReference;
 use PDepend\Source\AST\ASTPropertyPostfix;
 use PDepend\Source\AST\ASTSelfReference;
 use PDepend\Source\AST\ASTVariable;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.2
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTArgumentsParsingTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
+++ b/tests/php/PDepend/Source/Parser/ASTFormalParameterParsingTest.php
@@ -46,17 +46,19 @@ namespace PDepend\Source\Parser;
 
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTParentReference;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.2
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class ASTFormalParameterParsingTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/NamespaceResovingTest.php
+++ b/tests/php/PDepend/Source/Parser/NamespaceResovingTest.php
@@ -45,17 +45,19 @@
 namespace PDepend\Source\Parser;
 
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the namespace resolving in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.5
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class NamespaceResovingTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/SymbolTableTest.php
+++ b/tests/php/PDepend/Source/Parser/SymbolTableTest.php
@@ -44,14 +44,14 @@
 namespace PDepend\Source\Parser;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link SymbolTable} class.
- *
- * @covers \PDepend\Source\Parser\SymbolTable
- *
- * @group unittest
  */
+#[CoversClass(SymbolTable::class)]
+#[Group('unittest')]
 class SymbolTableTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/TokenStackTest.php
+++ b/tests/php/PDepend/Source/Parser/TokenStackTest.php
@@ -45,17 +45,18 @@
 namespace PDepend\Source\Parser;
 
 use PDepend\Source\Tokenizer\Token;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Parser\TokenStack} class.
  *
- * @covers \PDepend\Source\Parser\TokenStack
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.0
- *
- * @group unittest
  */
+#[CoversClass(TokenStack::class)]
+#[Group('unittest')]
 class TokenStackTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Parser/UnstructuredCodeTest.php
+++ b/tests/php/PDepend/Source/Parser/UnstructuredCodeTest.php
@@ -44,16 +44,19 @@
 
 namespace PDepend\Source\Parser;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
 /**
  * Tests for unstructured code handling in the {@link \PDepend\Source\Language\PHP\AbstractPHPParser} class.
  *
- * @covers \PDepend\Source\Language\PHP\AbstractPHPParser
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 1.0.0
- *
- * @group unittest
  */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
 class UnstructuredCodeTest extends AbstractParserTestCase
 {
     /**

--- a/tests/php/PDepend/Source/Tokenizer/TokenTest.php
+++ b/tests/php/PDepend/Source/Tokenizer/TokenTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Source\Tokenizer;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Source\Tokenizer\Token} class.
  *
- * @covers \PDepend\Source\Tokenizer\Token
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Token::class)]
+#[Group('unittest')]
 class TokenTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/TextUI/CommandTest.php
+++ b/tests/php/PDepend/TextUI/CommandTest.php
@@ -49,18 +49,19 @@ use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTNamespace;
 use PDepend\Util\ConfigurationInstance;
 use PDepend\Util\Log;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use ReflectionClass;
 use stdClass;
 
 /**
  * Test case for the text ui command.
  *
- * @covers \PDepend\TextUI\Command
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Command::class)]
+#[Group('unittest')]
 class CommandTest extends AbstractTestCase
 {
     /** Expected output of the --version option. */
@@ -152,7 +153,11 @@ class CommandTest extends AbstractTestCase
     public function testCommandCliErrorMessageIfNoArgvArrayExists(): void
     {
         [, $actual] = $this->executeCommand();
-        $startsWith = 'Unknown error, no $argv array available.' . PHP_EOL . PHP_EOL;
+        if (false === (bool) ini_get('register_argc_argv')) {
+            $startsWith = 'Please enable register_argc_argv in your php.ini.' . PHP_EOL . PHP_EOL;
+        } else {
+            $startsWith = 'Unknown error, no $argv array available.' . PHP_EOL . PHP_EOL;
+        }
         static::assertIsString($actual);
         $this->assertHelpOutput($actual, $startsWith);
     }

--- a/tests/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/tests/php/PDepend/TextUI/ResultPrinterTest.php
@@ -49,16 +49,17 @@ use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Source\AST\ASTMethod;
 use PDepend\Source\Language\PHP\PHPBuilder;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the default text ui result printer.
  *
- * @covers \PDepend\TextUI\ResultPrinter
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(ResultPrinter::class)]
+#[Group('unittest')]
 class ResultPrinterTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/TextUI/RunnerTest.php
+++ b/tests/php/PDepend/TextUI/RunnerTest.php
@@ -53,18 +53,19 @@ use PDepend\Report\ReportGeneratorFactory;
 use PDepend\Source\AST\ASTArtifactList;
 use PDepend\Source\AST\ASTArtifactList\PackageArtifactFilter;
 use PDepend\Source\AST\ASTNamespace;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
  * Test case for the text ui runner.
  *
- * @covers \PDepend\TextUI\Runner
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Runner::class)]
+#[Group('unittest')]
 class RunnerTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/Cache/AbstractDriverTestCase.php
+++ b/tests/php/PDepend/Util/Cache/AbstractDriverTestCase.php
@@ -44,6 +44,7 @@
 namespace PDepend\Util\Cache;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Abstract test case that validates the behavior of concrete driver
@@ -51,9 +52,8 @@ use PDepend\AbstractTestCase;
  *
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[Group('unittest')]
 abstract class AbstractDriverTestCase extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/Cache/CacheFactoryTest.php
+++ b/tests/php/PDepend/Util/Cache/CacheFactoryTest.php
@@ -47,17 +47,18 @@ use PDepend\AbstractTestCase;
 use PDepend\Application;
 use PDepend\Util\Cache\Driver\FileCacheDriver;
 use PDepend\Util\Cache\Driver\MemoryCacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\CacheFactory} class.
  *
- * @covers \PDepend\Util\Cache\CacheFactory
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(CacheFactory::class)]
+#[Group('unittest')]
 class CacheFactoryTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
+++ b/tests/php/PDepend/Util/Cache/Driver/File/FileCacheDirectoryTest.php
@@ -46,17 +46,18 @@ namespace PDepend\Util\Cache\Driver\File;
 
 use PDepend\AbstractTestCase;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheDirectory} class.
  *
- * @covers \PDepend\Util\Cache\Driver\File\FileCacheDirectory
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
  * @since 0.10.0
- *
- * @group unittest
  */
+#[CoversClass(FileCacheDirectory::class)]
+#[Group('unittest')]
 class FileCacheDirectoryTest extends AbstractTestCase
 {
     /** Temporary cache directory. */

--- a/tests/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
+++ b/tests/php/PDepend/Util/Cache/Driver/File/FileCacheGarbageCollectorTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Util\Cache\Driver\File;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector} class.
  *
- * @covers \PDepend\Util\Cache\Driver\File\FileCacheGarbageCollector
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(FileCacheGarbageCollector::class)]
+#[Group('unittest')]
 class FileCacheGarbageCollectorTest extends AbstractTestCase
 {
     /** Temporary cache directory. */

--- a/tests/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
+++ b/tests/php/PDepend/Util/Cache/Driver/FileCacheDriverTest.php
@@ -45,17 +45,18 @@ namespace PDepend\Util\Cache\Driver;
 
 use PDepend\Util\Cache\AbstractDriverTestCase;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\FileCacheDriver} class.
  *
- * @covers \PDepend\Util\Cache\Driver\FileCacheDriver
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(FileCacheDriver::class)]
+#[Group('unittest')]
 class FileCacheDriverTest extends AbstractDriverTestCase
 {
     /** Temporary cache directory. */

--- a/tests/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
+++ b/tests/php/PDepend/Util/Cache/Driver/MemoryCacheDriverTest.php
@@ -45,16 +45,17 @@ namespace PDepend\Util\Cache\Driver;
 
 use PDepend\Util\Cache\AbstractDriverTestCase;
 use PDepend\Util\Cache\CacheDriver;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Util\Cache\Driver\MemoryCacheDriver} class.
  *
- * @covers \PDepend\Util\Cache\Driver\MemoryCacheDriver
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(MemoryCacheDriver::class)]
+#[Group('unittest')]
 class MemoryCacheDriverTest extends AbstractDriverTestCase
 {
     /**

--- a/tests/php/PDepend/Util/ConfigurationTest.php
+++ b/tests/php/PDepend/Util/ConfigurationTest.php
@@ -46,18 +46,19 @@ namespace PDepend\Util;
 
 use OutOfRangeException;
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**
  * Test case for the {@link \PDepend\Util\Configuration} class.
  *
- * @covers \PDepend\Util\Configuration
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @since 0.10.0
- *
- * @group unittest
  */
+#[CoversClass(Configuration::class)]
+#[Group('unittest')]
 class ConfigurationTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/Coverage/CloverReportTest.php
+++ b/tests/php/PDepend/Util/Coverage/CloverReportTest.php
@@ -46,17 +46,18 @@ namespace PDepend\Util\Coverage;
 use PDepend\AbstractTestCase;
 use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTMethod;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use SimpleXMLElement;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\CloverReport} class.
  *
- * @covers \PDepend\Util\Coverage\CloverReport
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(CloverReport::class)]
+#[Group('unittest')]
 class CloverReportTest extends AbstractTestCase
 {
     /**
@@ -192,20 +193,20 @@ class CloverReportTest extends AbstractTestCase
             ->getMock();
         $file->expects(static::any())
             ->method('getFileName')
-            ->will(static::returnValue('/' . $name . '.php'));
+            ->willReturn('/' . $name . '.php');
 
         $method = $this->getMockBuilder(ASTMethod::class)
             ->setConstructorArgs([$name])
             ->getMock();
         $method->expects(static::once())
             ->method('getCompilationUnit')
-            ->will(static::returnValue($file));
+            ->willReturn($file);
         $method->expects(static::once())
             ->method('getStartLine')
-            ->will(static::returnValue($startLine));
+            ->willReturn($startLine);
         $method->expects(static::once())
             ->method('getEndLine')
-            ->will(static::returnValue($endLine));
+            ->willReturn($endLine);
 
         return $method;
     }

--- a/tests/php/PDepend/Util/Coverage/FactoryTest.php
+++ b/tests/php/PDepend/Util/Coverage/FactoryTest.php
@@ -44,17 +44,18 @@
 namespace PDepend\Util\Coverage;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use RuntimeException;
 
 /**
  * Test case for the {@link \PDepend\Util\Coverage\Factory} class.
  *
- * @covers \PDepend\Util\Coverage\Factory
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Factory::class)]
+#[Group('unittest')]
 class FactoryTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/FileUtilTest.php
+++ b/tests/php/PDepend/Util/FileUtilTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Util\FileUtil} class.
  *
- * @covers \PDepend\Util\FileUtil
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(FileUtil::class)]
+#[Group('unittest')]
 class FileUtilTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/IdBuilderTest.php
+++ b/tests/php/PDepend/Util/IdBuilderTest.php
@@ -50,17 +50,18 @@ use PDepend\Source\AST\ASTCompilationUnit;
 use PDepend\Source\AST\ASTFunction;
 use PDepend\Source\AST\ASTInterface;
 use PDepend\Source\AST\ASTMethod;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for the {@link \PDepend\Util\IdBuilder} class.
  *
- * @covers \PDepend\Util\IdBuilder
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
  * @since 0.9.12
- *
- * @group unittest
  */
+#[CoversClass(IdBuilder::class)]
+#[Group('unittest')]
 class IdBuilderTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/ImageConvertTest.php
+++ b/tests/php/PDepend/Util/ImageConvertTest.php
@@ -44,17 +44,18 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use stdClass;
 
 /**
  * Test case for the image convert utility class.
  *
- * @covers \PDepend\Util\ImageConvert
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php  BSD License
- *
- * @group unittest
  */
+#[CoversClass(ImageConvert::class)]
+#[Group('unittest')]
 class ImageConvertTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/TypeTest.php
+++ b/tests/php/PDepend/Util/TypeTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for type utility class.
  *
- * @covers \PDepend\Util\Type
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Type::class)]
+#[Group('unittest')]
 class TypeTest extends AbstractTestCase
 {
     /**

--- a/tests/php/PDepend/Util/Utf8UtilTest.php
+++ b/tests/php/PDepend/Util/Utf8UtilTest.php
@@ -44,16 +44,17 @@
 namespace PDepend\Util;
 
 use PDepend\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Test case for type utility class.
  *
- * @covers \PDepend\Util\Utf8Util
  * @copyright 2008-2017 Manuel Pichler. All rights reserved.
  * @license http://www.opensource.org/licenses/bsd-license.php BSD License
- *
- * @group unittest
  */
+#[CoversClass(Utf8Util::class)]
+#[Group('unittest')]
 class Utf8UtilTest extends AbstractTestCase
 {
     public function testEnsureEncoding(): void


### PR DESCRIPTION
Type: bugfix / feature
Issue: #901
Breaking change: no

- Update PHPStan to 2.1.32
- Enable PHPStan on PHP 8.4
- Enable PHP 8.5 in CI
- Correct newly discovered issues
- Allow PHPUnit 11
- Fix deprecations
- Corrected coverage on a couple of tests

Note: per test method coverage is no longer possible in PHPUnit 12 we would either have to split the tests up in to multiple classes or accept (which is what I have done is this PR) that other method in the test class may also result in test coverage of the classes tested  see: https://github.com/sebastianbergmann/phpunit/issues/5837#issuecomment-2119118036