### PR TITLE
Catch all exceptions during parsing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
         coverage: xdebug
 
     - name: Imagick SVG support
-      run: sudo apt-get install libmagickcore-6.q16-3-extra
+      run: sudo apt-get update && sudo apt-get install libmagickcore-6.q16-3-extra
 
     - name: Cache Composer packages
       id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,12 @@
     ],
     "config": {
         "process-timeout": 900,
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "ignore": [
+                "PKSA-z3gr-8qht-p93v"
+            ]
+        }
     },
     "extra": {
         "branch-alias": {

--- a/src/Engine.php
+++ b/src/Engine.php
@@ -80,6 +80,7 @@ use RuntimeException;
 use SplFileInfo;
 use SplFileObject;
 use stdClass;
+use Throwable;
 
 /**
  * PDepend analyzes php class files and generates metrics.
@@ -156,10 +157,10 @@ class Engine
     private array $options = [];
 
     /**
-     * List of all {@link ParserException} that were caught during
+     * List of all {@link Throwable} that were caught during
      * the parsing process.
      *
-     * @var list<ParserException>
+     * @var list<Throwable>
      */
     private array $parseExceptions = [];
 
@@ -351,7 +352,7 @@ class Engine
      * Returns an <b>array</b> with all {@link ParserException}
      * that were caught during the parsing process.
      *
-     * @return ParserException[]
+     * @return Throwable[]
      */
     public function getExceptions(): array
     {
@@ -607,7 +608,7 @@ class Engine
 
                     $data = unserialize($serializedData);
 
-                    if ($data instanceof ParserException) {
+                    if ($data instanceof Throwable) {
                         $this->parseExceptions[] = $data;
                     }
 
@@ -651,7 +652,7 @@ class Engine
 
         try {
             $parser->parse();
-        } catch (ParserException $e) {
+        } catch (Throwable $e) {
             $this->parseExceptions[] = $e;
         }
     }


### PR DESCRIPTION
Type: bugfix
Fixes https://github.com/pdepend/pdepend/issues/947
Breaking change: yes

This catches all exceptions that happens during parsing instead of just `ParserException`. Specifically  we where sometimes encountering cases where `InvalidArgumentException` where sometimes cast when an unexpected modifier was found, which is a parsing error but only triggers when trying to create the AST object.

This is especially relevant for multi processing to avoid the child process dying with an unencoded output, but also for single process mode it's not ideal to die from just one file not being able to parse (the underlying reason here is a missing feature in PDepend's parser).

Note this adds an ignore for [PKSA-z3gr-8qht-p93v](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) which is needed for installing dependencies on PHP 8.1 as there is a conflict between paratest and newer version of PHPUnit 10, the maintainer of Paratest is [asking for € 1.000](https://github.com/paratestphp/paratest/issues/890#issuecomment-2357995833) to support PHP 8.1.

Additionally it runs `apt-get update` during CI to avoid 404 in cases where the package list of the CI image is outdated.