### PR TITLE
Fix parsing of self::class-constant fetch in attribute arguments

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -291,6 +291,9 @@ abstract class AbstractPHPParser
     /** @var list<ASTAttribute> */
     private array $attributes = [];
 
+    /** True while parsing arguments of an attribute expression. */
+    private bool $inAttributeArguments = false;
+
     /**
      * Internal state flag, that will be set to <b>true</b> when the parser has
      * prefixed a qualified name with the actual namespace.
@@ -3663,7 +3666,13 @@ abstract class AbstractPHPParser
             $allocation = $this->builder->buildAstAllocationExpression('new');
             $allocation = $this->parseAllocationExpressionTypeReference($allocation);
             if ($this->isNextTokenArguments()) {
-                $allocation->addChild($this->parseArguments());
+                $this->inAttributeArguments = true;
+
+                try {
+                    $allocation->addChild($this->parseArguments());
+                } finally {
+                    $this->inAttributeArguments = false;
+                }
             }
             $attribute->addChild($allocation);
             $current = $this->tokenizer->peek();
@@ -5484,12 +5493,34 @@ abstract class AbstractPHPParser
         $this->consumeComments();
 
         if ($this->tokenizer->peek() === Tokens::T_DOUBLE_COLON) {
+            if (
+                !isset($this->classOrInterface)
+                && $this->inAttributeArguments
+                && $this->isClassConstantFetchAfterDoubleColon()
+            ) {
+                return $this->parseStaticMemberPrimaryPrefix(
+                    $this->builder->buildAstConstant($token->image),
+                );
+            }
+
             return $this->parseStaticMemberPrimaryPrefix(
                 $this->parseSelfReference($token),
             );
         }
 
         return $this->builder->buildAstConstant($token->image);
+    }
+
+    private function isClassConstantFetchAfterDoubleColon(): bool
+    {
+        return in_array(
+            $this->tokenizer->peekNext(),
+            [
+                Tokens::T_STRING,
+                Tokens::T_CLASS,
+            ],
+            true,
+        );
     }
 
     /**

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP81/AttributeTest.php
@@ -44,6 +44,8 @@ namespace PDepend\Source\Language\PHP\Features\PHP81;
 use PDepend\Source\AST\ASTAttribute;
 use PDepend\Source\AST\ASTClass;
 use PDepend\Source\AST\ASTClosure;
+use PDepend\Source\AST\ASTConstantPostfix;
+use PDepend\Source\AST\ASTNamedArgument;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Group;
@@ -57,6 +59,23 @@ use PHPUnit\Framework\Attributes\Group;
 #[Group('php8')]
 class AttributeTest extends PHPParserVersion81TestCase
 {
+    public function testAttributeArgumentAllowsSelfClassConstantFetch(): void
+    {
+        $class = $this->getFirstClassForTestCase();
+        $attribute = $class->findChildrenOfType(ASTAttribute::class)[0];
+
+        static::assertCount(1, $attribute->findChildrenOfType(ASTConstantPostfix::class));
+    }
+
+    public function testAttributeNamedArgumentAllowsSelfClassConstantFetch(): void
+    {
+        $class = $this->getFirstClassForTestCase();
+        $attribute = $class->findChildrenOfType(ASTAttribute::class)[0];
+
+        static::assertCount(1, $attribute->findChildrenOfType(ASTNamedArgument::class));
+        static::assertCount(1, $attribute->findChildrenOfType(ASTConstantPostfix::class));
+    }
+
     public function testAttribute(): void
     {
         $namespace = $this->parseCodeResourceForTest()->current();

--- a/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeArgumentAllowsSelfClassConstantFetch.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeArgumentAllowsSelfClassConstantFetch.php
@@ -1,0 +1,7 @@
+<?php
+
+#[Attr(self::NAME)]
+class TestAttributeArgumentAllowsSelfClassConstantFetch
+{
+    private const NAME = 'name';
+}

--- a/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeNamedArgumentAllowsSelfClassConstantFetch.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeNamedArgumentAllowsSelfClassConstantFetch.php
@@ -1,0 +1,7 @@
+<?php
+
+#[Attr(name: self::NAME)]
+class TestAttributeNamedArgumentAllowsSelfClassConstantFetch
+{
+    private const NAME = 'name';
+}


### PR DESCRIPTION
Type: bugfix  
Issue:  #954
Breaking change: no

This PR fixes a parser error for valid PHP attribute arguments using class constant fetch with `self::`, for example:

```php
#[Attr(self::NAME)]
#[Attr(name: self::NAME)]
```

Before this change, parsing could fail with:

`The keyword "self" was used outside of a class/method scope.`

Why this happened:
- Attribute expressions are parsed before the class scope is fully available in this parser path.
- `self::...` in attribute arguments was routed through `parseSelfReference()`, which enforces class/method scope and threw `InvalidStateException`.

What changed:
- Added a minimal, context-scoped parser adjustment in [AbstractPHPParser.php](/Users/jpvdw/PhpstormProjects/pdepend/src/Source/Language/PHP/AbstractPHPParser.php):
  - Track when parser is inside attribute arguments.
  - In that context only, allow `self::` class-constant fetch (`T_STRING` / `T_CLASS`) to parse as static member constant access without calling `parseSelfReference()`.

Tests added:
- `testAttributeArgumentAllowsSelfClassConstantFetch`
- `testAttributeNamedArgumentAllowsSelfClassConstantFetch`
- Fixtures:
  - `tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeArgumentAllowsSelfClassConstantFetch.php`
  - `tests/resources/files/Source/Language/PHP/Features/PHP81/Attribute/testAttributeNamedArgumentAllowsSelfClassConstantFetch.php`

Validation:
- New tests fail without fix, pass with fix.
- Full suite passes (`composer test`).
- Styling check passes (`php-cs-fixer --dry-run --diff`).
