### PR TITLE
Expose file count to process listeners

### DIFF
--- a/src/DbusUI/ResultPrinter.php
+++ b/src/DbusUI/ResultPrinter.php
@@ -71,10 +71,8 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
 
     /**
      * Is called when PDepend starts the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
      */
-    public function startParseProcess(Builder $builder): void
+    public function startParseProcess(int $fileCount): void
     {
         $this->startTime = time();
     }

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -296,9 +296,7 @@ class Engine
     {
         $this->builder = new PHPBuilder();
 
-        $this->fireStartParseProcess($this->builder);
         $this->performParseProcess();
-        $this->fireEndParseProcess($this->builder);
 
         // Get global filter collection
         $collection = CollectionArtifactFilter::getInstance();
@@ -424,25 +422,21 @@ class Engine
 
     /**
      * Send the start parsing process event.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
      */
-    protected function fireStartParseProcess(Builder $builder): void
+    protected function fireStartParseProcess(int $fileCount): void
     {
         foreach ($this->listeners as $listener) {
-            $listener->startParseProcess($builder);
+            $listener->startParseProcess($fileCount);
         }
     }
 
     /**
      * Send the end parsing process event.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
      */
-    protected function fireEndParseProcess(Builder $builder): void
+    protected function fireEndParseProcess(): void
     {
         foreach ($this->listeners as $listener) {
-            $listener->endParseProcess($builder);
+            $listener->endParseProcess();
         }
     }
 
@@ -524,11 +518,14 @@ class Engine
 
         $files = $this->createFileIterator();
         $fileCount = count($files);
+        $this->fireStartParseProcess($fileCount);
 
         if ($fileCount > 1 && (!defined('PHP_WINDOWS_VERSION_BUILD') || extension_loaded('sockets'))) {
             $coreCount = (new CpuCoreCounter())->getCount();
             if ($coreCount > 1) {
                 if ($this->runMultiProcessParse($files, $fileCount, $coreCount)) {
+                    $this->fireEndParseProcess();
+
                     return;
                 }
             }
@@ -541,6 +538,8 @@ class Engine
             $this->parseFile($tokenizer, $file);
             $this->fireEndFileParsing();
         }
+
+        $this->fireEndParseProcess();
     }
 
     private function runWorker(): void

--- a/src/ProcessListener.php
+++ b/src/ProcessListener.php
@@ -45,9 +45,7 @@ namespace PDepend;
 
 // @codeCoverageIgnoreStart
 use PDepend\Metrics\AnalyzerListener;
-use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\ASTVisitListener;
-use PDepend\Source\Builder\Builder;
 
 /**
  * This listener can be used to get informations about the current pdepend process.
@@ -59,17 +57,13 @@ interface ProcessListener extends AnalyzerListener, ASTVisitListener
 {
     /**
      * Is called when PDepend starts the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
      */
-    public function startParseProcess(Builder $builder): void;
+    public function startParseProcess(int $fileCount): void;
 
     /**
      * Is called when PDepend has finished the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder The used node builder instance.
      */
-    public function endParseProcess(Builder $builder): void;
+    public function endParseProcess(): void;
 
     /**
      * Is called when PDepend starts parsing of a new file.

--- a/src/TextUI/ResultPrinter.php
+++ b/src/TextUI/ResultPrinter.php
@@ -46,9 +46,7 @@ namespace PDepend\TextUI;
 use PDepend\Metrics\Analyzer;
 use PDepend\ProcessListener;
 use PDepend\Source\AST\AbstractASTArtifact;
-use PDepend\Source\AST\ASTNamespace;
 use PDepend\Source\ASTVisitor\AbstractASTVisitListener;
-use PDepend\Source\Builder\Builder;
 
 /**
  * Prints current the PDepend status information.
@@ -66,22 +64,24 @@ class ResultPrinter extends AbstractASTVisitListener implements ProcessListener
 
     /**
      * Is called when PDepend starts the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder
      */
-    public function startParseProcess(Builder $builder): void
+    public function startParseProcess(int $fileCount): void
     {
         $this->count = 0;
 
-        echo "Parsing source files:\n";
+        if ($fileCount > 1) {
+            echo "Parsing {$fileCount} source files:\n";
+
+            return;
+        }
+
+        echo "Parsing source file:\n";
     }
 
     /**
      * Is called when PDepend has finished the file parsing process.
-     *
-     * @param Builder<ASTNamespace> $builder
      */
-    public function endParseProcess(Builder $builder): void
+    public function endParseProcess(): void
     {
         $this->finish();
     }

--- a/tests/php/PDepend/ApplicationTest.php
+++ b/tests/php/PDepend/ApplicationTest.php
@@ -98,7 +98,7 @@ class ApplicationTest extends AbstractTestCase
         unlink('foo.xml');
         chdir($cwd);
 
-        static::assertMatchesRegularExpression('/Parsing source files:\s*\.\s+1/', $output);
+        static::assertMatchesRegularExpression('/Parsing source file:\s*\.\s+1/', $output);
         static::assertMatchesRegularExpression('/<class\s.*name="FooBar"/', $xml);
         static::assertMatchesRegularExpression('/<file\s.*name="php:\/\/stdin"/', $xml);
     }

--- a/tests/php/PDepend/TextUI/ResultPrinterTest.php
+++ b/tests/php/PDepend/TextUI/ResultPrinterTest.php
@@ -47,7 +47,6 @@ use PDepend\AbstractTestCase;
 use PDepend\Metrics\Analyzer\ClassLevelAnalyzer;
 use PDepend\Metrics\Analyzer\DependencyAnalyzer;
 use PDepend\Source\AST\ASTMethod;
-use PDepend\Source\Language\PHP\PHPBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
@@ -66,14 +65,11 @@ class ResultPrinterTest extends AbstractTestCase
      */
     public function testResultPrinterOutputForSingleEntry(): void
     {
-        // Create dummy objects
-        $builder = new PHPBuilder();
-
         $printer = new ResultPrinter();
 
         ob_start();
         $printer->startFileParsing();
-        $printer->endParseProcess($builder);
+        $printer->endParseProcess();
         $actual = ob_get_contents();
         ob_end_clean();
 
@@ -87,16 +83,13 @@ class ResultPrinterTest extends AbstractTestCase
      */
     public function testResultPrinterOutputForMultipleEntries(): void
     {
-        // Create dummy objects
-        $builder = new PHPBuilder();
-
         $printer = new ResultPrinter();
 
         ob_start();
         for ($i = 0; $i < 73; ++$i) {
             $printer->startFileParsing();
         }
-        $printer->endParseProcess($builder);
+        $printer->endParseProcess();
         $actual = ob_get_contents();
         ob_end_clean();
 
@@ -159,11 +152,11 @@ class ResultPrinterTest extends AbstractTestCase
     public function testStartParseProcess(): void
     {
         self::expectOutput(
-            'Parsing source files:',
+            'Parsing 42 source files:',
             function (): void {
                 $printer = new ResultPrinter();
 
-                $printer->startParseProcess(new PHPBuilder());
+                $printer->startParseProcess(42);
             }
         );
     }


### PR DESCRIPTION
Type: feature
Issue: #923
Breaking change: yes

This lets exposes the total file count to the process listeners allowing them to give the user a better feel for how long the scanning process will take.

## Breaking change

This fully removes access to the Builder since this was never used for anything and already partially removed in https://github.com/pdepend/pdepend/pull/877