### PR TITLE
Fix parsing properties with Disjoint Normal Form type hints

### DIFF
--- a/src/Source/AST/ASTProperty.php
+++ b/src/Source/AST/ASTProperty.php
@@ -43,6 +43,7 @@
 
 namespace PDepend\Source\AST;
 
+use OutOfBoundsException;
 use Stringable;
 
 /**
@@ -171,6 +172,14 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
         }
 
         return $typeNode->isArray();
+    }
+
+    /**
+     * @throws OutOfBoundsException
+     */
+    public function getType(): ASTType
+    {
+        return $this->fieldDeclaration->getType();
     }
 
     /**

--- a/src/Source/Language/PHP/PHPParserVersion82.php
+++ b/src/Source/Language/PHP/PHPParserVersion82.php
@@ -66,6 +66,7 @@ abstract class PHPParserVersion82 extends AbstractPHPParser
 
     /** @var array<int, int> */
     protected array $possiblePropertyTypes = [
+        Tokens::T_PARENTHESIS_OPEN,
         Tokens::T_STRING,
         Tokens::T_ARRAY,
         Tokens::T_QUESTION_MARK,

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypesTest.php
@@ -41,6 +41,7 @@
 
 namespace PDepend\Source\Language\PHP\Features\PHP82;
 
+use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClassOrInterfaceReference;
 use PDepend\Source\AST\ASTIntersectionType;
 use PDepend\Source\AST\ASTScalarType;
@@ -156,5 +157,15 @@ class DisjunctiveNormalFormTypesTest extends PHPParserVersion82TestCase
 
         static::assertInstanceOf(ASTUnionType::class, $type);
         static::assertSame('(A&B&C)|true|(D&((E&F)|G))', $type->getImage());
+    }
+
+    public function testPropertyNestedParentheses(): void
+    {
+        /** @var ASTClass */
+        $class = $this->parseCodeResourceForTest()->current()->getTypes()[0];
+        $type = $class->getProperties()[0]->getType();
+
+        static::assertInstanceOf(ASTUnionType::class, $type);
+        static::assertSame('(A&B&C)|true|(D&E)', $type->getImage());
     }
 }

--- a/tests/resources/files/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypes/testPropertyNestedParentheses.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP82/DisjunctiveNormalFormTypes/testPropertyNestedParentheses.php
@@ -1,0 +1,5 @@
+<?php
+
+class ITest {
+    public (A&B&C)|true|(D&E) $var;
+}


### PR DESCRIPTION
Type: bugfix
fixes #912
Breaking change: no

This fixes parsing of DNF types on properties, a feature added in PHP 8.2.