### PR TITLE
Update easy-doc version constraint in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "brianium/paratest": "^7.3",
-        "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
+        "easy-doc/easy-doc": "^1.2.3",
         "friendsofphp/php-cs-fixer": "^3.57",
         "gregwar/rst": "^1.0.6",
         "phpstan/phpstan": "~2.1.32",


### PR DESCRIPTION
Type: documentation update  
Breaking change: no

No need to maintain comparability, it's already dropped from phpmd.