### PR TITLE
Update branch alias in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.x-dev"
+            "dev-3.x": "3.x-dev"
         }
     },
     "scripts": {


### PR DESCRIPTION
By updating the branch alias it should be possible to require this version by "pdepend/pdepend": "dev-3.x"

It will allow migrating to Symfony 8.

