### PR TITLE
Correct react dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1",
         "php-64bit": "*",
         "fidry/cpu-core-counter": "^1.1",
-        "react/event-loop": "^1.6",
+        "react/child-process": "^0.6.7",
         "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
Type: bugfix
Breaking change: no

I didn't do proper testing with `--no-dev` on  https://github.com/pdepend/pdepend/pull/916 and missed this dependency, which it self depends on the event-loop. This fixes the dependencies properly.