### PR TITLE
Fix namespace-prefixed scalar defaults

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -8225,6 +8225,16 @@ abstract class AbstractPHPParser
 
                 case Tokens::T_STRING:
                 case Tokens::T_BACKSLASH:
+                    if ($tokenType === Tokens::T_BACKSLASH) {
+                        $scalarTokenTypes = [Tokens::T_NULL, Tokens::T_TRUE, Tokens::T_FALSE];
+
+                        if (in_array($this->tokenizer->peekNext(), $scalarTokenTypes, true)) {
+                            $this->consumeToken(Tokens::T_BACKSLASH);
+
+                            break;
+                        }
+                    }
+
                     $node = $this->builder->buildAstClassOrInterfaceReference(
                         $this->parseQualifiedName(),
                     );

--- a/tests/php/PDepend/Bugs/ParserBug929Test.php
+++ b/tests/php/PDepend/Bugs/ParserBug929Test.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PDepend\Bugs;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Ticket;
+
+#[Ticket('929')]
+#[Group('regressiontest')]
+class ParserBug929Test extends AbstractRegressionTestCase
+{
+    public function testParserHandlesNamespacePrefixedScalarDefaults(): void
+    {
+        $parameters = $this->getFirstMethodForTestCase()->getParameters();
+
+        static::assertFalse($parameters[0]->getDefaultValue());
+        static::assertTrue($parameters[1]->getDefaultValue());
+        static::assertNull($parameters[2]->getDefaultValue());
+    }
+}

--- a/tests/resources/files/bugs/929/testParserHandlesNamespacePrefixedScalarDefaults.php
+++ b/tests/resources/files/bugs/929/testParserHandlesNamespacePrefixedScalarDefaults.php
@@ -1,0 +1,12 @@
+<?php
+
+class XmlRenderer
+{
+    private static function tag(
+        bool $false = \false,
+        bool $true = \true,
+        ?bool $null = \null,
+    ): string {
+        return '';
+    }
+}


### PR DESCRIPTION
Type: bugfix  
Issue: Fixes #929  
Breaking change: no

PHP accepts `\false`, `\true`, and `\null` as namespace-prefixed scalar constants, but PDepend currently sends the leading separator through qualified-name parsing and fails on the scalar token.

This change consumes the root namespace separator only when it precedes one of those scalar tokens, then lets the existing scalar branches preserve their normal AST values. Other qualified names continue through the existing path. A focused regression covers all three values.

Validation:
- `vendor/bin/phpunit tests/php/PDepend/Bugs tests/php/PDepend/Source/Language/PHP/PHPParserGenericTest.php` (316 tests, 950 assertions)
- `vendor/bin/phpstan analyse --memory-limit=1G`
- PHP syntax checks and `git diff --check`
- Full ParaTest: 7,016 of 7,017 tests pass; the remaining `ApplicationTest::testBinCanReadInput` failure is caused by its unquoted binary path when the checkout directory contains a space.