### PR TITLE
make core usage configurable

### DIFF
--- a/src/Engine.php
+++ b/src/Engine.php
@@ -163,6 +163,9 @@ class Engine
      */
     private array $parseExceptions = [];
 
+    /** number of cores to use for parsing */
+    private ?int $cores = null;
+
     /**
      * Constructs a new php depend facade.
      *
@@ -283,6 +286,12 @@ class Engine
         if (!in_array($listener, $this->listeners, true)) {
             $this->listeners[] = $listener;
         }
+    }
+
+    /** number of cores to use for parsing */
+    public function setCores(?int $cores): void
+    {
+        $this->cores = $cores;
     }
 
     /**
@@ -521,7 +530,7 @@ class Engine
         $this->fireStartParseProcess($fileCount);
 
         if ($fileCount > 1 && (!defined('PHP_WINDOWS_VERSION_BUILD') || extension_loaded('sockets'))) {
-            $coreCount = (new CpuCoreCounter())->getCount();
+            $coreCount = $this->cores ?? (new CpuCoreCounter())->getCount();
             if ($coreCount > 1) {
                 if ($this->runMultiProcessParse($files, $fileCount, $coreCount)) {
                     $this->fireEndParseProcess();

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -163,8 +163,8 @@ class Engine
      */
     private array $parseExceptions = [];
 
-    /** number of cores to use for parsing */
-    private ?int $cores = null;
+    /** number of threads to use for parsing */
+    private ?int $threads = null;
 
     /**
      * Constructs a new php depend facade.
@@ -288,10 +288,12 @@ class Engine
         }
     }
 
-    /** number of cores to use for parsing */
-    public function setCores(?int $cores): void
+    /**
+     * number of threads to use for parsing
+     */
+    public function setThreads(?int $threads): void
     {
-        $this->cores = $cores;
+        $this->threads = $threads;
     }
 
     /**
@@ -530,9 +532,9 @@ class Engine
         $this->fireStartParseProcess($fileCount);
 
         if ($fileCount > 1 && (!defined('PHP_WINDOWS_VERSION_BUILD') || extension_loaded('sockets'))) {
-            $coreCount = $this->cores ?? (new CpuCoreCounter())->getCount();
-            if ($coreCount > 1) {
-                if ($this->runMultiProcessParse($files, $fileCount, $coreCount)) {
+            $threadCount = $this->threads ?? (new CpuCoreCounter())->getCount();
+            if ($threadCount > 1) {
+                if ($this->runMultiProcessParse($files, $fileCount, $threadCount)) {
                     $this->fireEndParseProcess();
 
                     return;

--- a/src/TextUI/Command.php
+++ b/src/TextUI/Command.php
@@ -214,6 +214,13 @@ class Command
             unset($options['--without-annotations']);
         }
 
+        // check whether threads are set and the option contains a value
+        if (isset($options['--threads'])) {
+            assert(is_numeric($options['--threads']));
+            $this->runner->setThreads((int) $options['--threads']);
+            unset($options['--threads']);
+        }
+
         if (isset($options['--worker'])) {
             $runSilent = true;
             $this->runner->setWorker();
@@ -473,6 +480,7 @@ class Command
             'Do not parse doc comment annotations.',
             $length,
         );
+        $this->printOption('--threads=<value>', 'Number of threads to use for parsing.', $length);
         echo PHP_EOL;
 
         $this->printOption('--quiet', 'Prints errors only.', $length);

--- a/src/TextUI/Runner.php
+++ b/src/TextUI/Runner.php
@@ -221,6 +221,14 @@ class Runner
     }
 
     /**
+     * set number of threads to use by the engine
+     */
+    public function setThreads(int $threads): void
+    {
+        $this->engine->setThreads($threads);
+    }
+
+    /**
      * Starts the main PDepend process and returns <b>true</b> after a successful
      * execution.
      *

--- a/tests/php/PDepend/TextUI/CommandTest.php
+++ b/tests/php/PDepend/TextUI/CommandTest.php
@@ -456,6 +456,13 @@ class CommandTest extends AbstractTestCase
         static::assertStringContainsString('--coverage-report=<file>', $actual);
     }
 
+    public function testTextUiCommandOutputContainsExpectedThreadsOption(): void
+    {
+        [, $actual] = $this->executeCommand([]);
+        static::assertIsString($actual);
+        static::assertStringContainsString('--threads=<value>', $actual);
+    }
+
     /**
      * testTextUiCommandFailesWithExpectedErrorCodeWhenCoverageReportFileDoesNotExist
      */


### PR DESCRIPTION
Type: feature
Issue: https://github.com/phpmd/phpmd/issues/1267
Breaking change: no

make the number of cores used for parsing configurable.

i feel a bit bad for not adding a test for this, but that would require me to change the construct signature of the enige which i'm not sure it's worth it (but more than happy to do so)