### PR TITLE
Improve FQN parsing

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -832,8 +832,9 @@ abstract class AbstractPHPParser
     private function parseClassName(): string
     {
         $type = $this->tokenizer->peek();
+        $isNamespace = $this->tokenizer->peekNext() === Tokens::T_BACKSLASH;
 
-        if ($this->isClassName($type)) {
+        if ($this->isClassName($type, $isNamespace)) {
             return $this->consumeToken($type)->image;
         }
 
@@ -845,26 +846,40 @@ abstract class AbstractPHPParser
      * name part.
      *
      * @param int $tokenType The type of a parsed token.
+     * @param bool $isNamespace Allso allow valid namespace elements.
+     *
+     * @see https://www.php.net/manual/en/reserved.other-reserved-words.php
      * @since 0.10.6
      */
-    private function isClassName(int $tokenType): bool
+    private function isClassName(int $tokenType, bool $isNamespace = false): bool
     {
-        return match ($tokenType) {
-            Tokens::T_DIR,
-            Tokens::T_USE,
-            Tokens::T_GOTO,
-            Tokens::T_NULL,
-            Tokens::T_NS_C,
-            Tokens::T_TRUE,
-            Tokens::T_CLONE,
+        if ($isNamespace && in_array($tokenType, [
             Tokens::T_FALSE,
-            Tokens::T_TRAIT,
-            Tokens::T_STRING,
-            Tokens::T_TRAIT_C,
+            Tokens::T_FINAL,
+            Tokens::T_NULL,
+            Tokens::T_PARENT,
+            Tokens::T_TRUE,
+            Tokens::T_SELF,
+        ], true)) {
+            return true;
+        }
+
+        return match ($tokenType) {
+            Tokens::T_ARRAY,
             Tokens::T_CALLABLE,
+            Tokens::T_CLASS,
+            Tokens::T_CLONE,
+            Tokens::T_DIR,
+            Tokens::T_FN,
+            Tokens::T_GOTO,
             Tokens::T_INSTEADOF,
             Tokens::T_NAMESPACE,
-            Tokens::T_READONLY => true,
+            Tokens::T_NS_C,
+            Tokens::T_READONLY,
+            Tokens::T_STRING,
+            Tokens::T_TRAIT,
+            Tokens::T_TRAIT_C,
+            Tokens::T_USE => true,
             default => false,
         };
     }
@@ -7448,6 +7463,7 @@ abstract class AbstractPHPParser
         // Consume comments and fetch first token type
         $this->consumeComments();
         $tokenType = $this->tokenizer->peek();
+        $isNamespace = $this->tokenizer->peekNext() === Tokens::T_BACKSLASH;
 
         $qualifiedName = [];
 
@@ -7461,7 +7477,7 @@ abstract class AbstractPHPParser
 
             // Set prefixed flag to true
             $this->namespacePrefixReplaced = true;
-        } elseif ($this->isClassName($tokenType)) {
+        } elseif ($this->isClassName($tokenType, $isNamespace)) {
             $qualifiedName[] = $this->parseClassName();
 
             $this->consumeComments();

--- a/tests/php/PDepend/Bugs/KeywordsInNamespace889Test.php
+++ b/tests/php/PDepend/Bugs/KeywordsInNamespace889Test.php
@@ -43,61 +43,21 @@
 
 namespace PDepend\Bugs;
 
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
 
 /**
- * Test case for ticket #169.
- *
- * @copyright 2008-2017 Manuel Pichler. All rights reserved.
- * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ * Test case for ticket 889, namespace contaning keywords.
  */
-#[Group('regressiontest')]
-class ClassAndInterfaceNamesBug169Test extends AbstractRegressionTestCase
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+class KeywordsInNamespace889Test extends AbstractRegressionTestCase
 {
     /**
-     * testParserAcceptsNullAsClassName
+     * Tests that a namespace can contain 'parent' and that a class can be called 'array'.
      */
-    public function testParserAcceptsNullAsClassName(): void
-    {
-        $this->parseCodeResourceForTest();
-    }
-
-    /**
-     * testParserAcceptsNullAsInterfaceName
-     */
-    public function testParserAcceptsNullAsInterfaceName(): void
-    {
-        $this->parseCodeResourceForTest();
-    }
-
-    /**
-     * testParserAcceptsTrueAsClassName
-     */
-    public function testParserAcceptsTrueAsClassName(): void
-    {
-        $this->parseCodeResourceForTest();
-    }
-
-    /**
-     * testParserAcceptsTrueAsInterfaceName
-     */
-    public function testParserAcceptsTrueAsInterfaceName(): void
-    {
-        $this->parseCodeResourceForTest();
-    }
-
-    /**
-     * testParserAcceptsFalseAsClassName
-     */
-    public function testParserAcceptsFalseAsClassName(): void
-    {
-        $this->parseCodeResourceForTest();
-    }
-
-    /**
-     * testParserAcceptsFalseAsInterfaceName
-     */
-    public function testParserAcceptsFalseAsInterfaceName(): void
+    public function testNewKeyword(): void
     {
         $this->parseCodeResourceForTest();
     }

--- a/tests/php/PDepend/Bugs/ParserBug17264279Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug17264279Test.php
@@ -67,33 +67,9 @@ class ParserBug17264279Test extends AbstractRegressionTestCase
     }
 
     /**
-     * testParserAcceptsNullAsClassName
-     */
-    public function testParserAcceptsNullAsClassName(): void
-    {
-        static::assertNotNull($this->parseCodeResourceForTest());
-    }
-
-    /**
-     * testParserAcceptsTrueAsClassName
-     */
-    public function testParserAcceptsTrueAsClassName(): void
-    {
-        static::assertNotNull($this->parseCodeResourceForTest());
-    }
-
-    /**
      * testParserAcceptsCloneAsClassName
      */
     public function testParserAcceptsCloneAsClassName(): void
-    {
-        static::assertNotNull($this->parseCodeResourceForTest());
-    }
-
-    /**
-     * testParserAcceptsFalseAsClassName
-     */
-    public function testParserAcceptsFalseAsClassName(): void
     {
         static::assertNotNull($this->parseCodeResourceForTest());
     }

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -96,60 +96,6 @@ class PHPParserGenericTest extends AbstractTestCase
     }
 
     /**
-     * testParserAcceptsNullAsClassName
-     */
-    public function testParserAcceptsNullAsClassName(): void
-    {
-        $class = $this->getFirstTypeForTestCase();
-        static::assertSame('Null', $class->getImage());
-    }
-
-    /**
-     * testParserAcceptsNullAsInterfaceName
-     */
-    public function testParserAcceptsNullAsInterfaceName(): void
-    {
-        $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('Null', $interface->getImage());
-    }
-
-    /**
-     * testParserAcceptsTrueAsClassName
-     */
-    public function testParserAcceptsTrueAsClassName(): void
-    {
-        $class = $this->getFirstTypeForTestCase();
-        static::assertSame('True', $class->getImage());
-    }
-
-    /**
-     * testParserAcceptsTrueAsInterfaceName
-     */
-    public function testParserAcceptsTrueAsInterfaceName(): void
-    {
-        $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('True', $interface->getImage());
-    }
-
-    /**
-     * testParserAcceptsFalseAsClassName
-     */
-    public function testParserAcceptsFalseAsClassName(): void
-    {
-        $class = $this->getFirstTypeForTestCase();
-        static::assertSame('False', $class->getImage());
-    }
-
-    /**
-     * testParserAcceptsFalseAsInterfaceName
-     */
-    public function testParserAcceptsFalseAsInterfaceName(): void
-    {
-        $interface = $this->getFirstTypeForTestCase();
-        static::assertSame('False', $interface->getImage());
-    }
-
-    /**
      * testParserAcceptsInsteadofAsClassName
      */
     public function testParserAcceptsInsteadofAsClassName(): void

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsFalseAsClassName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsFalseAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class False {
-    
-}

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsFalseAsInterfaceName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsFalseAsInterfaceName.php
@@ -1,4 +1,0 @@
-<?php
-interface False {
-    
-}

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsNullAsClassName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsNullAsClassName.php
@@ -1,5 +1,0 @@
-<?php
-class Null
-{
-    
-}

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsNullAsInterfaceName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsNullAsInterfaceName.php
@@ -1,5 +1,0 @@
-<?php
-interface Null
-{
-    
-}

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsTrueAsClassName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsTrueAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class True {
-    
-}

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsTrueAsInterfaceName.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testParserAcceptsTrueAsInterfaceName.php
@@ -1,4 +1,0 @@
-<?php
-interface True {
-    
-}

--- a/tests/resources/files/bugs/1412288686/testFalseKeywordInNamespace.php
+++ b/tests/resources/files/bugs/1412288686/testFalseKeywordInNamespace.php
@@ -1,6 +1,4 @@
 <?php
 
-namespace False;
-namespace Foo\False;
 namespace False\Bar;
 namespace Foo\False\Bar;

--- a/tests/resources/files/bugs/1412288686/testTrueKeywordInNamespace.php
+++ b/tests/resources/files/bugs/1412288686/testTrueKeywordInNamespace.php
@@ -1,6 +1,4 @@
 <?php
 
-namespace True;
-namespace Foo\True;
 namespace True\Bar;
 namespace Foo\True\Bar;

--- a/tests/resources/files/bugs/169/testParserAcceptsFalseAsClassName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsFalseAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class False {
-    
-}

--- a/tests/resources/files/bugs/169/testParserAcceptsFalseAsInterfaceName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsFalseAsInterfaceName.php
@@ -1,4 +1,0 @@
-<?php
-interface False {
-    
-}

--- a/tests/resources/files/bugs/169/testParserAcceptsNullAsClassName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsNullAsClassName.php
@@ -1,5 +1,0 @@
-<?php
-class Null
-{
-    
-}

--- a/tests/resources/files/bugs/169/testParserAcceptsNullAsInterfaceName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsNullAsInterfaceName.php
@@ -1,5 +1,0 @@
-<?php
-interface Null
-{
-    
-}

--- a/tests/resources/files/bugs/169/testParserAcceptsTrueAsClassName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsTrueAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class True {
-    
-}

--- a/tests/resources/files/bugs/169/testParserAcceptsTrueAsInterfaceName.php
+++ b/tests/resources/files/bugs/169/testParserAcceptsTrueAsInterfaceName.php
@@ -1,4 +1,0 @@
-<?php
-interface True {
-    
-}

--- a/tests/resources/files/bugs/17264279/testParserAcceptsFalseAsClassName.php
+++ b/tests/resources/files/bugs/17264279/testParserAcceptsFalseAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class False {
-    
-}

--- a/tests/resources/files/bugs/17264279/testParserAcceptsNullAsClassName.php
+++ b/tests/resources/files/bugs/17264279/testParserAcceptsNullAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class Null {
-    
-}

--- a/tests/resources/files/bugs/17264279/testParserAcceptsTrueAsClassName.php
+++ b/tests/resources/files/bugs/17264279/testParserAcceptsTrueAsClassName.php
@@ -1,4 +1,0 @@
-<?php
-class True {
-    
-}

--- a/tests/resources/files/bugs/889/testNewKeyword.php
+++ b/tests/resources/files/bugs/889/testNewKeyword.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Parent\Array as ParentArray;
+
+class Array
+{
+}


### PR DESCRIPTION
Type: bugfix
Issue: #889 & #709
Breaking change: no

Some keywords like true, false, and null are no longer permitted as class names as of PHP 7.0. In addition some keywords where not permitted despite being valid. This PR addresses most of the issues and was tested on a vendor folder with 18518 files.

See https://www.php.net/manual/en/reserved.other-reserved-words.php for a list of invalid class names and notes about usage in namespace an previous versions.