### PR TITLE
Add GitHub Actions workflow for Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,41 @@
+name: Windows
+
+on:
+  push:
+    branches: [ 'master', '2.x', '3.x' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  tests:
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.1' ]
+        setup: [ 'stable' ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: :sockets, json
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache library packages
+        id: composer-cache
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ matrix.php }}-${{ matrix.setup }}-${{ hashFiles('composer.json') }}
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-progress --prefer-${{ matrix.setup }}
+
+      - name: Run test suite
+        run: composer test

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -525,7 +525,7 @@ class Engine
         $files = $this->createFileIterator();
         $fileCount = count($files);
 
-        if ($fileCount > 1) {
+        if ($fileCount > 1 && (!defined('PHP_WINDOWS_VERSION_BUILD') || extension_loaded('sockets'))) {
             $coreCount = (new CpuCoreCounter())->getCount();
             if ($coreCount > 1) {
                 if ($this->runMultiProcessParse($files, $fileCount, $coreCount)) {

--- a/src/Util/FileUtil.php
+++ b/src/Util/FileUtil.php
@@ -59,10 +59,10 @@ final class FileUtil
      */
     public static function getDefaultCacheDir(): string
     {
-        $home = self::getUserCacheDir();
+        $cacheDir = self::getUserCacheDir();
 
-        if (file_exists($home) && is_writable($home)) {
-            return $home;
+        if ($cacheDir && file_exists($cacheDir) && is_writable($cacheDir)) {
+            return $cacheDir;
         }
 
         return self::getSysTempDir();
@@ -81,19 +81,24 @@ final class FileUtil
      *
      * @since  0.10.0
      */
-    public static function getUserCacheDir(): string
+    public static function getUserCacheDir(): ?string
     {
-        $cacheHomeDir = getenv('XDG_CACHE_HOME');
-        if ($cacheHomeDir) {
-            return $cacheHomeDir;
-        }
-
-        $userHomeDir = getenv('HOME');
-        if ($userHomeDir) {
-            return $userHomeDir . '/.cache';
+        $cacheDir = getenv('XDG_CACHE_HOME');
+        if ($cacheDir) {
+            return $cacheDir;
         }
 
         // The HOME environment isn't always set on Windows, then we do a fallback to the HOMEDRIVE and HOMEPATH
-        return getenv('HOMEDRIVE') . getenv('HOMEPATH');
+        $homeDir = getenv('HOME') ?: getenv('HOMEDRIVE') . getenv('HOMEPATH');
+        if ($homeDir) {
+            $cacheDir = $homeDir . DIRECTORY_SEPARATOR . '.cache';
+            if (file_exists($homeDir) && !file_exists($cacheDir) && is_writable($homeDir)) {
+                mkdir($cacheDir);
+            }
+
+            return $cacheDir;
+        }
+
+        return null;
     }
 }

--- a/tests/php/PDepend/Source/AST/ASTCompilationUnitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTCompilationUnitTest.php
@@ -282,7 +282,8 @@ class ASTCompilationUnitTest extends AbstractTestCase
         $file = new ASTCompilationUnit($this->createCodeResourceUriForTest());
 
         $actual = $file->getSource();
-        $expected = file_get_contents($this->createCodeResourceUriForTest());
+        $expected = file_get_contents($this->createCodeResourceUriForTest()) ?: '';
+        $expected = str_replace("\r\n", "\n", $expected);
 
         static::assertEquals($expected, $actual);
     }

--- a/tests/php/PDepend/Util/FileUtilTest.php
+++ b/tests/php/PDepend/Util/FileUtilTest.php
@@ -75,7 +75,7 @@ class FileUtilTest extends AbstractTestCase
     {
         $homeDir = getenv('HOME') ?: getenv('HOMEDRIVE') . getenv('HOMEPATH');
         static::assertEquals(
-            $homeDir . '/.cache',
+            $homeDir . DIRECTORY_SEPARATOR . '.cache',
             FileUtil::getUserCacheDir()
         );
     }
@@ -85,8 +85,9 @@ class FileUtilTest extends AbstractTestCase
      */
     public function testGetDefaultCacheDirReturnsExpectedUserHomeDirectory(): void
     {
+        $homeDir = getenv('HOME') ?: getenv('HOMEDRIVE') . getenv('HOMEPATH');
         static::assertEquals(
-            getenv('HOME') . '/.cache',
+            $homeDir . DIRECTORY_SEPARATOR . '.cache',
             FileUtil::getDefaultCacheDir()
         );
     }


### PR DESCRIPTION
Type: bugfix
Issue: #919
Breaking change: no

This tests that things work correctly on Windows without ext-sockets (required for multi processing). And also fixes a couple of Windows specific issues:
- Find cache folder on Windows
- Fallback to single threading when ext-sockets aren't installed on Windows