### PR TITLE
Improve attribute parsing

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -291,7 +291,7 @@ abstract class AbstractPHPParser
     ];
 
     /** @var list<ASTAttribute> */
-    protected array $attributes = [];
+    private array $attributes = [];
 
     /**
      * Internal state flag, that will be set to <b>true</b> when the parser has
@@ -736,11 +736,6 @@ abstract class AbstractPHPParser
                 case Tokens::T_CLOSE_TAG:
                     $this->parseNonePhpCode();
                     $this->reset();
-
-                    break;
-
-                case Tokens::T_ATTRIBUTE:
-                    $this->attributes[] = $this->parseAttributeExpression();
 
                     break;
 
@@ -1391,7 +1386,7 @@ abstract class AbstractPHPParser
                     break;
 
                 case Tokens::T_ATTRIBUTE:
-                    $this->attributes[] = $this->parseAttributeExpression();
+                    $this->parseAttributeExpression();
 
                     break;
 
@@ -3673,7 +3668,7 @@ abstract class AbstractPHPParser
     /**
      * @throws TokenStreamEndException
      */
-    protected function parseAttributeExpression(): ASTAttribute
+    protected function parseAttributeExpression(): void
     {
         $start = $this->consumeToken(Tokens::T_ATTRIBUTE);
         $attribute = $this->builder->buildASTAttribute($start->image);
@@ -3685,7 +3680,13 @@ abstract class AbstractPHPParser
                 $allocation->addChild($this->parseArguments());
             }
             $attribute->addChild($allocation);
-            if ($this->tokenizer->peek() !== Tokens::T_COMMA) {
+            $current = $this->tokenizer->peek();
+            if ($current === Tokens::T_COMMA && $this->tokenizer->peekNext() === Tokens::T_SQUARED_BRACKET_CLOSE) {
+                $this->consumeToken(Tokens::T_COMMA);
+
+                break;
+            }
+            if ($current !== Tokens::T_COMMA) {
                 break;
             }
             $this->consumeToken(Tokens::T_COMMA);
@@ -3700,7 +3701,7 @@ abstract class AbstractPHPParser
             $end->endColumn,
         );
 
-        return $attribute;
+        $this->attributes[] = $attribute;
     }
 
     /**
@@ -6540,8 +6541,10 @@ abstract class AbstractPHPParser
                 break;
             }
 
-            if ($tokenType === Tokens::T_ATTRIBUTE) {
-                $this->attributes[] = $this->parseAttributeExpression();
+            while ($tokenType === Tokens::T_ATTRIBUTE) {
+                $this->parseAttributeExpression();
+                $this->consumeComments();
+                $tokenType = $this->tokenizer->peek();
             }
 
             $formalParameters->addChild(
@@ -6833,10 +6836,6 @@ abstract class AbstractPHPParser
         $parameter = $this->builder->buildAstFormalParameter();
 
         $peek = $this->tokenizer->peek();
-
-        if (Tokens::T_ATTRIBUTE === $peek) {
-            $parameter->addChild($this->parseAttributeExpression());
-        }
 
         if (Tokens::T_ELLIPSIS === $peek) {
             $this->consumeToken(Tokens::T_ELLIPSIS);
@@ -7264,6 +7263,11 @@ abstract class AbstractPHPParser
 
             case Tokens::T_YIELD:
                 return $this->parseYield(true);
+
+            case Tokens::T_ATTRIBUTE:
+                $this->parseAttributeExpression();
+
+                return $this->parseOptionalStatement();
         }
 
         $this->tokenStack->push();

--- a/src/Source/Language/PHP/PHPParserVersion84.php
+++ b/src/Source/Language/PHP/PHPParserVersion84.php
@@ -223,7 +223,7 @@ abstract class PHPParserVersion84 extends PHPParserVersion83
         $tokenType = $this->tokenizer->peek();
 
         while ($tokenType === Tokens::T_ATTRIBUTE) {
-            $this->attributes[] = $this->parseAttributeExpression();
+            $this->parseAttributeExpression();
             $this->consumeComments();
             $tokenType = $this->tokenizer->peek();
         }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
@@ -69,7 +69,7 @@ class AttributeTest extends PHPParserVersion81TestCase
         $a = $classlikes[1];
 
         $aAttributes = $a->findChildrenOfType(ASTAttribute::class);
-        static::assertCount(8, $aAttributes);
+        static::assertCount(12, $aAttributes);
         // Attribute2
         static::assertSame($a, $aAttributes[0]->getParent());
         // Attribute3
@@ -80,8 +80,12 @@ class AttributeTest extends PHPParserVersion81TestCase
 
         $methods = $a->getAllMethods();
 
-        // Autowire
+        // Promo1
         static::assertCount(1, $methods['__construct']->getParameters()[0]->getAttributes());
+        // Promo2 & Promo3
+        static::assertCount(2, $methods['__construct']->getParameters()[1]->getAttributes());
+        // Promo4
+        static::assertCount(1, $methods['__construct']->getParameters()[2]->getAttributes());
 
         $getById = $methods['getbyid'];
         // Route
@@ -95,6 +99,10 @@ class AttributeTest extends PHPParserVersion81TestCase
         // Foo, Bar
         static::assertSame($foobar, $foobar->findChildrenOfType(ASTAttribute::class)[0]->getParent());
 
+        $foobar2 = $methods['foobar2'];
+        // Foo, Bar,
+        static::assertSame($foobar2, $foobar2->findChildrenOfType(ASTAttribute::class)[0]->getParent());
+
         $bMethod = $methods['b'];
         $parameter = $bMethod->getParameters()[0];
         static::assertSame('$bar', $parameter->getImage());
@@ -104,5 +112,12 @@ class AttributeTest extends PHPParserVersion81TestCase
         $function = $namespace->getFunctions()->current();
         // FunBar
         static::assertSame($function, $function->findChildrenOfType(ASTAttribute::class)[0]->getParent());
+
+        /** @var ASTClass */
+        $b = $classlikes[2];
+        $bAttributes = $b->findChildrenOfType(ASTAttribute::class);
+        static::assertCount(1, $bAttributes);
+        // Foo
+        static::assertSame($b, $bAttributes[0]->getParent());
     }
 }

--- a/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
@@ -13,8 +13,16 @@ class A
     #[Prop]
     public int $prop;
 
-    public function __construct(#[Autowire] protected InjectedClass $dependency)
-    {
+    public function __construct(
+        #[Promo1]
+        protected int $name,
+        #[Promo2]
+        #[Promo3]
+        protected int $count,
+        #[Promo4]
+        /** Trailing comment */
+        protected array $list,
+    ) {
 
     }
 
@@ -36,6 +44,15 @@ class A
         // ...
     }
 
+    #[
+        Foo,
+        Bar,
+    ]
+    public function foobar2()
+    {
+        // ...
+    }
+
     public function b(#[Foo()] $bar)
     {
 
@@ -44,4 +61,11 @@ class A
 
 #[FunBar]
 function funbar(): void {
+}
+
+if (rand()) {
+    #[Foo(Bar::class)]
+    class B
+    {
+    }
 }


### PR DESCRIPTION
Type: bugfix
Issue: #922
Breaking change: no

This addresses 4 parsing issues for attributes:
- Multiple attributes on promoted properties
- Attributes on classes that are conditionally defined
- Comments following an attribute on promoted properties
- Trailing comma in an attribute