### PR TITLE
Add support for properties on interfaces

### DIFF
--- a/src/Metrics/Analyzer/ClassLevelAnalyzer.php
+++ b/src/Metrics/Analyzer/ClassLevelAnalyzer.php
@@ -303,9 +303,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
      * Calculates the Variables Inheritance of a class metric, this method only
      * counts protected and public properties of parent classes.
      *
-     * @param ASTClass|ASTEnum|ASTTrait $class The context class instance.
+     * @param ASTClass|ASTTrait $class The context class instance.
      */
-    private function calculateVarsi(ASTClass|ASTEnum|ASTTrait $class): int
+    private function calculateVarsi(ASTClass|ASTTrait $class): int
     {
         // List of properties, this method only counts not overwritten properties
         $properties = [];
@@ -315,6 +315,9 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
         }
 
         foreach ($class->getParentClasses() as $parent) {
+            if ($parent instanceof ASTEnum) {
+                continue;
+            }
             foreach ($parent->getProperties() as $prop) {
                 if (!$prop->isPrivate() && !isset($properties[$prop->getImage()])) {
                     $properties[$prop->getImage()] = true;
@@ -378,7 +381,10 @@ class ClassLevelAnalyzer extends AbstractAnalyzer implements AggregateAnalyzer, 
     private function calculateAbstractASTClassOrInterfaceMetrics(ASTClass|ASTEnum|ASTTrait $class): void
     {
         $impl = count($class->getInterfaces());
-        $varsi = $this->calculateVarsi($class);
+        $varsi = 0;
+        if (!$class instanceof ASTEnum) {
+            $varsi = $this->calculateVarsi($class);
+        }
         $wmci = $this->calculateWmciForClass($class);
 
         $this->nodeMetrics[$class->getId()] = [

--- a/src/Source/AST/ASTEnum.php
+++ b/src/Source/AST/ASTEnum.php
@@ -154,19 +154,6 @@ class ASTEnum extends AbstractASTClassOrInterface
     }
 
     /**
-     * Returns empty ASTArtifactList, enum has no properties.
-     *
-     * @return ASTArtifactList<ASTProperty>
-     */
-    public function getProperties(): ASTArtifactList
-    {
-        /** @var ASTProperty[] $list */
-        $list = [];
-
-        return new ASTArtifactList($list);
-    }
-
-    /**
      * @return ASTArtifactList<AbstractASTClassOrInterface>
      */
     public function getInterfaces(): ASTArtifactList

--- a/src/Source/AST/ASTFieldDeclaration.php
+++ b/src/Source/AST/ASTFieldDeclaration.php
@@ -120,12 +120,13 @@ class ASTFieldDeclaration extends AbstractASTNode
                   & ~State::IS_STATIC
                   & ~State::IS_READONLY
                   & ~State::IS_PRIVATE_SET
-                  & ~State::IS_PROTECTED_SET;
+                  & ~State::IS_PROTECTED_SET
+                  & ~State::IS_ABSTRACT;
 
         if (($expected & $modifiers) !== 0) {
             throw new InvalidArgumentException(
                 'Invalid field modifiers given, allowed modifiers are ' .
-                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_STATIC.',
+                'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE, IS_STATIC, IS_READONLY, IS_PRIVATE_SET, IS_PROTECTED_SET and IS_ABSTRACT.',
             );
         }
 

--- a/src/Source/AST/ASTInterface.php
+++ b/src/Source/AST/ASTInterface.php
@@ -59,6 +59,20 @@ class ASTInterface extends AbstractASTClassOrInterface
      */
     protected int $modifiers = State::IS_IMPLICIT_ABSTRACT;
 
+    /** @var ASTProperty[] */
+    private array $properties;
+
+    public function __sleep(): array
+    {
+        $properties = parent::__sleep();
+
+        if (static::class === self::class) {
+            return ['properties', ...$properties];
+        }
+
+        return $properties;
+    }
+
     /**
      * The magic wakeup method will be called by PHP's runtime environment when
      * a serialized instance of this class was unserialized. This implementation
@@ -80,6 +94,33 @@ class ASTInterface extends AbstractASTClassOrInterface
     public function isAbstract(): bool
     {
         return true;
+    }
+
+    /**
+     * Returns all properties for this class.
+     *
+     * @return ASTArtifactList<ASTProperty>
+     */
+    public function getProperties(): ASTArtifactList
+    {
+        if (!isset($this->properties)) {
+            $this->properties = [];
+
+            $declarations = $this->findChildrenOfType(ASTFieldDeclaration::class);
+            foreach ($declarations as $declaration) {
+                $declarators = $declaration->findChildrenOfType(ASTVariableDeclarator::class);
+
+                foreach ($declarators as $declarator) {
+                    $property = new ASTProperty($declaration, $declarator);
+                    $property->setDeclaringClass($this);
+                    $property->setCompilationUnit($this->getCompilationUnit());
+
+                    $this->properties[] = $property;
+                }
+            }
+        }
+
+        return new ASTArtifactList($this->properties);
     }
 
     /**

--- a/src/Source/AST/ASTProperty.php
+++ b/src/Source/AST/ASTProperty.php
@@ -55,7 +55,7 @@ use Stringable;
 class ASTProperty extends AbstractASTArtifact implements Stringable
 {
     /** The parent type object. */
-    private ASTClass $declaringClass;
+    private AbstractASTClassOrInterface $declaringClass;
 
     /**
      * Constructs a new item for the given field declaration and variable
@@ -289,7 +289,7 @@ class ASTProperty extends AbstractASTArtifact implements Stringable
      *
      * @since  0.9.6
      */
-    public function setDeclaringClass(ASTClass $declaringClass): void
+    public function setDeclaringClass(AbstractASTClassOrInterface $declaringClass): void
     {
         $this->declaringClass = $declaringClass;
     }

--- a/src/Source/AST/ASTPropertyHook.php
+++ b/src/Source/AST/ASTPropertyHook.php
@@ -93,6 +93,7 @@ class ASTPropertyHook extends AbstractASTCallable
         $expected = ~State::IS_PUBLIC
                   & ~State::IS_PROTECTED
                   & ~State::IS_PRIVATE
+                  & ~State::IS_ABSTRACT
                   & ~State::IS_FINAL;
 
         if (($expected & $modifiers) !== 0) {

--- a/src/Source/ASTVisitor/AbstractASTVisitor.php
+++ b/src/Source/ASTVisitor/AbstractASTVisitor.php
@@ -127,9 +127,6 @@ abstract class AbstractASTVisitor implements ASTVisitor
             $this->dispatch($unit);
         }
 
-        foreach ($enum->getProperties() as $property) {
-            $this->dispatch($property);
-        }
         foreach ($enum->getMethods() as $method) {
             $this->dispatch($method);
         }

--- a/src/Source/Language/PHP/PHPParserVersion84.php
+++ b/src/Source/Language/PHP/PHPParserVersion84.php
@@ -254,27 +254,32 @@ abstract class PHPParserVersion84 extends PHPParserVersion83
                 }
             }
 
-            $hook->setModifiers($modifiers);
-
             $this->consumeToken(Tokens::T_STRING);
 
             $tokenType = $this->tokenizer->peek();
 
-            if ($tokenType === Tokens::T_PARENTHESIS_OPEN) {
-                $hook->addChild($this->parseFormalParameters($hook));
-                $tokenType = $this->tokenizer->peek();
+            if ($tokenType === Tokens::T_SEMICOLON) {
+                $this->consumeToken(Tokens::T_SEMICOLON);
+                $modifiers |= State::IS_ABSTRACT;
+            } else {
+                if ($tokenType === Tokens::T_PARENTHESIS_OPEN) {
+                    $hook->addChild($this->parseFormalParameters($hook));
+                    $tokenType = $this->tokenizer->peek();
+                }
+
+                if ($tokenType === Tokens::T_CURLY_BRACE_OPEN) {
+                    $hook->addChild($this->parseScope());
+                } else {
+                    $hook->addChild(
+                        $this->buildReturnStatement(
+                            $this->consumeToken(Tokens::T_DOUBLE_ARROW)
+                        )
+                    );
+                    $this->consumeToken(Tokens::T_SEMICOLON);
+                }
             }
 
-            if ($tokenType === Tokens::T_CURLY_BRACE_OPEN) {
-                $hook->addChild($this->parseScope());
-            } else {
-                $hook->addChild(
-                    $this->buildReturnStatement(
-                        $this->consumeToken(Tokens::T_DOUBLE_ARROW)
-                    )
-                );
-                $this->consumeToken(Tokens::T_SEMICOLON);
-            }
+            $hook->setModifiers($modifiers);
 
             $declaration->addChild($hook);
 

--- a/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
+++ b/tests/php/PDepend/Source/AST/ASTFieldDeclarationTest.php
@@ -172,7 +172,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
         );
         $this->expectExceptionMessage(
             'Invalid field modifiers given, allowed modifiers are ' .
-            'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE and IS_STATIC.'
+            'IS_PUBLIC, IS_PROTECTED, IS_PRIVATE, IS_STATIC, IS_READONLY, IS_PRIVATE_SET, IS_PROTECTED_SET and IS_ABSTRACT.'
         );
 
         $declaration->setModifiers($modifiers);
@@ -186,16 +186,7 @@ class ASTFieldDeclarationTest extends ASTNodeTestCase
     public static function dataProviderSetModifiersThrowsExpectedExceptionForInvalidModifiers(): array
     {
         return [
-            [State::IS_ABSTRACT],
             [State::IS_FINAL],
-            [
-                State::IS_PRIVATE |
-                State::IS_ABSTRACT,
-            ],
-            [
-                State::IS_PROTECTED |
-                State::IS_ABSTRACT,
-            ],
             [
                 State::IS_PUBLIC |
                 State::IS_FINAL,

--- a/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTInterfaceTest.php
@@ -780,6 +780,7 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
 
         static::assertEquals(
             [
+                'properties',
                 'constants',
                 'interfaceReferences',
                 'parentClassReference',
@@ -848,5 +849,11 @@ class ASTInterfaceTest extends AbstractASTArtifactTestCase
         $interface->setContext($context);
 
         return $interface;
+    }
+
+    public function testGetPropertiesReturnsExpectedNumberOfProperties(): void
+    {
+        $class = $this->getFirstInterfaceForTestCase();
+        static::assertCount(4, $class->getProperties());
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/EnumTest.php
@@ -104,7 +104,6 @@ class EnumTest extends PHPParserVersion81TestCase
         static::assertTrue($enum->isFinal());
         static::assertFalse($enum->isAnonymous());
         static::assertFalse($enum->isAbstract());
-        static::assertCount(0, $enum->getProperties());
         static::assertSame(
             [
                 'UnitEnum' => 'UnitEnum',

--- a/tests/resources/files/Source/AST/ASTInterface/testGetPropertiesReturnsExpectedNumberOfProperties.php
+++ b/tests/resources/files/Source/AST/ASTInterface/testGetPropertiesReturnsExpectedNumberOfProperties.php
@@ -1,0 +1,9 @@
+<?php
+
+interface XyzInterface
+{
+    public $any { get; }
+    public int $status { get; }
+    public string $name { set; }
+    public array $list { set; get; }
+}


### PR DESCRIPTION
Type: bugfix / feature
Fixes #946
Breaking change: yes

- Remove fake properties from Enum (they can't have them, so lets not pretend)
- Add support for properties on interfaces
- Add support for abstract property hooks
- Correct exception message
- Allow for abstract properties

Removing the `getProperties()` method from `ASTEnum` is a breaking change, it was not overwriting anything so despite making it possible to simplify thing by allowing for enums to be treated much the same as Traits and Classes it also encouraged redundant work in other cases, and these differences already had to be taken into account for Interfaces.