### PR TITLE
Move default cache folder to .cache

### DIFF
--- a/src/DependencyInjection/TreeBuilderFactory.php
+++ b/src/DependencyInjection/TreeBuilderFactory.php
@@ -71,7 +71,7 @@ class TreeBuilderFactory
      */
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        $home = FileUtil::getUserHomeDirOrSysTempDir();
+        $home = FileUtil::getDefaultCacheDir();
 
         $treeBuilder = new TreeBuilder('pdepend', 'array');
         $rootNode = $treeBuilder->getRootNode();
@@ -81,7 +81,7 @@ class TreeBuilderFactory
         $cacheNode->enumNode('driver')->defaultValue('file')->values(['file', 'memory']);
         $cacheNode->scalarNode('location')
             ->info('This value is only used for the file cache.')
-            ->defaultValue($home . '/.pdepend');
+            ->defaultValue($home . '/pdepend');
         $cacheNode->integerNode('ttl')
             ->info('This value is only used for the file cache. Value in seconds.')
             ->defaultValue(self::DEFAULT_TTL);

--- a/src/Util/FileUtil.php
+++ b/src/Util/FileUtil.php
@@ -57,9 +57,9 @@ final class FileUtil
      *
      * @since  0.10.0
      */
-    public static function getUserHomeDirOrSysTempDir(): string
+    public static function getDefaultCacheDir(): string
     {
-        $home = self::getUserHomeDir();
+        $home = self::getUserCacheDir();
 
         if (file_exists($home) && is_writable($home)) {
             return $home;
@@ -81,15 +81,19 @@ final class FileUtil
      *
      * @since  0.10.0
      */
-    public static function getUserHomeDir(): string
+    public static function getUserCacheDir(): string
     {
-        $userHomeDir = getenv('HOME');
-
-        if (!$userHomeDir) {
-            // The HOME environment isn't always set on Windows, then we do a fallback to the HOMEDRIVE and HOMEPATH
-            $userHomeDir = getenv('HOMEDRIVE') . getenv('HOMEPATH');
+        $cacheHomeDir = getenv('XDG_CACHE_HOME');
+        if ($cacheHomeDir) {
+            return $cacheHomeDir;
         }
 
-        return $userHomeDir;
+        $userHomeDir = getenv('HOME');
+        if ($userHomeDir) {
+            return $userHomeDir . '/.cache';
+        }
+
+        // The HOME environment isn't always set on Windows, then we do a fallback to the HOMEDRIVE and HOMEPATH
+        return getenv('HOMEDRIVE') . getenv('HOMEPATH');
     }
 }

--- a/tests/php/PDepend/Util/FileUtilTest.php
+++ b/tests/php/PDepend/Util/FileUtilTest.php
@@ -69,25 +69,25 @@ class FileUtilTest extends AbstractTestCase
     }
 
     /**
-     * testGetUserHomeDirReturnsExpectedDirectory
+     * testGetUserCacheDirReturnsExpectedDirectory
      */
-    public function testGetUserHomeDirReturnsExpectedDirectory(): void
+    public function testGetUserCacheDirReturnsExpectedDirectory(): void
     {
         $homeDir = getenv('HOME') ?: getenv('HOMEDRIVE') . getenv('HOMEPATH');
         static::assertEquals(
-            $homeDir,
-            FileUtil::getUserHomeDir()
+            $homeDir . '/.cache',
+            FileUtil::getUserCacheDir()
         );
     }
 
     /**
-     * testGetUserHomeDirOrSysTempDirReturnsExpectedUserHomeDirectory
+     * testGetDefaultCacheDirReturnsExpectedUserHomeDirectory
      */
-    public function testGetUserHomeDirOrSysTempDirReturnsExpectedUserHomeDirectory(): void
+    public function testGetDefaultCacheDirReturnsExpectedUserHomeDirectory(): void
     {
         static::assertEquals(
-            getenv('HOME'),
-            FileUtil::getUserHomeDirOrSysTempDir()
+            getenv('HOME') . '/.cache',
+            FileUtil::getDefaultCacheDir()
         );
     }
 }


### PR DESCRIPTION
Type: refactoring
fixes #897
Breaking change: no

This moves the default cache folder to `~/.cache/pdepend` but also checks `XDG_CACHE_HOME` to see if there is a different preferred location.