### PR TITLE
Better handeling of worker issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": ">=8.1",
         "php-64bit": "*",
+        "ext-sockets": "*",
         "fidry/cpu-core-counter": "^1.1",
         "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -72,6 +72,7 @@ use PDepend\Source\Parser\ParserException;
 use PDepend\Util\Cache\CacheFactory;
 use PDepend\Util\Configuration;
 use React\EventLoop\Factory as LoopFactory;
+use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
@@ -527,9 +528,9 @@ class Engine
         if ($fileCount > 1) {
             $coreCount = (new CpuCoreCounter())->getCount();
             if ($coreCount > 1) {
-                $this->runMultiProcessParse($files, $fileCount, $coreCount);
-
-                return;
+                if ($this->runMultiProcessParse($files, $fileCount, $coreCount)) {
+                    return;
+                }
             }
         }
 
@@ -575,7 +576,7 @@ class Engine
     /**
      * @param ArrayIterator<int, string> $files
      */
-    private function runMultiProcessParse(ArrayIterator $files, int $fileCount, int $coreCount): void
+    private function runMultiProcessParse(ArrayIterator $files, int $fileCount, int $coreCount): bool
     {
         $processFactory = new ProcessFactory($this->withoutAnnotations);
         $loop = LoopFactory::create();
@@ -586,7 +587,12 @@ class Engine
             $buffers[$proccessNo] = '';
             $process->start($loop);
 
-            assert(is_callable($process->stdout));
+            if (!$process->stdout instanceof ReadableStreamInterface
+                || !$process->stdin instanceof WritableStreamInterface
+            ) {
+                return false;
+            }
+
             $process->stdout->on('data', function (string $chunk) use (&$buffers, $proccessNo, $files, $process): void {
                 $buffers[$proccessNo] .= $chunk;
 
@@ -606,26 +612,24 @@ class Engine
                         $this->parseExceptions[] = $data;
                     }
 
-                    if ($process->stdin instanceof WritableStreamInterface) {
-                        if ($files->valid()) {
-                            $process->stdin->write($files->current() . "\n");
-                            $files->next();
-                        } else {
-                            $process->stdin->end();
-                        }
+                    if ($files->valid()) {
+                        $process->stdin->write($files->current() . "\n");
+                        $files->next();
+                    } else {
+                        $process->stdin->end();
                     }
                     $this->fireEndFileParsing();
                 }
             });
 
-            if ($process->stdin instanceof WritableStreamInterface) {
-                $process->stdin->write($files->current() . "\n");
-                $files->next();
-            }
+            $process->stdin->write($files->current() . "\n");
+            $files->next();
         }
         $loop->run();
         $cache = $this->cacheFactory->create();
         $this->builder->setCache($cache);
+
+        return true;
     }
 
     private function parseFile(PHPTokenizerInternal $tokenizer, string $file): void


### PR DESCRIPTION
Type: bugfix
fixes #913
Breaking change: no

ext-sockets is required for communicating with workers on Windows, we enable it on all platforms for simplicity.

Additionally it now does better checks for worker initialization and if it fails it falls back to single threading. We could technically leave out the ext-sockets requirement but I don't think it's really worth it to not require this extension as it's widely available and things works better with it, and we avoid having multiple code paths.