### PR TITLE
Add missing react/event-loop dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "php": ">=8.1",
         "php-64bit": "*",
         "fidry/cpu-core-counter": "^1.1",
+        "react/event-loop": "^1.6",
         "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
Type: bugfix
Breaking change: no

We use this for parallel processing, it's not triggered any issues for us since we get this via php-cs-fixer's dependencies when installing development dependencies. But for production we need to declare it explicitly.

We could go with ^1.2.0, but I don't see a real reason to go with anything lower then the current ^1.6.0.