### PR TITLE
Fix Phar build process

### DIFF
--- a/.github/workflows/phar.yml
+++ b/.github/workflows/phar.yml
@@ -13,6 +13,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     env:
       COMPOSER_NO_INTERACTION: 1
 
@@ -72,10 +74,12 @@ jobs:
 
       - name: Release pdepend.phar
         if: github.event_name == 'release'
-        uses: skx/github-action-publish-binaries@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: |
-            pdepend.phar
-            pdepend.phar.asc
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          assets=(pdepend.phar)
+          if [ -f pdepend.phar.asc ]; then
+            assets+=(pdepend.phar.asc)
+          fi
+          gh release upload "$TAG_NAME" "${assets[@]}" --clobber


### PR DESCRIPTION
Type: bugfix
Breaking change: no

The docker image we relied on is no more, transition to using `gh` instead.