### PR TITLE
Fix parsing Attributes for closures and functions

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -1709,6 +1709,7 @@ abstract class AbstractPHPParser
 
         $function = $this->builder->buildFunction($functionName);
         $function->setCompilationUnit($this->compilationUnit);
+        $this->attachAttributes($function);
         $function->setId($this->idBuilder->forFunction($function));
 
         $this->parseCallableDeclaration($function);
@@ -1780,6 +1781,7 @@ abstract class AbstractPHPParser
         }
 
         $closure = $this->builder->buildAstClosure();
+        $this->attachAttributes($closure);
         $closure->setReturnsByReference($this->parseOptionalByReference());
         $closure->addChild($this->parseFormalParameters($closure));
         $closure = $this->parseOptionalBoundVariables($closure);
@@ -3538,6 +3540,11 @@ abstract class AbstractPHPParser
                 case Tokens::T_COMMENT:
                 case Tokens::T_DOC_COMMENT:
                     $this->consumeToken($tokenType);
+
+                    break;
+
+                case Tokens::T_ATTRIBUTE:
+                    $this->parseAttributeExpression();
 
                     break;
 

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
@@ -43,6 +43,7 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 
 use PDepend\Source\AST\ASTAttribute;
 use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTClosure;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -109,7 +110,9 @@ class AttributeTest extends PHPParserVersion81TestCase
         // Foo
         static::assertCount(1, $parameter->getAttributes());
 
-        $function = $namespace->getFunctions()->current();
+        $functions = $namespace->getFunctions();
+
+        $function = $functions[0];
         // FunBar
         static::assertSame($function, $function->findChildrenOfType(ASTAttribute::class)[0]->getParent());
 
@@ -119,5 +122,13 @@ class AttributeTest extends PHPParserVersion81TestCase
         static::assertCount(1, $bAttributes);
         // Foo
         static::assertSame($b, $bAttributes[0]->getParent());
+
+        $innerFunction = $functions[1];
+        // InnerAtt
+        static::assertSame($innerFunction, $innerFunction->findChildrenOfType(ASTAttribute::class)[0]->getParent());
+
+        $closure = $functions[3]->findChildrenOfType(ASTClosure::class)[0];
+        // ClosureAtt
+        static::assertSame($closure, $closure->findChildrenOfType(ASTAttribute::class)[0]->getParent());
     }
 }

--- a/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttribute.php
@@ -69,3 +69,15 @@ if (rand()) {
     {
     }
 }
+
+function outerFunc() {
+    #[InnerAtt]
+    function innerFunc($abc)
+    {
+    }
+}
+
+function generator()
+{
+	return #[ClosureAtt] function ($abc) {};
+}


### PR DESCRIPTION
Type: bugfix / feature
Fixes #943
Breaking change: no

- Attach attrbutes to functions
- Fix parse attributes for closures