### PR TITLE
Parse attributes for promoted properties

### DIFF
--- a/src/Source/AST/ASTParameter.php
+++ b/src/Source/AST/ASTParameter.php
@@ -297,6 +297,14 @@ class ASTParameter extends AbstractASTArtifact implements Stringable
     }
 
     /**
+     * @return ASTAttribute[]
+     */
+    public function getAttributes(): array
+    {
+        return $this->formalParameter->findChildrenOfType(ASTAttribute::class);
+    }
+
+    /**
      * This method will return <b>true</b> when this parameter is optional and
      * can be left blank on invocation.
      *

--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -3660,14 +3660,17 @@ abstract class AbstractPHPParser
         $start = $this->consumeToken(Tokens::T_ATTRIBUTE);
         $attribute = $this->builder->buildASTAttribute($start->image);
 
-        if (is_object($expr = $this->parseOptionalExpression())) {
-            $attribute->addChild($expr);
-        }
-        while ($this->tokenizer->peek() === Tokens::T_COMMA) {
-            $this->consumeToken(Tokens::T_COMMA);
-            if (is_object($expr = $this->parseOptionalExpression())) {
-                $attribute->addChild($expr);
+        while (true) {
+            $allocation = $this->builder->buildAstAllocationExpression('new');
+            $allocation = $this->parseAllocationExpressionTypeReference($allocation);
+            if ($this->isNextTokenArguments()) {
+                $allocation->addChild($this->parseArguments());
             }
+            $attribute->addChild($allocation);
+            if ($this->tokenizer->peek() !== Tokens::T_COMMA) {
+                break;
+            }
+            $this->consumeToken(Tokens::T_COMMA);
         }
 
         $end = $this->consumeToken(Tokens::T_SQUARED_BRACKET_CLOSE);
@@ -6463,6 +6466,8 @@ abstract class AbstractPHPParser
 
         $parameter = $this->parseFormalParameterOrTypeHintOrByReference();
 
+        $this->attachAttributes($parameter);
+
         if ($modifier) {
             $parameter->setModifiers($modifier);
         }
@@ -6515,6 +6520,10 @@ abstract class AbstractPHPParser
 
             if ($tokenType === Tokens::T_PARENTHESIS_CLOSE) {
                 break;
+            }
+
+            if ($tokenType === Tokens::T_ATTRIBUTE) {
+                $this->attributes[] = $this->parseAttributeExpression();
             }
 
             $formalParameters->addChild(

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
@@ -69,7 +69,7 @@ class AttributeTest extends PHPParserVersion81TestCase
         $a = $classlikes[1];
 
         $aAttributes = $a->findChildrenOfType(ASTAttribute::class);
-        static::assertCount(7, $aAttributes);
+        static::assertCount(8, $aAttributes);
         // Attribute2
         static::assertSame($a, $aAttributes[0]->getParent());
         // Attribute3
@@ -79,6 +79,9 @@ class AttributeTest extends PHPParserVersion81TestCase
         static::assertCount(1, $a->getProperties()[0]->getAttributes());
 
         $methods = $a->getAllMethods();
+
+        // Autowire
+        static::assertCount(1, $methods['__construct']->getParameters()[0]->getAttributes());
 
         $getById = $methods['getbyid'];
         // Route
@@ -93,10 +96,10 @@ class AttributeTest extends PHPParserVersion81TestCase
         static::assertSame($foobar, $foobar->findChildrenOfType(ASTAttribute::class)[0]->getParent());
 
         $bMethod = $methods['b'];
-        $parameters = $bMethod->getParameters();
-
+        $parameter = $bMethod->getParameters()[0];
+        static::assertSame('$bar', $parameter->getImage());
         // Foo
-        static::assertSame('$bar', $parameters[0]->getImage());
+        static::assertCount(1, $parameter->getAttributes());
 
         $function = $namespace->getFunctions()->current();
         // FunBar

--- a/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
@@ -13,6 +13,11 @@ class A
     #[Prop]
     public int $prop;
 
+    public function __construct(#[Autowire] protected InjectedClass $dependency)
+    {
+
+    }
+
     #[Route('/thing/{id}', name: 'get_thing_by_id', requirements: ["id" => "\d+"], methods: ['GET'])]
     public function getById(Request $request): Response
     {


### PR DESCRIPTION
Type: bugfix
Reported here: https://github.com/pdepend/pdepend/issues/702#issuecomment-3696098538
Breaking change: no

Parse attributes in promoted properties, and expose attributes for properties.

This also makes it parse attributes as AstAllocationExpression rather then consts and function calls.