### PR TITLE
Fix parsing nested alternate if else elseif

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -346,6 +346,9 @@ abstract class AbstractPHPParser
     /** True if current statement is echoing (such as after <?=) */
     private bool $echoing = false;
 
+    /** True if current statement is alternative else or elseif */
+    private bool $isAlternativeTerminated = false;
+
     /**
      * Constructs a new source parser.
      *
@@ -3153,7 +3156,10 @@ abstract class AbstractPHPParser
     private function parseOptionalAlternativeScopeTermination(): void
     {
         $tokenType = $this->tokenizer->peek();
+        $this->isAlternativeTerminated = false;
+
         if ($this->isAlternativeScopeTermination($tokenType)) {
+            $this->isAlternativeTerminated = true;
             $this->parseAlternativeScopeTermination($tokenType);
         }
     }
@@ -4196,8 +4202,13 @@ abstract class AbstractPHPParser
         $stmt = $this->builder->buildAstIfStatement($token->image);
         $stmt->addChild($this->parseParenthesisExpression());
 
+        $this->consumeComments();
+        $isAlternative = $this->tokenizer->peek() === Tokens::T_COLON;
+
         $this->parseStatementBody($stmt);
-        $this->parseOptionalElseOrElseIfStatement($stmt);
+        if (!$isAlternative || !$this->isAlternativeTerminated) {
+            $this->parseOptionalElseOrElseIfStatement($stmt);
+        }
 
         return $this->setNodePositionsAndReturn($stmt);
     }
@@ -4215,8 +4226,13 @@ abstract class AbstractPHPParser
         $stmt = $this->builder->buildAstElseIfStatement($token->image);
         $stmt->addChild($this->parseParenthesisExpression());
 
+        $this->consumeComments();
+        $isAlternative = $this->tokenizer->peek() === Tokens::T_COLON;
+
         $this->parseStatementBody($stmt);
-        $this->parseOptionalElseOrElseIfStatement($stmt);
+        if (!$isAlternative || !$this->isAlternativeTerminated) {
+            $this->parseOptionalElseOrElseIfStatement($stmt);
+        }
 
         return $this->setNodePositionsAndReturn($stmt);
     }

--- a/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php
@@ -500,6 +500,11 @@ class PHPParserGenericTest extends AbstractTestCase
         static::assertEmpty($this->parseCodeResourceForTest());
     }
 
+    public function testNestedAlternativeWithElse(): void
+    {
+        static::assertEmpty($this->parseCodeResourceForTest());
+    }
+
     /**
      * Returns the first class or interface that could be found in the code under
      * test for the calling test case.

--- a/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testNestedAlternativeWithElse.php
+++ b/tests/resources/files/Source/Language/PHP/PHPParserGeneric/testNestedAlternativeWithElse.php
@@ -1,0 +1,6 @@
+<?php
+if (true):
+    if (true):
+    endif;
+else:
+endif;


### PR DESCRIPTION
Type: bugfix
Issue: https://github.com/phpmd/phpmd/issues/892
Breaking change: no

The issue turned out to be related more to the parser thinking that the `else:` could belong to an `if` that had already been terminated to an `endif` statment more so then being related to `;` or `?>`, as such this replaces: https://github.com/pdepend/pdepend/pull/553, figuring out what was the cause of the issue was by fare the hardest part of solving this task, it took several failed attempt from my side as well.

I'm solving this with a parser state property since there isn't a good way to know if the statment has been terminated after the terminator has been consumed and the return value is already being used for the scope, it's not ideal but it's a very short lived state so I think it should be ok.

You can better understand the issue if it's transformed like this:

Original report:
```php
<?php if (true): ?>
  <?php if (true): ?>
  <?php endif ?>
<?php else: ?>
<?php endif ?>
```

Simplified case:
```php
<?php
if (true):
    if (true):
    endif;
else:
endif;
```

Bad interpretation:
```php
<?php
if (true) {
    if (true) {
    }
else {
}
```