### PR TITLE
fix(parser): parse parenthesized instanceof type

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -2710,9 +2710,17 @@ abstract class AbstractPHPParser
     {
         // Consume the "instanceof" keyword and strip comments
         $token = $this->consumeToken(Tokens::T_INSTANCEOF);
+        $expr = $this->builder->buildAstInstanceOfExpression($token->image);
+
+        $this->consumeComments();
+        if ($this->tokenizer->peek() === Tokens::T_PARENTHESIS_OPEN) {
+            $expr->addChild($this->parseParenthesisExpression());
+
+            return $expr;
+        }
 
         return $this->parseExpressionTypeReference(
-            $this->builder->buildAstInstanceOfExpression($token->image),
+            $expr,
             false,
         );
     }

--- a/tests/php/PDepend/Bugs/ParserBug930Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug930Test.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PDepend\Bugs;
+
+use PDepend\Source\AST\ASTCastExpression;
+use PDepend\Source\AST\ASTInstanceOfExpression;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
+#[Ticket('930')]
+#[Group('regressiontest')]
+class ParserBug930Test extends AbstractRegressionTestCase
+{
+    public function testParserHandlesCastExpressionAfterInstanceOf(): void
+    {
+        $function = $this->getFirstFunctionForTestCase();
+        $instanceOf = $function->getFirstChildOfType(ASTInstanceOfExpression::class);
+
+        static::assertInstanceOf(ASTInstanceOfExpression::class, $instanceOf);
+        static::assertSame(
+            '(string)',
+            $instanceOf->getFirstChildOfType(ASTCastExpression::class)?->getImage(),
+        );
+        static::assertCount(0, $function->getDependencies());
+    }
+}

--- a/tests/resources/files/bugs/930/testParserHandlesCastExpressionAfterInstanceOf.php
+++ b/tests/resources/files/bugs/930/testParserHandlesCastExpressionAfterInstanceOf.php
@@ -1,0 +1,7 @@
+<?php
+
+function testParserHandlesCastExpressionAfterInstanceOf($job, $jobToFake)
+{
+    if ($job instanceof ((string) $jobToFake)) {
+    }
+}


### PR DESCRIPTION
Type: bugfix  
Issue: #930  
Breaking change: no

## Summary

- parse a parenthesized expression on the right-hand side of `instanceof`
- keep the existing static and variable type-reference paths unchanged
- add a regression fixture that verifies the nested string cast and avoids a false static dependency

## Root cause

The `instanceof` parser always delegated its right-hand side to the type-reference parser. PHP 8.4 accepts a parenthesized expression there, but that path only supports identifiers, variables, and member references, so it rejected the opening parenthesis before reaching the cast.

## Verification

- native PHP 8.4.23 syntax check and PDepend CLI reproduction
- 51 related parser tests with 87 assertions
- 7,014-test ParaTest run with 15,388 assertions; two environment-specific tests were excluded because this local workspace path contains a space and the sandbox cannot write `~/.cache`
- PHPStan 2.1.56 with no errors
- PHP CS Fixer full-repository dry run: 0 of 567 files need changes
- PHP syntax checks and `git diff --check`

Fixes #930.
