### PR TITLE
Make sockets optional, fix serialization on docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "php": ">=8.1",
         "php-64bit": "*",
-        "ext-sockets": "*",
         "fidry/cpu-core-counter": "^1.1",
         "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
@@ -50,6 +49,9 @@
         "branch-alias": {
             "dev-master": "2.x-dev"
         }
+    },
+    "suggest": {
+        "ext-sockets": "Recommended on Windows for multiprocessing support"
     },
     "scripts": {
         "analyse": [

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -71,7 +71,7 @@ use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PDepend\Source\Parser\ParserException;
 use PDepend\Util\Cache\CacheFactory;
 use PDepend\Util\Configuration;
-use React\EventLoop\Factory as LoopFactory;
+use React\EventLoop\Loop;
 use React\Stream\ReadableStreamInterface;
 use React\Stream\WritableStreamInterface;
 use RecursiveDirectoryIterator;
@@ -579,7 +579,7 @@ class Engine
     private function runMultiProcessParse(ArrayIterator $files, int $fileCount, int $coreCount): bool
     {
         $processFactory = new ProcessFactory($this->withoutAnnotations);
-        $loop = LoopFactory::create();
+        $loop = Loop::get();
         $proccessCount = min($fileCount, $coreCount);
         $buffers = [];
         for ($proccessNo = 0; $proccessNo < $proccessCount; $proccessNo++) {

--- a/src/ProcessFactory.php
+++ b/src/ProcessFactory.php
@@ -60,16 +60,16 @@ final class ProcessFactory
     {
         $commandArgs = $this->getCommandArgs();
 
-        return new Process(
-            implode(' ', $commandArgs),
-            null,
-            null,
-            [
+        $fds = null;
+        if (extension_loaded('sockets')) {
+            $fds = [
                 ['socket'],
                 ['socket'],
                 ['socket'],
-            ]
-        );
+            ];
+        }
+
+        return new Process(implode(' ', $commandArgs), null, null, $fds);
     }
 
     /**

--- a/src/Source/AST/ASTClass.php
+++ b/src/Source/AST/ASTClass.php
@@ -63,7 +63,13 @@ class ASTClass extends AbstractASTClassOrInterface
 
     public function __sleep(): array
     {
-        return ['properties', ...parent::__sleep()];
+        $properties = parent::__sleep();
+
+        if (static::class === self::class) {
+            return ['properties', ...$properties];
+        }
+
+        return $properties;
     }
 
     /**

--- a/src/Source/AST/ASTMethod.php
+++ b/src/Source/AST/ASTMethod.php
@@ -68,7 +68,7 @@ class ASTMethod extends AbstractASTCallable
      */
     public function __sleep(): array
     {
-        return ['modifiers', ...parent::__sleep()];
+        return ['modifiers', 'parentClass', ...parent::__sleep()];
     }
 
     /**

--- a/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
+++ b/tests/php/PDepend/Source/AST/ASTAnonymousClassTest.php
@@ -83,6 +83,16 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
         static::assertEquals(5, $expr->getEndColumn());
     }
 
+    public function testAnonymousClassSupportsProperties(): void
+    {
+        $property = $this->getFirstAnonymousClassInFunction()
+            ->getProperties()
+            ->current();
+
+        static::assertSame(5, $property->getStartLine());
+        static::assertSame(5, $property->getEndLine());
+    }
+
     /**
      * testMagicSleepMethodReturnsExpectedSetOfPropertyNames
      */
@@ -94,7 +104,6 @@ class ASTAnonymousClassTest extends ASTNodeTestCase
         static::assertEquals(
             [
                 'metadata',
-                'properties',
                 'constants',
                 'interfaceReferences',
                 'parentClassReference',

--- a/tests/php/PDepend/Source/AST/ASTMethodTest.php
+++ b/tests/php/PDepend/Source/AST/ASTMethodTest.php
@@ -94,6 +94,7 @@ class ASTMethodTest extends AbstractASTArtifactTestCase
         static::assertEquals(
             [
                 'modifiers',
+                'parentClass',
                 'cache',
                 'id',
                 'name',

--- a/tests/resources/files/Source/AST/ASTAnonymousClass/testAnonymousClassSupportsProperties.php
+++ b/tests/resources/files/Source/AST/ASTAnonymousClass/testAnonymousClassSupportsProperties.php
@@ -1,0 +1,12 @@
+<?php
+function testAnonymousClassSupportsProperties()
+{
+    $o = new class() {
+        public int $a = 0;
+
+        public function sum(): int
+        {
+            return $this->a++;
+        }
+    };
+}


### PR DESCRIPTION
Type: bugfix
Fixes #913
Breaking change: no

- Fixes serialization of `ASTMethod` and `ASTTrait` in docker (I don't know specifically why it's more picky then a regular installation on Debian/Ubuntu)
- Make ext-sockets optional (but suggested for Windows
- Fix deprecation as suggested here https://github.com/pdepend/pdepend/commit/a348a12d483e221f8e0e027953f3b5437d700f41#r173362126
- Added a test for anonymous classes with properties

I have tested by running it on the pdepend root (including all tests, fixtures, and vendor folders) and the vender folder of a large package (18k files) which uncovered one more issue (`ASTMethod`) then what was reported in #913.