### PR TITLE
Only apply traits once

### DIFF
--- a/src/Source/AST/AbstractASTType.php
+++ b/src/Source/AST/AbstractASTType.php
@@ -344,6 +344,7 @@ abstract class AbstractASTType extends AbstractASTArtifact
     protected function getTraitMethods(): array
     {
         $methods = [];
+        $visited = [];
 
         /** @var ASTTraitUseStatement[] */
         $uses = $this->findChildrenOfType(
@@ -358,6 +359,12 @@ abstract class AbstractASTType extends AbstractASTArtifact
                 $priorMethods[strtolower($precedence->getImage())] = true;
             }
             foreach ($use->getAllMethods() as $method) {
+                $id = $method->getParent()?->getNamespacedName() . ':' . $method->getImage();
+                if (isset($visited[$id])) {
+                    continue;
+                }
+                $visited[$id] = true;
+
                 foreach ($uses as $use2) {
                     if ($use2->hasExcludeFor($method)) {
                         continue 2;

--- a/tests/php/PDepend/Source/AST/ASTTraitTest.php
+++ b/tests/php/PDepend/Source/AST/ASTTraitTest.php
@@ -240,6 +240,14 @@ class ASTTraitTest extends AbstractASTArtifactTestCase
         static::assertCount(1, $trait->getAllMethods());
     }
 
+    #[Group('issue-936')]
+    public function testGetAllMethodsWithDerivedTraitMethods(): void
+    {
+        /** @var ASTClass */
+        $classlikes = $this->parseCodeResourceForTest()->current()->getTypes()[3];
+        static::assertCount(1, $classlikes->getAllMethods());
+    }
+
     /**
      * testGetAllChildrenReturnsAnEmptyArrayByDefault
      *

--- a/tests/resources/files/Source/AST/ASTTrait/testGetAllMethodsWithDerivedTraitMethods.php
+++ b/tests/resources/files/Source/AST/ASTTrait/testGetAllMethodsWithDerivedTraitMethods.php
@@ -1,0 +1,15 @@
+<?php
+
+class Unrelated {}
+
+trait Base {
+	function foo() {}
+}
+
+trait Derived1 {
+	use Base;
+}
+
+class Concrete extends Unrelated {
+	use Base, Derived1;
+}


### PR DESCRIPTION
Type: bugfix
Issue: #936
Breaking change: no

Previously it would crash when gathering methods if there where multiple paths to the same trait.