### PR TITLE
Allow modifiers on annonymous classes

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -470,6 +470,8 @@ abstract class AbstractPHPParser
     {
         $this->consumeComments();
 
+        $this->parseClassModifiers();
+
         if (Tokens::T_CLASS !== $this->tokenizer->peek()) {
             return null;
         }
@@ -491,6 +493,7 @@ abstract class AbstractPHPParser
         );
         $class->setCompilationUnit($this->compilationUnit);
         $class->setUserDefined();
+        $class->setModifiers($this->modifiers);
 
         if ($this->isNextTokenArguments()) {
             $class->addChild($this->parseArguments());

--- a/tests/php/PDepend/Bugs/AnnonymousReadonlyClass888Test.php
+++ b/tests/php/PDepend/Bugs/AnnonymousReadonlyClass888Test.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Bugs;
+
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Test case for ticket 888, parsing readonly classes.
+ */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+class AnnonymousReadonlyClass888Test extends AbstractRegressionTestCase
+{
+    /**
+     * Tests that an annonymous class can be readonly.
+     */
+    public function testNewKeyword(): void
+    {
+        $this->parseCodeResourceForTest();
+    }
+}

--- a/tests/resources/files/bugs/888/testNewKeyword.php
+++ b/tests/resources/files/bugs/888/testNewKeyword.php
@@ -1,0 +1,3 @@
+<?php
+
+$foo = new readonly class () {};


### PR DESCRIPTION
Type: bugfix
Issue: #888
Breaking change: no

This fixes parsing of anonymous classes with modifiers.