### PR TITLE
Add support for static and readonly property hooks

### DIFF
--- a/src/Source/Language/PHP/PHPParserVersion84.php
+++ b/src/Source/Language/PHP/PHPParserVersion84.php
@@ -162,6 +162,24 @@ abstract class PHPParserVersion84 extends PHPParserVersion83
             $this->consumeComments();
 
             $tokenType = $this->tokenizer->peek();
+
+            return $this->parsePostAsymmetricVisibilityModifiers($tokenType, $modifiers);
+        }
+
+        return parent::parseUnknownDeclaration($tokenType, $modifiers);
+    }
+
+    /**
+     * Hook for handling additional modifiers after asymmetric visibility tokens.
+     * Override in later parser versions to support new modifier combinations.
+     */
+    protected function parsePostAsymmetricVisibilityModifiers(int $tokenType, int $modifiers): AbstractASTNode
+    {
+        if ($tokenType === Tokens::T_READONLY) {
+            $modifiers |= State::IS_READONLY;
+            $this->consumeToken(Tokens::T_READONLY);
+            $this->consumeComments();
+            $tokenType = $this->tokenizer->peek();
         }
 
         return parent::parseUnknownDeclaration($tokenType, $modifiers);

--- a/src/Source/Language/PHP/PHPParserVersion85.php
+++ b/src/Source/Language/PHP/PHPParserVersion85.php
@@ -45,7 +45,9 @@
 
 namespace PDepend\Source\Language\PHP;
 
+use PDepend\Source\AST\AbstractASTNode;
 use PDepend\Source\AST\ASTNode;
+use PDepend\Source\AST\State;
 use PDepend\Source\Tokenizer\Tokens;
 
 /**
@@ -84,5 +86,17 @@ abstract class PHPParserVersion85 extends PHPParserVersion84
         }
 
         return null;
+    }
+
+    protected function parsePostAsymmetricVisibilityModifiers(int $tokenType, int $modifiers): AbstractASTNode
+    {
+        if ($tokenType === Tokens::T_STATIC) {
+            $modifiers |= State::IS_STATIC;
+            $this->consumeToken(Tokens::T_STATIC);
+            $this->consumeComments();
+            $tokenType = $this->tokenizer->peek();
+        }
+
+        return parent::parsePostAsymmetricVisibilityModifiers($tokenType, $modifiers);
     }
 }

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibilityTest.php
@@ -46,6 +46,7 @@ use PDepend\Source\AST\ASTConstantDeclarator;
 use PDepend\Source\AST\ASTFieldDeclaration;
 use PDepend\Source\AST\ASTFormalParameter;
 use PDepend\Source\AST\ASTFormalParameters;
+use PDepend\Source\AST\State;
 use PDepend\Source\Language\PHP\PHPParserVersion84;
 use PDepend\Source\Language\PHP\PHPTokenizerInternal;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -82,6 +83,27 @@ class AsymmetricPropertyVisibilityTest extends PHPParserVersion84TestCase
         static::assertFalse($properties[0]->isPrivate());
         static::assertFalse($properties[0]->isProtectedSet());
         static::assertTrue($properties[0]->isPrivateSet());
+    }
+
+    /**
+     * testReadonlyProperty
+     */
+    public function testReadonlyProperty(): void
+    {
+        $class = $this->getFirstTypeForTestCase();
+        assert($class instanceof ASTClass);
+
+        /** @var ASTFieldDeclaration[] $properties */
+        $properties = $class->getChildren();
+
+        static::assertCount(1, $properties);
+
+        static::assertTrue($properties[0]->isPublic());
+        static::assertFalse($properties[0]->isProtected());
+        static::assertFalse($properties[0]->isPrivate());
+        static::assertFalse($properties[0]->isProtectedSet());
+        static::assertTrue($properties[0]->isPrivateSet());
+        static::assertSame(State::IS_READONLY, $properties[0]->getModifiers() & State::IS_READONLY);
     }
 
     /**

--- a/tests/php/PDepend/Source/Language/PHP/Features/PHP85/AsymmetricPropertyVisibilityTest.php
+++ b/tests/php/PDepend/Source/Language/PHP/Features/PHP85/AsymmetricPropertyVisibilityTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of PDepend.
+ *
+ * Copyright (c) 2008-2026 Manuel Pichler <mapi@pdepend.org>.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *
+ *   * Neither the name of Manuel Pichler nor the names of his
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * @copyright 2008-2026 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+
+namespace PDepend\Source\Language\PHP\Features\PHP85;
+
+use PDepend\Source\AST\ASTClass;
+use PDepend\Source\AST\ASTFieldDeclaration;
+use PDepend\Source\Language\PHP\PHPParserVersion85;
+use PDepend\Source\Language\PHP\PHPTokenizerInternal;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * @copyright 2008-2026 Manuel Pichler. All rights reserved.
+ * @license http://www.opensource.org/licenses/bsd-license.php BSD License
+ */
+#[CoversClass(PHPTokenizerInternal::class)]
+#[CoversClass(ASTFieldDeclaration::class)]
+#[CoversClass(PHPParserVersion85::class)]
+#[Group('unittest')]
+#[Group('php8.5')]
+class AsymmetricPropertyVisibilityTest extends PHPParserVersion85TestCase
+{
+    /**
+     * testStaticProperty
+     */
+    public function testStaticProperty(): void
+    {
+        $class = $this->getFirstTypeForTestCase();
+        assert($class instanceof ASTClass);
+
+        /** @var ASTFieldDeclaration[] $properties */
+        $properties = $class->getChildren();
+
+        static::assertCount(1, $properties);
+
+        static::assertTrue($properties[0]->isPublic());
+        static::assertFalse($properties[0]->isProtected());
+        static::assertFalse($properties[0]->isPrivate());
+        static::assertFalse($properties[0]->isProtectedSet());
+        static::assertTrue($properties[0]->isPrivateSet());
+        static::assertTrue($properties[0]->isStatic());
+    }
+}

--- a/tests/resources/files/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibility/testReadonlyProperty.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP84/AsymmetricPropertyVisibility/testReadonlyProperty.php
@@ -1,0 +1,6 @@
+<?php
+
+class testReadonlyProperty
+{
+    public private(set) readonly string $model;
+}

--- a/tests/resources/files/Source/Language/PHP/Features/PHP85/AsymmetricPropertyVisibility/testStaticProperty.php
+++ b/tests/resources/files/Source/Language/PHP/Features/PHP85/AsymmetricPropertyVisibility/testStaticProperty.php
@@ -1,0 +1,6 @@
+<?php
+
+class testStaticProperty
+{
+    public private(set) static ?string $model;
+}


### PR DESCRIPTION
Type: bugfix / feature
Fixes: https://github.com/phpmd/phpmd/issues/1334
Breaking change: no

Support for PHP 8.4 readonly property hooks and PHP 8.5 static property hooks.