### PR TITLE
Fix  parsing static outside of class

### DIFF
--- a/src/Source/Language/PHP/AbstractPHPParser.php
+++ b/src/Source/Language/PHP/AbstractPHPParser.php
@@ -5396,25 +5396,22 @@ abstract class AbstractPHPParser
     /**
      * This method parses a {@link ASTStaticReference} node.
      *
+     * When the keyword "static" is used outside of a class scope, which is
+     * syntactically valid PHP that only fails at runtime, this method falls
+     * back to a plain {@link ASTClassOrInterfaceReference} because there is
+     * no class or interface the reference could point to.
+     *
      * @param Token $token The "static" keyword token.
-     * @throws ParserException
-     * @throws InvalidStateException
      * @since 0.9.6
      */
-    private function parseStaticReference(Token $token): ASTStaticReference
+    private function parseStaticReference(Token $token): ASTClassOrInterfaceReference
     {
         // Strip optional comments
         $this->consumeComments();
 
-        if (!isset($this->classOrInterface)) {
-            throw new InvalidStateException(
-                $token->startLine,
-                (string) $this->compilationUnit,
-                'The keyword "static" was used outside of a class/method scope.',
-            );
-        }
-
-        $ref = $this->builder->buildAstStaticReference($this->classOrInterface);
+        $ref = isset($this->classOrInterface)
+            ? $this->builder->buildAstStaticReference($this->classOrInterface)
+            : $this->builder->buildAstClassOrInterfaceReference('static');
         $ref->configureLinesAndColumns(
             $token->startLine,
             $token->endLine,
@@ -6805,7 +6802,7 @@ abstract class AbstractPHPParser
         return $this->parseSelfReference($this->consumeToken(Tokens::T_SELF));
     }
 
-    private function parseStaticType(): ASTStaticReference
+    private function parseStaticType(): ASTClassOrInterfaceReference
     {
         return $this->parseStaticReference($this->consumeToken(Tokens::T_STATIC));
     }

--- a/tests/php/PDepend/Bugs/StaticOutsideOfClass932Test.php
+++ b/tests/php/PDepend/Bugs/StaticOutsideOfClass932Test.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of PDepend.
+ *
+ * PHP Version 5
+ *
+ * Copyright (c) 2008-2017 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2017 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Bugs;
+
+use PDepend\Source\Language\PHP\AbstractPHPParser;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Test case for ticket 932, parsing "static" outside of a class scope.
+ *
+ * Using "static" outside of a class scope is a runtime error in PHP,
+ * but it is syntactically valid, so the parser must not fail on it.
+ */
+#[CoversClass(AbstractPHPParser::class)]
+#[Group('unittest')]
+class StaticOutsideOfClass932Test extends AbstractRegressionTestCase
+{
+    /**
+     * Tests that a static method call in the global scope can be parsed.
+     */
+    public function testStaticMethodCallInGlobalScope(): void
+    {
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
+     * Tests that a static method call in a closure can be parsed.
+     */
+    public function testStaticMethodCallInClosure(): void
+    {
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
+     * Tests that a "new static()" allocation in a closure can be parsed.
+     */
+    public function testStaticAllocationInClosure(): void
+    {
+        $this->parseCodeResourceForTest();
+    }
+
+    /**
+     * Tests that static constant, property and class-constant accesses in
+     * the global scope can be parsed.
+     */
+    public function testStaticMemberAccessInGlobalScope(): void
+    {
+        $this->parseCodeResourceForTest();
+    }
+}

--- a/tests/php/PDepend/Source/AST/ASTStaticReferenceTest.php
+++ b/tests/php/PDepend/Source/AST/ASTStaticReferenceTest.php
@@ -47,7 +47,6 @@ use PDepend\Source\Builder\Builder;
 use PDepend\Source\Builder\BuilderContext;
 use PDepend\Source\Builder\BuilderContext\GlobalBuilderContext;
 use PDepend\Source\Language\PHP\AbstractPHPParser;
-use PDepend\Source\Parser\InvalidStateException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\Attributes\Group;
@@ -101,33 +100,25 @@ class ASTStaticReferenceTest extends ASTNodeTestCase
     }
 
     /**
-     * Tests that an invalid static results in the expected exception.
+     * Tests that a static allocation outside of a class scope is parsed as a
+     * plain class reference.
      */
-    public function testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException(): void
+    public function testStaticReferenceAllocationOutsideOfClassScope(): void
     {
-        $this->expectException(
-            InvalidStateException::class
-        );
-        $this->expectExceptionMessage(
-            'The keyword "static" was used outside of a class/method scope.'
-        );
-
-        $this->parseCodeResourceForTest();
+        $reference = $this->getFirstNodeOfTypeInFunction(ASTClassOrInterfaceReference::class);
+        static::assertNotInstanceOf(ASTStaticReference::class, $reference);
+        static::assertEquals('static', $reference->getImage());
     }
 
     /**
-     * Tests that an invalid static results in the expected exception.
+     * Tests that a static member primary prefix outside of a class scope is
+     * parsed as a plain class reference.
      */
-    public function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException(): void
+    public function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScope(): void
     {
-        $this->expectException(
-            InvalidStateException::class
-        );
-        $this->expectExceptionMessage(
-            'The keyword "static" was used outside of a class/method scope.'
-        );
-
-        $this->parseCodeResourceForTest();
+        $reference = $this->getFirstNodeOfTypeInFunction(ASTClassOrInterfaceReference::class);
+        static::assertNotInstanceOf(ASTStaticReference::class, $reference);
+        static::assertEquals('static', $reference->getImage());
     }
 
     /**

--- a/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceAllocationOutsideOfClassScope.php
+++ b/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceAllocationOutsideOfClassScope.php
@@ -1,0 +1,5 @@
+<?php
+function testStaticReferenceAllocationOutsideOfClassScope()
+{
+    new static();
+}

--- a/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException.php
+++ b/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException.php
@@ -1,5 +1,0 @@
-<?php
-function testStaticReferenceAllocationOutsideOfClassScopeThrowsExpectedException()
-{
-    new static();
-}

--- a/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceMemberPrimaryPrefixOutsideOfClassScope.php
+++ b/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceMemberPrimaryPrefixOutsideOfClassScope.php
@@ -1,0 +1,5 @@
+<?php
+function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScope()
+{
+    static::foo();
+}

--- a/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException.php
+++ b/tests/resources/files/Source/AST/ASTStaticReference/testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException.php
@@ -1,5 +1,0 @@
-<?php
-function testStaticReferenceMemberPrimaryPrefixOutsideOfClassScopeThrowsExpectedException()
-{
-    static::foo();
-}

--- a/tests/resources/files/bugs/932/testStaticAllocationInClosure.php
+++ b/tests/resources/files/bugs/932/testStaticAllocationInClosure.php
@@ -1,0 +1,5 @@
+<?php
+
+$closure = function () {
+    return new static();
+};

--- a/tests/resources/files/bugs/932/testStaticMemberAccessInGlobalScope.php
+++ b/tests/resources/files/bugs/932/testStaticMemberAccessInGlobalScope.php
@@ -1,0 +1,5 @@
+<?php
+
+echo static::class;
+echo static::FOO;
+$x = static::$prop;

--- a/tests/resources/files/bugs/932/testStaticMethodCallInClosure.php
+++ b/tests/resources/files/bugs/932/testStaticMethodCallInClosure.php
@@ -1,0 +1,5 @@
+<?php
+
+$closure = function () {
+    return static::init();
+};

--- a/tests/resources/files/bugs/932/testStaticMethodCallInGlobalScope.php
+++ b/tests/resources/files/bugs/932/testStaticMethodCallInGlobalScope.php
@@ -1,0 +1,3 @@
+<?php
+
+static::init();


### PR DESCRIPTION
Type: bugfix
Issue: https://github.com/pdepend/pdepend/issues/932
Breaking change: no

This PR fixes a parser error for the `static` keyword used outside of a class scope, which is syntactically valid PHP, for example:

```php
static::init();

$closure = function () {
    return new static();
};
```

Before this change, parsing failed with:

> The keyword "static" was used outside of a class/method scope.

Why this happened:
- `parseStaticReference()` builds an `ASTStaticReference`, which requires the enclosing class as its owner.
- In the global scope, in plain functions and in closures there is no enclosing class, so the method threw `InvalidStateException` and aborted the analysis of the whole file. In a closure the code is not even a runtime error, since the closure can be bound to a class with `Closure::bind()`.

What changed:
- `parseStaticReference()` in `AbstractPHPParser.php` no longer throws when there is no enclosing class. It falls back to a plain `ASTClassOrInterfaceReference` with the image `static`, because there is no class the reference could point to. Inside a class scope the behavior is unchanged.
- The return types of `parseStaticReference()` and `parseStaticType()` widen to the supertype `ASTClassOrInterfaceReference` (both are private methods, all call sites accept the wider type).

Tests added:
- `StaticOutsideOfClass932Test` with four fixtures under `tests/resources/files/bugs/932/`: a static method call in the global scope, a static method call in a closure, `new static()` in a closure, and `static::class` / constant / property access in the global scope.
- The two tests in `ASTStaticReferenceTest` that asserted the exception now assert the fallback node: an `ASTClassOrInterfaceReference`, not an `ASTStaticReference`, with the image `static`.

Validation:
- New tests fail without the fix (4 errors), pass with the fix.
- Full suite passes (7021 tests, 15411 assertions).
- composer cs-check passes.